### PR TITLE
fix(mcp): clear project context mappings on full project delete

### DIFF
--- a/backend/mcp/project-context.test.ts
+++ b/backend/mcp/project-context.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { projectContextService } from './project-context';
+
+describe('projectContextService.clearByProjectId', () => {
+	beforeEach(() => {
+		projectContextService.clear();
+	});
+
+	test('removes session and stream mappings for the project only', () => {
+		projectContextService.registerSession('session-a', 'project-1');
+		projectContextService.registerStream('stream-a', 'project-1', 'session-a');
+		projectContextService.registerSession('session-b', 'project-2');
+		projectContextService.registerStream('stream-b', 'project-2', 'session-b');
+
+		projectContextService.clearByProjectId('project-1');
+
+		expect(projectContextService.getProjectIdForSession('session-a')).toBeNull();
+		expect(projectContextService.getProjectIdForStream('stream-a')).toBeNull();
+		expect(projectContextService.getProjectIdForSession('session-b')).toBe('project-2');
+		expect(projectContextService.getLastUsedProjectId()).toBe('project-2');
+	});
+});

--- a/backend/mcp/project-context.ts
+++ b/backend/mcp/project-context.ts
@@ -207,12 +207,47 @@ class ProjectContextService {
 	}
 
 	/**
+	 * Remove all session/stream mappings for a project (e.g. when the project
+	 * row is deleted and no users remain).
+	 */
+	clearByProjectId(projectId: string): void {
+		for (const [sessionId, pid] of [...this.sessionProjectMap.entries()]) {
+			if (pid === projectId) {
+				this.sessionProjectMap.delete(sessionId);
+			}
+		}
+
+		const streamIds = new Set<string>();
+		for (const [streamId, pid] of this.streamProjectMap.entries()) {
+			if (pid === projectId) {
+				streamIds.add(streamId);
+			}
+		}
+		for (const [streamId, info] of this.activeStreams.entries()) {
+			if (info.projectId === projectId) {
+				streamIds.add(streamId);
+			}
+		}
+		for (const streamId of streamIds) {
+			this.unregisterStream(streamId);
+		}
+
+		if (this.lastUsedProjectId === projectId) {
+			this.lastUsedProjectId = null;
+		}
+
+		debug.log('mcp', `Cleared MCP project context for project ${projectId}`);
+	}
+
+	/**
 	 * Clear all mappings (for testing or cleanup)
 	 */
 	clear(): void {
 		this.sessionProjectMap.clear();
 		this.streamProjectMap.clear();
+		this.activeStreams.clear();
 		this.streamSignals.clear();
+		this.mostRecentActiveStream = null;
 		this.lastUsedProjectId = null;
 		debug.log('mcp', '🧹 Cleared all project context mappings');
 	}

--- a/backend/ws/projects/crud.ts
+++ b/backend/ws/projects/crud.ts
@@ -21,6 +21,7 @@ import { terminalStreamManager } from '../../terminal/stream-manager';
 import { broadcastPresence } from '../projects/status';
 import { debug } from '$shared/utils/logger';
 import { requireProjectAccess } from '../access';
+import { projectContextService } from '../../mcp/project-context';
 
 export const crudHandler = createRouter()
 	// List all projects for the current user
@@ -165,6 +166,7 @@ export const crudHandler = createRouter()
 		if (mode === 'full') {
 			const remainingUsers = projectQueries.getUserCountForProject(data.id);
 			if (remainingUsers === 0) {
+				projectContextService.clearByProjectId(data.id);
 				projectQueries.deleteProject(data.id);
 			}
 		}


### PR DESCRIPTION
## Summary

MCP tools in Clopen (browser automation, helpers, remote HTTP MCP bridges) need to know **which project** they are acting on. The Claude Agent SDK does not pass a custom `projectId` into tool handlers, so the backend keeps that mapping in `projectContextService` (`backend/mcp/project-context.ts`).

The stream manager registers context when chat starts (`registerSession`, `registerStream`, `registerStreamSignal`) and tears down **per stream** when a stream ends (`unregisterStream`). There was no symmetric cleanup when the **project itself** is deleted from the database. Session rows and chat streams may already be gone, but in-memory maps could still point MCP resolution at a `projectId` that no longer exists.

This PR adds `clearByProjectId(projectId)` and calls it from `projects:delete` when the last user performs a **full** delete.

---

### How project context is used today

`ProjectContextService` holds several related structures:

