### PR TITLE
fix(db-client): scope connections by owner and redact sensitive credentials

### DIFF
--- a/backend/database/migrations/035_add_owner_to_db_client_connections.ts
+++ b/backend/database/migrations/035_add_owner_to_db_client_connections.ts
@@ -1,0 +1,34 @@
+import type { DatabaseConnection } from '$shared/types/database/connection';
+import { debug } from '$shared/utils/logger';
+
+export const description = 'Add owner_user_id to db_client_connections table';
+
+export const up = (db: DatabaseConnection): void => {
+	debug.log('migration', 'Adding owner_user_id to db_client_connections...');
+
+	// SQLite does not support IF NOT EXISTS for ADD COLUMN, so we ignore duplicate-column errors.
+	try {
+		db.exec(`
+			ALTER TABLE db_client_connections
+			ADD COLUMN owner_user_id TEXT
+		`);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (!message.toLowerCase().includes('duplicate column name')) {
+			throw error;
+		}
+	}
+
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_db_client_conn_owner
+		ON db_client_connections(owner_user_id)
+	`);
+
+	debug.log('migration', 'owner_user_id migration completed');
+};
+
+export const down = (db: DatabaseConnection): void => {
+	// SQLite cannot drop columns without table rebuild; keep rollback non-destructive.
+	debug.log('migration', 'Dropping idx_db_client_conn_owner index...');
+	db.exec('DROP INDEX IF EXISTS idx_db_client_conn_owner');
+};

--- a/backend/database/migrations/index.ts
+++ b/backend/database/migrations/index.ts
@@ -33,6 +33,7 @@ import * as migration031 from './031_create_db_client_tables';
 import * as migration032 from './032_seed_copilot_provider';
 import * as migration033 from './033_seed_codex_provider';
 import * as migration034 from './034_seed_qwen_provider';
+import * as migration035 from './035_add_owner_to_db_client_connections';
 
 // Export all migrations in order
 export const migrations = [
@@ -239,6 +240,12 @@ export const migrations = [
 		description: migration034.description,
 		up: migration034.up,
 		down: migration034.down
+	},
+	{
+		id: '035',
+		description: migration035.description,
+		up: migration035.up,
+		down: migration035.down
 	}
 ];
 

--- a/backend/database/queries/db-client-connection-queries.ts
+++ b/backend/database/queries/db-client-connection-queries.ts
@@ -64,6 +64,28 @@ function rowToConnection(row: DBDbClientConnectionRow): DbClientConnection {
 	};
 }
 
+function redactConnectionSecrets(connection: DbClientConnection): DbClientConnection {
+	return {
+		...connection,
+		password: null,
+		ssh: {
+			...connection.ssh,
+			password: undefined,
+			privateKey: undefined,
+			passphrase: undefined
+		}
+	};
+}
+
+function hasConnectionAccess(
+	row: DBDbClientConnectionRow,
+	userId: string,
+	isAdmin: boolean
+): boolean {
+	if (isAdmin) return true;
+	return row.owner_user_id === userId;
+}
+
 interface InsertParams {
 	name: string;
 	driver: DbDriver;
@@ -77,9 +99,10 @@ interface InsertParams {
 	ssh: DbClientSshConfig;
 	options: Record<string, unknown>;
 	color: string | null;
+	ownerUserId: string | null;
 }
 
-function normalizeInput(input: DbClientConnectionInput): InsertParams {
+function normalizeInput(input: DbClientConnectionInput, ownerUserId: string | null): InsertParams {
 	const ssh: DbClientSshConfig = {
 		...DEFAULT_SSH,
 		...(input.ssh ?? {})
@@ -96,11 +119,102 @@ function normalizeInput(input: DbClientConnectionInput): InsertParams {
 		sslCa: input.sslCa ?? null,
 		ssh,
 		options: input.options ?? {},
-		color: input.color ?? null
+		color: input.color ?? null,
+		ownerUserId
 	};
 }
 
+function getRowById(id: string): DBDbClientConnectionRow | null {
+	const db = getDatabase();
+	return db.prepare(`
+		SELECT * FROM db_client_connections WHERE id = ?
+	`).get(id) as DBDbClientConnectionRow | null;
+}
+
+function insertConnection(input: DbClientConnectionInput, ownerUserId: string | null): DbClientConnection {
+	const db = getDatabase();
+	const id = crypto.randomUUID();
+	const now = new Date().toISOString();
+	const params = normalizeInput(input, ownerUserId);
+
+	db.prepare(`
+		INSERT INTO db_client_connections (
+			id, name, driver,
+			host, port, username, password, database,
+			ssl_mode, ssl_ca,
+			ssh_enabled, ssh_host, ssh_port, ssh_username, ssh_auth_method,
+			ssh_password, ssh_private_key, ssh_passphrase,
+			options_json, color,
+			owner_user_id,
+			created_at, updated_at, last_used_at
+		) VALUES (
+			?, ?, ?,
+			?, ?, ?, ?, ?,
+			?, ?,
+			?, ?, ?, ?, ?,
+			?, ?, ?,
+			?, ?,
+			?,
+			?, ?, ?
+		)
+	`).run(
+		id, params.name, params.driver,
+		params.host, params.port, params.username, params.password, params.database,
+		params.sslMode, params.sslCa,
+		params.ssh.enabled ? 1 : 0,
+		params.ssh.host || null,
+		params.ssh.port,
+		params.ssh.username || null,
+		params.ssh.authMethod,
+		params.ssh.password || null,
+		params.ssh.privateKey || null,
+		params.ssh.passphrase || null,
+		JSON.stringify(params.options),
+		params.color,
+		params.ownerUserId,
+		now, now, null
+	);
+
+	const row = getRowById(id);
+	if (!row) {
+		throw new Error('db-client connection not found');
+	}
+	return rowToConnection(row);
+}
+
 export const dbClientConnectionQueries = {
+	listForUser(userId: string, isAdmin: boolean): DbClientConnection[] {
+		const db = getDatabase();
+		const rows = (isAdmin
+			? db.prepare(`
+				SELECT * FROM db_client_connections
+				ORDER BY (last_used_at IS NULL), last_used_at DESC, created_at DESC
+			`).all()
+			: db.prepare(`
+				SELECT * FROM db_client_connections
+				WHERE owner_user_id = ?
+				ORDER BY (last_used_at IS NULL), last_used_at DESC, created_at DESC
+			`).all(userId)) as DBDbClientConnectionRow[];
+
+		return rows.map((row) => redactConnectionSecrets(rowToConnection(row)));
+	},
+
+	getForUser(id: string, userId: string, isAdmin: boolean): DbClientConnection | null {
+		const row = getRowById(id);
+		if (!row || !hasConnectionAccess(row, userId, isAdmin)) {
+			return null;
+		}
+		return redactConnectionSecrets(rowToConnection(row));
+	},
+
+	ensureAccess(id: string, userId: string, isAdmin: boolean): DbClientConnection {
+		const row = getRowById(id);
+		if (!row || !hasConnectionAccess(row, userId, isAdmin)) {
+			throw new Error('db-client connection not found');
+		}
+		return rowToConnection(row);
+	},
+
 	list(): DbClientConnection[] {
 		const db = getDatabase();
 		const rows = db.prepare(`
@@ -111,61 +225,22 @@ export const dbClientConnectionQueries = {
 	},
 
 	get(id: string): DbClientConnection | null {
-		const db = getDatabase();
-		const row = db.prepare(`
-			SELECT * FROM db_client_connections WHERE id = ?
-		`).get(id) as DBDbClientConnectionRow | null;
+		const row = getRowById(id);
 		return row ? rowToConnection(row) : null;
 	},
 
 	create(input: DbClientConnectionInput): DbClientConnection {
-		const db = getDatabase();
-		const id = crypto.randomUUID();
-		const now = new Date().toISOString();
-		const params = normalizeInput(input);
+		return insertConnection(input, null);
+	},
 
-		db.prepare(`
-			INSERT INTO db_client_connections (
-				id, name, driver,
-				host, port, username, password, database,
-				ssl_mode, ssl_ca,
-				ssh_enabled, ssh_host, ssh_port, ssh_username, ssh_auth_method,
-				ssh_password, ssh_private_key, ssh_passphrase,
-				options_json, color,
-				created_at, updated_at, last_used_at
-			) VALUES (
-				?, ?, ?,
-				?, ?, ?, ?, ?,
-				?, ?,
-				?, ?, ?, ?, ?,
-				?, ?, ?,
-				?, ?,
-				?, ?, ?
-			)
-		`).run(
-			id, params.name, params.driver,
-			params.host, params.port, params.username, params.password, params.database,
-			params.sslMode, params.sslCa,
-			params.ssh.enabled ? 1 : 0,
-			params.ssh.host || null,
-			params.ssh.port,
-			params.ssh.username || null,
-			params.ssh.authMethod,
-			params.ssh.password || null,
-			params.ssh.privateKey || null,
-			params.ssh.passphrase || null,
-			JSON.stringify(params.options),
-			params.color,
-			now, now, null
-		);
-
-		const row = db.prepare('SELECT * FROM db_client_connections WHERE id = ?').get(id) as DBDbClientConnectionRow;
-		return rowToConnection(row);
+	createForUser(input: DbClientConnectionInput, ownerUserId: string): DbClientConnection {
+		const connection = insertConnection(input, ownerUserId);
+		return redactConnectionSecrets(connection);
 	},
 
 	update(id: string, patch: Partial<DbClientConnectionInput>): DbClientConnection {
 		const db = getDatabase();
-		const existing = db.prepare('SELECT * FROM db_client_connections WHERE id = ?').get(id) as DBDbClientConnectionRow | null;
+		const existing = getRowById(id);
 		if (!existing) {
 			throw new Error('db-client connection not found');
 		}
@@ -220,8 +295,22 @@ export const dbClientConnectionQueries = {
 		values.push(id);
 		db.prepare(`UPDATE db_client_connections SET ${sets.join(', ')} WHERE id = ?`).run(...values);
 
-		const row = db.prepare('SELECT * FROM db_client_connections WHERE id = ?').get(id) as DBDbClientConnectionRow;
+		const row = getRowById(id);
+		if (!row) {
+			throw new Error('db-client connection not found');
+		}
 		return rowToConnection(row);
+	},
+
+	updateForUser(
+		id: string,
+		patch: Partial<DbClientConnectionInput>,
+		userId: string,
+		isAdmin: boolean
+	): DbClientConnection {
+		this.ensureAccess(id, userId, isAdmin);
+		const updated = this.update(id, patch);
+		return redactConnectionSecrets(updated);
 	},
 
 	delete(id: string): void {
@@ -229,9 +318,19 @@ export const dbClientConnectionQueries = {
 		db.prepare('DELETE FROM db_client_connections WHERE id = ?').run(id);
 	},
 
+	deleteForUser(id: string, userId: string, isAdmin: boolean): void {
+		this.ensureAccess(id, userId, isAdmin);
+		this.delete(id);
+	},
+
 	markUsed(id: string): void {
 		const db = getDatabase();
 		const now = new Date().toISOString();
 		db.prepare('UPDATE db_client_connections SET last_used_at = ? WHERE id = ?').run(now, id);
+	},
+
+	markUsedForUser(id: string, userId: string, isAdmin: boolean): void {
+		this.ensureAccess(id, userId, isAdmin);
+		this.markUsed(id);
 	}
 };

--- a/backend/database/queries/db-client-connection-queries.ts
+++ b/backend/database/queries/db-client-connection-queries.ts
@@ -86,6 +86,14 @@ function hasConnectionAccess(
 	return row.owner_user_id === userId;
 }
 
+function preserveExistingSecret(
+	patchValue: string | undefined,
+	existingValue: string | null
+): string | null {
+	if (patchValue === undefined || patchValue === '') return existingValue;
+	return patchValue;
+}
+
 interface InsertParams {
 	name: string;
 	driver: DbDriver;
@@ -257,7 +265,7 @@ export const dbClientConnectionQueries = {
 		if (patch.host !== undefined) push('host', patch.host || null);
 		if (patch.port !== undefined) push('port', patch.port ?? null);
 		if (patch.username !== undefined) push('username', patch.username || null);
-		if (patch.password !== undefined) push('password', patch.password || null);
+		if (patch.password !== undefined && patch.password !== '') push('password', patch.password);
 		if (patch.database !== undefined) push('database', patch.database || null);
 		if (patch.sslMode !== undefined) push('ssl_mode', patch.sslMode);
 		if (patch.sslCa !== undefined) push('ssl_ca', patch.sslCa || null);
@@ -276,14 +284,18 @@ export const dbClientConnectionQueries = {
 				passphrase: existing.ssh_passphrase ?? '',
 				...patch.ssh
 			};
+			const sshPassword = preserveExistingSecret(patch.ssh.password, existing.ssh_password);
+			const sshPrivateKey = preserveExistingSecret(patch.ssh.privateKey, existing.ssh_private_key);
+			const sshPassphrase = preserveExistingSecret(patch.ssh.passphrase, existing.ssh_passphrase);
+
 			push('ssh_enabled', merged.enabled ? 1 : 0);
 			push('ssh_host', merged.host || null);
 			push('ssh_port', merged.port);
 			push('ssh_username', merged.username || null);
 			push('ssh_auth_method', merged.authMethod);
-			push('ssh_password', merged.password || null);
-			push('ssh_private_key', merged.privateKey || null);
-			push('ssh_passphrase', merged.passphrase || null);
+			push('ssh_password', sshPassword);
+			push('ssh_private_key', sshPrivateKey);
+			push('ssh_passphrase', sshPassphrase);
 		}
 
 		push('updated_at', new Date().toISOString());
@@ -327,10 +339,5 @@ export const dbClientConnectionQueries = {
 		const db = getDatabase();
 		const now = new Date().toISOString();
 		db.prepare('UPDATE db_client_connections SET last_used_at = ? WHERE id = ?').run(now, id);
-	},
-
-	markUsedForUser(id: string, userId: string, isAdmin: boolean): void {
-		this.ensureAccess(id, userId, isAdmin);
-		this.markUsed(id);
 	}
 };

--- a/backend/ws/db-client/access.ts
+++ b/backend/ws/db-client/access.ts
@@ -1,0 +1,19 @@
+import type { WSConnection } from '$shared/utils/ws-server';
+import { ws } from '$backend/utils/ws';
+import { dbClientConnectionQueries } from '../../database/queries';
+
+export interface DbClientPrincipal {
+	userId: string;
+	isAdmin: boolean;
+}
+
+export function getDbClientPrincipal(conn: WSConnection): DbClientPrincipal {
+	const userId = ws.getUserId(conn);
+	const isAdmin = ws.getRole(conn) === 'admin';
+	return { userId, isAdmin };
+}
+
+export function requireDbClientConnectionAccess(conn: WSConnection, connectionId: string) {
+	const { userId, isAdmin } = getDbClientPrincipal(conn);
+	return dbClientConnectionQueries.ensureAccess(connectionId, userId, isAdmin);
+}

--- a/backend/ws/db-client/connections.ts
+++ b/backend/ws/db-client/connections.ts
@@ -180,8 +180,9 @@ export const connectionsHandler = createRouter()
 		if (isInput(data)) {
 			return connectionManager.test(ensureInputDefaults(data as DbClientConnectionInput));
 		}
-		requireDbClientConnectionAccess(conn, data.id);
-		return connectionManager.test({ id: (data as { id: string }).id });
+		const id = (data as { id: string }).id;
+		requireDbClientConnectionAccess(conn, id);
+		return connectionManager.test({ id });
 	})
 
 	.http('db-client:health', {

--- a/backend/ws/db-client/connections.ts
+++ b/backend/ws/db-client/connections.ts
@@ -14,6 +14,7 @@ import type {
 	DbSslMode
 } from '$shared/types/db-client';
 import { debug } from '$shared/utils/logger';
+import { getDbClientPrincipal, requireDbClientConnectionAccess } from './access';
 
 const driverSchema = t.Union([
 	t.Literal('mysql'),
@@ -111,28 +112,34 @@ export const connectionsHandler = createRouter()
 	.http('db-client:list', {
 		data: t.Object({}),
 		response: t.Array(t.Any())
-	}, async () => {
+	}, async ({ conn }) => {
 		await initializeDatabase();
-		return dbClientConnectionQueries.list();
+		const { userId, isAdmin } = getDbClientPrincipal(conn);
+		return dbClientConnectionQueries.listForUser(userId, isAdmin);
 	})
 
 	.http('db-client:get', {
 		data: t.Object({ id: t.String({ minLength: 1 }) }),
 		response: t.Any()
-	}, async ({ data }) => {
-		const conn = dbClientConnectionQueries.get(data.id);
-		if (!conn) throw new Error('db-client connection not found');
-		return conn;
+	}, async ({ data, conn }) => {
+		const { userId, isAdmin } = getDbClientPrincipal(conn);
+		const connection = dbClientConnectionQueries.getForUser(data.id, userId, isAdmin);
+		if (!connection) throw new Error('db-client connection not found');
+		return connection;
 	})
 
 	.http('db-client:create', {
 		data: connectionInputSchema,
 		response: t.Any()
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		await initializeDatabase();
-		const conn = dbClientConnectionQueries.create(ensureInputDefaults(data as DbClientConnectionInput));
-		debug.log('db-client', `created connection ${conn.id} (${conn.driver})`);
-		return conn;
+		const { userId } = getDbClientPrincipal(conn);
+		const created = dbClientConnectionQueries.createForUser(
+			ensureInputDefaults(data as DbClientConnectionInput),
+			userId
+		);
+		debug.log('db-client', `created connection ${created.id} (${created.driver})`);
+		return created;
 	})
 
 	.http('db-client:update', {
@@ -141,7 +148,9 @@ export const connectionsHandler = createRouter()
 			patch: connectionPatchSchema
 		}),
 		response: t.Any()
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		const { userId, isAdmin } = getDbClientPrincipal(conn);
+		requireDbClientConnectionAccess(conn, data.id);
 		const patch = data.patch as Partial<DbClientConnectionInput>;
 		const normalized: Partial<DbClientConnectionInput> = {
 			...patch,
@@ -149,32 +158,36 @@ export const connectionsHandler = createRouter()
 		};
 		// Drop the live adapter so the next access re-opens with new settings.
 		await connectionManager.release(data.id);
-		return dbClientConnectionQueries.update(data.id, normalized);
+		return dbClientConnectionQueries.updateForUser(data.id, normalized, userId, isAdmin);
 	})
 
 	.http('db-client:delete', {
 		data: t.Object({ id: t.String({ minLength: 1 }) }),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		const { userId, isAdmin } = getDbClientPrincipal(conn);
+		requireDbClientConnectionAccess(conn, data.id);
 		await connectionManager.release(data.id);
-		dbClientConnectionQueries.delete(data.id);
+		dbClientConnectionQueries.deleteForUser(data.id, userId, isAdmin);
 		return { ok: true };
 	})
 
 	.http('db-client:test', {
 		data: connectionTestSchema,
 		response: healthSchema
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		await initializeDatabase();
 		if (isInput(data)) {
 			return connectionManager.test(ensureInputDefaults(data as DbClientConnectionInput));
 		}
+		requireDbClientConnectionAccess(conn, data.id);
 		return connectionManager.test({ id: (data as { id: string }).id });
 	})
 
 	.http('db-client:health', {
 		data: t.Object({ id: t.String({ minLength: 1 }) }),
 		response: healthSchema
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.id);
 		return connectionManager.test({ id: data.id });
 	});

--- a/backend/ws/db-client/io.ts
+++ b/backend/ws/db-client/io.ts
@@ -12,8 +12,8 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { connectionManager } from '../../db-client/connection-manager';
-import { dbClientConnectionQueries } from '../../database/queries';
 import type { DbClientObjectDetails, DbClientQueryResult } from '$shared/types/db-client';
+import { requireDbClientConnectionAccess } from './access';
 
 type SqlDriver = 'mysql' | 'postgres' | 'sqlite';
 
@@ -154,10 +154,9 @@ export const ioHandler = createRouter()
 			content: t.String(),
 			mimeType: t.String()
 		})
