### PR TITLE
fix(authz): enforce project/session/message ownership across ws routes

### DIFF
--- a/backend/database/queries/project-queries.ts
+++ b/backend/database/queries/project-queries.ts
@@ -34,6 +34,16 @@ export const projectQueries = {
 		`).get(path) as Project | null;
 	},
 
+	userHasProject(userId: string, projectId: string): boolean {
+		const db = getDatabase();
+		const result = db.prepare(`
+			SELECT 1 as ok FROM user_projects
+			WHERE user_id = ? AND project_id = ?
+			LIMIT 1
+		`).get(userId, projectId) as { ok: number } | undefined;
+		return Boolean(result);
+	},
+
 	create(project: Omit<Project, 'id'>): Project {
 		const db = getDatabase();
 		const id = crypto.randomUUID();

--- a/backend/database/queries/project-queries.ts
+++ b/backend/database/queries/project-queries.ts
@@ -133,11 +133,6 @@ export const projectQueries = {
 
 	setFilesPanelState(userId: string, projectId: string, state: string | null): void {
 		const db = getDatabase();
-		const now = new Date().toISOString();
-		db.prepare(`
-			INSERT OR IGNORE INTO user_projects (user_id, project_id, joined_at)
-			VALUES (?, ?, ?)
-		`).run(userId, projectId, now);
 		db.prepare(`
 			UPDATE user_projects
 			SET files_panel_state = ?

--- a/backend/engine/install-runner.ts
+++ b/backend/engine/install-runner.ts
@@ -361,6 +361,10 @@ export function getSession(sessionId: string) {
 	return session ? sessionSnapshot(session) : null;
 }
 
+export function getSessionOwner(sessionId: string): string | null {
+	return sessions.get(sessionId)?.startedBy ?? null;
+}
+
 export function getActiveSessionForTool(tool: ToolId) {
 	const id = activeByTool.get(tool);
 	if (!id) return null;

--- a/backend/ws/README.md
+++ b/backend/ws/README.md
@@ -129,7 +129,7 @@ export const wsRouter = createRouter()
 ### 3. Use in Frontend
 
 ```typescript
-import ws from '$lib/utils/ws';
+import ws from '$frontend/utils/ws';
 
 // HTTP-style request-response
 try {
@@ -781,10 +781,10 @@ ws.getConnectionCount(projectId?)
 
 ### Frontend Client API
 
-**File: `frontend/shared/ws.ts`**
+**File: `frontend/utils/ws.ts`**
 
 ```typescript
-import ws from '$lib/utils/ws';
+import ws from '$frontend/utils/ws';
 
 // HTTP request
 const data = await ws.http('namespace:action', { ... });
@@ -1286,6 +1286,64 @@ email: t.String({ format: 'email' })
 
 ---
 
+### 10. Authorization Guards (IDOR Prevention)
+
+Connection context (Best Practice 6) tells you **who** is calling. Authorization guards
+verify **whether they may touch the resource they named in the payload**. Required
+whenever a handler accepts a `projectId`, `sessionId`, `messageId`, `streamId`,
+`projectPath`, or any other resource id from the client.
+
+**Guards live in `backend/ws/access.ts`:**
+
+| Helper                          | Use when handler accepts…                                           |
+| ------------------------------- | ------------------------------------------------------------------- |
+| `requireProjectAccess`          | a `projectId` (or a path/PTY/stream you resolved to a `projectId`) |
+| `requireSessionAccess`          | a `chatSessionId` / `sessionId` from `chat_sessions`                |
+| `requireMessageAccess`          | a `messageId` from `chat_messages`                                  |
+| `requireCurrentProjectAccess`   | the handler relies on `ws.getProjectId(conn)` and must enforce it  |
+
+**DO:**
+```typescript
+.http('snapshot:restore', {
+  data: t.Object({ sessionId: t.String(), messageId: t.String() })
+}, async ({ data, conn }) => {
+  requireSessionAccess(conn, data.sessionId);  // ✅ guard before any work
+  // … perform restore
+})
+
+.on('terminal:input', {
+  data: t.Object({ sessionId: t.String(), data: t.Any() })
+}, async ({ data, conn }) => {
+  const ptySession = ptySessionManager.getSession(data.sessionId);
+  if (!ptySession?.projectId) throw new Error('Session not found');
+  requireProjectAccess(conn, ptySession.projectId); // ✅ resolve to projectId, then guard
+  // … forward input
+})
+```
+
+**DON'T:**
+```typescript
+.http('snapshot:restore', {
+  data: t.Object({ sessionId: t.String() })
+}, async ({ data }) => {
+  // ❌ Anyone with a session id can mutate another user's project
+  await snapshotService.restore(data.sessionId);
+})
+```
+
+**Why:**
+- Connection identity ≠ resource ownership. A user authenticated as Alice can still
+  send Bob's `sessionId` in the payload — the guard is what stops that.
+- Guards throw on miss; treat them as fail-closed. Never `try/catch` away an access error.
+- DB-layer functions (`projectQueries.setFilesPanelState`, etc.) must NOT silently
+  upsert membership rows (e.g., `INSERT OR IGNORE INTO user_projects`); that pattern
+  bypasses the guard. Membership is established only through `projects:join` flows.
+
+**When you need a new shape of guard, extend `access.ts` rather than inlining ad-hoc
+queries** so the audit surface stays in one file.
+
+---
+
 ## Troubleshooting
 
 ### Handler Not Working
@@ -1433,6 +1491,15 @@ Use this checklist when creating or auditing modules:
 - [ ] Same event uses same scope across files
 - [ ] User-specific events use `user` scope
 - [ ] Project-shared events use `project` scope
+
+### 6. Authorization Guards
+- [ ] Every handler that accepts a resource id (`projectId`, `sessionId`, `messageId`,
+      `streamId`, `projectPath`, etc.) calls the matching `require*Access` helper
+      from `backend/ws/access.ts` BEFORE touching the resource
+- [ ] Handlers that rely on connection's current project use `requireCurrentProjectAccess`
+- [ ] Resources without a direct id (PTY sessions, install sessions) resolve to a
+      `projectId` / owner first, then guard
+- [ ] DB-layer functions do NOT silently `INSERT OR IGNORE` membership rows
 
 ---
 

--- a/backend/ws/access.ts
+++ b/backend/ws/access.ts
@@ -1,0 +1,56 @@
+import type { WSConnection } from '$shared/utils/ws-server';
+import type { Project, ChatSession, DatabaseMessage } from '$shared/types/database/schema';
+import { ws } from '$backend/utils/ws';
+import { projectQueries, sessionQueries, messageQueries } from '$backend/database/queries';
+
+export function requireProjectAccess(conn: WSConnection, projectId: string): Project {
+	const userId = ws.getUserId(conn);
+	const hasAccess = projectQueries.userHasProject(userId, projectId);
+	if (!hasAccess) {
+		throw new Error('Project not found');
+	}
+
+	const project = projectQueries.getById(projectId);
+	if (!project) {
+		throw new Error('Project not found');
+	}
+
+	return project;
+}
+
+export function requireCurrentProjectAccess(conn: WSConnection): {
+	userId: string;
+	projectId: string;
+	project: Project;
+} {
+	const userId = ws.getUserId(conn);
+	const projectId = ws.getProjectId(conn);
+	const project = requireProjectAccess(conn, projectId);
+	return { userId, projectId, project };
+}
+
+export function requireSessionAccess(conn: WSConnection, sessionId: string): ChatSession {
+	const session = sessionQueries.getById(sessionId);
+	if (!session) {
+		throw new Error('Session not found');
+	}
+
+	const userId = ws.getUserId(conn);
+	const hasAccess = projectQueries.userHasProject(userId, session.project_id);
+	if (!hasAccess) {
+		throw new Error('Session not found');
+	}
+
+	return session;
+}
+
+export function requireMessageAccess(conn: WSConnection, messageId: string): DatabaseMessage {
+	const message = messageQueries.getById(messageId);
+	if (!message) {
+		throw new Error('Message not found');
+	}
+
+	// Message access inherits session access controls.
+	requireSessionAccess(conn, message.session_id);
+	return message;
+}

--- a/backend/ws/chat/stream.ts
+++ b/backend/ws/chat/stream.ts
@@ -14,6 +14,7 @@ import { debug } from '$shared/utils/logger';
 import { ws } from '$backend/utils/ws';
 import { broadcastPresence } from '../projects/status';
 import { sessionQueries, messageQueries } from '../../database/queries';
+import { requireSessionAccess } from '../access';
 
 // ============================================================================
 // Global stream lifecycle handler (module-level, not per-connection)
@@ -77,6 +78,7 @@ export const streamHandler = createRouter()
 			chatSessionId: t.String()
 		})
 	}, ({ data, conn }) => {
+		requireSessionAccess(conn, data.chatSessionId);
 		// Leave all previous chat sessions first (1 session at a time per connection)
 		ws.leaveAllChatSessions(conn);
 		ws.joinChatSession(conn, data.chatSessionId);
@@ -120,6 +122,7 @@ export const streamHandler = createRouter()
 			})
 		})
 	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.chatSessionId);
 		const projectId = ws.getProjectId(conn);
 
 		try {
@@ -291,6 +294,7 @@ export const streamHandler = createRouter()
 			chatSessionId: t.String()
 		})
 	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.chatSessionId);
 		const projectId = ws.getProjectId(conn);
 
 		try {
@@ -435,6 +439,7 @@ export const streamHandler = createRouter()
 			answers: t.Record(t.String(), t.String())
 		})
 	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.chatSessionId);
 		const projectId = ws.getProjectId(conn);
 
 		try {
@@ -483,6 +488,10 @@ export const streamHandler = createRouter()
 	}, async ({ data, conn }) => {
 		const projectId = ws.getProjectId(conn);
 
+		if (data.chatSessionId) {
+			requireSessionAccess(conn, data.chatSessionId);
+		}
+
 		const streamState = data.chatSessionId
 			? streamManager.getSessionStream(data.chatSessionId, projectId)
 			: undefined;
@@ -523,6 +532,7 @@ export const streamHandler = createRouter()
 			chatSessionId: t.String()
 		})
 	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.chatSessionId);
 		const projectId = ws.getProjectId(conn);
 		const chatSessionId = data.chatSessionId;
 
