### PR TITLE
fix(tunnel): restrict tunnel routes to admins

### DIFF
--- a/backend/auth/permissions.ts
+++ b/backend/auth/permissions.ts
@@ -38,6 +38,8 @@ export const ADMIN_ONLY_ROUTES = new Set([
 	'system-tools:install-session'
 ]);
 
+const ADMIN_ONLY_ROUTE_PREFIXES = ['tunnel:'];
+
 /**
  * Check if a route action is allowed for the given auth state.
  * In no-auth mode, all routes are allowed (bypasses authentication check).
@@ -63,7 +65,10 @@ export function checkRouteAccess(
 	}
 
 	// Admin-only routes
-	if (ADMIN_ONLY_ROUTES.has(action) && role !== 'admin') {
+	const requiresAdmin = ADMIN_ONLY_ROUTES.has(action) ||
+		ADMIN_ONLY_ROUTE_PREFIXES.some((prefix) => action.startsWith(prefix));
+
+	if (requiresAdmin && role !== 'admin') {
 		return { allowed: false, error: 'Admin access required' };
 	}
 


### PR DESCRIPTION
## Summary
This PR restricts all `tunnel:*` WebSocket routes to admin users.

## Why
Tunnel management can expose local services, store Cloudflare tunnel tokens, mutate ingress rules, and log out local cloudflared auth. Those operations are privileged and should not be available to regular authenticated users.

## Changements
- Added an admin-only route prefix for `tunnel:*`.
- Kept the existing explicit admin-only route list intact.
- Ensured current and future tunnel routes are covered without needing to enumerate every action manually.

## Validation
- Ran `git diff --check`.
- Could not run `bun run check` locally because Bun is not installed in this environment.