-	}, async ({ data }) => {
-		const conn = dbClientConnectionQueries.get(data.connectionId);
-		if (!conn) throw new Error('connection not found');
-		const driver = conn.driver;
+	}, async ({ data, conn }) => {
+		const connection = requireDbClientConnectionAccess(conn, data.connectionId);
+		const driver = connection.driver;
 		const withData = data.schemaOnly ? false : (data.withData ?? true);
 
 		const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
@@ -340,10 +339,9 @@ export const ioHandler = createRouter()
 			count: t.Number(),
 			message: t.String()
 		})
-	}, async ({ data }) => {
-		const conn = dbClientConnectionQueries.get(data.connectionId);
-		if (!conn) throw new Error('connection not found');
-		const driver = conn.driver;
+	}, async ({ data, conn }) => {
+		const connection = requireDbClientConnectionAccess(conn, data.connectionId);
+		const driver = connection.driver;
 		const adapter = await connectionManager.get(data.connectionId);
 
 		if (driver === 'mysql' || driver === 'postgres' || driver === 'sqlite') {

--- a/backend/ws/db-client/query.ts
+++ b/backend/ws/db-client/query.ts
@@ -6,13 +6,14 @@ import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { connectionManager } from '../../db-client/connection-manager';
 import { runSafely } from '../../db-client/query-executor';
-import { dbClientConnectionQueries, dbClientQueryHistoryQueries } from '../../database/queries';
-import type { DbClientQueryResult } from '$shared/types/db-client';
+import { dbClientQueryHistoryQueries } from '../../database/queries';
+import { getDbClientPrincipal, requireDbClientConnectionAccess } from './access';
 
 const HISTORY_KEEP_PER_CONNECTION = 200;
 
 function recordHistory(input: {
 	connectionId: string;
+	userId: string | null;
 	query: string;
 	status: 'success' | 'error';
 	durationMs: number | null;
@@ -22,7 +23,7 @@ function recordHistory(input: {
 	try {
 		dbClientQueryHistoryQueries.insert({
 			connectionId: input.connectionId,
-			userId: null,
+			userId: input.userId,
 			query: input.query,
 			durationMs: input.durationMs,
 			rowCount: input.rowCount,
@@ -47,19 +48,42 @@ export const queryHandler = createRouter()
 			limit: t.Optional(t.Number())
 		}),
 		response: t.Any()
-	}, async ({ data }) => {
-		const conn = dbClientConnectionQueries.get(data.connectionId);
-		if (!conn) throw new Error('db-client connection not found');
+	}, async ({ data, conn }) => {
+		const { userId } = getDbClientPrincipal(conn);
+		const connection = requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
-		return runSafely({
-			driver: conn.driver,
-			adapter,
-			query: data.query,
-			params: data.params,
-			mode: 'read',
-			database: data.database,
-			limit: data.limit
-		});
+		try {
+			const result = await runSafely({
+				driver: connection.driver,
+				adapter,
+				query: data.query,
+				params: data.params,
+				mode: 'read',
+				database: data.database,
+				limit: data.limit
+			});
+			recordHistory({
+				connectionId: data.connectionId,
+				userId,
+				query: data.query,
+				status: 'success',
+				durationMs: result.durationMs ?? null,
+				rowCount: result.rowCount ?? null,
+				error: null
+			});
+			return result;
+		} catch (error) {
+			recordHistory({
+				connectionId: data.connectionId,
+				userId,
+				query: data.query,
+				status: 'error',
+				durationMs: null,
+				rowCount: null,
+				error: error instanceof Error ? error.message : String(error)
+			});
+			throw error;
+		}
 	})
 
 	.http('db-client:execute-write', {
@@ -70,18 +94,41 @@ export const queryHandler = createRouter()
 			database: t.Optional(t.String())
 		}),
 		response: t.Any()
-	}, async ({ data }) => {
-		const conn = dbClientConnectionQueries.get(data.connectionId);
-		if (!conn) throw new Error('db-client connection not found');
+	}, async ({ data, conn }) => {
+		const { userId } = getDbClientPrincipal(conn);
+		const connection = requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
-		return runSafely({
-			driver: conn.driver,
-			adapter,
-			query: data.query,
-			params: data.params,
-			mode: 'write',
-			database: data.database
-		});
+		try {
+			const result = await runSafely({
+				driver: connection.driver,
+				adapter,
+				query: data.query,
+				params: data.params,
+				mode: 'write',
+				database: data.database
+			});
+			recordHistory({
+				connectionId: data.connectionId,
+				userId,
+				query: data.query,
+				status: 'success',
+				durationMs: result.durationMs ?? null,
+				rowCount: result.rowCount ?? null,
+				error: null
+			});
+			return result;
+		} catch (error) {
+			recordHistory({
+				connectionId: data.connectionId,
+				userId,
+				query: data.query,
+				status: 'error',
+				durationMs: null,
+				rowCount: null,
+				error: error instanceof Error ? error.message : String(error)
+			});
+			throw error;
+		}
 	})
 
 	.http('db-client:explain', {
@@ -91,7 +138,8 @@ export const queryHandler = createRouter()
 			database: t.Optional(t.String())
 		}),
 		response: t.Any()
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.explain) throw new Error('Driver does not support EXPLAIN');
 		return adapter.explain(data.query, { database: data.database });
@@ -100,7 +148,8 @@ export const queryHandler = createRouter()
 	.http('db-client:cancel', {
 		data: t.Object({ connectionId: t.String({ minLength: 1 }) }),
 		response: t.Object({ ok: t.Boolean() })
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (adapter.cancel) await adapter.cancel();
 		return { ok: true };
@@ -115,7 +164,8 @@ export const queryHandler = createRouter()
 			row: t.Record(t.String(), t.Any())
 		}),
 		response: t.Any()
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.insertRow) throw new Error('Driver does not support insertRow');
 		return adapter.insertRow(data.table, data.row, {
@@ -134,7 +184,8 @@ export const queryHandler = createRouter()
 			changes: t.Record(t.String(), t.Any())
 		}),
 		response: t.Any()
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.updateRow) throw new Error('Driver does not support updateRow');
 		return adapter.updateRow(data.table, data.pk, data.changes, {
@@ -152,7 +203,8 @@ export const queryHandler = createRouter()
 			pks: t.Array(t.Record(t.String(), t.Any()))
 		}),
 		response: t.Any()
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.deleteRows) throw new Error('Driver does not support deleteRows');
 		return adapter.deleteRows(data.table, data.pks, {

--- a/backend/ws/db-client/schema.ts
+++ b/backend/ws/db-client/schema.ts
@@ -6,6 +6,7 @@ import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { connectionManager } from '../../db-client/connection-manager';
 import type { DbClientSchemaNodeType } from '$shared/types/db-client';
+import { requireDbClientConnectionAccess } from './access';
 
 const nodeTypeSchema = t.Union([
 	t.Literal('database'),
@@ -22,7 +23,8 @@ export const schemaHandler = createRouter()
 	.http('db-client:list-databases', {
 		data: t.Object({ connectionId: t.String({ minLength: 1 }) }),
 		response: t.Array(t.Any())
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.listDatabases) return [];
 		return adapter.listDatabases();
@@ -34,7 +36,8 @@ export const schemaHandler = createRouter()
 			database: t.Optional(t.String())
 		}),
 		response: t.Array(t.Any())
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.listSchemas) return [];
 		return adapter.listSchemas(data.database);
@@ -47,7 +50,8 @@ export const schemaHandler = createRouter()
 			schema: t.Optional(t.String())
 		}),
 		response: t.Array(t.Any())
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.listObjects) return [];
 		return adapter.listObjects(data.database, data.schema);