@@ -568,7 +578,8 @@ export const streamHandler = createRouter()
 			messageId: t.Union([t.String(), t.Null()]),
 			messageTimestamp: t.Union([t.String(), t.Null()])
 		})
-	}, ({ data }) => {
+	}, ({ data, conn }) => {
+		requireSessionAccess(conn, data.chatSessionId);
 		const chatSessionId = data.chatSessionId;
 
 		// Store on server for late joiners / refresh (keyed by chatSessionId)
@@ -600,8 +611,11 @@ export const streamHandler = createRouter()
 			messageId: t.Union([t.String(), t.Null()]),
 			messageTimestamp: t.Union([t.String(), t.Null()])
 		})
-	}, ({ data }) => {
+	}, ({ data, conn }) => {
 		const chatSessionId = data.chatSessionId || '';
+		if (chatSessionId) {
+			requireSessionAccess(conn, chatSessionId);
+		}
 		const editState = chatSessionEditMode.get(chatSessionId);
 		return editState || { isEditing: false, messageId: null, messageTimestamp: null };
 	})
@@ -620,7 +634,8 @@ export const streamHandler = createRouter()
 				base64: t.String()
 			})))
 		})
-	}, ({ data }) => {
+	}, ({ data, conn }) => {
+		requireSessionAccess(conn, data.chatSessionId);
 		const chatSessionId = data.chatSessionId;
 
 		// Store latest input state on server for late-joining users (keyed by chatSessionId)
@@ -653,8 +668,11 @@ export const streamHandler = createRouter()
 				base64: t.String()
 			})))
 		})
-	}, ({ data }) => {
+	}, ({ data, conn }) => {
 		const chatSessionId = data.chatSessionId || '';
+		if (chatSessionId) {
+			requireSessionAccess(conn, chatSessionId);
+		}
 		const state = chatSessionInputState.get(chatSessionId);
 		return state || { text: '', senderId: '' };
 	})
@@ -669,7 +687,8 @@ export const streamHandler = createRouter()
 			modelId: t.String(),
 			modelName: t.String()
 		})
