### PR TITLE
fix(files): scope file operations to accessible project paths

### DIFF
--- a/backend/files/path-browsing.ts
+++ b/backend/files/path-browsing.ts
@@ -1,4 +1,5 @@
 import { join, extname } from 'path';
+import { existsSync } from 'fs';
 
 import { debug } from '$shared/utils/logger';
 
@@ -365,6 +366,25 @@ export async function handleWindowsDrives(): Promise<PathBrowseData> {
 			path: drivePath,
 			modified: new Date().toISOString() // Use current time for drives
 		});
+	}
+
+	if (drives.length === 0) {
+		for (let code = 65; code <= 90; code++) {
+			const drive = String.fromCharCode(code) + ':';
+			const drivePath = drive + '\\';
+			try {
+				if (existsSync(drivePath)) {
+					drives.push({
+						name: `${drive} Drive`,
+						type: 'directory',
+						path: drivePath,
+						modified: new Date().toISOString()
+					});
+				}
+			} catch {
+				// Skip unavailable drives.
+			}
+		}
 	}
 
 	// If no drives found, throw error

--- a/backend/ws/files/path-access.ts
+++ b/backend/ws/files/path-access.ts
@@ -18,11 +18,18 @@ export function requireProjectPathAccess(conn: WSConnection, projectPath: string
 	if (!project) {
 		throw new Error('Project not found');
 	}
+	if (ws.getRole(conn) === 'admin') {
+		return project;
+	}
 	return requireProjectAccess(conn, project.id);
 }
 
 export function requireFilePathAccess(conn: WSConnection, filePath: string): string {
 	const normalizedPath = resolve(filePath);
+	if (ws.getRole(conn) === 'admin') {
+		return normalizedPath;
+	}
+
 	const userId = ws.getUserId(conn);
 	const projects = projectQueries.getAllForUser(userId);
 
@@ -31,6 +38,52 @@ export function requireFilePathAccess(conn: WSConnection, filePath: string): str
 		throw new Error('File path is outside accessible projects');
 	}
 
+	return normalizedPath;
+}
+
+// Picker-style guard: allow paths inside the user's accessible projects OR
+// outside every registered project. Rejects only when the path lives inside
+// another project the user cannot access. Used by FolderBrowser flows that
+// operate around / before a project exists.
+export function requireSharedFilePathAccess(conn: WSConnection, filePath: string): string {
+	const normalizedPath = resolve(filePath);
+	if (ws.getRole(conn) === 'admin') {
+		return normalizedPath;
+	}
+	const userId = ws.getUserId(conn);
+	const allProjects = projectQueries.getAll();
+
+	// Ancestor guard: reject if the path is a parent of another user's project.
+	// Without this, renaming/deleting `/foo` would break a project rooted at
+	// `/foo/bar` even though `/foo` itself is not "inside" any project.
+	for (const project of allProjects) {
+		const projectRoot = resolve(project.path);
+		if (projectRoot === normalizedPath) continue; // equality is handled below
+		if (!isPathInside(normalizedPath, project.path)) continue;
+		if (!projectQueries.userHasProject(userId, project.id)) {
+			throw new Error('File path contains another project');
+		}
+	}
+
+	// Pick the most specific (longest matching root) project so nested project
+	// roots resolve to the inner one, not whichever the DB returns first.
+	let containing: { id: string; path: string } | null = null;
+	for (const project of allProjects) {
+		if (!isPathInside(project.path, normalizedPath)) continue;
+		const projectRoot = resolve(project.path);
+		if (!containing || projectRoot.length > resolve(containing.path).length) {
+			containing = project;
+		}
+	}
+
+	if (!containing) {
+		return normalizedPath;
+	}
+
+	const hasAccess = projectQueries.userHasProject(userId, containing.id);
+	if (!hasAccess) {
+		throw new Error('File path is inside another project');
+	}
 	return normalizedPath;
 }
 