@@ -62,7 +66,8 @@ export const schemaHandler = createRouter()
 			type: nodeTypeSchema
 		}),
 		response: t.Any()
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.getObjectDetails) {
 			throw new Error('Driver does not support object details');

--- a/backend/ws/db-client/structure.ts
+++ b/backend/ws/db-client/structure.ts
@@ -6,6 +6,7 @@ import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { connectionManager } from '../../db-client/connection-manager';
 import type { AlterOperation, IndexDefinition, TableDefinition } from '../../db-client/drivers/types';
+import { requireDbClientConnectionAccess } from './access';
 
 const columnDefinitionSchema = t.Object({
 	name: t.String({ minLength: 1 }),
@@ -43,7 +44,8 @@ export const structureHandler = createRouter()
 			name: t.String({ minLength: 1 })
 		}),
 		response: t.Object({ ok: t.Boolean(), ddl: t.String() })
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.createDatabase) throw new Error('Driver does not support database creation');
 		const ddl = await adapter.createDatabase(data.name);
@@ -58,7 +60,8 @@ export const structureHandler = createRouter()
 			definition: tableDefinitionSchema
 		}),
 		response: t.Object({ ok: t.Boolean(), ddl: t.String() })
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.createTable) throw new Error('Driver does not support createTable');
 		const ddl = await adapter.createTable(data.definition as TableDefinition, {
@@ -77,7 +80,8 @@ export const structureHandler = createRouter()
 			operations: t.Array(alterOpSchema)
 		}),
 		response: t.Object({ ok: t.Boolean(), ddl: t.String() })
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.alterTable) throw new Error('Driver does not support alterTable');
 		const ddl = await adapter.alterTable(data.name, data.operations as AlterOperation[], {
@@ -95,7 +99,8 @@ export const structureHandler = createRouter()
 			name: t.String({ minLength: 1 })
 		}),
 		response: t.Object({ ok: t.Boolean(), ddl: t.String() })
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.dropTable) throw new Error('Driver does not support dropTable');
 		const ddl = await adapter.dropTable(data.name, {
@@ -113,7 +118,8 @@ export const structureHandler = createRouter()
 			name: t.String({ minLength: 1 })
 		}),
 		response: t.Object({ ok: t.Boolean(), ddl: t.String() })
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.truncateTable) throw new Error('Driver does not support truncateTable');
 		const ddl = await adapter.truncateTable(data.name, {
@@ -132,7 +138,8 @@ export const structureHandler = createRouter()
 			newName: t.String({ minLength: 1 })
 		}),
 		response: t.Object({ ok: t.Boolean(), ddl: t.String() })
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.renameTable) throw new Error('Driver does not support renameTable');
 		const ddl = await adapter.renameTable(data.name, data.newName, {
@@ -151,7 +158,8 @@ export const structureHandler = createRouter()
 			indexDef: indexDefinitionSchema
 		}),
 		response: t.Object({ ok: t.Boolean(), ddl: t.String() })
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.createIndex) throw new Error('Driver does not support createIndex');
 		const ddl = await adapter.createIndex(data.tableName, data.indexDef as IndexDefinition, {
@@ -170,7 +178,8 @@ export const structureHandler = createRouter()
 			indexName: t.String({ minLength: 1 })
 		}),
 		response: t.Object({ ok: t.Boolean(), ddl: t.String() })
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.dropIndex) throw new Error('Driver does not support dropIndex');
 		const ddl = await adapter.dropIndex(data.tableName, data.indexName, {
@@ -189,7 +198,8 @@ export const structureHandler = createRouter()
 			query: t.String({ minLength: 1 })
 		}),
 		response: t.Object({ ok: t.Boolean(), ddl: t.String() })
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.createView) throw new Error('Driver does not support createView');
 		const ddl = await adapter.createView(data.name, data.query, {
@@ -207,7 +217,8 @@ export const structureHandler = createRouter()
 			name: t.String({ minLength: 1 })
 		}),
 		response: t.Object({ ok: t.Boolean(), ddl: t.String() })
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		requireDbClientConnectionAccess(conn, data.connectionId);
 		const adapter = await connectionManager.get(data.connectionId);
 		if (!adapter.dropView) throw new Error('Driver does not support dropView');
 		const ddl = await adapter.dropView(data.name, {
@@ -216,3 +227,4 @@ export const structureHandler = createRouter()
 		});
 		return { ok: true, ddl };
 	});
