### PR TITLE
fix(auth): add in-memory mutex to prevent setup race condition

### DIFF
--- a/backend/auth/auth-service.ts
+++ b/backend/auth/auth-service.ts
@@ -9,6 +9,7 @@ import type { Project } from '$shared/types/database/schema';
 import { generateSessionToken, generatePAT, generateInviteToken, hashToken, getTokenType } from './tokens';
 import { generateColorFromString, getInitials } from '$backend/utils/user-helpers';
 import { debug } from '$shared/utils/logger';
+import { acquireSetupLock, releaseSetupLock } from './setup-lock';
 
 /** Default session lifetime in days */
 const DEFAULT_SESSION_DAYS = 30;
@@ -154,40 +155,49 @@ export function createOrGetNoAuthAdmin(): AuthResult {
  * Only works when no users exist.
  */
 export function createAdmin(name: string): SetupResult {
-	if (!needsSetup()) {
-		throw new Error('Setup already completed. Admin account exists.');
+	// Acquire setup lock to prevent race conditions
+	if (!acquireSetupLock()) {
+		throw new Error('Setup already in progress');
 	}
 
-	const trimmedName = name.trim();
-	if (trimmedName.length === 0) {
-		throw new Error('Name cannot be empty');
+	try {
+		if (!needsSetup()) {
+			throw new Error('Setup already completed. Admin account exists.');
+		}
+
+		const trimmedName = name.trim();
+		if (trimmedName.length === 0) {
+			throw new Error('Name cannot be empty');
+		}
+
+		const userId = `user-${crypto.randomUUID()}`;
+		const now = new Date().toISOString();
+		const pat = generatePAT();
+		const patHash = hashToken(pat);
+
+		const dbUser = authQueries.createUser({
+			id: userId,
+			name: trimmedName,
+			color: generateColorFromString(trimmedName),
+			avatar: getInitials(trimmedName),
+			role: 'admin',
+			personal_access_token_hash: patHash,
+			created_at: now
+		});
+
+		const { sessionToken, expiresAt } = createSessionForUser(userId);
+
+		debug.log('auth', `Admin account created: ${trimmedName} (${userId})`);
+
+		return {
+			user: toAuthUser(dbUser),
+			sessionToken,
+			expiresAt,
+			personalAccessToken: pat
+		};
+	} finally {
+		releaseSetupLock();
 	}
-
-	const userId = `user-${crypto.randomUUID()}`;
-	const now = new Date().toISOString();
-	const pat = generatePAT();
-	const patHash = hashToken(pat);
-
-	const dbUser = authQueries.createUser({
-		id: userId,
-		name: trimmedName,
-		color: generateColorFromString(trimmedName),
-		avatar: getInitials(trimmedName),
-		role: 'admin',
-		personal_access_token_hash: patHash,
-		created_at: now
-	});
-
-	const { sessionToken, expiresAt } = createSessionForUser(userId);
-
-	debug.log('auth', `Admin account created: ${trimmedName} (${userId})`);
-
-	return {
-		user: toAuthUser(dbUser),
-		sessionToken,
-		expiresAt,
-		personalAccessToken: pat
-	};
 }
 
 /**

--- a/backend/auth/setup-lock.test.ts
+++ b/backend/auth/setup-lock.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { acquireSetupLock, releaseSetupLock, isSetupLocked } from './setup-lock';
+
+describe('setup-lock', () => {
+	beforeEach(() => {
+		// Ensure lock is released before each test
+		releaseSetupLock();
+	});
+
+	afterEach(() => {
+		// Clean up after each test
+		releaseSetupLock();
+	});
+
+	test('acquireSetupLock returns true when lock is available', () => {
+		expect(acquireSetupLock()).toBe(true);
+	});
+
+	test('acquireSetupLock returns false when lock is already held', () => {
+		expect(acquireSetupLock()).toBe(true);
+		expect(acquireSetupLock()).toBe(false);
+	});
+
+	test('isSetupLocked returns true after lock is acquired', () => {
+		acquireSetupLock();
+		expect(isSetupLocked()).toBe(true);
+	});
+
+	test('isSetupLocked returns false when lock is not held', () => {
+		expect(isSetupLocked()).toBe(false);
+	});
+
+	test('releaseSetupLock allows re-acquiring', () => {
+		acquireSetupLock();
+		releaseSetupLock();
+		expect(acquireSetupLock()).toBe(true);
+	});
+
+	test('releaseSetupLock when not locked does not throw', () => {
+		expect(() => releaseSetupLock()).not.toThrow();
+	});
+});

--- a/backend/auth/setup-lock.ts
+++ b/backend/auth/setup-lock.ts
@@ -1,0 +1,49 @@
+/**
+ * Setup Lock
+ *
+ * Prevents race conditions during initial system setup by ensuring only one
+ * setup request can proceed at a time. This is an in-memory mutex that
+ * serializes concurrent setup requests.
+ *
+ * Usage:
+ * ```ts
+ * if (!acquireSetupLock()) {
+ *   throw new Error('Setup already in progress');
+ * }
+ * try {
+ *   // perform setup
+ * } finally {
+ *   releaseSetupLock();
+ * }
+ * ```
+ */
+
+let isLocked = false;
+
+/**
+ * Attempt to acquire the setup lock.
+ * @returns true if lock was acquired, false if already held
+ */
+export function acquireSetupLock(): boolean {
+	if (isLocked) {
+		return false;
+	}
+	isLocked = true;
+	return true;
+}
+
+/**
+ * Release the setup lock.
+ * Safe to call even if lock is not held (no-op).
+ */
+export function releaseSetupLock(): void {
+	isLocked = false;
+}
+
+/**
+ * Check if the setup lock is currently held.
+ * @returns true if a setup operation is in progress
+ */
+export function isSetupLocked(): boolean {
+	return isLocked;
+}

--- a/backend/ws/auth/login.ts
+++ b/backend/ws/auth/login.ts
@@ -13,6 +13,7 @@ import {
 	createOrGetNoAuthAdmin,
 	needsSetup
 } from '$backend/auth/auth-service';
+import { acquireSetupLock, releaseSetupLock } from '$backend/auth/setup-lock';
 import { settingsQueries } from '$backend/database/queries';
 import { getTokenType } from '$backend/auth/tokens';
 import { authRateLimiter } from '$backend/auth/rate-limiter';
@@ -66,26 +67,35 @@ export const loginHandler = createRouter()
 			expiresAt: t.String()
 		})
 	}, async ({ conn }) => {
-		if (!needsSetup()) {
-			throw new Error('Setup already completed.');
+		// Acquire setup lock to prevent race conditions
+		if (!acquireSetupLock()) {
+			throw new Error('Setup already in progress');
 		}
 
-		// Save authMode to system settings
-		const currentSettings = settingsQueries.get('system:settings');
-		const parsed = currentSettings?.value
-			? (typeof currentSettings.value === 'string' ? JSON.parse(currentSettings.value) : currentSettings.value)
-			: {};
-		parsed.authMode = 'none';
-		settingsQueries.set('system:settings', JSON.stringify(parsed));
+		try {
+			if (!needsSetup()) {
+				throw new Error('Setup already completed.');
+			}
 
-		// Create or get default admin
-		const result = createOrGetNoAuthAdmin();
+			// Save authMode to system settings
+			const currentSettings = settingsQueries.get('system:settings');
+			const parsed = currentSettings?.value
+				? (typeof currentSettings.value === 'string' ? JSON.parse(currentSettings.value) : currentSettings.value)
+				: {};
+			parsed.authMode = 'none';
+			settingsQueries.set('system:settings', JSON.stringify(parsed));
 
-		// Set auth on connection
-		const tokenHash = (await import('$backend/auth/tokens')).hashToken(result.sessionToken);
-		ws.setAuth(conn, result.user.id, result.user.role, tokenHash);
+			// Create or get default admin
+			const result = createOrGetNoAuthAdmin();
 
-		return result;
+			// Set auth on connection
+			const tokenHash = (await import('$backend/auth/tokens')).hashToken(result.sessionToken);
+			ws.setAuth(conn, result.user.id, result.user.role, tokenHash);
+
+			return result;
+		} finally {
+			releaseSetupLock();
+		}
 	})
 
 	// Auto-login for no-auth mode (returning visitors)