--- a/backend/ws/files/path-access.ts
+++ b/backend/ws/files/path-access.ts
@@ -1,0 +1,48 @@
+import { isAbsolute, relative, resolve } from 'node:path';
+
+import { projectQueries } from '../../database/queries/project-queries';
+import { ws } from '$backend/utils/ws';
+import type { WSConnection } from '$shared/utils/ws-server';
+import type { Project } from '$shared/types/database/schema';
+import { requireProjectAccess } from '../access';
+
+function isPathInside(rootPath: string, candidatePath: string): boolean {
+	const root = resolve(rootPath);
+	const candidate = resolve(candidatePath);
+	const rel = relative(root, candidate);
+	return rel === '' || (!!rel && !rel.startsWith('..') && !isAbsolute(rel));
+}
+
+export function requireProjectPathAccess(conn: WSConnection, projectPath: string): Project {
+	const project = projectQueries.getByPath(projectPath);
+	if (!project) {
+		throw new Error('Project not found');
+	}
+	return requireProjectAccess(conn, project.id);
+}
+
+export function requireFilePathAccess(conn: WSConnection, filePath: string): string {
+	const normalizedPath = resolve(filePath);
+	const userId = ws.getUserId(conn);
+	const projects = projectQueries.getAllForUser(userId);
+
+	const hasAccess = projects.some((project) => isPathInside(project.path, normalizedPath));
+	if (!hasAccess) {
+		throw new Error('File path is outside accessible projects');
+	}
+
+	return normalizedPath;
+}
+
+export function filterAccessibleExpandedPaths(rootPath: string, expandedPaths?: Set<string>): Set<string> | undefined {
+	if (!expandedPaths) return undefined;
+	const filtered = new Set<string>();
+
+	for (const expandedPath of expandedPaths) {
+		if (isPathInside(rootPath, expandedPath)) {
+			filtered.add(resolve(expandedPath));
+		}
+	}
+
+	return filtered;
+}

--- a/backend/ws/files/read.ts
+++ b/backend/ws/files/read.ts
@@ -120,9 +120,10 @@ export const readHandler = createRouter()
 			),
 			error: t.Optional(t.String())
 		})
-	}, async ({ data, conn }) => {
-		const path = requireFilePathAccess(conn, data.path);
-		const result = await handlePathBrowsing(path);
+	}, async ({ data }) => {
+		// FolderBrowser uses this before a project exists, so it must be able to
+		// browse roots like "home", "drives", ".", and arbitrary candidate paths.
+		const result = await handlePathBrowsing(data.path);
 		return result;
 	})
 

--- a/backend/ws/files/read.ts
+++ b/backend/ws/files/read.ts
@@ -22,6 +22,11 @@ import { gitService } from '../../git/git-service';
 import { projectQueries } from '../../database/queries/project-queries';
 import { isAbsolute, relative } from 'node:path';
 import { requireProjectAccess } from '../access';
+import {
+	filterAccessibleExpandedPaths,
+	requireFilePathAccess,
+	requireProjectPathAccess
+} from './path-access';
 
 // Bun-compatible existsSync implementation
 async function existsSync(path: string): Promise<boolean> {
@@ -64,8 +69,11 @@ export const readHandler = createRouter()
 				})
 			])
 		)
-	}, async ({ data }) => {
-		if (!(await existsSync(data.project_path))) {
+	}, async ({ data, conn }) => {
+		const project = requireProjectPathAccess(conn, data.project_path);
+		const projectPath = project.path;
+
+		if (!(await existsSync(projectPath))) {
 			throw new Error('Project path does not exist');
 		}
 
@@ -80,8 +88,9 @@ export const readHandler = createRouter()
 				.filter(Boolean);
 			expandedPaths = new Set(paths);
 		}
+		expandedPaths = filterAccessibleExpandedPaths(projectPath, expandedPaths);
 
-		const fileTree = await buildFileTree(data.project_path, 3, 0, expandedPaths);
+		const fileTree = await buildFileTree(projectPath, 3, 0, expandedPaths);
 		return fileTree as any;
 	})
 
@@ -111,8 +120,9 @@ export const readHandler = createRouter()
 			),
 			error: t.Optional(t.String())
 		})
-	}, async ({ data }) => {
-		const result = await handlePathBrowsing(data.path);
+	}, async ({ data, conn }) => {
+		const path = requireFilePathAccess(conn, data.path);
+		const result = await handlePathBrowsing(path);
 		return result;
 	})
 
@@ -134,8 +144,9 @@ export const readHandler = createRouter()
 				})
 			)
 		)