| Structure | Purpose |
|-----------|---------|
| `sessionProjectMap` | `chatSessionId` → `projectId` |
| `streamProjectMap` | `streamId` → `projectId` |
| `activeStreams` | stream metadata (`chatSessionId`, `projectId`, `startedAt`) |
| `mostRecentActiveStream` | fallback when AsyncLocalStorage does not carry context (e.g. remote MCP HTTP) |
| `streamSignals` | per-stream `AbortSignal` for fast cancel during tool runs |
| `lastUsedProjectId` | last-resort fallback in `getCurrentProjectId()` |

`getCurrentProjectId()` walks execution context, session/stream maps, most-recent stream, then `lastUsedProjectId`. Browser automation and other MCP entry points rely on that chain (see `backend/mcp/servers/browser-automation/*`, `backend/mcp/config.ts`, `backend/mcp/servers/helper.ts`).

If a deleted project's id is still the “most recent” or “last used” value, a later tool invocation with weak context could resolve the wrong project or a ghost id. That is especially awkward for browser tabs and project-scoped paths where silent mis-routing is worse than a hard failure.

---

### What was missing on project delete

`projects:delete` already cleans terminal streams, and on **full** delete cancels chat streams, deletes sessions/snapshots, and removes the `projects` row when `remainingUsers === 0`. None of that cleared `projectContextService`.

`unregisterStream` / `unregisterSession` only run on the normal stream lifecycle. After bulk session deletion during project delete, some map entries could remain until the server restarts, or `lastUsedProjectId` could still reference the removed project.

---

### What `clearByProjectId` does

1. **Sessions** — removes every `sessionProjectMap` entry whose value equals the given `projectId`.
2. **Streams** — collects stream ids from both `streamProjectMap` and `activeStreams` for that project, then calls `unregisterStream` for each so stream maps, active stream tracking, abort signals, and `mostRecentActiveStream` are updated consistently (reusing existing logic instead of duplicating it).
3. **Last-used fallback** — if `lastUsedProjectId === projectId`, sets it to `null`. Other projects' sessions left in memory keep their `lastUsedProjectId` (see test below).

The method is synchronous; it only mutates in-memory maps.

---

### Hook in `projects:delete`

Call site uses the same guard as the engine-disposal PR ([#253](https://github.com/myrialabs/clopen/pull/253)):

- `mode === 'full'`
- `remainingUsers === 0` after `removeUserProject`
- immediately **before** `projectQueries.deleteProject`

We do **not** clear MCP context on `mode: 'remove'` (project kept for restore / other members) or when other users still have access — same reasoning as not disposing shared per-project engines while the project row still exists.

---

### Small fix to `clear()`

`clear()` (used in tests) now also resets `activeStreams` and `mostRecentActiveStream`. Previously it only cleared `sessionProjectMap`, `streamProjectMap`, and `streamSignals`, which could leave test state inconsistent with production maps. No production behavior change except more reliable test isolation.

---

### Tests

`backend/mcp/project-context.test.ts` covers:

- Two projects registered with sessions/streams
- `clearByProjectId('project-1')` removes only project-1 mappings
- project-2 mappings and `lastUsedProjectId` (`'project-2'`) remain

Run: `bun test backend/mcp/project-context.test.ts`

---

### Relation to other PRs

- **Engine dispose ([#253](https://github.com/myrialabs/clopen/pull/253)):** complementary — engines vs MCP maps; same delete guard.
- **Frontend cleanup ([#252](https://github.com/myrialabs/clopen/pull/252)):** client-side Maps/panels; this is **server-side** MCP routing.
- **Backend cleanup registry ([#255](https://github.com/myrialabs/clopen/pull/255)):** may move this call behind `runProjectCleanups()`; behavior intent unchanged.

If both this PR and #255 land, reconcile the single call site in `crud.ts` during merge.

---

### Risk / compatibility

- Low risk: additive API, one call site, no schema changes.
- `unregisterStream` is already used in production; we batch it for all streams tied to the deleted project.
- No change to MCP registration during normal streaming.

## Validation

- `bun test backend/mcp/project-context.test.ts`
- Reviewed call path: `stream-manager` register/unregister vs `projects:delete` full + last user
- **Manual (optional):** start a chat stream (registers MCP context), full-delete the project as the only user, confirm subsequent MCP/browser tools on another project do not pick up the old `projectId` via `getLastUsedProjectId()` / stale stream maps