### PR DESCRIPTION
## The problem

The initial setup flow has a classic race condition. Both `auth:setup` and `auth:setup-no-auth` work the same way: first they call `needsSetup()` to check if any users exist, then they create the first admin account.

If two setup requests arrive at the same time — maybe a user double-clicked the button, or a load balancer retried the request — both can pass the `needsSetup()` check before either one creates the user. Result: two admin accounts get created instead of one.

It's a time-of-check-time-of-use (TOCTOU) gap. The check and the action aren't atomic.

## The fix

Added a simple in-memory mutex (`setup-lock.ts`) that serializes setup requests. Only one setup can run at a time.

**`backend/auth/setup-lock.ts`** (new)
- `acquireSetupLock()` — returns `true` if the lock was free and is now held, `false` if someone else is already setting up
- `releaseSetupLock()` — frees the lock. Safe to call even if it wasn't held (no-op)
- `isSetupLocked()` — check current state, mostly for debugging

**`backend/auth/auth-service.ts`**
- `createAdmin()` now acquires the lock at the top, checks `needsSetup()` inside the lock, and releases in a `finally` block. If the lock is already held, it throws "Setup already in progress" immediately.

**`backend/ws/auth/login.ts`**
- The `auth:setup-no-auth` handler does the same — acquires lock before checking `needsSetup()`, releases in `finally`.

So the sequence is now:
1. Request A arrives, acquires lock
2. Request B arrives, lock is held → throws immediately
3. Request A checks `needsSetup()` (safe, no race), creates admin
4. Request A releases lock

## Tests

```
bun test backend/auth/setup-lock.test.ts

✓ acquireSetupLock returns true when lock is available
✓ acquireSetupLock returns false when lock is already held
✓ isSetupLocked returns true after lock is acquired
✓ isSetupLocked returns false when lock is not held
✓ releaseSetupLock allows re-acquiring
✓ releaseSetupLock when not locked does not throw

6 pass, 0 fail
```

Lint is clean.

## Why an in-memory lock

Clopen is designed as a single-instance local tool. It runs on your machine, one process. There's no cluster, no load balancer, no multi-instance deployment. An in-memory boolean flag is the simplest thing that works.

If Clopen ever gets deployed in a multi-instance setup (which isn't on the roadmap), this would need to become a distributed lock — something like a SQLite advisory lock or a Redis SET NX. But for now, that's overengineering a problem that doesn't exist.

## What I didn't change

I didn't add a database-level unique constraint on the admin role or anything like that. The `needsSetup()` check is the right gate — the lock just makes it atomic. Adding DB constraints would be a belt-and-suspenders approach, but it would also require migration logic and error handling for constraint violations, which is more surface area for a scenario that's already covered by the lock.