-	}, ({ data }) => {
+	}, ({ data, conn }) => {
+		requireSessionAccess(conn, data.chatSessionId);
 		const chatSessionId = data.chatSessionId;
 
 		// Store latest model state on server for late joiners / refresh
@@ -707,7 +726,8 @@ export const streamHandler = createRouter()
 			accountId: t.Union([t.Number(), t.Null()]),
 			accountName: t.Optional(t.Union([t.String(), t.Null()]))
 		})
-	}, ({ data }) => {
+	}, ({ data, conn }) => {
+		requireSessionAccess(conn, data.chatSessionId);
 		const chatSessionId = data.chatSessionId;
 
 		// Store latest account state on server for late joiners / refresh

--- a/backend/ws/files/read.ts
+++ b/backend/ws/files/read.ts
@@ -21,6 +21,7 @@ import { handlePathBrowsing } from '../../files/path-browsing';
 import { gitService } from '../../git/git-service';
 import { projectQueries } from '../../database/queries/project-queries';
 import { isAbsolute, relative } from 'node:path';
+import { requireProjectAccess } from '../access';
 
 // Bun-compatible existsSync implementation
 async function existsSync(path: string): Promise<boolean> {
@@ -168,7 +169,8 @@ export const readHandler = createRouter()
 			content: t.Union([t.String(), t.Null()]),
 			ref: t.String()
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireProjectAccess(conn, data.projectId);
 		const project = projectQueries.getById(data.projectId);
 		if (!project) throw new Error('Project not found');
 

--- a/backend/ws/files/state.ts
+++ b/backend/ws/files/state.ts
@@ -11,6 +11,7 @@ import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { projectQueries } from '../../database/queries/project-queries';
 import { ws as wsServer } from '../../utils/ws';
+import { requireProjectAccess } from '../access';
 
 export const filesStateHandler = createRouter()
 	.http('files:get-panel-state', {
@@ -21,6 +22,7 @@ export const filesStateHandler = createRouter()
 			state: t.Union([t.String(), t.Null()])
 		})
 	}, async ({ data, conn }) => {
+		requireProjectAccess(conn, data.projectId);
 		const userId = wsServer.getUserId(conn);
 		const state = projectQueries.getFilesPanelState(userId, data.projectId);
 		return { state };
@@ -33,6 +35,7 @@ export const filesStateHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
+		requireProjectAccess(conn, data.projectId);
 		const userId = wsServer.getUserId(conn);
 		projectQueries.setFilesPanelState(userId, data.projectId, data.state);
 		return { ok: true };

--- a/backend/ws/files/watch.ts
+++ b/backend/ws/files/watch.ts
@@ -12,6 +12,8 @@ import { createRouter } from '$shared/utils/ws-server';
 import { fileWatcher } from '$backend/files/file-watcher';
 import { debug } from '$shared/utils/logger';
 import { ws } from '$backend/utils/ws';
+import { projectQueries } from '../../database/queries/project-queries';
+import { requireProjectAccess } from '../access';
 
 export const watchHandler = createRouter()
 	// Start watching a project directory
@@ -20,8 +22,12 @@ export const watchHandler = createRouter()
 			projectPath: t.String({ minLength: 1 })
 		})
 	}, async ({ data, conn }) => {
-		const projectId = ws.getProjectId(conn);
 		const { projectPath } = data;
+
+		const project = projectQueries.getByPath(projectPath);
+		if (!project) throw new Error('Project not found');
+		requireProjectAccess(conn, project.id);
+		const projectId = project.id;
 
 		try {
 			// Check if already watching

--- a/backend/ws/git/branch.ts
+++ b/backend/ws/git/branch.ts
@@ -5,7 +5,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { projectQueries } from '../../database/queries/project-queries';
+import { requireProjectAccess } from '../access';
 
 const BranchSchema = t.Object({
 	name: t.String(),
@@ -29,9 +29,8 @@ export const branchHandler = createRouter()
 			ahead: t.Number(),
 			behind: t.Number()
 		})
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		return await gitService.getBranches(project.path);
 	})
 
@@ -42,9 +41,8 @@ export const branchHandler = createRouter()
 			startPoint: t.Optional(t.String())
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.createBranch(project.path, data.name, data.startPoint);
 		return { ok: true };
 	})
@@ -55,9 +53,8 @@ export const branchHandler = createRouter()
 			name: t.String()
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.switchBranch(project.path, data.name);
 		return { ok: true };
 	})
@@ -69,9 +66,8 @@ export const branchHandler = createRouter()
 			force: t.Optional(t.Boolean())
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.deleteBranch(project.path, data.name, data.force);
 		return { ok: true };
 	})
@@ -83,9 +79,8 @@ export const branchHandler = createRouter()
 			newName: t.String({ minLength: 1 })
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.renameBranch(project.path, data.oldName, data.newName);
 		return { ok: true };
 	})
@@ -99,8 +94,7 @@ export const branchHandler = createRouter()
 			success: t.Boolean(),
 			message: t.String()
 		})
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		return await gitService.mergeBranch(project.path, data.branchName);
 	});

--- a/backend/ws/git/commit-message.ts
+++ b/backend/ws/git/commit-message.ts
@@ -7,11 +7,11 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { execGit } from '../../git/git-executor';
-import { projectQueries } from '../../database/queries/project-queries';
 import { initializeEngine } from '../../engine';
 import type { EngineType } from '$shared/types/unified';
 import type { GeneratedCommitMessage } from '$shared/types/git';
 import { debug } from '$shared/utils/logger';
+import { requireProjectAccess } from '../access';
 
 const COMMIT_MESSAGE_SCHEMA = {
 	type: 'object',
@@ -49,9 +49,8 @@ export const commitMessageHandler = createRouter()
 		response: t.Object({
 			message: t.String()
 		})
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 
 		// Get raw staged diff text
 		const diffResult = await execGit(['diff', '--cached'], project.path);

--- a/backend/ws/git/commit.ts
+++ b/backend/ws/git/commit.ts
@@ -5,7 +5,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { projectQueries } from '../../database/queries/project-queries';
+import { requireProjectAccess } from '../access';
 
 export const commitHandler = createRouter()
 	.http('git:commit', {
@@ -16,9 +16,8 @@ export const commitHandler = createRouter()
 		response: t.Object({
 			hash: t.String()
 		})
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		const hash = await gitService.commit(project.path, data.message);
 		return { hash };
 	})
@@ -31,9 +30,8 @@ export const commitHandler = createRouter()
 		response: t.Object({
 			hash: t.String()
 		})
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		const hash = await gitService.amendCommit(project.path, data.message);
 		return { hash };
 	});

