### PR TITLE
fix(auth): require admin role for privileged settings and system operations

### DIFF
--- a/backend/auth/permissions.ts
+++ b/backend/auth/permissions.ts
@@ -26,7 +26,10 @@ export const ADMIN_ONLY_ROUTES = new Set([
 	'auth:revoke-invite',
 	'auth:list-users',
 	'auth:remove-user',
-	'settings:update-system',
+	'settings:update',
+	'settings:update-batch',
+	'system:run-update',
+	'system:clear-data',
 	// System Tools — binary installation is an admin-only operation.
 	'system-tools:status',
 	'system-tools:status-all',
@@ -67,3 +70,4 @@ export function checkRouteAccess(
 	// All other routes — any authenticated user
 	return { allowed: true };
 }
+


### PR DESCRIPTION
## Summary
This PR closes a privilege gap in route permission mapping for sensitive backend operations.

## Why
A mismatched route key (`settings:update-system`) existed in the admin-only list, while the actual privileged routes (`settings:update`, `settings:update-batch`, `system:run-update`, `system:clear-data`) were not properly admin-gated.

## What changed
- Updated permission mapping to mark these routes as admin-only:
- `settings:update`
- `settings:update-batch`
- `system:run-update`
- `system:clear-data`
- Removed the incorrect/unused `settings:update-system` mapping.

## impact
Non-admin authenticated users are now blocked from changing privileged settings and running dangerous system-level actions.

## Notes
This aligns backend enforcement with expected admin-only behavior in the UI.
