### PR TITLE
fix(error-handling): log swallowed errors instead of silently catching

### DIFF
--- a/backend/db-client/connection-manager.ts
+++ b/backend/db-client/connection-manager.ts
@@ -73,7 +73,9 @@ class ConnectionManager {
 		try {
 			await adapter.connect(conn, tunnel?.localPort);
 		} catch (err) {
-			if (tunnel) await tunnel.close().catch(() => {});
+			if (tunnel) await tunnel.close().catch((err) => {
+				debug.warn('db-client', 'Failed to close SSH tunnel after adapter connect error:', err);
+			});
 			throw err;
 		}
 
@@ -164,8 +166,12 @@ class ConnectionManager {
 				error: err instanceof Error ? err.message : String(err)
 			};
 		} finally {
-			if (adapter) await adapter.close().catch(() => {});
-			if (tunnel) await tunnel.close().catch(() => {});
+			if (adapter) await adapter.close().catch((err) => {
+				debug.warn('db-client', 'Transient adapter close error during health test:', err);
+			});
+			if (tunnel) await tunnel.close().catch((err) => {
+				debug.warn('db-client', 'Transient tunnel close error during health test:', err);
+			});
 		}
 	}
 

--- a/backend/tunnel/global-tunnel-manager.ts
+++ b/backend/tunnel/global-tunnel-manager.ts
@@ -195,7 +195,9 @@ class GlobalTunnelManager {
 		if (instance.autoStopTimer) clearTimeout(instance.autoStopTimer);
 		try {
 			instance.tunnel.stop();
-		} catch { /* ignore */ }
+		} catch (err) {
+			debug.warn('tunnel', `Failed to stop quick tunnel on port ${port}:`, err);
+		}
 		this.quickTunnels.delete(port);
 		debug.log('tunnel', `Quick tunnel stopped on port ${port}`);
 		this.notifyStatusChanged();
@@ -297,7 +299,9 @@ class GlobalTunnelManager {
 
 		try {
 			instance.tunnel.stop();
-		} catch { /* ignore */ }
+		} catch (err) {
+			debug.warn('tunnel', `Failed to stop remote tunnel ${instance.label}:`, err);
+		}
 		this.remoteTunnels.delete(configId);
 		debug.log('tunnel', `Remote tunnel stopped: ${instance.label}`);
 		this.notifyStatusChanged();
@@ -548,7 +552,9 @@ class GlobalTunnelManager {
 
 		try {
 			instance.tunnel.stop();
-		} catch { /* ignore */ }
+		} catch (err) {
+			debug.warn('tunnel', `Failed to stop local tunnel ${instance.name}:`, err);
+		}
 		this.localTunnels.delete(configId);
 		debug.log('tunnel', `Local tunnel stopped: ${instance.name}`);
 		this.notifyStatusChanged();

--- a/backend/utils/ws.ts
+++ b/backend/utils/ws.ts
@@ -182,7 +182,11 @@ class WSServer {
 		// Run all registered cleanup functions
 		if (state?.cleanups.size) {
 			for (const cleanup of state.cleanups) {
-				try { cleanup(); } catch { /* ignore cleanup errors */ }
+				try {
+				cleanup();
+			} catch (err) {
+				debug.warn('websocket', `Cleanup error for connection ${id}:`, err);
+			}
 			}
 			debug.log('websocket', `Ran ${state.cleanups.size} cleanup(s) for connection ${id}`);
 		}

--- a/backend/utils/ws.ts
+++ b/backend/utils/ws.ts
@@ -183,10 +183,10 @@ class WSServer {
 		if (state?.cleanups.size) {
 			for (const cleanup of state.cleanups) {
 				try {
-				cleanup();
-			} catch (err) {
-				debug.warn('websocket', `Cleanup error for connection ${id}:`, err);
-			}
+					cleanup();
+				} catch (err) {
+					debug.warn('websocket', `Cleanup error for connection ${id}:`, err);
+				}
 			}
 			debug.log('websocket', `Ran ${state.cleanups.size} cleanup(s) for connection ${id}`);
 		}

--- a/backend/ws/chat/stream.ts
+++ b/backend/ws/chat/stream.ts
@@ -48,7 +48,9 @@ streamManager.on('stream:lifecycle', (event: { status: string; streamId: string;
 	});
 
 	// Broadcast updated presence (status indicators for all projects)
-	broadcastPresence().catch(() => {});
+	broadcastPresence().catch((err) => {
+		debug.warn('chat', 'Presence broadcast error after stream lifecycle:', err);
+	});
 });
 
 // Notify project members when a snapshot is captured (so the timeline modal can refresh stats)
