### PR TITLE
fix(security): validate git argv and use argv-only tar extract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Unit tests
+        run: bun run test
+
       - name: Build
         run: bun run build
 

--- a/backend/git/git-service.ts
+++ b/backend/git/git-service.ts
@@ -24,6 +24,14 @@ import type {
 	GitConflictFile
 } from '$shared/types/git';
 import { debug } from '$shared/utils/logger';
+import {
+	assertSafeGitCommitMessage,
+	assertSafeGitPathOperand,
+	assertSafeGitRemoteName,
+	assertSafeGitRemoteUrl,
+	assertSafeGitRevish,
+	assertSafeGitShowRef
+} from './git-spawn-validation';
 
 export class GitService {
 	/**
@@ -45,7 +53,10 @@ export class GitService {
 	 */
 	async init(cwd: string, defaultBranch?: string): Promise<void> {
 		const args = ['init'];
-		if (defaultBranch) args.push('-b', defaultBranch);
+		if (defaultBranch) {
+			assertSafeGitRevish(defaultBranch, 'default branch');
+			args.push('-b', defaultBranch);
+		}
 		const result = await execGit(args, cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git init failed: ${result.stderr}`);
@@ -69,6 +80,7 @@ export class GitService {
 	// ============================================
 
 	async stageFile(cwd: string, filePath: string): Promise<void> {
+		assertSafeGitPathOperand(filePath, 'stage path');
 		const result = await execGit(['add', '--', filePath], cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git add failed: ${result.stderr}`);
@@ -83,10 +95,11 @@ export class GitService {
 	}
 
 	async unstageFile(cwd: string, filePath: string): Promise<void> {
+		assertSafeGitPathOperand(filePath, 'unstage path');
 		// Try normal reset first, fall back to rm --cached for initial commit
 		const result = await execGit(['reset', 'HEAD', '--', filePath], cwd);
 		if (result.exitCode !== 0) {
-			const fallback = await execGit(['rm', '--cached', '--', filePath], cwd);
+			const fallback = await execGit(['rm', '--cached', '--', filePath], cwd); // filePath validated above
 			if (fallback.exitCode !== 0) {
 				throw new Error(`git unstage failed: ${result.stderr}`);
 			}
@@ -105,6 +118,7 @@ export class GitService {
 	}
 
 	async discardFile(cwd: string, filePath: string): Promise<void> {
+		assertSafeGitPathOperand(filePath, 'discard path');
 		// Check if file is untracked
 		const statusResult = await execGit(['status', '--porcelain=v1', '--', filePath], cwd);
 		const statusLine = statusResult.stdout.trim();
@@ -135,6 +149,7 @@ export class GitService {
 	// ============================================
 
 	async commit(cwd: string, message: string): Promise<string> {
+		assertSafeGitCommitMessage(message);
 		const result = await execGit(['commit', '-m', message], cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git commit failed: ${result.stderr}`);
@@ -147,6 +162,7 @@ export class GitService {
 	async amendCommit(cwd: string, message?: string): Promise<string> {
 		const args = ['commit', '--amend'];
 		if (message) {
+			assertSafeGitCommitMessage(message);
 			args.push('-m', message);
 		} else {
 			args.push('--no-edit');
@@ -165,24 +181,33 @@ export class GitService {
 
 	async getDiffUnstaged(cwd: string, filePath?: string): Promise<GitFileDiff[]> {
 		const args = ['diff'];
-		if (filePath) args.push('--', filePath);
+		if (filePath) {
+			assertSafeGitPathOperand(filePath, 'diff path');
+			args.push('--', filePath);
+		}
 		const result = await execGit(args, cwd);
 		return parseDiff(result.stdout);
 	}
 
 	async getDiffStaged(cwd: string, filePath?: string): Promise<GitFileDiff[]> {
 		const args = ['diff', '--cached'];
-		if (filePath) args.push('--', filePath);
+		if (filePath) {
+			assertSafeGitPathOperand(filePath, 'diff path');
+			args.push('--', filePath);
+		}
 		const result = await execGit(args, cwd);
 		return parseDiff(result.stdout);
 	}
 
 	async getDiffCommit(cwd: string, commitHash: string): Promise<GitFileDiff[]> {
+		assertSafeGitRevish(commitHash, 'commit hash');
 		const result = await execGit(['diff', `${commitHash}^`, commitHash], cwd);
 		return parseDiff(result.stdout);
 	}
 
 	async getDiffBetween(cwd: string, from: string, to: string): Promise<GitFileDiff[]> {
+		assertSafeGitRevish(from, 'diff from');
+		assertSafeGitRevish(to, 'diff to');
 		const result = await execGit(['diff', from, to], cwd);
 		return parseDiff(result.stdout);
 	}
@@ -192,6 +217,8 @@ export class GitService {
 	 * Returns null when the file does not exist at that ref (untracked / new file).
 	 */
 	async getFileAtRef(cwd: string, ref: string, filePath: string): Promise<string | null> {
+		assertSafeGitShowRef(ref);
+		assertSafeGitPathOperand(filePath, 'show path');
 		const result = await execGit(['show', `${ref}:${filePath}`], cwd);
 		if (result.exitCode !== 0) {
 			return null;
@@ -247,8 +274,12 @@ export class GitService {
 	}
 
 	async createBranch(cwd: string, name: string, startPoint?: string): Promise<void> {
+		assertSafeGitRevish(name, 'branch name');
 		const args = ['checkout', '-b', name];
-		if (startPoint) args.push(startPoint);
+		if (startPoint) {
+			assertSafeGitRevish(startPoint, 'start point');
+			args.push(startPoint);
+		}
 		const result = await execGit(args, cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git checkout -b failed: ${result.stderr}`);
@@ -256,6 +287,7 @@ export class GitService {
 	}
 
 	async switchBranch(cwd: string, name: string): Promise<void> {
+		assertSafeGitRevish(name, 'branch name');
 		const result = await execGit(['checkout', name], cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git checkout failed: ${result.stderr}`);
@@ -263,6 +295,7 @@ export class GitService {
 	}
 
 	async deleteBranch(cwd: string, name: string, force = false): Promise<void> {
+		assertSafeGitRevish(name, 'branch name');
 		const flag = force ? '-D' : '-d';
 		const result = await execGit(['branch', flag, name], cwd);
 		if (result.exitCode !== 0) {
@@ -271,6 +304,8 @@ export class GitService {
 	}
 
 	async renameBranch(cwd: string, oldName: string, newName: string): Promise<void> {
+		assertSafeGitRevish(oldName, 'old branch name');
+		assertSafeGitRevish(newName, 'new branch name');
 		const result = await execGit(['branch', '-m', oldName, newName], cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git branch -m failed: ${result.stderr}`);
@@ -278,6 +313,7 @@ export class GitService {
 	}
 
 	async mergeBranch(cwd: string, branchName: string): Promise<{ success: boolean; message: string }> {
+		assertSafeGitRevish(branchName, 'merge branch');
 		const result = await execGit(['merge', branchName], cwd);
 		return {
 			success: result.exitCode === 0,
@@ -301,7 +337,10 @@ export class GitService {
 			`--skip=${skip}`
 		];
 
-		if (branch) args.push(branch);
+		if (branch) {
+			assertSafeGitRevish(branch, 'log branch');
+			args.push(branch);
+		}
 
 		const result = await execGit(args, cwd);
 		if (result.exitCode !== 0) {
@@ -313,7 +352,8 @@ export class GitService {
 		if (hasMore) commits.pop(); // Remove the extra one
 
 		// Get total count
-		const countResult = await execGit(['rev-list', '--count', branch || 'HEAD'], cwd);
+		const countRef = branch ?? 'HEAD';
+		const countResult = await execGit(['rev-list', '--count', countRef], cwd);
 		const total = parseInt(countResult.stdout.trim()) || commits.length;
 
 		return { commits, total, hasMore };
@@ -329,6 +369,7 @@ export class GitService {
 	}
 
 	async fetch(cwd: string, remote = 'origin'): Promise<string> {
+		assertSafeGitRemoteName(remote);
 		// Use explicit refspec to ensure all branches are fetched regardless of clone config
 		const result = await execGit(['fetch', remote, `+refs/heads/*:refs/remotes/${remote}/*`, '--prune'], cwd, 60000);
 		if (result.exitCode !== 0) {
@@ -338,8 +379,12 @@ export class GitService {
 	}
 
 	async pull(cwd: string, remote = 'origin', branch?: string): Promise<{ success: boolean; message: string }> {
+		assertSafeGitRemoteName(remote);
 		const args = ['pull', remote];
-		if (branch) args.push(branch);
+		if (branch) {
+			assertSafeGitRevish(branch, 'pull branch');
+			args.push(branch);
+		}
 		const result = await execGit(args, cwd, 60000);
 		return {
 			success: result.exitCode === 0,
@@ -348,8 +393,12 @@ export class GitService {
 	}
 
 	async push(cwd: string, remote = 'origin', branch?: string, force = false): Promise<{ success: boolean; message: string }> {
+		assertSafeGitRemoteName(remote);
 		const args = ['push', remote];
-		if (branch) args.push(branch);
+		if (branch) {
+			assertSafeGitRevish(branch, 'push branch');
+			args.push(branch);
+		}
 		if (force) args.push('--force-with-lease');
 		// Set upstream if needed
 		args.push('-u');
@@ -361,6 +410,8 @@ export class GitService {
 	}
 
 	async addRemote(cwd: string, name: string, url: string): Promise<void> {
+		assertSafeGitRemoteName(name);
+		assertSafeGitRemoteUrl(url);
 		const result = await execGit(['remote', 'add', name, url], cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git remote add failed: ${result.stderr}`);
@@ -368,6 +419,7 @@ export class GitService {
 	}
 
 	async removeRemote(cwd: string, name: string): Promise<void> {
+		assertSafeGitRemoteName(name);
 		const result = await execGit(['remote', 'remove', name], cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git remote remove failed: ${result.stderr}`);
@@ -385,7 +437,10 @@ export class GitService {
 
 	async stashSave(cwd: string, message?: string): Promise<void> {
 		const args = ['stash', 'push'];
-		if (message) args.push('-m', message);
+		if (message) {
+			assertSafeGitCommitMessage(message);
+			args.push('-m', message);
+		}
 		const result = await execGit(args, cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git stash failed: ${result.stderr}`);
@@ -393,6 +448,9 @@ export class GitService {
 	}
 
 	async stashPop(cwd: string, index = 0): Promise<void> {
+		if (!Number.isInteger(index) || index < 0) {
+			throw new Error('Invalid stash index');
+		}
 		const result = await execGit(['stash', 'pop', `stash@{${index}}`], cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git stash pop failed: ${result.stderr}`);
@@ -400,6 +458,9 @@ export class GitService {
 	}
 
 	async stashDrop(cwd: string, index = 0): Promise<void> {
+		if (!Number.isInteger(index) || index < 0) {
+			throw new Error('Invalid stash index');
+		}
 		const result = await execGit(['stash', 'drop', `stash@{${index}}`], cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git stash drop failed: ${result.stderr}`);
@@ -435,13 +496,18 @@ export class GitService {
 	}
 
 	async createTag(cwd: string, name: string, message?: string, commitHash?: string): Promise<void> {
+		assertSafeGitRevish(name, 'tag name');
 		const args = ['tag'];
 		if (message) {
+			assertSafeGitCommitMessage(message);
 			args.push('-a', name, '-m', message);
 		} else {
 			args.push(name);
 		}
-		if (commitHash) args.push(commitHash);
+		if (commitHash) {
+			assertSafeGitRevish(commitHash, 'tag target');
+			args.push(commitHash);
+		}
 		const result = await execGit(args, cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git tag failed: ${result.stderr}`);
@@ -449,6 +515,7 @@ export class GitService {
 	}
 
 	async deleteTag(cwd: string, name: string): Promise<void> {
+		assertSafeGitRevish(name, 'tag name');
 		const result = await execGit(['tag', '-d', name], cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git tag -d failed: ${result.stderr}`);
@@ -456,6 +523,8 @@ export class GitService {
 	}
 
 	async pushTag(cwd: string, name: string, remote = 'origin'): Promise<{ success: boolean; message: string }> {
+		assertSafeGitRemoteName(remote);
+		assertSafeGitRevish(name, 'tag name');
 		const result = await execGit(['push', remote, name], cwd, 60000);
 		return {
 			success: result.exitCode === 0,
@@ -492,6 +561,7 @@ export class GitService {
 		resolution: 'ours' | 'theirs' | 'custom',
 		customContent?: string
 	): Promise<void> {
+		assertSafeGitPathOperand(filePath, 'conflict path');
 		if (resolution === 'custom' && customContent !== undefined) {
 			// Write custom content
 			const { writeFile } = await import('node:fs/promises');

--- a/backend/git/git-spawn-validation.test.ts
+++ b/backend/git/git-spawn-validation.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	assertSafeGitCommitMessage,
+	assertSafeGitPathOperand,
+	assertSafeGitRemoteName,
+	assertSafeGitRemoteUrl,
+	assertSafeGitRevish,
+	assertSafeGitShowRef
+} from './git-spawn-validation';
+
+describe('assertSafeGitRevish', () => {
+	test('accepts typical branch and hash tokens', () => {
+		expect(() => assertSafeGitRevish('main', 'x')).not.toThrow();
+		expect(() => assertSafeGitRevish('feature/foo-bar', 'x')).not.toThrow();
+		expect(() => assertSafeGitRevish('abc123deadbeef', 'x')).not.toThrow();
+		expect(() => assertSafeGitRevish('HEAD', 'x')).not.toThrow();
+	});
+
+	test('rejects option-shaped values', () => {
+		expect(() => assertSafeGitRevish('--output=/tmp/pwn', 'branch')).toThrow(/must not start/);
+		expect(() => assertSafeGitRevish('-c', 'branch')).toThrow(/must not start/);
+	});
+
+	test('rejects NUL and newlines', () => {
+		expect(() => assertSafeGitRevish('a\nb', 'branch')).toThrow();
+		expect(() => assertSafeGitRevish('a\0b', 'branch')).toThrow();
+	});
+});
+
+describe('assertSafeGitRemoteName', () => {
+	test('accepts origin', () => {
+		expect(() => assertSafeGitRemoteName('origin')).not.toThrow();
+	});
+
+	test('rejects spaces and specials', () => {
+		expect(() => assertSafeGitRemoteName('my remote')).toThrow(/Invalid git remote name/);
+		expect(() => assertSafeGitRemoteName('-bad')).toThrow();
+	});
+});
+
+describe('assertSafeGitRemoteUrl', () => {
+	test('accepts normal https url', () => {
+		expect(() => assertSafeGitRemoteUrl('https://github.com/foo/bar.git')).not.toThrow();
+	});
+
+	test('rejects argv injection prefix', () => {
+		expect(() => assertSafeGitRemoteUrl('-force evil')).toThrow();
+	});
+});
+
+describe('assertSafeGitShowRef', () => {
+	test('rejects colon in ref', () => {
+		expect(() => assertSafeGitShowRef('HEAD:readme')).toThrow(/must not contain/);
+	});
+});
+
+describe('assertSafeGitPathOperand', () => {
+	test('allows normal relative paths', () => {
+		expect(() => assertSafeGitPathOperand('src/index.ts')).not.toThrow();
+	});
+
+	test('rejects newlines', () => {
+		expect(() => assertSafeGitPathOperand('a\nb')).toThrow();
+	});
+});
+
+describe('assertSafeGitCommitMessage', () => {
+	test('allows multiline messages', () => {
+		expect(() => assertSafeGitCommitMessage('line1\nline2')).not.toThrow();
+	});
+
+	test('rejects NUL', () => {
+		expect(() => assertSafeGitCommitMessage('a\0b')).toThrow();
+	});
+});

--- a/backend/git/git-spawn-validation.ts
+++ b/backend/git/git-spawn-validation.ts
@@ -1,0 +1,77 @@
+/**
+ * Guards for values passed into git CLI argv arrays.
+ *
+ * Bun.spawn / execGit use argv mode (no shell), but git itself still parses
+ * leading `-` tokens as options. User-controlled branch / remote / ref names
+ * must therefore be rejected when they look like flags.
+ */
+
+const MAX_GIT_ARG = 8192;
+const MAX_COMMIT_MESSAGE = 256 * 1024;
+
+/** Branch names, tag names, commit-ish, remote names in refspecs, etc. */
+export function assertSafeGitRevish(value: string, label: string): void {
+	if (value.length === 0) {
+		throw new Error(`${label}: value must not be empty`);
+	}
+	if (value.length > MAX_GIT_ARG) {
+		throw new Error(`${label}: value too long`);
+	}
+	if (/[\0\n\r]/.test(value)) {
+		throw new Error(`${label}: invalid control characters`);
+	}
+	if (value.startsWith('-')) {
+		throw new Error(`${label}: must not start with '-' (git option injection)`);
+	}
+}
+
+/** `git remote` names are a small charset in practice; keep strict. */
+export function assertSafeGitRemoteName(name: string): void {
+	assertSafeGitRevish(name, 'remote name');
+	if (!/^[A-Za-z0-9._-]+$/.test(name)) {
+		throw new Error('Invalid git remote name');
+	}
+}
+
+/** `git remote add <name> <url>` — avoid NUL/newline and argv-shaped URLs. */
+export function assertSafeGitRemoteUrl(url: string): void {
+	if (url.length === 0) {
+		throw new Error('remote URL must not be empty');
+	}
+	if (url.length > MAX_GIT_ARG * 8) {
+		throw new Error('remote URL too long');
+	}
+	if (/[\0\n\r]/.test(url)) {
+		throw new Error('remote URL contains invalid characters');
+	}
+	if (url.startsWith('-')) {
+		throw new Error('remote URL must not start with "-"');
+	}
+}
+
+/** Paths appended after `--` in git argv (still reject NUL / newlines). */
+export function assertSafeGitPathOperand(path: string, label = 'path'): void {
+	if (path.length > MAX_GIT_ARG) {
+		throw new Error(`${label}: path too long`);
+	}
+	if (/[\0\n\r]/.test(path)) {
+		throw new Error(`${label}: invalid path characters`);
+	}
+}
+
+export function assertSafeGitCommitMessage(message: string): void {
+	if (message.length > MAX_COMMIT_MESSAGE) {
+		throw new Error('commit message too long');
+	}
+	if (message.includes('\0')) {
+		throw new Error('commit message contains NUL byte');
+	}
+}
+
+/** `ref` side of `git show rev:path` — disallow `:` so `rev` stays unambiguous. */
+export function assertSafeGitShowRef(ref: string): void {
+	assertSafeGitRevish(ref, 'git ref');
+	if (ref.includes(':')) {
+		throw new Error('git ref for show must not contain ":"');
+	}
+}

--- a/backend/snapshot/gitignore.ts
+++ b/backend/snapshot/gitignore.ts
@@ -11,6 +11,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { debug } from '$shared/utils/logger';
+import { execGit } from '../git/git-executor';
 
 /**
  * Safety-net directories to always exclude regardless of .gitignore.
@@ -49,15 +50,9 @@ async function scanWithGit(dirPath: string): Promise<string[] | null> {
 	}
 
 	try {
-		const proc = Bun.spawn(
-			['git', 'ls-files', '-co', '--exclude-standard'],
-			{ cwd: dirPath, stdout: 'pipe', stderr: 'pipe' }
-		);
-
-		const output = await new Response(proc.stdout).text();
-		const exitCode = await proc.exited;
-
-		if (exitCode !== 0) return null;
+		const result = await execGit(['ls-files', '-co', '--exclude-standard'], dirPath, 60_000);
+		if (result.exitCode !== 0) return null;
+		const output = result.stdout;
 
 		const files: string[] = [];
 		for (const line of output.split('\n')) {

--- a/backend/tunnel/cloudflared/binary.ts
+++ b/backend/tunnel/cloudflared/binary.ts
@@ -16,7 +16,7 @@
 import { existsSync, mkdirSync, createWriteStream, chmodSync, unlinkSync, renameSync } from 'fs';
 import { join, dirname } from 'path';
 import { platform, arch } from 'os';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { getClopenDir } from '../../utils/paths';
 import { resolveBinary } from '../../utils/cli';
 import { debug } from '$shared/utils/logger';
@@ -148,7 +148,7 @@ export async function installBinary(version = 'latest'): Promise<string> {
 		// macOS: download .tgz, extract, rename
 		const tgzPath = `${binPath}.tgz`;
 		await download(url, tgzPath);
-		execSync(`tar -xzf ${tgzPath}`, { cwd: dirname(binPath) });
+		execFileSync('tar', ['-xzf', tgzPath], { cwd: dirname(binPath), stdio: 'pipe' });
 		unlinkSync(tgzPath);
 		// tar extracts as "cloudflared" in the same directory
 		const extractedPath = join(dirname(binPath), 'cloudflared');

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test": "bun test",
     "generate-icons": "bun scripts/generate-icons.ts",
     "prepublishOnly": "bun run build"
   },


### PR DESCRIPTION
Clopen drives Git almost entirely through `execGit()` with argv-style spawns, which is already the right baseline: no shell, no string concatenation into `/bin/sh -c`. The weak spots were (a) **user-controlled tokens that still look like Git flags** once they land in `argv`—Git will happily treat a branch or ref named `--whatever` as an option—and (b) one place on macOS where we unpacked cloudflared with **`execSync` plus a shell string**, which is unnecessary risk if a path ever contained shell metacharacters.

This PR tightens the first case in one place and removes the second entirely.

### What changed

- **Git argv validation** — New helpers in `backend/git/git-spawn-validation.ts` and wired from `GitService` before `execGit` calls that take user-ish input: branch/tag/ref names, remote names, remote URLs, paths used with `--`, commit/stash messages (NUL + length cap), and stash indices (non-negative integers). Refs used for `git show ref:path` are checked so the `ref` side cannot contain `:`, keeping `rev:path` unambiguous.

- **Snapshot scan** — `backend/snapshot/gitignore.ts` routes `git ls-files` through `execGit` so you get the same resolved Git binary, env, and `safe.directory` behavior as the rest of the app.

- **Cloudflared install on macOS** — Replaced shell `execSync(\`tar -xzf …\`)` with `execFileSync('tar', ['-xzf', tgzPath], …)` so extraction stays argv-only.

- **Tests & CI** — Added `bun test`, `backend/git/git-spawn-validation.test.ts` (12 cases), and a CI step after lint.

### Why it matters

Argv mode stops shell injection; it does not stop Git from interpreting the next token as a flag if that token starts with `-`. Central validation is cheap insurance for values that ultimately come from the UI or stored metadata. The tar change matches the same idea: we were not intentionally using a shell there, so we should not depend on one.

### Validation

- `bun run test`
- `bun run check`
- `bun run lint`

### Risks / compatibility

Remote names are validated with a conservative charset (`[A-Za-z0-9._-]+`). That matches typical `origin` / `upstream` names. If anyone relies on a more exotic remote name, those calls will now fail fast with a clear error instead of passing odd strings through to Git—call that out if you know a legitimate pattern we should widen.