### PR TITLE
feat(auth): add expired session cleanup scheduler

### DIFF
--- a/backend/auth/session-cleanup.ts
+++ b/backend/auth/session-cleanup.ts
@@ -1,0 +1,58 @@
+/**
+ * Expired Session Cleanup Scheduler
+ *
+ * Periodically removes expired auth sessions from the database.
+ * Without this, the auth_sessions table grows unbounded as expired
+ * sessions are never purged in long-running deployments.
+ *
+ * Pattern: same timer + dispose() approach as AuthRateLimiter.
+ */
+
+import { authQueries } from '../database/queries';
+import { debug } from '$shared/utils/logger';
+
+/** How often to sweep for expired sessions (1 hour) */
+const CLEANUP_INTERVAL_MS = 60 * 60_000;
+
+class SessionCleanupScheduler {
+	private timer: ReturnType<typeof setInterval> | null = null;
+
+	constructor() {
+		// Timer is started in start(), not here — database may not be initialized yet.
+	}
+
+	/**
+	 * Start the periodic cleanup timer and run an initial sweep.
+	 * Must be called AFTER database initialization.
+	 */
+	start(): void {
+		if (this.timer) return; // Already started
+		this.timer = setInterval(() => this.cleanup(), CLEANUP_INTERVAL_MS);
+		// Run once at startup so long-stale sessions are cleared immediately
+		this.cleanup();
+	}
+
+	private cleanup(): void {
+		try {
+			const deleted = authQueries.deleteExpiredSessions();
+			if (deleted > 0) {
+				debug.log('auth', `Session cleanup: removed ${deleted} expired session(s)`);
+			}
+		} catch (error) {
+			debug.warn('auth', 'Session cleanup failed:', error);
+		}
+	}
+
+	/**
+	 * Dispose — stop cleanup timer. Called during graceful shutdown.
+	 */
+	dispose(): void {
+		if (this.timer) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+	}
+}
+
+/** Singleton instance — started when the module is imported */
+export const sessionCleanupScheduler = new SessionCleanupScheduler();

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -37,6 +37,7 @@ import { handleMcpRequest, closeMcpServer } from './mcp/remote-server';
 // Auth middleware
 import { checkRouteAccess } from './auth/permissions';
 import { authRateLimiter } from './auth';
+import { sessionCleanupScheduler } from './auth/session-cleanup';
 import { ws as wsServer } from './utils/ws';
 
 // Register auth gate on WebSocket router — blocks unauthenticated/unauthorized access
@@ -141,6 +142,8 @@ async function startServer() {
 	try {
 		await initializeDatabase();
 		debug.log('database', '✅ Database initialized successfully');
+		// Start expired session cleanup now that the database is ready
+		sessionCleanupScheduler.start();
 	} catch (error) {
 		debug.warn('database', '⚠️ Database initialization failed:', error);
 	}
@@ -189,6 +192,8 @@ async function gracefulShutdown() {
 		app.stop();
 		// Dispose rate limiter timer
 		authRateLimiter.dispose();
+		// Dispose expired session cleanup timer
+		sessionCleanupScheduler.dispose();
 		// Close MCP remote server (before engines, as they may still reference it)
 		await closeMcpServer();
 		// Cleanup browser preview sessions


### PR DESCRIPTION
## What's going on

[authQueries.deleteExpiredSessions()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/database/queries/auth-queries.ts:147:1-152:2) exists in the codebase but is never called anywhere. That means once a session token passes its expiry date, it just sits in the `auth_sessions` table forever. In a long-running deployment, this table grows indefinitely — not a crisis, but a slow leak that's easy to fix.

## What this adds

A lightweight [SessionCleanupScheduler](cci:2://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/auth/session-cleanup.ts:16:0-45:1) that:

- Runs [deleteExpiredSessions()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/database/queries/auth-queries.ts:147:1-152:2) once at startup (clears any backlog that accumulated while the server was down)
- Repeats every hour via `setInterval`
- Logs how many sessions were removed (only when > 0, to avoid noise)
- Exposes a [dispose()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/auth/rate-limiter.ts:132:1-140:2) method for graceful shutdown

The pattern mirrors [AuthRateLimiter](cci:2://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/auth/rate-limiter.ts:43:0-141:1) — singleton with a timer, [dispose()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/auth/rate-limiter.ts:132:1-140:2) called during shutdown in [backend/index.ts](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/index.ts:0:0-0:0).

One thing worth noting: the scheduler's [start()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/auth/session-cleanup.ts:23:1-32:2) is called **after** [initializeDatabase()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/database/index.ts:9:0-32:1) completes, not in the constructor. The initial version tried to run cleanup at import time, which failed because the database isn't connected yet when modules are first loaded.

## Files changed

- [backend/auth/session-cleanup.ts](cci:7://file:///d:/Portfolio%20Data/Learning%20PR/clopen/backend/auth/session-cleanup.ts:0:0-0:0) — new file, the scheduler
- [backend/index.ts](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/index.ts:0:0-0:0) — import + [start()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/auth/session-cleanup.ts:23:1-32:2) after DB init + [dispose()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/clopen/backend/auth/rate-limiter.ts:132:1-140:2) in graceful shutdown

## Verified locally

Ran `bun scripts/dev.ts` — server starts clean, no "Database not initialized" errors, scheduler starts after DB init completes as expected.