@@ -83,7 +85,9 @@ export const streamHandler = createRouter()
 		ws.leaveAllChatSessions(conn);
 		ws.joinChatSession(conn, data.chatSessionId);
 		// Broadcast presence so all clients see updated chatSessionUsers
-		broadcastPresence().catch(() => {});
+		broadcastPresence().catch((err) => {
+			debug.warn('chat', 'Presence broadcast error after chat join-session:', err);
+		});
 	})
 
 	// Leave a chat session room
@@ -94,7 +98,9 @@ export const streamHandler = createRouter()
 	}, ({ data, conn }) => {
 		ws.leaveChatSession(conn, data.chatSessionId);
 		// Broadcast presence so all clients see updated chatSessionUsers
-		broadcastPresence().catch(() => {});
+		broadcastPresence().catch((err) => {
+			debug.warn('chat', 'Presence broadcast error after chat leave-session:', err);
+		});
 	})
 
 	// Start chat stream
@@ -155,7 +161,9 @@ export const streamHandler = createRouter()
 				// User message is broadcast by stream-manager via event subscription below
 				// (includes resume, sender info, and saved message ID)
 			}
-			broadcastPresence().catch(() => {});
+			broadcastPresence().catch((err) => {
+				debug.warn('chat', 'Presence broadcast error on chat:stream start:', err);
+			});
 
 			// Subscribe to stream events (event-driven, no polling)
 			// Use ws.emit.chatSession() for session-scoped chat events
@@ -170,7 +178,9 @@ export const streamHandler = createRouter()
 								timestamp: event.data.timestamp,
 								seq: event.seq
 							});
-							broadcastPresence().catch(() => {});
+							broadcastPresence().catch((err) => {
+								debug.warn('chat', 'Presence broadcast error on stream connection event:', err);
+							});
 							break;
 
 						case 'message': {
@@ -193,7 +203,9 @@ export const streamHandler = createRouter()
 								item.type === 'tool_use' && item.name === 'AskUserQuestion'
 							);
 							if (askToolUse || msgContent.some((item: any) => item.type === 'tool_result')) {
-								broadcastPresence().catch(() => {});
+								broadcastPresence().catch((err) => {
+									debug.warn('chat', 'Presence broadcast error on waiting-input state change:', err);
+								});
 							}
 							// Notify all project members when AskUserQuestion arrives (sound + push)
 							if (askToolUse && projectId) {
@@ -338,7 +350,9 @@ export const streamHandler = createRouter()
 								item.type === 'tool_use' && item.name === 'AskUserQuestion'
 							);
 							if (reconnAskToolUse || reconnMsgContent.some((item: any) => item.type === 'tool_result')) {
-								broadcastPresence().catch(() => {});
+								broadcastPresence().catch((err) => {
+									debug.warn('chat', 'Presence broadcast error on reconnect waiting-input state change:', err);
+								});
 							}
 							if (reconnAskToolUse && projectId) {
 								ws.emit.projectMembers(projectId, 'chat:waiting-input', {
@@ -546,7 +560,9 @@ export const streamHandler = createRouter()
 					status: 'cancelled',
 					processId: ''
 				});
-				broadcastPresence().catch(() => {});
+				broadcastPresence().catch((err) => {
+					debug.warn('chat', 'Presence broadcast error after cancel (stream not found):', err);
+				});
 				return;
 			}
 
@@ -557,7 +573,9 @@ export const streamHandler = createRouter()
 				processId: streamState.processId
 			});
 			// Always broadcast presence after cancel attempt to update all clients
