### PR TITLE
fix(auth): gate tunnel mutations and admin-only settings sections

### DIFF
--- a/backend/auth/permissions.ts
+++ b/backend/auth/permissions.ts
@@ -70,7 +70,25 @@ export const ADMIN_ONLY_ROUTES = new Set([
 	'engine:opencode-account-delete',
 	'engine:opencode-account-rename',
 	'engine:opencode-server-restart',
-	'engine:opencode-models-dev-fetch'
+	'engine:opencode-models-dev-fetch',
+	// Tunnel — remote/local management mutates global Cloudflare credentials,
+	// cloudflared auth, and ingress rules. Quick Tunnel is ephemeral and stays
+	// open. Read-only routes (status, *-list, ingress, auth-status) stay open so
+	// any authenticated user can see what is active.
+	'tunnel:remote:config:add',
+	'tunnel:remote:config:remove',
+	'tunnel:remote:start',
+	'tunnel:remote:stop',
+	'tunnel:local:login-start',
+	'tunnel:local:login-cancel',
+	'tunnel:local:logout',
+	'tunnel:local:set-zone',
+	'tunnel:local:create',
+	'tunnel:local:delete',
+	'tunnel:local:ingress:add',
+	'tunnel:local:ingress:remove',
+	'tunnel:local:start',
+	'tunnel:local:stop'
 ]);
 
 /**

--- a/frontend/components/settings/SettingsModal.svelte
+++ b/frontend/components/settings/SettingsModal.svelte
@@ -34,11 +34,12 @@
 	const isAdmin = $derived(authStore.isAdmin);
 	const isNoAuth = $derived(systemSettings.authMode === 'none');
 
-	// Filter sections: hide admin-only tabs for non-admins, hide team in no-auth mode
+	// Filter sections: hide admin-only tabs for non-admins. Team stays visible for
+	// admins in both modes; the No Login case renders an informational notice
+	// inside the section instead of hiding it.
 	const visibleSections = $derived(
 		settingsSections.filter(s => {
 			if (s.adminOnly && !isAdmin) return false;
-			if (s.id === 'team' && isNoAuth) return false;
 			return true;
 		})
 	);
@@ -200,7 +201,7 @@
 						<div in:fly={{ x: 20, duration: 200 }}>
 							<NotificationSettings />
 						</div>
-					{:else if activeSection === 'tunnel'}
+					{:else if activeSection === 'tunnel' && isAdmin}
 						<div in:fly={{ x: 20, duration: 200 }}>
 							<TunnelSettings />
 						</div>
@@ -216,12 +217,28 @@
 						<div in:fly={{ x: 20, duration: 200 }}>
 							<SystemToolsSettings />
 						</div>
-					{:else if activeSection === 'team' && isAdmin && !isNoAuth}
+					{:else if activeSection === 'team' && isAdmin}
 						<div in:fly={{ x: 20, duration: 200 }}>
-							<TeamSettings />
-							<div class="mt-6">
-								<InviteManagement />
-							</div>
+							{#if isNoAuth}
+								<div class="py-1">
+									<h3 class="text-base font-bold text-slate-900 dark:text-slate-100 mb-1.5">Team</h3>
+									<p class="text-sm text-slate-600 dark:text-slate-500 mb-5">Manage team members and invites</p>
+									<div class="flex items-start gap-3 p-4 bg-amber-500/5 dark:bg-amber-500/10 border border-amber-500/20 rounded-xl">
+										<Icon name="lucide:info" class="w-5 h-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+										<div class="text-sm text-slate-700 dark:text-slate-300">
+											<p class="font-semibold mb-1">Team management is only available in With Login mode</p>
+											<p class="text-slate-600 dark:text-slate-400">
+												The server is currently running in No Login mode, where a single anonymous user has full access. Switch the auth mode to With Login in Settings &rarr; Security to enable user invites, role assignment, and member removal.
+											</p>
+										</div>
+									</div>
+								</div>
+							{:else}
+								<TeamSettings />
+								<div class="mt-6">
+									<InviteManagement />
+								</div>
+							{/if}
 						</div>
 					{:else if activeSection === 'security' && isAdmin}
 						<div in:fly={{ x: 20, duration: 200 }}>

--- a/frontend/components/settings/SettingsView.svelte
+++ b/frontend/components/settings/SettingsView.svelte
@@ -33,8 +33,10 @@
 			<!-- Notification Settings -->
 			<NotificationSettings />
 
-			<!-- Tunnel Settings -->
-			<TunnelSettings />
+			<!-- Tunnel Settings (admin-only) -->
+			{#if isAdmin}
+				<TunnelSettings />
+			{/if}
 
 			<!-- Account (hidden in no-auth mode) -->
 			{#if !isNoAuth}

--- a/frontend/components/tunnel/TunnelActive.svelte
+++ b/frontend/components/tunnel/TunnelActive.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { tunnelStore } from '$frontend/stores/features/tunnel.svelte';
+	import { authStore } from '$frontend/stores/features/auth.svelte';
 	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import TunnelQRCode from './TunnelQRCode.svelte';
 	import { addNotification } from '$frontend/stores/ui/notification.svelte';
@@ -37,6 +38,7 @@
 	);
 	const ingressHostnames = $derived(ingress?.filter((r) => r.hostname) ?? []);
 	const isManagedTunnel = $derived(type === 'remote' || type === 'local');
+	const isAdmin = $derived(authStore.isAdmin);
 
 	// Build a unified list of URL entries for consistent rendering
 	const urlEntries = $derived(() => {
@@ -149,7 +151,7 @@
 					<Icon name="lucide:circle-x" class="w-3.5 h-3.5" />
 					Stop
 				</button>
-			{:else}
+			{:else if isAdmin}
 				<span class="text-2xs text-slate-400 dark:text-slate-500 italic">Managed in Settings</span>
 			{/if}
 		</div>

--- a/frontend/components/tunnel/TunnelModal.svelte
+++ b/frontend/components/tunnel/TunnelModal.svelte
@@ -6,6 +6,7 @@
 	import TunnelActive from './TunnelActive.svelte';
 	import { tunnelStore } from '$frontend/stores/features/tunnel.svelte';
 	import { openSettingsModal } from '$frontend/stores/ui/settings-modal.svelte';
+	import { authStore } from '$frontend/stores/features/auth.svelte';
 	import ws from '$frontend/utils/ws';
 
 	interface Props {
@@ -16,6 +17,7 @@
 	let { isOpen = $bindable(), onClose }: Props = $props();
 
 	const activeTunnels = $derived(tunnelStore.tunnels);
+	const isAdmin = $derived(authStore.isAdmin);
 
 	// Deduplicate tunnels by unique key to prevent each_key_duplicate
 	const uniqueTunnels = $derived(() => {
@@ -87,15 +89,17 @@
 			</div>
 		{/if}
 
-		<!-- Settings hint -->
-		<div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700/30">
-			<Icon name="lucide:info" class="w-3.5 h-3.5 text-slate-400 shrink-0" />
-			<p class="text-xs text-slate-400 dark:text-slate-500">
-				For persistent custom domains, configure tunnels in
-				<button type="button" class="text-violet-600 dark:text-violet-400 hover:underline cursor-pointer font-medium" onclick={goToSettings}>
-					Settings &rarr; Tunnel
-				</button>
-			</p>
-		</div>
+		<!-- Settings hint (admin only — non-admin users cannot access Settings → Tunnel) -->
+		{#if isAdmin}
+			<div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700/30">
+				<Icon name="lucide:info" class="w-3.5 h-3.5 text-slate-400 shrink-0" />
+				<p class="text-xs text-slate-400 dark:text-slate-500">
+					For persistent custom domains, configure tunnels in
+					<button type="button" class="text-violet-600 dark:text-violet-400 hover:underline cursor-pointer font-medium" onclick={goToSettings}>
+						Settings &rarr; Tunnel
+					</button>
+				</p>
+			</div>
+		{/if}
 	</div>
 </Modal>

--- a/frontend/stores/ui/settings-modal.svelte.ts
+++ b/frontend/stores/ui/settings-modal.svelte.ts
@@ -56,7 +56,8 @@ export const settingsSections: SettingsSectionMeta[] = [
 		id: 'tunnel',
 		label: 'Tunnel',
 		icon: 'lucide:globe',
-		description: 'Cloudflare tunnel services'
+		description: 'Cloudflare tunnel services',
+		adminOnly: true
 	},
 	{
 		id: 'appearance',


### PR DESCRIPTION
## Summary
Restrict privileged tunnel routes to admin users and align frontend visibility of admin-only Settings sections.

## Why
Tunnel mutations (Cloudflare credentials, ingress rules, cloudflared auth) are global system operations and must not be reachable by member users. Quick Tunnel stays open since it is ephemeral and stores no credentials.

## Changes
- Enumerate tunnel mutation routes in `ADMIN_ONLY_ROUTES` (consistent with the existing `engine:*` pattern). Quick Tunnel and read-only routes stay open for any authenticated user.
- Hide Settings → Tunnel from non-admin users (`settings-modal.svelte.ts`, `SettingsView.svelte`, `SettingsModal.svelte`).
- Hide the "Settings → Tunnel" hint in `TunnelModal.svelte` for non-admin.
- Gate the "Managed in Settings" hint in `TunnelActive.svelte` for non-admin.
- Keep Settings → Team visible to admins in No Login mode with an in-section notice explaining the feature requires With Login.

## Test plan
- [x] `bun run check` passes
- [x] `bun run lint` passes
- [x] Manual: as member, Settings → Tunnel hidden; Public Tunnel modal opens, Quick Tunnel works, no admin-only error toasts
- [x] Manual: as admin in No Login mode, Settings → Team shows notice
- [x] Manual: as admin in With Login mode, all sections behave unchanged

## Security impact
Closes an authorization gap where any authenticated member could call `tunnel:*` mutations (start/stop, ingress, create/delete, cloudflared login/logout). After this PR these operations require role=admin at the WS auth gate. Read-only tunnel routes remain open by design — same pattern as `engine:*`.

## Notes
Builds on #227 by @DeryFerd, reshaped after review to follow the explicit-enumeration pattern (preserves Quick Tunnel for members) and to fold in matching frontend visibility fixes.