+

--- a/frontend/components/db-client/sidebar/ConnectionForm.svelte
+++ b/frontend/components/db-client/sidebar/ConnectionForm.svelte
@@ -88,9 +88,9 @@
 					port: sshPort || 22,
 					username: sshUsername,
 					authMethod: sshAuthMethod,
-					password: sshAuthMethod === 'password' ? sshPassword : undefined,
-					privateKey: sshAuthMethod === 'key' ? sshPrivateKey : undefined,
-					passphrase: sshAuthMethod === 'key' ? sshPassphrase : undefined
+					password: sshAuthMethod === 'password' ? sshPassword || undefined : undefined,
+					privateKey: sshAuthMethod === 'key' ? sshPrivateKey || undefined : undefined,
+					passphrase: sshAuthMethod === 'key' ? sshPassphrase || undefined : undefined
 				}
 			: { enabled: false };
 

--- a/shared/types/database/schema.ts
+++ b/shared/types/database/schema.ts
@@ -199,6 +199,7 @@ export interface DBDbClientConnectionRow {
 	ssh_passphrase: string | null;
 	options_json: string | null;
 	color: string | null;
+	owner_user_id: string | null;
 	created_at: string;
 	updated_at: string;
 	last_used_at: string | null;


### PR DESCRIPTION
This PR adds ownership enforcement for db-client connections and prevents credential leakage in API responses.

## Why?
DB client connections were globally accessible and returned sensitive credential fields in list/get responses.

## Changes
- Added migration `035_add_owner_to_db_client_connections`:
- introduces `owner_user_id`
- adds index for owner lookups
- Added ownership-aware query methods for db-client connections.
- Enforced per-user/admin access checks across all `db-client:*` WebSocket handlers.
- Redacted sensitive fields from response payloads:
- `password`
- `ssh.password`
- `ssh.privateKey`
- `ssh.passphrase`
- Wired query history writes with current user context.
- Preserved existing DB and SSH secrets when editing redacted connection forms.

## Security impact
- Prevents unauthorized users from using or modifying other users' saved DB connections.
- Prevents accidental exposure of stored credentials through API responses.

## Legacy data note
Existing db-client connections created before migration `035_add_owner_to_db_client_connections` have `owner_user_id = NULL`. After upgrading, those legacy connections remain visible to admins only because there is no reliable historical owner signal. Operators should ask users to recreate legacy connections or manually assign ownership via SQL when appropriate.

## Note
Admins still retain global access by design; regular users are restricted to their own connections.
