### PR TITLE
fix(projects): prevent implicit project membership by path

### DIFF
--- a/backend/ws/projects/crud.ts
+++ b/backend/ws/projects/crud.ts
@@ -3,7 +3,7 @@
  *
  * HTTP endpoints for project management:
  * - List all projects (per-user)
- * - Create new project (or join existing)
+ * - Create new project (or return an existing project already joined by the user)
  * - Get project by ID
  * - Update project info
  * - Delete project (remove user association, cleanup if orphaned)
@@ -34,7 +34,7 @@ export const crudHandler = createRouter()
 		return projects;
 	})
 
-	// Create new project (or join existing by path)
+	// Create new project (or return an existing project already joined by the user)
 	.http('projects:create', {
 		data: t.Object({
 			name: t.String({ minLength: 1 }),
@@ -49,8 +49,9 @@ export const crudHandler = createRouter()
 		// Check if project with this path already exists
 		const existing = projectQueries.getByPath(path);
 		if (existing) {
-			// Project exists - just add user association (join)
-			projectQueries.addUserProject(userId, existing.id);
+			if (!projectQueries.userHasProject(userId, existing.id)) {
+				throw new Error('Project path is already registered');
+			}
 			return existing;
 		}
 


### PR DESCRIPTION
This PR prevents users from implicitly joining an existing project just by creating a project with the same filesystem path.

## Why this
Project access checks rely on membership in `user_projects`. Previously, `projects:create` would automatically add the current user to an existing project when the submitted path matched. In multi-user mode, that could allow a user who knows or guesses a project path to grant themselves access.

## Changes
- Preserve the existing behavior for users who already have access to the project.
- Reject duplicate project paths when the current user is not already a member.
- Update comments to describe the safer behavior clearly.

## Validation
- Ran `git diff --check`.
- Could not run `bun run check` locally because Bun is not installed in this environment.
