### PR TITLE
fix(engine): dispose project engines when project is fully removed

### DIFF
--- a/backend/ws/projects/crud.ts
+++ b/backend/ws/projects/crud.ts
@@ -21,6 +21,7 @@ import { terminalStreamManager } from '../../terminal/stream-manager';
 import { broadcastPresence } from '../projects/status';
 import { debug } from '$shared/utils/logger';
 import { requireProjectAccess } from '../access';
+import { disposeProjectEngines } from '../../engine';
 
 export const crudHandler = createRouter()
 	// List all projects for the current user
@@ -165,6 +166,9 @@ export const crudHandler = createRouter()
 		if (mode === 'full') {
 			const remainingUsers = projectQueries.getUserCountForProject(data.id);
 			if (remainingUsers === 0) {
+				await disposeProjectEngines(data.id).catch((err) => {
+					debug.warn('project', `Engine cleanup error during project delete:`, err);
+				});
 				projectQueries.deleteProject(data.id);
 			}
 		}


### PR DESCRIPTION
## Summary

Clopen runs chat streaming through **per-project** engine instances (`getProjectEngine` / `initializeProjectEngine` in `backend/engine/index.ts`). Each `projectId` gets its own map of engine types (Claude Code, OpenCode, Copilot, Codex, Qwen). That isolation is intentional: abort controllers, in-flight queries, and adapter state for Project A must not interfere with Project B on the same server.

When a project is torn down, those instances need to go away too. `disposeProjectEngines(projectId)` already exists: it calls `dispose()` on every engine for that project, logs per-type failures without throwing, and removes the outer `projectEngines` entry. The engine README documents this as the hook to run **when a project closes**. Until now, nothing in the project lifecycle actually called it.

### What `projects:delete` already did

The delete handler in `backend/ws/projects/crud.ts` already does a fair amount of cleanup:

- Terminal PTY streams for the project (`terminalStreamManager.cleanupProjectStreams`)
- On **full** delete: cancel chat streams per session, clear snapshot baselines, delete sessions from SQLite, GC orphaned snapshot blobs, emit `sessions:session-deleted`
- Always: drop the current user's `user_projects` row
- On **full** delete when nobody else is assigned: delete the `projects` row

What was missing is the **engine registry** side of that story. After a full delete with no remaining users, the DB row could be gone while `projectEngines` still held live adapter instances keyed by the old `projectId`.

### What this PR changes

Import `disposeProjectEngines` into `crud.ts` and await it in the existing branch where the project record is about to be removed:

- `mode === 'full'`
- `remainingUsers === 0` (checked **after** `removeUserProject`, so we're really the last member)
- immediately **before** `projectQueries.deleteProject(data.id)`

Failures are caught and logged with `debug.warn` so a stuck or slow `dispose()` does not block deleting the project from the database.

### Why the guard matters (remove vs full, shared projects)

**`mode: 'remove'`** only removes your membership; the project row and sessions can stay for restore or for other users. We do **not** call `disposeProjectEngines` there. Disposing would tear down engines that other people might still be chatting on.

**`mode: 'full'`** with other users still assigned also skips disposal—we only run it when `getUserCountForProject` returns zero.

That matches how dangerous the cleanup is: `projectEngines` is **server-wide**, not per-user.

### What gets disposed in practice

`disposeProjectEngines` iterates whatever engine types were created for that project (lazy-created on first stream). Each adapter's `dispose()` is responsible for its own teardown (subscriptions, subprocess handles where applicable, etc.). Types that were never used for that project simply aren't in the inner map.

This PR does not change global singleton engines (`getEngine`) used for `models:list`, settings, and other non-streaming routes. Shutdown paths like `disposeAllEngines()` are unchanged.

### Relation to other PRs

- **MCP context cleanup ([#254](https://github.com/myrialabs/clopen/pull/254)):** same delete guard; clears `projectContextService` maps instead of engines.
- **Backend cleanup registry ([#255](https://github.com/myrialabs/clopen/pull/255)):** may fold this `disposeProjectEngines` call into `runProjectCleanups()`; behavior intent unchanged.
- **Frontend cleanup ([#252](https://github.com/myrialabs/clopen/pull/252)):** client-side state; complementary.

If [#255](https://github.com/myrialabs/clopen/pull/255) merges, you can close this PR and keep the engine handler in the registry only—avoid duplicating the inline call in `crud.ts`.

### Risk / compatibility

- **Low risk**, small diff: one import, one awaited call, one error handler.
- No API or schema changes.
- No change to remove-only or multi-user full-delete behavior beyond the orphaned-engine case.

## Validation

- `bun test backend/auth/permissions.test.ts` on branch `fix/engine/dispose-engines-on-project-delete`
- Code review against `backend/engine/index.ts` (`disposeProjectEngines`) and the delete flow in `backend/ws/projects/crud.ts`
- **Expected behavior (manual, if you want to double-check in a running instance):**
  1. Create a project, start at least one chat stream so a per-project engine is materialized.
  2. As the **only** user, delete the project with **full** delete.
  3. Confirm the project disappears and no stale engine state remains for that `projectId` (no further streams; after server logs, no lingering dispose errors).
  4. Repeat with **remove** from list (project kept): engines for that `projectId` should **not** be disposed while the project row still exists.
  5. Optional: two users on one project—user A full-deletes while user B remains—engines should **not** be disposed until the last user leaves.