-			broadcastPresence().catch(() => {});
+			broadcastPresence().catch((err) => {
+				debug.warn('chat', 'Presence broadcast error after stream cancel:', err);
+			});
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 			ws.emit.chatSession(chatSessionId, 'chat:error', {
@@ -565,7 +583,9 @@ export const streamHandler = createRouter()
 				error: errorMessage,
 				timestamp: new Date().toISOString()
 			});
-			broadcastPresence().catch(() => {});
+			broadcastPresence().catch((err) => {
+				debug.warn('chat', 'Presence broadcast error after cancel exception:', err);
+			});
 		}
 	})
 

--- a/backend/ws/db-client/query.ts
+++ b/backend/ws/db-client/query.ts
@@ -8,6 +8,7 @@ import { connectionManager } from '../../db-client/connection-manager';
 import { runSafely } from '../../db-client/query-executor';
 import { dbClientQueryHistoryQueries } from '../../database/queries';
 import { getDbClientPrincipal, requireDbClientConnectionAccess } from './access';
+import { debug } from '$shared/utils/logger';
 
 const HISTORY_KEEP_PER_CONNECTION = 200;
 
@@ -33,8 +34,9 @@ function recordHistory(input: {
 		if (Math.random() < 0.05) {
 			dbClientQueryHistoryQueries.prune(input.connectionId, HISTORY_KEEP_PER_CONNECTION);
 		}
-	} catch {
+	} catch (err) {
 		// history must never break query execution
+		debug.warn('db-client', 'Failed to record query history:', err);
 	}
 }
 

--- a/backend/ws/projects/crud.ts
+++ b/backend/ws/projects/crud.ts
@@ -111,7 +111,9 @@ export const crudHandler = createRouter()
 			if (sessions.length > 0) {
 				// Cancel active chat streams
 				await Promise.all(
-					sessions.map(s => streamManager.cleanupSessionStreams(s.id).catch(() => {}))
+					sessions.map(s => streamManager.cleanupSessionStreams(s.id).catch((err) => {
+						debug.warn('project', `Stream cleanup error for session ${s.id} during project delete:`, err);
+					}))
 				);
 
 				// Collect blob hashes before deleting
@@ -163,7 +165,9 @@ export const crudHandler = createRouter()
 			}
 		}
 
-		broadcastPresence().catch(() => {});
+		broadcastPresence().catch((err) => {
+			debug.warn('project', 'Presence broadcast error after project delete:', err);
+		});
 
 		return {
 			id: data.id,

--- a/backend/ws/projects/status.ts
+++ b/backend/ws/projects/status.ts
@@ -71,7 +71,9 @@ export const statusHandler = createRouter()
 				ws.addCleanup(conn, () => {
 					updateUserPresence(projectId, userId, '', 'leave');
 					debug.log('project', `Auto-cleaned presence for ${userId} from project ${projectId}`);
-					broadcastPresence().catch(() => {});
+					broadcastPresence().catch((err) => {
+						debug.warn('project', `Presence broadcast error after auto-cleanup for ${userId}:`, err);
+					});
 				});
 
 				await broadcastPresence();

--- a/backend/ws/sessions/crud.ts
+++ b/backend/ws/sessions/crud.ts
@@ -272,7 +272,9 @@ export const crudHandler = createRouter()
 		});
 
 		// Broadcast updated presence so status indicators reflect the deletion
-		broadcastPresence().catch(() => {});
+		broadcastPresence().catch((err) => {
+			debug.warn('session', 'Presence broadcast error after session deletion:', err);
+		});
 
 		return {
 			message: 'Session deleted successfully'
@@ -297,7 +299,9 @@ export const crudHandler = createRouter()
 
 		// Cancel and clean up active streams for all sessions
 		await Promise.all(
-			sessions.map(s => streamManager.cleanupSessionStreams(s.id).catch(() => {}))
+			sessions.map(s => streamManager.cleanupSessionStreams(s.id).catch((err) => {
+				debug.warn('session', `Stream cleanup error for session ${s.id}:`, err);
+			}))
 		);
 
 		// Collect ALL blob hashes before deleting anything:
@@ -348,7 +352,9 @@ export const crudHandler = createRouter()
 			});
 		}
 
