### PR TITLE
fix(status): purge presence map when project is fully deleted

### DIFF
--- a/backend/project/status-manager.test.ts
+++ b/backend/project/status-manager.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	clearProjectPresence,
+	getProjectStatusData,
+	updateUserPresence
+} from './status-manager';
+
+async function getSingleProjectStatus(projectId: string) {
+	const status = await getProjectStatusData(projectId);
+	if (Array.isArray(status)) {
+		throw new Error('expected single-project status payload');
+	}
+	return status;
+}
+
+describe('clearProjectPresence', () => {
+	test('removes active users for the project from status data', async () => {
+		updateUserPresence('proj-presence', 'user-1', 'Alice', 'join');
+
+		const before = await getSingleProjectStatus('proj-presence');
+		expect(before.activeUsers).toHaveLength(1);
+
+		clearProjectPresence('proj-presence');
+
+		const after = await getSingleProjectStatus('proj-presence');
+		expect(after.activeUsers).toEqual([]);
+	});
+
+	test('is a no-op when the project has no presence entry', () => {
+		expect(() => clearProjectPresence('proj-never-seen')).not.toThrow();
+	});
+});

--- a/backend/project/status-manager.ts
+++ b/backend/project/status-manager.ts
@@ -176,6 +176,13 @@ export async function getProjectStatusData(projectId?: string) {
   }
 }
 
+/**
+ * Drop in-memory presence for a project (e.g. after full project delete).
+ */
+export function clearProjectPresence(projectId: string): void {
+  projectUsers.delete(projectId);
+}
+
 // Update user presence
 export function updateUserPresence(projectId: string, userId: string, userName: string, action: string) {
   cleanupInactiveUsers();

--- a/backend/ws/projects/crud.ts
+++ b/backend/ws/projects/crud.ts
@@ -21,6 +21,7 @@ import { terminalStreamManager } from '../../terminal/stream-manager';
 import { broadcastPresence } from '../projects/status';
 import { debug } from '$shared/utils/logger';
 import { requireProjectAccess } from '../access';
+import { clearProjectPresence } from '../../project/status-manager';
 
 export const crudHandler = createRouter()
 	// List all projects for the current user
@@ -165,6 +166,7 @@ export const crudHandler = createRouter()
 		if (mode === 'full') {
 			const remainingUsers = projectQueries.getUserCountForProject(data.id);
 			if (remainingUsers === 0) {
+				clearProjectPresence(data.id);
 				projectQueries.deleteProject(data.id);
 			}
 		}


### PR DESCRIPTION
## What was going wrong

Collaboration presence in Clopen lives in a process-local `Map` inside `backend/project/status-manager.ts`, not in SQLite. When someone triggers a **full** project delete (`projects:delete` with `mode: 'full'`) and they're the last member, the handler already tears down sessions, chat streams, terminal streams, and eventually the project row. The presence map did not get the same treatment.

`updateUserPresence` only drops a project key when the last user explicitly leaves or when the five-minute idle sweep runs. After a full delete, `getProjectStatusData(projectId)` could still return `activeUsers` for a project id that no longer exists in the database. That mostly shows up as confusing collaboration/status UI—stale names on a ghost project—not as a security hole, but it's inconsistent with how aggressively we clean up everything else on delete.

## What this PR does

Adds a small, explicit `clearProjectPresence(projectId)` that deletes the map entry for that project. It runs in `backend/ws/projects/crud.ts` only in the narrow case we care about: full delete, zero remaining users, immediately before `projectQueries.deleteProject`.

No new WebSocket events, no change to join/leave flows, and no behavior change for `mode: 'remove'` (project row kept for restore).

## Files touched

| File | Change |
|------|--------|
| `backend/project/status-manager.ts` | New `clearProjectPresence()` |
| `backend/ws/projects/crud.ts` | Call it on orphaned full delete |
| `backend/project/status-manager.test.ts` | Join → clear → assert empty `activeUsers`; no-op on unknown id |

## How I checked it

- `bun test backend/project/status-manager.test.ts`
- `bun run check`
- `bun run lint`

I did not run the full app for this one; the bug is entirely in-memory state tied to a code path we can assert in unit tests. Happy to do a manual delete pass if a maintainer wants eyes on the collaboration panel.

## Merge note

Targets **`main`** directly. Independent of the cleanup-registry work in #255. If that registry lands later, we *could* also register `clearProjectPresence` there—but the `crud.ts` call alone is sufficient and avoids wiring the same cleanup twice unless someone deliberately wants a single registry entry.