### PR TITLE
fix(security): standardize access denial error messages

### DIFF
--- a/backend/auth/auth-service.ts
+++ b/backend/auth/auth-service.ts
@@ -492,11 +492,11 @@ export function listUserProjects(userId: string): Project[] {
 export function assignProjectToUser(userId: string, projectId: string): boolean {
 	const user = authQueries.getUserById(userId);
 	if (!user) {
-		throw new Error('User not found');
+		throw new Error('Access denied');
 	}
 	const project = projectQueries.getById(projectId);
 	if (!project) {
-		throw new Error('Project not found');
+		throw new Error('Access denied');
 	}
 	if (projectQueries.userHasProject(userId, projectId)) {
 		return false;
@@ -513,11 +513,11 @@ export function assignProjectToUser(userId: string, projectId: string): boolean 
 export function unassignProjectFromUser(userId: string, projectId: string): boolean {
 	const user = authQueries.getUserById(userId);
 	if (!user) {
-		throw new Error('User not found');
+		throw new Error('Access denied');
 	}
 	const project = projectQueries.getById(projectId);
 	if (!project) {
-		throw new Error('Project not found');
+		throw new Error('Access denied');
 	}
 	if (!projectQueries.userHasProject(userId, projectId)) {
 		return false;

--- a/backend/ws/access.ts
+++ b/backend/ws/access.ts
@@ -7,12 +7,12 @@ export function requireProjectAccess(conn: WSConnection, projectId: string): Pro
 	const userId = ws.getUserId(conn);
 	const hasAccess = projectQueries.userHasProject(userId, projectId);
 	if (!hasAccess) {
-		throw new Error('Project not found');
+		throw new Error('Access denied');
 	}
 
 	const project = projectQueries.getById(projectId);
 	if (!project) {
-		throw new Error('Project not found');
+		throw new Error('Access denied');
 	}
 
 	return project;
@@ -32,13 +32,13 @@ export function requireCurrentProjectAccess(conn: WSConnection): {
 export function requireSessionAccess(conn: WSConnection, sessionId: string): ChatSession {
 	const session = sessionQueries.getById(sessionId);
 	if (!session) {
-		throw new Error('Session not found');
+		throw new Error('Access denied');
 	}
 
 	const userId = ws.getUserId(conn);
 	const hasAccess = projectQueries.userHasProject(userId, session.project_id);
 	if (!hasAccess) {
-		throw new Error('Session not found');
+		throw new Error('Access denied');
 	}
 
 	return session;
@@ -47,7 +47,7 @@ export function requireSessionAccess(conn: WSConnection, sessionId: string): Cha
 export function requireMessageAccess(conn: WSConnection, messageId: string): DatabaseMessage {
 	const message = messageQueries.getById(messageId);
 	if (!message) {
-		throw new Error('Message not found');
+		throw new Error('Access denied');
 	}
 
 	// Message access inherits session access controls.

--- a/backend/ws/files/path-access.ts
+++ b/backend/ws/files/path-access.ts
@@ -16,7 +16,7 @@ function isPathInside(rootPath: string, candidatePath: string): boolean {
 export function requireProjectPathAccess(conn: WSConnection, projectPath: string): Project {
 	const project = projectQueries.getByPath(projectPath);
 	if (!project) {
-		throw new Error('Project not found');
+		throw new Error('Access denied');
 	}
 	if (ws.getRole(conn) === 'admin') {
 		return project;
@@ -35,7 +35,7 @@ export function requireFilePathAccess(conn: WSConnection, filePath: string): str
 
 	const hasAccess = projects.some((project) => isPathInside(project.path, normalizedPath));
 	if (!hasAccess) {
-		throw new Error('File path is outside accessible projects');
+		throw new Error('Access denied');
 	}
 
 	return normalizedPath;
@@ -61,7 +61,7 @@ export function requireSharedFilePathAccess(conn: WSConnection, filePath: string
 		if (projectRoot === normalizedPath) continue; // equality is handled below
 		if (!isPathInside(normalizedPath, project.path)) continue;
 		if (!projectQueries.userHasProject(userId, project.id)) {
-			throw new Error('File path contains another project');
+			throw new Error('Access denied');
 		}
 	}
 
@@ -82,7 +82,7 @@ export function requireSharedFilePathAccess(conn: WSConnection, filePath: string
 
 	const hasAccess = projectQueries.userHasProject(userId, containing.id);
 	if (!hasAccess) {
-		throw new Error('File path is inside another project');
+		throw new Error('Access denied');
 	}
 	return normalizedPath;
 }

--- a/backend/ws/files/read.ts
+++ b/backend/ws/files/read.ts
@@ -185,7 +185,7 @@ export const readHandler = createRouter()
 	}, async ({ data, conn }) => {
 		requireProjectAccess(conn, data.projectId);
 		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Project not found');
+		if (!project) throw new Error('Access denied');
 
 		const ref = data.ref || 'HEAD';
 

--- a/backend/ws/files/watch.ts
+++ b/backend/ws/files/watch.ts
@@ -25,7 +25,7 @@ export const watchHandler = createRouter()
 		const { projectPath } = data;
 
 		const project = projectQueries.getByPath(projectPath);
-		if (!project) throw new Error('Project not found');
+		if (!project) throw new Error('Access denied');
 		requireProjectAccess(conn, project.id);
 		const projectId = project.id;
 

--- a/backend/ws/preview/browser/console.ts
+++ b/backend/ws/preview/browser/console.ts
@@ -33,7 +33,7 @@ export const consolePreviewHandler = createRouter()
 		const success = previewService.clearConsoleLogs(tab.id);
 
 		if (!success) {
-			throw new Error('Session not found');
+			throw new Error('Access denied');
 		}
 
 		return { message: 'Console logs cleared' };
@@ -69,7 +69,7 @@ export const consolePreviewHandler = createRouter()
 		const success = previewService.toggleConsoleLogging(tab.id, data.enabled);
 
 		if (!success) {
-			throw new Error('Session not found');
+			throw new Error('Access denied');
 		}
 
 		return {

--- a/backend/ws/sessions/crud.ts
+++ b/backend/ws/sessions/crud.ts
@@ -398,7 +398,7 @@ export const crudHandler = createRouter()
 		const session = requireSessionAccess(conn, data.sessionId);
 		requireProjectAccess(conn, data.projectId);
 		if (session.project_id !== data.projectId) {
-			throw new Error('Session not found');
+			throw new Error('Access denied');
 		}
 		sessionQueries.markUnread(userId, data.sessionId, data.projectId);
 		debug.log('session', `[unread] Marked session ${data.sessionId} as UNREAD for user ${userId} in project ${data.projectId}`);

--- a/backend/ws/terminal/access.ts
+++ b/backend/ws/terminal/access.ts
@@ -17,7 +17,7 @@ type TerminalStream = NonNullable<ReturnType<typeof terminalStreamManager.getStr
 export function requirePtySessionAccess(conn: WSConnection, sessionId: string): PtySession {
 	const session = ptySessionManager.getSession(sessionId);
 	if (!session || !session.projectId) {
-		throw new Error('Session not found');
+		throw new Error('Access denied');
 	}
 	requireProjectAccess(conn, session.projectId);
 	return session;
@@ -26,7 +26,7 @@ export function requirePtySessionAccess(conn: WSConnection, sessionId: string): 
 export function requireTerminalStreamAccess(conn: WSConnection, streamId: string): TerminalStream {
 	const stream = terminalStreamManager.getStream(streamId);
 	if (!stream || !stream.projectId) {
-		throw new Error('Stream not found');
+		throw new Error('Access denied');
 	}
 	requireProjectAccess(conn, stream.projectId);
 	return stream;
@@ -49,7 +49,7 @@ export function requireTerminalLookupAccess(
 
 	const projectId = session?.projectId || stream?.projectId;
 	if (!projectId) {
-		throw new Error('Session not found');
+		throw new Error('Access denied');
 	}
 	requireProjectAccess(conn, projectId);
 	return { projectId, stream, session };

--- a/backend/ws/terminal/persistence.ts
+++ b/backend/ws/terminal/persistence.ts
@@ -88,7 +88,7 @@ export const persistenceHandler = createRouter()
 			const fallbackProjectId = ws.getProjectId(conn);
 			ws.emit.project(fallbackProjectId, 'terminal:error', {
 				sessionId,
-				error: 'Stream not found'
+				error: 'Access denied'
 			});
 			return;
 		}

--- a/backend/ws/terminal/session.ts
+++ b/backend/ws/terminal/session.ts
@@ -58,7 +58,7 @@ export const sessionHandler = createRouter()
 		// caller's current project. Prevents hijacking another project's PTY id.
 		const existingForOwnership = ptySessionManager.getSession(sessionId);
 		if (existingForOwnership && existingForOwnership.projectId && existingForOwnership.projectId !== projectId) {
-			throw new Error('Session not found');
+			throw new Error('Access denied');
 		}
 
 		debug.log('terminal', `🌐 WebSocket: Creating PTY session: ${sessionId}`);
@@ -313,7 +313,7 @@ export const sessionHandler = createRouter()
 			debug.log('terminal', `💀 [kill-session] No active PTY session found for: ${sessionId}`);
 			return { sessionId };
 		}
-		if (!session.projectId) throw new Error('Session not found');
+		if (!session.projectId) throw new Error('Access denied');
 		requireProjectAccess(conn, session.projectId);
 
 		debug.log('terminal', `💀 [kill-session] Killing PTY session: ${sessionId}`);


### PR DESCRIPTION
Access denial errors previously distinguished "doesn't exist" from "no access," giving attackers a probe oracle to enumerate resources by observing which error variant they got back.

Standardized all access denial paths to throw or emit `"Access denied"` so the message text no longer discloses resource existence.

## Changes

22 sites across 10 files:

- `backend/auth/auth-service.ts` (2 locations) — `assignProjectToUser`, `unassignProjectFromUser`
- `backend/ws/access.ts` (5 locations) — `requireProjectAccess`, `requireSessionAccess`, `requireMessageAccess`
- `backend/ws/files/path-access.ts` (4 locations) — `requireProjectPathAccess`, `requireFilePathAccess`, `requireSharedFilePathAccess`
- `backend/ws/files/read.ts` (1 location)
- `backend/ws/files/watch.ts` (1 location)
- `backend/ws/sessions/crud.ts` (1 location)
- `backend/ws/terminal/access.ts` (3 locations) — `requirePtySessionAccess`, `requireTerminalStreamAccess`, `requireTerminalLookupAccess`
- `backend/ws/terminal/session.ts` (2 locations)
- `backend/ws/terminal/persistence.ts` (1 location) — `terminal:reconnect` emit
- `backend/ws/preview/browser/console.ts` (2 locations)

## Security impact

**Threat:** any authenticated member or unauthenticated visitor with WS access could distinguish "resource doesn't exist" from "resource exists but you have no access" by reading the error message text. This enabled enumeration of project IDs and paths, session IDs, message IDs, terminal session/stream IDs, and file paths inside other users' projects.

**Closed by this PR:** every access denial path now returns `"Access denied"` uniformly across throws and event emits. The message text no longer discloses resource existence.

**Out of scope:** timing-based existence inference (the cryptographic token storage already defeats this — see review discussion); HTTP status code variation (responses wrap uniformly as \`{ success: false }\` regardless).

## Testing

- \`bun run check\` passes (0 errors, 0 warnings).
- \`bun run lint\` passes clean.
- Verified the frontend dead-terminal-tab auto-close (\`frontend/stores/features/terminal.svelte.ts:498\`) is unaffected — it keys on \`"Session not found or PTY not available"\` emitted from \`backend/ws/terminal/stream.ts:40\`, which signals a runtime PTY write failure rather than an authorization decision and is intentionally left unchanged.

Addresses FINDING-004 from repository audit.