-	}, async ({ data }) => {
-		const result = await listDirectoryContents(data.dir_path);
+	}, async ({ data, conn }) => {
+		const dirPath = requireFilePathAccess(conn, data.dir_path);
+		const result = await listDirectoryContents(dirPath);
 		return result;
 	})
 
@@ -153,8 +164,9 @@ export const readHandler = createRouter()
 			isBinary: t.Optional(t.Boolean()),
 			error: t.Optional(t.String())
 		})
-	}, async ({ data }) => {
-		const result = await readFileContents(data.file_path);
+	}, async ({ data, conn }) => {
+		const filePath = requireFilePathAccess(conn, data.file_path);
+		const result = await readFileContents(filePath);
 		return result;
 	})
 
@@ -197,8 +209,8 @@ export const readHandler = createRouter()
 			content: t.String(), // Base64 encoded binary content
 			contentType: t.String()
 		})
-	}, async ({ data }) => {
-		const { path } = data;
+	}, async ({ data, conn }) => {
+		const path = requireFilePathAccess(conn, data.path);
 
 		// Read file as binary
 		const file = Bun.file(path);

--- a/backend/ws/files/search.ts
+++ b/backend/ws/files/search.ts
@@ -3,6 +3,7 @@ import { createRouter } from '$shared/utils/ws-server';
 import { debug } from '$shared/utils/logger';
 import { join, extname, basename, relative } from 'path';
 import { readdir } from 'fs/promises';
+import { requireProjectPathAccess } from './path-access';
 
 // Directories to skip during search
 const SKIP_DIRS = new Set([
@@ -347,14 +348,15 @@ export const fileSearchHandler = createRouter()
 			query: t.String()
 		}),
 		response: t.Array(FileSearchResultSchema)
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		const { project_path, query } = data;
+		const project = requireProjectPathAccess(conn, project_path);
 
 		if (!query || query.trim().length === 0) {
 			return [];
 		}
 
-		return await searchFilesByName(project_path, query);
+		return await searchFilesByName(project.path, query);
 	})
 	.http('files:search-code', {
 		data: t.Object({
@@ -376,7 +378,7 @@ export const fileSearchHandler = createRouter()
 			})),
 			totalMatches: t.Number()
 		}))
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		const {
 			project_path,
 			query,
@@ -386,12 +388,13 @@ export const fileSearchHandler = createRouter()
 			include_pattern,
 			exclude_pattern
 		} = data;
+		const project = requireProjectPathAccess(conn, project_path);
 
 		if (!query || query.trim().length === 0) {
 			return [];
 		}
 
