### PR TITLE
fix(files): enforce server-side access guard for browse-path

### DIFF
--- a/backend/ws/files/read.ts
+++ b/backend/ws/files/read.ts
@@ -25,7 +25,8 @@ import { requireProjectAccess } from '../access';
 import {
 	filterAccessibleExpandedPaths,
 	requireFilePathAccess,
-	requireProjectPathAccess
+	requireProjectPathAccess,
+	requireSharedFilePathAccess
 } from './path-access';
 
 // Bun-compatible existsSync implementation
@@ -120,10 +121,19 @@ export const readHandler = createRouter()
 			),
 			error: t.Optional(t.String())
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
 		// FolderBrowser uses this before a project exists, so it must be able to
 		// browse roots like "home", "drives", ".", and arbitrary candidate paths.
-		const result = await handlePathBrowsing(data.path);
+		// Security: enforce backend path ownership checks for real filesystem
+		// paths so non-admin users can't enumerate directories inside projects
+		// they are not assigned to.
+		const requestedPath = data.path === 'home'
+			? (process.env.HOME || process.env.USERPROFILE || process.cwd())
+			: (data.path === '.' || data.path === '' ? process.cwd() : data.path);
+		const guardedPath = data.path === 'drives'
+			? 'drives'
+			: requireSharedFilePathAccess(conn, requestedPath);
+		const result = await handlePathBrowsing(guardedPath);
 		return result;
 	})
 


### PR DESCRIPTION
### Summary
This patch closes a server-side authorization gap in the `files:browse-path` route.

Previously, `files:browse-path` directly called `handlePathBrowsing(data.path)` without checking whether the caller was allowed to browse that filesystem path. In practice, the UI already had client-side restrictions, but the backend route itself still trusted incoming paths. That meant a non-admin user could potentially enumerate directories outside their allowed project scope by calling the route directly.

### What changed
- Added `requireSharedFilePathAccess` import in `backend/ws/files/read.ts`.
- Updated `files:browse-path` handler signature to receive `conn`.
- Added server-side path normalization for special inputs:
- `home` resolves to user home directory.
- `.` / empty resolves to current working directory.
- `drives` remains allowed as the special root listing token.
- Enforced backend access guard for all real filesystem paths before browsing:
- Non-`drives` requests now go through `requireSharedFilePathAccess(conn, requestedPath)`.
- Only the guarded path is passed into `handlePathBrowsing`.

### Why this matters
This makes authorization enforcement consistent at the backend boundary, not only in frontend behavior. It reduces information disclosure risk in multi-user deployments by preventing unauthorized directory traversal/enumeration across projects owned by other users.

### Behavior impact
- Expected behavior for authorized users is unchanged.
- Unauthorized users now receive access denial for out-of-scope browse paths, even if they try to call the WS route directly.
- `drives` discovery flow remains available as designed.

### Validation
Executed on the fix branch:
- `bun run test` (pass)
- `bun run lint` (pass)
- `bun run check` (pass)

### Risk and compatibility
- Low-to-moderate risk.
- Scope is isolated to one route handler and existing access-control utility usage.
- No database schema changes.
- No frontend API contract changes beyond stricter access enforcement for unauthorized path requests.