--- a/backend/ws/git/conflict.ts
+++ b/backend/ws/git/conflict.ts
@@ -5,7 +5,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { projectQueries } from '../../database/queries/project-queries';
+import { requireProjectAccess } from '../access';
 
 const ConflictMarkerSchema = t.Object({
 	ourStart: t.Number(),
@@ -29,9 +29,8 @@ export const conflictHandler = createRouter()
 			content: t.String(),
 			markers: t.Array(ConflictMarkerSchema)
 		}))
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		return await gitService.getConflictFiles(project.path);
 	})
 
@@ -43,9 +42,8 @@ export const conflictHandler = createRouter()
 			customContent: t.Optional(t.String())
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.resolveConflict(
 			project.path,
 			data.filePath,
@@ -60,9 +58,8 @@ export const conflictHandler = createRouter()
 			projectId: t.String()
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.abortMerge(project.path);
 		return { ok: true };
 	});

--- a/backend/ws/git/diff.ts
+++ b/backend/ws/git/diff.ts
@@ -5,7 +5,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { projectQueries } from '../../database/queries/project-queries';
+import { requireProjectAccess } from '../access';
 
 const DiffHunkLineSchema = t.Object({
 	type: t.Union([t.Literal('add'), t.Literal('delete'), t.Literal('context'), t.Literal('header')]),
@@ -38,9 +38,8 @@ export const diffHandler = createRouter()
 			filePath: t.Optional(t.String())
 		}),
 		response: t.Array(FileDiffSchema)
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		return await gitService.getDiffUnstaged(project.path, data.filePath);
 	})
 
@@ -50,9 +49,8 @@ export const diffHandler = createRouter()
 			filePath: t.Optional(t.String())
 		}),
 		response: t.Array(FileDiffSchema)
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		return await gitService.getDiffStaged(project.path, data.filePath);
 	})
 
@@ -62,8 +60,7 @@ export const diffHandler = createRouter()
 			commitHash: t.String()
 		}),
 		response: t.Array(FileDiffSchema)
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		return await gitService.getDiffCommit(project.path, data.commitHash);
 	});

--- a/backend/ws/git/log.ts
+++ b/backend/ws/git/log.ts
@@ -5,7 +5,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { projectQueries } from '../../database/queries/project-queries';
+import { requireProjectAccess } from '../access';
 
 export const logHandler = createRouter()
 	.http('git:log', {
@@ -29,9 +29,8 @@ export const logHandler = createRouter()
 			total: t.Number(),
 			hasMore: t.Boolean()
 		})
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		return await gitService.getLog(
 			project.path,
 			data.limit ?? 50,

--- a/backend/ws/git/remote.ts
+++ b/backend/ws/git/remote.ts
@@ -5,7 +5,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { projectQueries } from '../../database/queries/project-queries';
+import { requireProjectAccess } from '../access';
 
 export const remoteHandler = createRouter()
 	.http('git:remotes', {
@@ -17,9 +17,8 @@ export const remoteHandler = createRouter()
 			fetchUrl: t.String(),
 			pushUrl: t.String()
 		}))
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		return await gitService.getRemotes(project.path);
 	})
 
@@ -31,9 +30,8 @@ export const remoteHandler = createRouter()
 		response: t.Object({
 			message: t.String()
 		})
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		const message = await gitService.fetch(project.path, data.remote);
 		return { message };
 	})
@@ -48,9 +46,8 @@ export const remoteHandler = createRouter()
 			success: t.Boolean(),
 			message: t.String()
 		})
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		return await gitService.pull(project.path, data.remote, data.branch);
 	})
 
@@ -65,9 +62,8 @@ export const remoteHandler = createRouter()
 			success: t.Boolean(),
 			message: t.String()
 		})
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		return await gitService.push(project.path, data.remote, data.branch, data.force);
 	})
 
@@ -78,9 +74,8 @@ export const remoteHandler = createRouter()
 			url: t.String()
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.addRemote(project.path, data.name, data.url);
 		return { ok: true };
 	})
@@ -91,9 +86,8 @@ export const remoteHandler = createRouter()
 			name: t.String()
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.removeRemote(project.path, data.name);
 		return { ok: true };
 	})
@@ -107,9 +101,8 @@ export const remoteHandler = createRouter()
 			message: t.String(),
 			date: t.String()
 		}))
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		return await gitService.stashList(project.path);
 	})
 
@@ -119,9 +112,8 @@ export const remoteHandler = createRouter()
 			message: t.Optional(t.String())
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.stashSave(project.path, data.message);
 		return { ok: true };
 	})
@@ -132,9 +124,8 @@ export const remoteHandler = createRouter()
 			index: t.Optional(t.Number())
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.stashPop(project.path, data.index);
 		return { ok: true };
 	})
@@ -145,9 +136,8 @@ export const remoteHandler = createRouter()
 			index: t.Optional(t.Number())
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.stashDrop(project.path, data.index);
 		return { ok: true };
 	})
@@ -163,9 +153,8 @@ export const remoteHandler = createRouter()
 			date: t.String(),
 			isAnnotated: t.Boolean()
 		}))
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		return await gitService.getTags(project.path);
 	})
 
@@ -177,9 +166,8 @@ export const remoteHandler = createRouter()
 			commitHash: t.Optional(t.String())
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.createTag(project.path, data.name, data.message, data.commitHash);
 		return { ok: true };
 	})
@@ -190,9 +178,8 @@ export const remoteHandler = createRouter()
 			name: t.String()
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.deleteTag(project.path, data.name);
 		return { ok: true };
 	})
@@ -207,8 +194,8 @@ export const remoteHandler = createRouter()
 			success: t.Boolean(),
 			message: t.String()
 		})
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		return await gitService.pushTag(project.path, data.name, data.remote);
 	});
+