-		return await searchCodeContent(project_path, query, {
+		return await searchCodeContent(project.path, query, {
 			caseSensitive: case_sensitive,
 			wholeWord: whole_word,
 			useRegex: use_regex,
@@ -419,7 +422,7 @@ export const fileSearchHandler = createRouter()
 			totalReplacements: t.Number(),
 			totalFiles: t.Number()
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		const {
 			project_path,
 			search_query,
@@ -430,12 +433,13 @@ export const fileSearchHandler = createRouter()
 			include_pattern,
 			exclude_pattern
 		} = data;
+		const project = requireProjectPathAccess(conn, project_path);
 
 		if (!search_query || search_query.trim().length === 0) {
 			return { results: [], totalReplacements: 0, totalFiles: 0 };
 		}
 
-		const results = await replaceInFiles(project_path, search_query, replace_with, {
+		const results = await replaceInFiles(project.path, search_query, replace_with, {
 			caseSensitive: case_sensitive,
 			wholeWord: whole_word,
 			useRegex: use_regex,

--- a/backend/ws/files/write.ts
+++ b/backend/ws/files/write.ts
@@ -24,7 +24,8 @@ import {
 	deleteOperation
 } from '../../files/file-operations';
 import { join } from 'node:path';
-import { requireFilePathAccess } from './path-access';
+import { stat as fsStat, readdir as fsReaddir, rename as fsRename, access as fsAccess } from 'node:fs/promises';
+import { requireFilePathAccess, requireSharedFilePathAccess } from './path-access';
 
 export const writeHandler = createRouter()
 	// Write file operation
@@ -75,7 +76,10 @@ export const writeHandler = createRouter()
 			modified: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const dirPath = requireFilePathAccess(conn, data.dirPath);
+		// Uses the shared guard so FolderBrowser can create candidate project
+		// folders outside any existing project, while still preventing writes
+		// inside another user's project.
+		const dirPath = requireSharedFilePathAccess(conn, data.dirPath);
 		return await createDirectoryOperation(dirPath);
 	})
 
@@ -152,4 +156,82 @@ export const writeHandler = createRouter()
 	}, async ({ data, conn }) => {
 		const filePath = requireFilePathAccess(conn, data.filePath);
 		return await deleteOperation(filePath, data.force);
+	})
+
+	// Delete an empty directory from FolderBrowser. Restricted to:
+	// - real directory (not a file)
+	// - empty contents (no force, no recursive)
+	// - shared guard (outside all projects, or inside the user's own project)
+	.http('files:delete-directory', {
+		data: t.Object({
+			dirPath: t.String()
+		}),
+		response: t.Object({
+			message: t.String(),
+			path: t.String()
+		})
+	}, async ({ data, conn }) => {
+		const dirPath = requireSharedFilePathAccess(conn, data.dirPath);
+
+		const stats = await fsStat(dirPath);
+		if (!stats.isDirectory()) {
+			throw new Error('Path is not a directory');
+		}
+		const entries = await fsReaddir(dirPath);
+		if (entries.length > 0) {
+			throw new Error('Directory is not empty');
+		}
+
+		return await deleteOperation(dirPath, false);
+	})
+
+	// Rename a directory from FolderBrowser (e.g. fix typo on a candidate
+	// project folder). Restricted to real directories on both sides and
+	// guarded by the shared path access policy. Uses fs.rename directly
+	// because Bun.file(...).exists() returns false for directories, which
+	// makes the generic renameOperation unusable here.
+	.http('files:rename-directory', {
+		data: t.Object({
+			oldPath: t.String(),
+			newPath: t.String()
+		}),
+		response: t.Object({
+			message: t.String(),
+			oldPath: t.String(),
+			newPath: t.String(),
+			modified: t.String()
+		})
+	}, async ({ data, conn }) => {
+		const oldPath = requireSharedFilePathAccess(conn, data.oldPath);
+		const newPath = requireSharedFilePathAccess(conn, data.newPath);
+
+		let oldStats;
+		try {
+			oldStats = await fsStat(oldPath);
+		} catch {
+			throw new Error('Source path does not exist');
+		}
+		if (!oldStats.isDirectory()) {
+			throw new Error('Source path is not a directory');
+		}
+
+		try {
+			await fsAccess(newPath);
+			throw new Error('Destination path already exists');
+		} catch (err) {
+			if (err instanceof Error && err.message === 'Destination path already exists') {
+				throw err;
+			}
+			// fsAccess threw because newPath does not exist — that is what we want.
+		}
+
+		await fsRename(oldPath, newPath);
+		const newStats = await fsStat(newPath);
+
+		return {
+			message: 'Directory renamed successfully',
+			oldPath,
+			newPath,
+			modified: newStats.mtime.toISOString()
+		};
 	});

--- a/backend/ws/files/write.ts
+++ b/backend/ws/files/write.ts
@@ -23,6 +23,8 @@ import {
 	uploadFileOperation,
 	deleteOperation
 } from '../../files/file-operations';
+import { join } from 'node:path';
+import { requireFilePathAccess } from './path-access';
 
 export const writeHandler = createRouter()
 	// Write file operation
@@ -36,12 +38,13 @@ export const writeHandler = createRouter()
 			size: t.Number(),
 			modified: t.String()
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		const filePath = requireFilePathAccess(conn, data.filePath);
 		debug.log('file', 'Write file operation:', {
-			filePath: data.filePath,
+			filePath,
 			contentLength: data.content.length
 		});
-		return await writeFileOperation(data.filePath, data.content);
+		return await writeFileOperation(filePath, data.content);
 	})
 
 	// Create file operation
@@ -56,8 +59,9 @@ export const writeHandler = createRouter()
 			size: t.Number(),
 			modified: t.String()
 		})
-	}, async ({ data }) => {
-		return await createFileOperation(data.filePath, data.content);
+	}, async ({ data, conn }) => {
+		const filePath = requireFilePathAccess(conn, data.filePath);
+		return await createFileOperation(filePath, data.content);
 	})
 
 	// Create directory operation
