### PR TITLE
feat(projects): add backend cleanup registry on project delete

### DIFF
--- a/backend/mcp/project-context.test.ts
+++ b/backend/mcp/project-context.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { projectContextService } from './project-context';
+
+describe('projectContextService.clearByProjectId', () => {
+	beforeEach(() => {
+		projectContextService.clear();
+	});
+
+	test('removes session and stream mappings for the project only', () => {
+		projectContextService.registerSession('session-a', 'project-1');
+		projectContextService.registerStream('stream-a', 'project-1', 'session-a');
+		projectContextService.registerSession('session-b', 'project-2');
+		projectContextService.registerStream('stream-b', 'project-2', 'session-b');
+
+		projectContextService.clearByProjectId('project-1');
+
+		expect(projectContextService.getProjectIdForSession('session-a')).toBeNull();
+		expect(projectContextService.getProjectIdForStream('stream-a')).toBeNull();
+		expect(projectContextService.getProjectIdForSession('session-b')).toBe('project-2');
+		expect(projectContextService.getLastUsedProjectId()).toBe('project-2');
+	});
+});

--- a/backend/mcp/project-context.ts
+++ b/backend/mcp/project-context.ts
@@ -207,12 +207,47 @@ class ProjectContextService {
 	}
 
 	/**
+	 * Remove all session/stream mappings for a project (e.g. when the project
+	 * row is deleted and no users remain).
+	 */
+	clearByProjectId(projectId: string): void {
+		for (const [sessionId, pid] of [...this.sessionProjectMap.entries()]) {
+			if (pid === projectId) {
+				this.sessionProjectMap.delete(sessionId);
+			}
+		}
+
+		const streamIds = new Set<string>();
+		for (const [streamId, pid] of this.streamProjectMap.entries()) {
+			if (pid === projectId) {
+				streamIds.add(streamId);
+			}
+		}
+		for (const [streamId, info] of this.activeStreams.entries()) {
+			if (info.projectId === projectId) {
+				streamIds.add(streamId);
+			}
+		}
+		for (const streamId of streamIds) {
+			this.unregisterStream(streamId);
+		}
+
+		if (this.lastUsedProjectId === projectId) {
+			this.lastUsedProjectId = null;
+		}
+
+		debug.log('mcp', `Cleared MCP project context for project ${projectId}`);
+	}
+
+	/**
 	 * Clear all mappings (for testing or cleanup)
 	 */
 	clear(): void {
 		this.sessionProjectMap.clear();
 		this.streamProjectMap.clear();
+		this.activeStreams.clear();
 		this.streamSignals.clear();
+		this.mostRecentActiveStream = null;
 		this.lastUsedProjectId = null;
 		debug.log('mcp', '🧹 Cleared all project context mappings');
 	}

--- a/backend/projects/project-cleanup-registry.test.ts
+++ b/backend/projects/project-cleanup-registry.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { projectCleanupRegistry } from './project-cleanup-registry';
+
+describe('projectCleanupRegistry', () => {
+	test('runAll invokes registered handlers', async () => {
+		const calls: string[] = [];
+		projectCleanupRegistry.register({
+			name: 'test-a',
+			run: async (projectId) => {
+				calls.push(`a:${projectId}`);
+			}
+		});
+		projectCleanupRegistry.register({
+			name: 'test-b',
+			run: (projectId) => {
+				calls.push(`b:${projectId}`);
+			}
+		});
+
+		await projectCleanupRegistry.runAll('proj-1');
+
+		expect(calls).toEqual(['a:proj-1', 'b:proj-1']);
+		projectCleanupRegistry._clearHandlers();
+	});
+
+	test('runAll continues when a handler throws', async () => {
+		const calls: string[] = [];
+		projectCleanupRegistry.register({
+			name: 'failing',
+			run: () => {
+				throw new Error('boom');
+			}
+		});
+		projectCleanupRegistry.register({
+			name: 'ok',
+			run: () => {
+				calls.push('ok');
+			}
+		});
+
+		await projectCleanupRegistry.runAll('proj-2');
+
+		expect(calls).toEqual(['ok']);
+		projectCleanupRegistry._clearHandlers();
+	});
+});