--- a/backend/ws/git/staging.ts
+++ b/backend/ws/git/staging.ts
@@ -5,7 +5,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { projectQueries } from '../../database/queries/project-queries';
+import { requireProjectAccess } from '../access';
 
 export const stagingHandler = createRouter()
 	.http('git:stage', {
@@ -14,9 +14,8 @@ export const stagingHandler = createRouter()
 			filePath: t.String()
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.stageFile(project.path, data.filePath);
 		return { ok: true };
 	})
@@ -26,9 +25,8 @@ export const stagingHandler = createRouter()
 			projectId: t.String()
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.stageAll(project.path);
 		return { ok: true };
 	})
@@ -39,9 +37,8 @@ export const stagingHandler = createRouter()
 			filePath: t.String()
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.unstageFile(project.path, data.filePath);
 		return { ok: true };
 	})
@@ -51,9 +48,8 @@ export const stagingHandler = createRouter()
 			projectId: t.String()
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.unstageAll(project.path);
 		return { ok: true };
 	})
@@ -64,9 +60,8 @@ export const stagingHandler = createRouter()
 			filePath: t.String()
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.discardFile(project.path, data.filePath);
 		return { ok: true };
 	})
@@ -76,9 +71,8 @@ export const stagingHandler = createRouter()
 			projectId: t.String()
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.discardAll(project.path);
 		return { ok: true };
 	});

--- a/backend/ws/git/status.ts
+++ b/backend/ws/git/status.ts
@@ -5,8 +5,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { projectQueries } from '../../database/queries/project-queries';
-import { ws as wsServer } from '../../utils/ws';
+import { requireProjectAccess } from '../access';
 
 export const statusHandler = createRouter()
 	.http('git:status', {
@@ -40,9 +39,8 @@ export const statusHandler = createRouter()
 				oldPath: t.Optional(t.String())
 			}))
 		})
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 
 		const isRepo = await gitService.isRepo(project.path);
 		if (!isRepo) {
@@ -65,9 +63,8 @@ export const statusHandler = createRouter()
 			defaultBranch: t.Optional(t.String())
 		}),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.init(project.path, data.defaultBranch);
 		return { ok: true };
 	})
@@ -80,9 +77,8 @@ export const statusHandler = createRouter()
 			isRepo: t.Boolean(),
 			root: t.Optional(t.String())
 		})
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
 
 		const isRepo = await gitService.isRepo(project.path);
 		const root = isRepo ? await gitService.getRoot(project.path) : undefined;

--- a/backend/ws/messages/crud.ts
+++ b/backend/ws/messages/crud.ts
@@ -11,6 +11,7 @@ import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { messageQueries } from '../../database/queries';
 import { loadMessage } from '$shared/utils/message-formatter';
+import { requireMessageAccess, requireSessionAccess } from '../access';
 
 export const crudHandler = createRouter()
 	// List messages
@@ -20,7 +21,8 @@ export const crudHandler = createRouter()
 			include_all: t.Optional(t.Boolean())
 		}),
 		response: t.Array(t.Any())
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.session_id);
 		if (data.include_all) {
 			// Return all messages including those in other branches (for History view)
 			const allMessages = messageQueries.getAllBySessionId(data.session_id);
@@ -37,13 +39,8 @@ export const crudHandler = createRouter()
 			messageId: t.String({ minLength: 1 })
 		}),
 		response: t.Any()
-	}, async ({ data }) => {
-		const message = messageQueries.getById(data.messageId);
-
-		if (!message) {
-			throw new Error('Message not found');
-		}
-
+	}, async ({ data, conn }) => {
+		const message = requireMessageAccess(conn, data.messageId);
 		return loadMessage(message);
 	})
 
@@ -55,12 +52,9 @@ export const crudHandler = createRouter()
 		response: t.Object({
 			message: t.String()
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		// Check if message exists first
-		const message = messageQueries.getById(data.messageId);
-		if (!message) {
-			throw new Error('Message not found');
-		}
+		requireMessageAccess(conn, data.messageId);
 
 		// Delete the message
 		messageQueries.delete(data.messageId);

--- a/backend/ws/projects/crud.ts
+++ b/backend/ws/projects/crud.ts
@@ -20,6 +20,7 @@ import { streamManager } from '../../chat/stream-manager';
 import { terminalStreamManager } from '../../terminal/stream-manager';
 import { broadcastPresence } from '../projects/status';
 import { debug } from '$shared/utils/logger';
+import { requireProjectAccess } from '../access';
 
 export const crudHandler = createRouter()
 	// List all projects for the current user
@@ -73,12 +74,8 @@ export const crudHandler = createRouter()
 			id: t.String({ minLength: 1 })
 		}),
 		response: t.Any()
-	}, async ({ data }) => {
-		const project = projectQueries.getById(data.id);
-
-		if (!project) {
-			throw new Error('Project not found');
-		}
+	}, async ({ data, conn }) => {
+		requireProjectAccess(conn, data.id);
 
 		// Update last_opened_at when getting project
 		projectQueries.updateLastOpened(data.id);
@@ -99,10 +96,7 @@ export const crudHandler = createRouter()
 		})
 	}, async ({ data, conn }) => {
 		const userId = ws.getUserId(conn);
-		const project = projectQueries.getById(data.id);
-		if (!project) {
-			throw new Error('Project not found');
-		}
+		requireProjectAccess(conn, data.id);
 
 		const mode = data.mode ?? 'remove';
 

--- a/backend/ws/projects/status.ts
+++ b/backend/ws/projects/status.ts
@@ -16,6 +16,7 @@ import { getProjectStatusData, updateUserPresence } from '../../project/status-m
 import { streamManager } from '../../chat/stream-manager';
 import { ws } from '$backend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { requireProjectAccess } from '../access';
 
 /**
  * Broadcast full presence state of all projects to all connected clients
@@ -94,6 +95,7 @@ export const statusHandler = createRouter()
 		// Use explicit projectId from client (avoids race condition when switching projects)
 		const projectId = data.projectId || ws.getProjectId(conn);
 		const userId = ws.getUserId(conn);
+		requireProjectAccess(conn, projectId);
 
 		try {
 			updateUserPresence(projectId, userId, '', 'leave');

--- a/backend/ws/sessions/crud.ts
+++ b/backend/ws/sessions/crud.ts
@@ -21,6 +21,7 @@ import { snapshotService } from '../../snapshot/snapshot-service';
 import { blobStore } from '../../snapshot/blob-store';
 import { broadcastPresence } from '../projects/status';
 import { debug } from '$shared/utils/logger';
+import { requireCurrentProjectAccess, requireProjectAccess, requireSessionAccess } from '../access';
 
 /** Elysia schema for ChatSession responses — all optional fields use t.Optional */
 const sessionSchema = t.Object({
@@ -85,8 +86,7 @@ export const crudHandler = createRouter()
 			}))
 		})
 	}, async ({ conn }) => {
-		const projectId = ws.getProjectId(conn);
-		const userId = ws.getUserId(conn);
+		const { projectId, userId } = requireCurrentProjectAccess(conn);
 		const sessions = sessionQueries.getByProjectId(projectId);
 
 		// Get the user's saved current session for this project
@@ -108,7 +108,7 @@ export const crudHandler = createRouter()
 		data: t.Object({}),
 		response: t.Array(sessionSchema)
 	}, async ({ conn }) => {
-		const projectId = ws.getProjectId(conn);
+		const { projectId } = requireCurrentProjectAccess(conn);
 		const sessions = sessionQueries.getActiveSessionsForProject(projectId);
 		return sessions.map(serializeSession);
 	})