@@ -70,8 +74,9 @@ export const writeHandler = createRouter()
 			path: t.String(),
 			modified: t.String()
 		})
-	}, async ({ data }) => {
-		return await createDirectoryOperation(data.dirPath);
+	}, async ({ data, conn }) => {
+		const dirPath = requireFilePathAccess(conn, data.dirPath);
+		return await createDirectoryOperation(dirPath);
 	})
 
 	// Rename operation
@@ -86,8 +91,10 @@ export const writeHandler = createRouter()
 			newPath: t.String(),
 			modified: t.String()
 		})
-	}, async ({ data }) => {
-		return await renameOperation(data.oldPath, data.newPath);
+	}, async ({ data, conn }) => {
+		const oldPath = requireFilePathAccess(conn, data.oldPath);
+		const newPath = requireFilePathAccess(conn, data.newPath);
+		return await renameOperation(oldPath, newPath);
 	})
 
 	// Duplicate operation
@@ -103,8 +110,10 @@ export const writeHandler = createRouter()
 			size: t.Number(),
 			modified: t.String()
 		})
-	}, async ({ data }) => {
-		return await duplicateOperation(data.sourcePath, data.targetPath);
+	}, async ({ data, conn }) => {
+		const sourcePath = requireFilePathAccess(conn, data.sourcePath);
+		const targetPath = requireFilePathAccess(conn, data.targetPath);
+		return await duplicateOperation(sourcePath, targetPath);
 	})
 
 	// Upload file operation
@@ -124,8 +133,10 @@ export const writeHandler = createRouter()
 			size: t.Number(),
 			modified: t.String()
 		})
-	}, async ({ data }) => {
-		return await uploadFileOperation(data.file, data.targetPath);
+	}, async ({ data, conn }) => {
+		const targetPath = requireFilePathAccess(conn, data.targetPath);
+		requireFilePathAccess(conn, join(targetPath, data.file.name));
+		return await uploadFileOperation(data.file, targetPath);
 	})
 
 	// Delete operation
@@ -138,6 +149,7 @@ export const writeHandler = createRouter()
 			message: t.String(),
 			path: t.String()
 		})
-	}, async ({ data }) => {
-		return await deleteOperation(data.filePath, data.force);
+	}, async ({ data, conn }) => {
+		const filePath = requireFilePathAccess(conn, data.filePath);
+		return await deleteOperation(filePath, data.force);
 	});

--- a/frontend/components/common/form/FolderBrowser.svelte
+++ b/frontend/components/common/form/FolderBrowser.svelte
@@ -41,6 +41,9 @@
 	let showDeleteFolder = $state(false);
 	let folderToDelete: FileItem | null = $state(null);
 	let deleteFolderConfirmName = $state('');
