### PR TITLE
fix(auth): restrict global logout-all to admins

### DIFF
--- a/backend/auth/permissions.test.ts
+++ b/backend/auth/permissions.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { ADMIN_ONLY_ROUTES, checkRouteAccess } from './permissions';
+
+describe('ADMIN_ONLY_ROUTES', () => {
+	test('includes high-impact global routes', () => {
+		const expectedAdminRoutes = [
+			'auth:logout-all',
+			'system:clear-data',
+			'settings:update',
+			'engine:codex-restart',
+			'tunnel:remote:start'
+		];
+
+		for (const action of expectedAdminRoutes) {
+			expect(ADMIN_ONLY_ROUTES.has(action)).toBe(true);
+		}
+	});
+});
+
+describe('checkRouteAccess', () => {
+	test('denies non-admin users from auth:logout-all', () => {
+		const result = checkRouteAccess('auth:logout-all', true, 'member');
+		expect(result).toEqual({ allowed: false, error: 'Admin access required' });
+	});
+
+	test('allows admin users to call auth:logout-all', () => {
+		const result = checkRouteAccess('auth:logout-all', true, 'admin');
+		expect(result).toEqual({ allowed: true });
+	});
+});

--- a/backend/auth/permissions.ts
+++ b/backend/auth/permissions.ts
@@ -21,6 +21,8 @@ export const PUBLIC_ROUTES = new Set([
 
 /** Routes that require admin role */
 export const ADMIN_ONLY_ROUTES = new Set([
+	// Auth session controls with global impact.
+	'auth:logout-all',
 	'auth:create-invite',
 	'auth:list-invites',
 	'auth:revoke-invite',


### PR DESCRIPTION
## Summary

This PR closes an authorization gap where `auth:logout-all` could be triggered by any authenticated user.  
The route now requires admin privileges, and regression tests were added to prevent future route-permission drift.

## Why This Change

`auth:logout-all` has global impact:
- invalidates all sessions
- broadcasts a force-logout event to all connected clients

Without explicit admin gating, a non-admin member could force all users (including admins) to be logged out.  
This is a privilege-boundary issue and should be restricted to admins only.

## What Changed

- Added `auth:logout-all` to the admin-only route set in:
  - `backend/auth/permissions.ts`
- Added focused regression tests in:
  - `backend/auth/permissions.test.ts`
- Test coverage now verifies:
  - `auth:logout-all` is included in `ADMIN_ONLY_ROUTES`
  - non-admin users are denied for `auth:logout-all`
  - admin users are allowed for `auth:logout-all`
  - key high-impact routes remain explicitly admin-only

## Validation

Executed locally:

- `bun test` (pass)
- `bun run check` (pass, 0 errors/warnings)
- `bun run lint` (pass)

## Risk / Compatibility

- Low risk for normal flows.
- Intended behavior change: non-admin users can no longer call `auth:logout-all`.
- No schema or migration changes.