@@ -121,7 +121,7 @@ export const crudHandler = createRouter()
 		}),
 		response: sessionSchema
 	}, async ({ data, conn }) => {
-		const projectId = ws.getProjectId(conn);
+		const { projectId } = requireCurrentProjectAccess(conn);
 		const now = new Date().toISOString();
 		const engine: EngineType = data.engine ?? 'claude-code';
 		const session = sessionQueries.create({
@@ -143,12 +143,8 @@ export const crudHandler = createRouter()
 			session: sessionSchema,
 			messages: t.Array(t.Any())
 		})
-	}, async ({ data }) => {
-		const session = sessionQueries.getById(data.id);
-
-		if (!session) {
-			throw new Error('Session not found');
-		}
+	}, async ({ data, conn }) => {
+		const session = requireSessionAccess(conn, data.id);
 
 		// Also get messages for this session
 		const messages = messageQueries.getBySessionId(data.id);
@@ -166,13 +162,7 @@ export const crudHandler = createRouter()
 		}),
 		response: sessionSchema
 	}, async ({ data, conn }) => {
-		const projectId = ws.getProjectId(conn);
-
-		// Get project details
-		const project = projectQueries.getById(projectId);
-		if (!project) {
-			throw new Error('Project not found');
-		}
+		const { projectId, project } = requireCurrentProjectAccess(conn);
 
 		// Check if an active session already exists BEFORE get-or-create
 		const existingActiveSession = (data.forceNew) ? null : sessionQueries.getActiveSessionForProject(projectId);
@@ -209,11 +199,8 @@ export const crudHandler = createRouter()
 			end_session: t.Optional(t.Boolean())
 		}),
 		response: sessionSchema
-	}, async ({ data }) => {
-		const session = sessionQueries.getById(data.id);
-		if (!session) {
-			throw new Error('Session not found');
-		}
+	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.id);
 
 		if (data.title) {
 			sessionQueries.updateTitle(data.id, data.title);
@@ -240,11 +227,7 @@ export const crudHandler = createRouter()
 			message: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const session = sessionQueries.getById(data.id);
-
-		if (!session) {
-			throw new Error('Session not found');
-		}
+		const session = requireSessionAccess(conn, data.id);
 
 		const projectId = session.project_id;
 
@@ -304,7 +287,7 @@ export const crudHandler = createRouter()
 			deletedCount: t.Number()
 		})
 	}, async ({ conn }) => {
-		const projectId = ws.getProjectId(conn);
+		const { projectId } = requireCurrentProjectAccess(conn);
 
 		// Get all sessions for this project to clean up streams
 		const sessions = sessionQueries.getByProjectId(projectId);
@@ -380,8 +363,8 @@ export const crudHandler = createRouter()
 			sessionId: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const projectId = ws.getProjectId(conn);
-		const userId = ws.getUserId(conn);
+		const { projectId, userId } = requireCurrentProjectAccess(conn);
+		requireSessionAccess(conn, data.sessionId);
 		projectQueries.setCurrentSessionId(userId, projectId, data.sessionId);
 		debug.log('session', `User ${userId} set current session to ${data.sessionId} in project ${projectId}`);
 	})
@@ -393,6 +376,7 @@ export const crudHandler = createRouter()
 		})
 	}, async ({ data, conn }) => {
 		const userId = ws.getUserId(conn);
+		requireSessionAccess(conn, data.sessionId);
 		sessionQueries.markRead(userId, data.sessionId);
 		debug.log('session', `[unread] Marked session ${data.sessionId} as READ for user ${userId}`);
 	})
@@ -405,6 +389,11 @@ export const crudHandler = createRouter()
 		})
 	}, async ({ data, conn }) => {
 		const userId = ws.getUserId(conn);
+		const session = requireSessionAccess(conn, data.sessionId);
+		requireProjectAccess(conn, data.projectId);
+		if (session.project_id !== data.projectId) {
+			throw new Error('Session not found');
+		}
 		sessionQueries.markUnread(userId, data.sessionId, data.projectId);
 		debug.log('session', `[unread] Marked session ${data.sessionId} as UNREAD for user ${userId} in project ${data.projectId}`);
 	})
@@ -418,7 +407,7 @@ export const crudHandler = createRouter()
 			sessionIds: t.Array(t.String())
 		})
 	}, async ({ data, conn }) => {
-		const projectId = ws.getProjectId(conn);
+		const { projectId } = requireCurrentProjectAccess(conn);
 		const sessionIds = sessionQueries.searchByMessageContent(projectId, data.query);
 		return { sessionIds };
 	});

--- a/backend/ws/snapshot/restore.ts
+++ b/backend/ws/snapshot/restore.ts
@@ -20,6 +20,7 @@ import {
 	INITIAL_NODE_ID
 } from '../../snapshot/helpers';
 import { ws } from '$backend/utils/ws';