+	let showRenameFolder = $state(false);
+	let folderToRename: FileItem | null = $state(null);
+	let renameFolderName = $state('');
 	let showHidden = $state(false);
 
 	const filteredItems = $derived(
@@ -420,10 +423,10 @@
 		try {
 			const folderPath = folderToDelete.path;
 
-			// Delete folder via WebSocket
-			await ws.http('files:delete', {
-				filePath: folderPath,
-				force: true  // Allow deletion of non-empty directories
+			// Picker-only route: rejects non-empty directories and paths inside
+			// other users' projects, even when forced.
+			await ws.http('files:delete-directory', {
+				dirPath: folderPath
 			});
 
 			// Store current path before clearing dialog state
@@ -454,7 +457,58 @@
 			error = err instanceof Error ? err.message : 'Failed to delete folder';
 		}
 	}
-	
+
+	function openRenameDialog(item: FileItem) {
+		folderToRename = item;
+		renameFolderName = item.name;
+		showRenameFolder = true;
+	}
+
+	async function renameFolder() {
+		if (!folderToRename) return;
+		const trimmed = renameFolderName.trim();
+		if (!trimmed || trimmed === folderToRename.name) {
+			showRenameFolder = false;
+			folderToRename = null;
+			return;
+		}
+
+		const oldPath = folderToRename.path;
+		const usesBackslash = oldPath.includes('\\');
+		const sep = usesBackslash ? '\\' : '/';
+		const lastSep = usesBackslash ? oldPath.lastIndexOf('\\') : oldPath.lastIndexOf('/');
+		const parent = lastSep >= 0 ? oldPath.slice(0, lastSep) : '';
+		const newPath = parent ? `${parent}${sep}${trimmed}` : trimmed;
+
+		try {
+			await ws.http('files:rename-directory', {
+				oldPath,
+				newPath
+			});
+
+			const pathToReload = currentPath;
+
+			if (selectedPath === oldPath) {
+				selectedPath = newPath;
+			}
+
+			showRenameFolder = false;
+			folderToRename = null;
+			renameFolderName = '';
+
+			await new Promise(resolve => setTimeout(resolve, 100));
+
+			if (pathToReload) {
+				loadDirectory(pathToReload);
+			} else {
+				const fallbackPath = currentPath || '.';
+				loadDirectory(fallbackPath);
+			}
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to rename folder';
+		}
+	}
+
 	// Initialize when dialog opens
 	$effect(() => {
 		if (isOpen) {
@@ -765,20 +819,34 @@
 								<button
 									onclick={(e) => {
 										e.stopPropagation();
+										openRenameDialog(item);
+									}}
+									class="flex p-1.5 rounded-lg hover:bg-violet-100 dark:hover:bg-violet-900/20 transition-colors group"
+									title="Rename folder"
+									aria-label="Rename {item.name}"
+								>
+									<Icon
+										name="lucide:pencil"
+										class="text-sm text-slate-400 dark:text-slate-500 group-hover:text-violet-500 dark:group-hover:text-violet-400"
+									/>
+								</button>
+								<button
+									onclick={(e) => {
+										e.stopPropagation();
 										openDeleteDialog(item);
 									}}
 									class="flex p-1.5 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/20 transition-colors group"
 									title="Delete folder"
 									aria-label="Delete {item.name}"
 								>
-									<Icon 
-										name="lucide:trash-2" 
-										class="text-sm text-slate-400 dark:text-slate-500 group-hover:text-red-500 dark:group-hover:text-red-400" 
+									<Icon
+										name="lucide:trash-2"
+										class="text-sm text-slate-400 dark:text-slate-500 group-hover:text-red-500 dark:group-hover:text-red-400"
 									/>
 								</button>
-								<Icon 
-									name="lucide:chevron-right" 
-									class="text-sm text-slate-400 dark:text-slate-500" 
+								<Icon
+									name="lucide:chevron-right"
+									class="text-sm text-slate-400 dark:text-slate-500"
 								/>
 							</div>
 						{/if}
@@ -853,4 +921,24 @@
 	showCancel={true}
 	confirmDisabled={deleteFolderConfirmName !== folderToDelete?.name}
 	onConfirm={deleteFolder}
+/>
+
+<!-- Rename Folder Dialog -->
+<Dialog
+	bind:isOpen={showRenameFolder}
+	onClose={() => {
+		showRenameFolder = false;
+		folderToRename = null;
+		renameFolderName = '';
+	}}
+	title="Rename Folder"
+	type="info"
+	message={`Rename "${folderToRename?.name || ''}" to:`}
+	bind:inputValue={renameFolderName}
+	inputPlaceholder="Enter new folder name"
+	confirmText="Rename"
+	cancelText="Cancel"
+	showCancel={true}
+	confirmDisabled={!renameFolderName.trim() || renameFolderName.trim() === folderToRename?.name}
+	onConfirm={renameFolder}
 />


### PR DESCRIPTION
## Summary
This PR scopes file read/write/search routes to project paths the current user can access.

## Why?
Several `files:*` WebSocket routes accepted client-provided paths directly. In multi-user mode, that could let an authenticated user read, search, modify, upload, or delete files outside projects they are allowed to access.

## Changes
- Added a reusable file path access helper for project-contained paths.
- Require project membership for `project_path` based file routes.
- Require file paths to be inside one of the current user's accessible projects.
- Filter expanded file-tree paths so they cannot escape the selected project root.
- Applied the guard to file read, browse, list, content, write, create, rename, duplicate, upload, delete, search, and replace routes.

## Validation
- Ran `git diff --check`.
- Could not run `bun run check` locally because Bun is not installed in this environment.