-		broadcastPresence().catch(() => {});
+		broadcastPresence().catch((err) => {
+			debug.warn('session', 'Presence broadcast error after bulk session deletion:', err);
+		});
 
 		debug.log('session', `Deleted all ${deletedIds.length} sessions in project: ${projectId}`);
 		return {


### PR DESCRIPTION
## What's the problem?

Several places across the backend catch errors and silently discard them with empty `catch` blocks — either `catch {}` or `catch(() => {})`. This means when something goes wrong in production, there's zero visibility into what failed. You're left guessing.

For example, if a WebSocket cleanup function throws during connection teardown, or an SSH tunnel fails to close after an adapter connect error, the failure vanishes into the void. The system keeps running, but you'd never know something went sideways until it cascades into a bigger problem.

## What changed?

Every empty or arrow-only `catch` block in the affected files now logs the error via `debug.warn()` before continuing. The original "don't let this break the main flow" intent is preserved — we're not throwing, just making the failure observable.

### File-by-file breakdown

| File | Location | Before | After |
|------|----------|--------|-------|
| [backend/utils/ws.ts](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/utils/ws.ts:0:0-0:0) | [unregister()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/utils/ws.ts:169:1-245:2) — cleanup functions | `catch { /* ignore */ }` | `catch (err) { debug.warn('websocket', ...) }` |
| [backend/ws/sessions/crud.ts](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/ws/sessions/crud.ts:0:0-0:0) | `sessions:delete` — broadcastPresence | `.catch(() => {})` | `.catch((err) => { debug.warn('session', ...) })` |
| [backend/ws/sessions/crud.ts](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/ws/sessions/crud.ts:0:0-0:0) | `sessions:delete-all` — broadcastPresence | `.catch(() => {})` | `.catch((err) => { debug.warn('session', ...) })` |
| [backend/ws/sessions/crud.ts](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/ws/sessions/crud.ts:0:0-0:0) | `sessions:delete-all` — stream cleanup | `.catch(() => {})` | `.catch((err) => { debug.warn('session', ...) })` |
| [backend/ws/db-client/query.ts](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/ws/db-client/query.ts:0:0-0:0) | [recordHistory()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/ws/db-client/query.ts:13:0-39:1) | `catch { /* history must never break */ }` | `catch (err) { debug.warn('db-client', ...); }` |
| [backend/db-client/connection-manager.ts](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/db-client/connection-manager.ts:0:0-0:0) | [openEntry()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/db-client/connection-manager.ts:62:1-80:2) — tunnel close on connect failure | `.catch(() => {})` | `.catch((err) => { debug.warn('db-client', ...) })` |
| [backend/db-client/connection-manager.ts](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/db-client/connection-manager.ts:0:0-0:0) | [test()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/db-client/connection-manager.ts:120:1-169:2) — transient adapter close | `.catch(() => {})` | `.catch((err) => { debug.warn('db-client', ...) })` |
| [backend/db-client/connection-manager.ts](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/db-client/connection-manager.ts:0:0-0:0) | [test()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/db-client/connection-manager.ts:120:1-169:2) — transient tunnel close | `.catch(() => {})` | `.catch((err) => { debug.warn('db-client', ...) })` |

> **Note:** [query.ts](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/ws/db-client/query.ts:0:0-0:0) didn't previously import `debug` — that import was added as part of this PR.

## Why not just throw?

These catch blocks exist for a reason — the failing operation is *non-critical* relative to the main flow. Forcing a throw would break the primary operation (e.g., a query execution failing because history recording failed, or a session deletion failing because a presence broadcast failed). Logging is the right middle ground: the main flow continues, but the failure is now visible in debug output.

## Testing

No functional behavior changes — only logging output. Existing error-handling paths remain identical; errors are still caught and suppressed from the caller's perspective.