+import { requireSessionAccess } from '../access';
 
 export const restoreHandler = createRouter()
 	/**
@@ -43,8 +44,9 @@ export const restoreHandler = createRouter()
 			})),
 			checkpointsToUndo: t.Array(t.String())
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		const { messageId, sessionId } = data;
+		requireSessionAccess(conn, sessionId);
 
 		debug.log('snapshot', `Checking restore conflicts for checkpoint ${messageId} in session ${sessionId}`);
 
@@ -107,8 +109,9 @@ export const restoreHandler = createRouter()
 			filesRestored: t.Optional(t.Number()),
 			filesSkipped: t.Optional(t.Number())
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		const { messageId, sessionId, conflictResolutions } = data;
+		requireSessionAccess(conn, sessionId);
 		const isInitialRestore = messageId === INITIAL_NODE_ID;
 
 		debug.log('snapshot', `RESTORE - ${isInitialRestore ? 'Restoring to initial state' : 'Moving HEAD to checkpoint'}`);

--- a/backend/ws/snapshot/timeline.ts
+++ b/backend/ws/snapshot/timeline.ts
@@ -20,6 +20,7 @@ import {
 	INITIAL_NODE_ID
 } from '../../snapshot/helpers';
 import type { CheckpointNode, TimelineResponse } from '../../snapshot/helpers';
+import { requireSessionAccess } from '../access';
 
 export const timelineHandler = createRouter()
 	.http('snapshot:get-timeline', {
@@ -30,8 +31,9 @@ export const timelineHandler = createRouter()
 			nodes: t.Array(t.Any()),
 			currentHeadId: t.Union([t.String(), t.Null()])
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		const { sessionId } = data;
+		requireSessionAccess(conn, sessionId);
 
 		debug.log('snapshot', 'TIMELINE - Building tree view');
 

--- a/backend/ws/system-tools/install.ts
+++ b/backend/ws/system-tools/install.ts
@@ -15,6 +15,7 @@ import {
 	startInstall,
 	cancelInstall,
 	getSession,
+	getSessionOwner,
 	InstallAlreadyRunningError,
 	InstallNotAutoInstallableError
 } from '$backend/engine/install-runner';
@@ -74,7 +75,11 @@ export const systemToolsInstallHandler = createRouter()
 	.http('system-tools:install-cancel', {
 		data: t.Object({ sessionId: t.String() }),
 		response: t.Object({ cancelled: t.Boolean() })
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		const userId = ws.getUserId(conn);
+		if (!userId) throw new Error('Not authenticated');
+		const owner = getSessionOwner(data.sessionId);
+		if (owner && owner !== userId) throw new Error('Install session not found');
 		const cancelled = cancelInstall(data.sessionId);
 		return { cancelled };
 	})
@@ -97,7 +102,11 @@ export const systemToolsInstallHandler = createRouter()
 				})
 			])
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		const userId = ws.getUserId(conn);
+		if (!userId) throw new Error('Not authenticated');
+		const owner = getSessionOwner(data.sessionId);
+		if (owner && owner !== userId) return { session: null };
 		return { session: getSession(data.sessionId) };
 	})
 

--- a/backend/ws/terminal/persistence.ts
+++ b/backend/ws/terminal/persistence.ts
@@ -13,6 +13,7 @@ import { terminalStreamManager } from '../../terminal/stream-manager';
 import { debug } from '$shared/utils/logger';
 import { ws } from '$backend/utils/ws';
 import { ptySessionManager } from '../../terminal/pty-session-manager';
+import { requireProjectAccess } from '../access';
 
 export const persistenceHandler = createRouter()
 	// Get stream status
@@ -21,8 +22,12 @@ export const persistenceHandler = createRouter()
 			streamId: t.String()
 		}),
 		response: t.Any()
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		const { streamId } = data;
+
+		const stream = terminalStreamManager.getStream(streamId);
+		if (!stream || !stream.projectId) throw new Error('Stream not found');
+		requireProjectAccess(conn, stream.projectId);
 
 		const status = terminalStreamManager.getStreamStatus(streamId);
 
@@ -46,8 +51,14 @@ export const persistenceHandler = createRouter()
 			status: t.String(),
 			timestamp: t.String()
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		const { sessionId, streamId } = data;
+
+		const ptySession = ptySessionManager.getSession(sessionId);
+		const stream = streamId ? terminalStreamManager.getStream(streamId) : terminalStreamManager.getStreamBySession(sessionId);
+		const projectId = ptySession?.projectId || stream?.projectId;
+		if (!projectId) throw new Error('Session not found');
+		requireProjectAccess(conn, projectId);
 
 		// Get serialized terminal state from headless xterm
 		let output = '';
@@ -77,17 +88,19 @@ export const persistenceHandler = createRouter()
 		})
 	}, async ({ data, conn }) => {
 		const { streamId, sessionId } = data;
-		const projectId = ws.getProjectId(conn);
 
 		const stream = terminalStreamManager.getStream(streamId);
 
-		if (!stream) {
-			ws.emit.project(projectId, 'terminal:error', {
+		if (!stream || !stream.projectId) {
+			const fallbackProjectId = ws.getProjectId(conn);
+			ws.emit.project(fallbackProjectId, 'terminal:error', {
 				sessionId,
 				error: 'Stream not found'
 			});
 			return;
 		}
+		requireProjectAccess(conn, stream.projectId);
+		const projectId = stream.projectId;
 
 		try {
 			// Send serialized terminal state (frontend writes it to xterm to restore)

--- a/backend/ws/terminal/session.ts
+++ b/backend/ws/terminal/session.ts
@@ -20,6 +20,7 @@ import { isWindows } from '../../terminal/shell-utils';
 import { existsSync } from '../../terminal/helpers';
 import { ws } from '$backend/utils/ws';
 import { activePtyProcesses } from '../../terminal/pty-manager';
+import { requireProjectAccess, requireCurrentProjectAccess } from '../access';
 
 export const sessionHandler = createRouter()
 	// Create new terminal session
@@ -50,7 +51,14 @@ export const sessionHandler = createRouter()
 			rows = 24
 		} = data;
 
-		const projectId = ws.getProjectId(conn);
+		const { projectId } = requireCurrentProjectAccess(conn);
+
+		// If a PTY session already exists for this id, it must belong to the
+		// caller's current project. Prevents hijacking another project's PTY id.
+		const existingForOwnership = ptySessionManager.getSession(sessionId);
+		if (existingForOwnership && existingForOwnership.projectId && existingForOwnership.projectId !== projectId) {
+			throw new Error('Session not found');
+		}
 
 		debug.log('terminal', `🌐 WebSocket: Creating PTY session: ${sessionId}`);
 
@@ -219,8 +227,11 @@ export const sessionHandler = createRouter()
 		response: t.Object({
 			sessionId: t.String()
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		const { sessionId } = data;
+		const ptySession = ptySessionManager.getSession(sessionId);
+		if (!ptySession || !ptySession.projectId) throw new Error('Session not found');
+		requireProjectAccess(conn, ptySession.projectId);
 		terminalStreamManager.clearHeadlessTerminal(sessionId);
 		return { sessionId };
 	})
@@ -237,8 +248,12 @@ export const sessionHandler = createRouter()
 			cols: t.Number(),
 			rows: t.Number()
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		const { sessionId, cols, rows } = data;
+
+		const ptySession = ptySessionManager.getSession(sessionId);
+		if (!ptySession || !ptySession.projectId) throw new Error('Session not found');
+		requireProjectAccess(conn, ptySession.projectId);
 
 		debug.log('terminal', `🔧 Resizing PTY session ${sessionId} to ${cols}x${rows}`);
 
@@ -263,16 +278,18 @@ export const sessionHandler = createRouter()
 			sessionId: t.String(),
 			pid: t.Number()
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		const { sessionId } = data;
-
-		debug.log('terminal', `🛑 Sending Ctrl+C signal to PTY session: ${sessionId}`);
 
 		const session = ptySessionManager.getSession(sessionId);
 
 		if (!session) {
 			throw new Error('No active PTY process found for this session');
 		}
+		if (!session.projectId) throw new Error('Session not found');
+		requireProjectAccess(conn, session.projectId);
+
+		debug.log('terminal', `🛑 Sending Ctrl+C signal to PTY session: ${sessionId}`);
 
 		const pid = session.pty.pid;
 
@@ -299,14 +316,16 @@ export const sessionHandler = createRouter()
 	}, async ({ data, conn }) => {
 		const { sessionId } = data;
 
-		debug.log('terminal', `💀 [kill-session] Killing PTY session: ${sessionId}`);
-
 		const session = ptySessionManager.getSession(sessionId);
 
 		if (!session) {
 			debug.log('terminal', `💀 [kill-session] No active PTY session found for: ${sessionId}`);
 			return { sessionId };
 		}
+		if (!session.projectId) throw new Error('Session not found');
+		requireProjectAccess(conn, session.projectId);
+
+		debug.log('terminal', `💀 [kill-session] Killing PTY session: ${sessionId}`);
 
 		const pid = session.pty?.pid;
 		debug.log('terminal', `💀 [kill-session] Found PTY session with PID: ${pid}`);
@@ -393,8 +412,18 @@ export const sessionHandler = createRouter()
 			pid: t.Optional(t.Number()),
 			message: t.Optional(t.String())
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		const { sessionId } = data;
+
+		const ptySession = ptySessionManager.getSession(sessionId);
+		if (!ptySession || !ptySession.projectId) {
+			return {
+				isActive: false,
+				sessionId,
+				message: 'PTY not found'
+			};
+		}
+		requireProjectAccess(conn, ptySession.projectId);
 
 		const pty = activePtyProcesses.get(sessionId);
 
@@ -430,8 +459,9 @@ export const sessionHandler = createRouter()
 				lastActivityAt: t.String()
 			}))
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		const { projectId } = data;
+		requireProjectAccess(conn, projectId);
 
 		const allSessions = ptySessionManager.getAllSessions();
 		const projectSessions = allSessions

--- a/backend/ws/terminal/stream.ts
+++ b/backend/ws/terminal/stream.ts
@@ -14,6 +14,7 @@ import { createRouter } from '$shared/utils/ws-server';
 import { ptySessionManager } from '../../terminal/pty-session-manager';
 import { debug } from '$shared/utils/logger';
 import { ws } from '$backend/utils/ws';
+import { requireProjectAccess } from '../access';
 
 export const streamHandler = createRouter()
 	// Send keyboard input to terminal
@@ -24,7 +25,13 @@ export const streamHandler = createRouter()
 		})
 	}, async ({ data, conn }) => {
 		const { sessionId, data: input } = data;
-		const projectId = ws.getProjectId(conn);
+
+		const ptySession = ptySessionManager.getSession(sessionId);
+		if (!ptySession || !ptySession.projectId) {
+			throw new Error('Session not found');
+		}
+		requireProjectAccess(conn, ptySession.projectId);
+		const projectId = ptySession.projectId;
 
 		try {
 			// Write to PTY stdin

--- a/shared/utils/ws-server.ts
+++ b/shared/utils/ws-server.ts
@@ -313,10 +313,24 @@ export class WSRouter<
 			handler: async ({ conn, data }) => {
 				// Import ws server to update context
 				const { ws: wsServer } = await import('$backend/utils/ws');
+				const { projectQueries } = await import('$backend/database/queries');
 
 				// userId is set exclusively by auth handlers (auth:login, auth:setup, auth:accept-invite)
 				// ws:set-context only handles projectId
 				if (data.projectId !== undefined) {
+					if (data.projectId !== null) {
+						const state = wsServer.getConnectionState(conn);
+						const userId = state?.userId;
+						if (!userId) {
+							throw new Error('Authentication required');
+						}
+
+						const hasProjectAccess = projectQueries.userHasProject(userId, data.projectId);
+						if (!hasProjectAccess) {
+							throw new Error('Project not found');
+						}
+					}
+
 					wsServer.setProject(conn, data.projectId);
 				}
 


### PR DESCRIPTION
## Summary
This PR hardens WebSocket authorization checks to prevent cross-project access (IDOR-style issues).

## Why
Some routes trusted `projectId`, `sessionId`, or `messageId` from the client payload without validating that the current user actually owns or belongs to that resource.

## Changes
Added centralized access guards for:
- project access
- session access
- message access
- Hardened `ws:set-context` to reject project context changes when the user is not a member of that project.
- Applied ownership checks across project/session/message handlers and all `git:*` routes that consume `projectId` from the client.

## Security impact
Users can no longer interact with resources outside their authorized project scope by guessing IDs.

## Notes
This is a security-focused change and should not alter normal behavior for valid project members.