--- a/backend/projects/project-cleanup-registry.test.ts
+++ b/backend/projects/project-cleanup-registry.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, test } from 'bun:test';
+import { beforeEach, describe, expect, test } from 'bun:test';
 import { projectCleanupRegistry } from './project-cleanup-registry';
 
 describe('projectCleanupRegistry', () => {
+	beforeEach(() => {
+		projectCleanupRegistry._clearHandlers();
+	});
+
 	test('runAll invokes registered handlers', async () => {
 		const calls: string[] = [];
 		projectCleanupRegistry.register({
@@ -20,7 +24,6 @@ describe('projectCleanupRegistry', () => {
 		await projectCleanupRegistry.runAll('proj-1');
 
 		expect(calls).toEqual(['a:proj-1', 'b:proj-1']);
-		projectCleanupRegistry._clearHandlers();
 	});
 
 	test('runAll continues when a handler throws', async () => {
@@ -41,6 +44,5 @@ describe('projectCleanupRegistry', () => {
 		await projectCleanupRegistry.runAll('proj-2');
 
 		expect(calls).toEqual(['ok']);
-		projectCleanupRegistry._clearHandlers();
 	});
 });

--- a/backend/projects/project-cleanup-registry.ts
+++ b/backend/projects/project-cleanup-registry.ts
@@ -23,6 +23,11 @@ class ProjectCleanupRegistry {
 	}
 
 	/** @internal Test helper */
+	_getHandlerNames(): string[] {
+		return this.handlers.map((handler) => handler.name);
+	}
+
+	/** @internal Test helper */
 	_clearHandlers(): void {
 		this.handlers = [];
 	}

--- a/backend/projects/project-cleanup-registry.ts
+++ b/backend/projects/project-cleanup-registry.ts
@@ -1,0 +1,39 @@
+import { debug } from '$shared/utils/logger';
+
+export type ProjectCleanupHandler = {
+	name: string;
+	run: (projectId: string) => void | Promise<void>;
+};
+
+class ProjectCleanupRegistry {
+	private handlers: ProjectCleanupHandler[] = [];
+
+	register(handler: ProjectCleanupHandler): void {
+		this.handlers.push(handler);
+	}
+
+	async runAll(projectId: string): Promise<void> {
+		for (const handler of this.handlers) {
+			try {
+				await handler.run(projectId);
+			} catch (error) {
+				debug.warn('project', `Cleanup handler "${handler.name}" failed for ${projectId}:`, error);
+			}
+		}
+	}
+
+	/** @internal Test helper */
+	_clearHandlers(): void {
+		this.handlers = [];
+	}
+}
+
+export const projectCleanupRegistry = new ProjectCleanupRegistry();
+
+export function registerProjectCleanup(handler: ProjectCleanupHandler): void {
+	projectCleanupRegistry.register(handler);
+}
+
+export async function runProjectCleanups(projectId: string): Promise<void> {
+	await projectCleanupRegistry.runAll(projectId);
+}

--- a/backend/projects/project-cleanup.integration.test.ts
+++ b/backend/projects/project-cleanup.integration.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { projectCleanupRegistry, runProjectCleanups } from './project-cleanup-registry';
+
+import './project-cleanup';
+
+const DEFAULT_CLEANUP_HANDLERS = ['engine', 'mcp-context', 'file-watcher'] as const;
+
+describe('project cleanup integration', () => {
+	test('registers default backend handlers when project-cleanup is loaded', () => {
+		const names = projectCleanupRegistry._getHandlerNames();
+		for (const expected of DEFAULT_CLEANUP_HANDLERS) {
+			expect(names).toContain(expected);
+		}
+		expect(names.indexOf('engine')).toBeLessThan(names.indexOf('mcp-context'));
+		expect(names.indexOf('mcp-context')).toBeLessThan(names.indexOf('file-watcher'));
+	});
+
+	test('runProjectCleanups runs default handlers without throwing', async () => {
+		await expect(runProjectCleanups('proj-cleanup-integration')).resolves.toBeUndefined();
+	});
+
+	test('runProjectCleanups forwards the project id to registered handlers', async () => {
+		const received: string[] = [];
+		projectCleanupRegistry.register({
+			name: 'integration-spy',
+			run: (projectId) => {
+				received.push(projectId);
+			}
+		});
+
+		await runProjectCleanups('proj-cleanup-spy');
+
+		expect(received).toEqual(['proj-cleanup-spy']);
+	});
+});

--- a/backend/projects/project-cleanup.integration.test.ts
+++ b/backend/projects/project-cleanup.integration.test.ts
@@ -3,7 +3,7 @@ import { projectCleanupRegistry, runProjectCleanups } from './project-cleanup-re
 
 import './project-cleanup';
 
-const DEFAULT_CLEANUP_HANDLERS = ['engine', 'mcp-context', 'file-watcher'] as const;
+const DEFAULT_CLEANUP_HANDLERS = ['engine', 'mcp-context', 'file-watcher', 'presence'] as const;
 
 describe('project cleanup integration', () => {
 	test('registers default backend handlers when project-cleanup is loaded', () => {
@@ -13,6 +13,7 @@ describe('project cleanup integration', () => {
 		}
 		expect(names.indexOf('engine')).toBeLessThan(names.indexOf('mcp-context'));
 		expect(names.indexOf('mcp-context')).toBeLessThan(names.indexOf('file-watcher'));
+		expect(names.indexOf('file-watcher')).toBeLessThan(names.indexOf('presence'));
 	});
 
 	test('runProjectCleanups runs default handlers without throwing', async () => {

--- a/backend/projects/project-cleanup.ts
+++ b/backend/projects/project-cleanup.ts
@@ -1,0 +1,32 @@
+/**
+ * Default backend cleanup handlers for fully removed projects.
+ */
+import { disposeProjectEngines } from '../engine';
+import { projectContextService } from '../mcp/project-context';
+import { fileWatcher } from '../files/file-watcher';
+import { clearProjectPresence } from '../project/status-manager';
+import { registerProjectCleanup } from './project-cleanup-registry';
+
+registerProjectCleanup({
+	name: 'engine',
+	run: (projectId) => disposeProjectEngines(projectId)
+});
+
+registerProjectCleanup({
+	name: 'mcp-context',
+	run: (projectId) => projectContextService.clearByProjectId(projectId)
+});
+
+registerProjectCleanup({
+	name: 'file-watcher',
+	run: (projectId) => {
+		fileWatcher.stopWatching(projectId);
+	}
+});
+
+registerProjectCleanup({
+	name: 'presence',
+	run: (projectId) => {
+		clearProjectPresence(projectId);
+	}
+});

--- a/backend/ws/projects/crud.ts
+++ b/backend/ws/projects/crud.ts
@@ -21,8 +21,8 @@ import { terminalStreamManager } from '../../terminal/stream-manager';
 import { broadcastPresence } from '../projects/status';
 import { debug } from '$shared/utils/logger';
 import { requireProjectAccess } from '../access';
-import { disposeProjectEngines } from '../../engine';
-import { clearProjectPresence } from '../../project/status-manager';
+import { runProjectCleanups } from '../../projects/project-cleanup-registry';
+import '../../projects/project-cleanup';
 
 export const crudHandler = createRouter()
 	// List all projects for the current user
@@ -167,10 +167,7 @@ export const crudHandler = createRouter()
 		if (mode === 'full') {
 			const remainingUsers = projectQueries.getUserCountForProject(data.id);
 			if (remainingUsers === 0) {
-				await disposeProjectEngines(data.id).catch((err) => {
-					debug.warn('project', `Engine cleanup error during project delete:`, err);
-				});
-				clearProjectPresence(data.id);
+				await runProjectCleanups(data.id);
 				projectQueries.deleteProject(data.id);
 			}
 		}


### PR DESCRIPTION
## Context

Project deletion in Clopen already does a lot in `backend/ws/projects/crud.ts`: terminal streams, optional full session/snapshot teardown, blob GC, and finally dropping the `projects` row when the last member leaves with `mode: 'full'`.

Several other subsystems keep **in-memory state keyed by `projectId`** on the server. They are not SQLite-backed and do not disappear when the database row is deleted:

- **Engines** — `projectEngines` in `backend/engine/index.ts` (per-project Claude/OpenCode/Copilot/Codex/Qwen clients)
- **MCP context** — `projectContextService` session/stream maps used because the Agent SDK does not pass `projectId` into tools
- **File watcher** — `fileWatcher` in `backend/files/file-watcher.ts` (FS watchers started when a client opens the files panel)

Today, adding cleanup for a new subsystem means remembering to edit `crud.ts` again. This PR introduces a small **registry** so project delete has a single extension point, and wires the three handlers above as the default set.

---

## Registry design

### Files

| File | Role |
|------|------|
| `backend/projects/project-cleanup-registry.ts` | Registry API: `registerProjectCleanup`, `runProjectCleanups`, `projectCleanupRegistry.runAll` |
| `backend/projects/project-cleanup.ts` | Side-effect module: registers default handlers at import time |
| `backend/ws/projects/crud.ts` | Calls `await runProjectCleanups(data.id)` before `deleteProject` |

### API shape

Handlers are plain objects:

```ts
{ name: string; run: (projectId: string) => void | Promise<void> }
```

`runAll(projectId)` runs them **in registration order**, `await`s async handlers, and **isolates failures**: one handler throwing logs `debug.warn` with the handler name and continues with the rest. That matches how `disposeProjectEngines` already swallows per-engine errors internally, but also protects unrelated handlers from a single bad teardown.

`crud.ts` imports:

```ts
import { runProjectCleanups } from '../../projects/project-cleanup-registry';
import '../../projects/project-cleanup'; // registers defaults
```

The side-effect import is deliberate: keep `crud` thin and let new subsystems add a line in `project-cleanup.ts` (or a future dedicated bootstrap file) instead of growing delete logic inline.

---

## Built-in handlers (v1)

Registered in `project-cleanup.ts`:

| Handler name | Action | Notes |
|--------------|--------|--------|
| `engine` | `disposeProjectEngines(projectId)` | Drops all per-project engine instances for that id |
| `mcp-context` | `projectContextService.clearByProjectId(projectId)` | New helper in this PR — see below |
| `file-watcher` | `fileWatcher.stopWatching(projectId)` | Closes main/sub/git watchers; no-op if not watching |

**Not** moved into the registry (unchanged on purpose):

- Terminal stream cleanup at the top of delete (always runs, different lifecycle)
- Chat `streamManager` / snapshot / blob work inside `mode === 'full'` (session-scoped, already orchestrated in delete)
- `removeUserProject` / presence broadcast

Those stay where they are because they are either user-scoped, session-scoped, or must run before session teardown.

---

## `clearByProjectId` (included in this PR)

The MCP handler needs project-level purge, not only per-stream `unregisterStream`. This PR adds `clearByProjectId` to `backend/mcp/project-context.ts`:

- Strip matching entries from `sessionProjectMap`
- Collect stream ids from `streamProjectMap` and `activeStreams`, then call `unregisterStream` for each (reuses signal / most-recent-stream logic)
- Clear `lastUsedProjectId` when it equals the deleted project

Also fixes `clear()` for tests: now clears `activeStreams` and `mostRecentActiveStream`, not only the session/stream/signal maps.

Unit test: `backend/mcp/project-context.test.ts`.

---

## When cleanup runs (same guard as engine/MCP-only PRs)

`runProjectCleanups` is only awaited when:

1. `mode === 'full'`
2. `remainingUsers === 0` after `removeUserProject`
3. immediately **before** `projectQueries.deleteProject`

**Not** on `mode: 'remove'` or when other users still have the project — shared `projectId` state must remain for collaborators.

Same guard as [#253](https://github.com/myrialabs/clopen/pull/253) and [#254](https://github.com/myrialabs/clopen/pull/254).

---

## Tests

### Unit tests

`backend/projects/project-cleanup-registry.test.ts`:

- Registered handlers run in order with the correct `projectId`
- A failing handler does not block later handlers

`backend/mcp/project-context.test.ts` — `clearByProjectId` isolation.

### Integration tests

`backend/projects/project-cleanup.integration.test.ts` loads `./project-cleanup` the same way `crud.ts` does and checks that:

- default handlers `engine`, `mcp-context`, and `file-watcher` are registered in order;
- `runProjectCleanups` completes without throwing for a non-existent project id (smoke over real handlers);
- handlers receive the `projectId` passed into `runProjectCleanups`.

The registry exposes `_getHandlerNames()` for these assertions (test-only, same pattern as `_clearHandlers()`).

```bash
bun test backend/mcp/project-context.test.ts backend/projects/
```

---

## Overlap / merge notes

This PR **includes** the engine dispose hook, MCP `clearByProjectId`, and file-watcher stop. If you merge this, consider **closing** the narrower PRs that only add inline cleanup in `crud.ts`:

- [#253](https://github.com/myrialabs/clopen/pull/253) — engine dispose only
- [#254](https://github.com/myrialabs/clopen/pull/254) — MCP context only

Alternatively merge [#253](https://github.com/myrialabs/clopen/pull/253) / [#254](https://github.com/myrialabs/clopen/pull/254) first and drop the duplicate lines when rebasing this branch.

- **Frontend cleanup ([#252](https://github.com/myrialabs/clopen/pull/252))** — complementary; client-side Maps/panels, not this registry.
- Future handlers (browser preview, tunnels, etc.) can `registerProjectCleanup` without touching delete again.

---

## Risk / compatibility

- Additive module layout; delete path gains one `await` before DB delete.
- Handler failures are logged, not propagated — project row deletion still proceeds.
- No migrations or public API changes.
- Import order: `project-cleanup` must load after registry (current imports satisfy that).

## Validation

- `bun test backend/mcp/project-context.test.ts backend/projects/`
- Read-through: `crud.ts` delete branch, `project-cleanup.ts` registrations, `disposeProjectEngines` / `stopWatching` behavior
- **Manual (optional):** full-delete as sole user on a project that had file watching + chat activity; confirm project removed and no stale watchers/engines/MCP resolution for that id on remaining projects
