### PR TITLE
fix(preview): prevent duplicate signal handler registration in BrowserTabManager

### DIFF
--- a/backend/preview/browser/browser-tab-manager.ts
+++ b/backend/preview/browser/browser-tab-manager.ts
@@ -44,6 +44,7 @@ export class BrowserTabManager extends EventEmitter {
 	// Tab activity tracking for cleanup
 	private tabActivity = new Map<string, number>();
 	private cleanupInterval: NodeJS.Timeout | null = null;
+	private signalHandlers: { sigterm: () => void; sigint: () => void } | null = null;
 
 	// Audio capture manager
 	private audioCapture = new BrowserAudioCapture();
@@ -1038,14 +1039,30 @@ export class BrowserTabManager extends EventEmitter {
 			this.performCleanup();
 		}, CLEANUP_INTERVAL);
 
-		// Cleanup on shutdown
+		// Cleanup on shutdown — track references so we can remove them later
+		// and prevent duplicate listeners if multiple BrowserTabManager
+		// instances are created.
 		const cleanup = () => {
 			if (this.cleanupInterval) clearInterval(this.cleanupInterval);
+			this.cleanupInterval = null;
 			this.tabActivity.clear();
+			this.removeSignalHandlers();
 		};
 
-		process.on('SIGTERM', cleanup);
-		process.on('SIGINT', cleanup);
+		this.signalHandlers = { sigterm: cleanup, sigint: cleanup };
+		process.on('SIGTERM', this.signalHandlers.sigterm);
+		process.on('SIGINT', this.signalHandlers.sigint);
+	}
+
+	/**
+	 * Remove previously registered signal handlers to prevent leaks
+	 * when multiple BrowserTabManager instances are created.
+	 */
+	private removeSignalHandlers(): void {
+		if (!this.signalHandlers) return;
+		process.off('SIGTERM', this.signalHandlers.sigterm);
+		process.off('SIGINT', this.signalHandlers.sigint);
+		this.signalHandlers = null;
 	}
 
 	/**
@@ -1147,6 +1164,9 @@ export class BrowserTabManager extends EventEmitter {
 			clearInterval(this.cleanupInterval);
 			this.cleanupInterval = null;
 		}
+
+		// Remove signal handlers to prevent leaks
+		this.removeSignalHandlers();
 
 		const tabIds = Array.from(this.tabs.keys());
 


### PR DESCRIPTION
## The leak

[BrowserTabManager.initializeCleanup()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/preview/browser/browser-tab-manager.ts:1027:1-1054:2) registers `SIGTERM` and `SIGINT` handlers on the `process` object every time it's called. The guard `if (this.cleanupInterval) return` prevents the *interval* from being registered twice on the same instance, but it doesn't prevent a **different instance** from stacking additional signal handlers.

In practice, [BrowserTabManager](cci:2://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/preview/browser/browser-tab-manager.ts:38:0-1207:1) is instantiated per project. If two projects are opened, you get two instances, each calling `process.on('SIGTERM', cleanup)`. Now there are two listeners. Three projects? Three listeners. They accumulate for the lifetime of the process and are never removed — even after [cleanup()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/preview/browser/browser-tab-manager.ts:1155:1-1199:2) is called, the handlers remain attached.

This matters because:

- Each handler holds a closure over `this` (the manager instance), preventing GC of old managers
- On shutdown, N handlers all fire and attempt to clear the same interval / tab maps
- `process.listeners('SIGTERM')` grows unboundedly

## The fix

Two changes:

**1. Track handler references** — Store the bound cleanup functions in a `signalHandlers` field so they can be identified and removed later:

    private signalHandlers: { sigterm: () => void; sigint: () => void } | null = null;

**2. Remove on cleanup** — New [removeSignalHandlers()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/preview/browser/browser-tab-manager.ts:1056:1-1065:2) method calls `process.off()` for both signals. It's called from:

- The signal handler itself (so it self-deregisters on fire)
- The [cleanup()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/preview/browser/browser-tab-manager.ts:1155:1-1199:2) method (so normal programmatic cleanup also removes them)

    private removeSignalHandlers(): void {
        if (!this.signalHandlers) return;
        process.off('SIGTERM', this.signalHandlers.sigterm);
        process.off('SIGINT', this.signalHandlers.sigint);
        this.signalHandlers = null;
    }

## Impact

| | Before | After |
|---|--------|-------|
| N projects open | 2N signal handlers, never removed | 2N signal handlers, properly cleaned up |
| After [cleanup()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/preview/browser/browser-tab-manager.ts:1155:1-1199:2) | Handlers still attached | Handlers removed via `process.off()` |
| GC of old managers | Leaked (closure retains `this`) | Releasable after handler removal |

No behavioral change to tab cleanup logic itself — just proper listener hygiene.

## Bonus fix

Also set `this.cleanupInterval = null` inside the signal handler's cleanup callback. Previously it was clearing the interval but leaving the field referencing the old timeout ID, which could confuse any future [initializeCleanup()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/preview/browser/browser-tab-manager.ts:1027:1-1054:2) guard check on a reused instance.