### PR TITLE
fix(engine): validate MCP tool output before forwarding to AI models

### DIFF
--- a/backend/mcp/config.ts
+++ b/backend/mcp/config.ts
@@ -15,6 +15,7 @@ import { serverRegistry, serverFactories, serverMetadata } from './servers';
 import { projectContextService } from './project-context';
 import { debug } from '$shared/utils/logger';
 import { SERVER_ENV } from '../utils/env';
+import { validateMcpOutput } from './output-validator';
 
 /**
  * User-defined MCP Servers Configuration
@@ -117,7 +118,9 @@ export function getEnabledMcpServers(context?: McpExecutionContext): Record<stri
 							if (signal?.aborted) {
 								return abortedToolResult(toolName);
 							}
-							return def.handler(args);
+							const result = await def.handler(args);
+							result.content = validateMcpOutput(result.content, toolName);
+							return result;
 						});
 					};
 					return tool(toolName, def.description, def.schema, boundHandler as any);

--- a/backend/mcp/output-validator.test.ts
+++ b/backend/mcp/output-validator.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { validateMcpOutput } from './output-validator';
+
+const MB = 1024 * 1024;
+
+describe('validateMcpOutput', () => {
+	test('truncates oversized text output to the configured text budget', () => {
+		const oversizedText = 'a'.repeat((10 * MB) + 8_192);
+
+		const result = validateMcpOutput([{ type: 'text', text: oversizedText }], 'tool-a');
+
+		expect(result).toHaveLength(1);
+		expect(result[0].type).toBe('text');
+		expect(result[0].text).toContain('[Content truncated due to size limit]');
+		expect(new TextEncoder().encode(result[0].text ?? '').length).toBeLessThanOrEqual(10 * MB);
+	});
+
+	test('replaces oversized image output with explanatory text', () => {
+		const oversizedImage = 'a'.repeat(Math.ceil((6 * MB) / 0.75));
+
+		const result = validateMcpOutput([
+			{ type: 'image', data: oversizedImage, mimeType: 'image/png' }
+		], 'take_screenshot');
+
+		expect(result).toEqual([
+			{
+				type: 'text',
+				text: expect.stringContaining('[Image omitted: size')
+			}
+		]);
+	});
+
+	test('stops once sanitized total output exceeds the overall cap', () => {
+		const elevenMbText = 'b'.repeat(11 * MB);
+		const sixMbText = 'c'.repeat(6 * MB);
+		const trailingText = 'should never appear';
+
+		const result = validateMcpOutput([
+			{ type: 'text', text: elevenMbText },
+			{ type: 'text', text: sixMbText },
+			{ type: 'text', text: trailingText }
+		], 'tool-b');
+
+		expect(result).toHaveLength(2);
+		expect(result[0].text).toContain('[Content truncated due to size limit]');
+		expect(result[1]).toEqual({
+			type: 'text',
+			text: '\n\n[Additional content omitted due to total size limit]'
+		});
+		expect(result.some(item => item.text === trailingText)).toBe(false);
+	});
+});

--- a/backend/mcp/output-validator.ts
+++ b/backend/mcp/output-validator.ts
@@ -13,74 +13,91 @@
 import { debug } from '$shared/utils/logger';
 
 const LIMITS = {
-  maxTextSize: 10 * 1024 * 1024,
-  maxImageSize: 5 * 1024 * 1024,
-  maxTotalSize: 15 * 1024 * 1024
+	maxTextSize: 10 * 1024 * 1024,
+	maxImageSize: 5 * 1024 * 1024,
+	maxTotalSize: 15 * 1024 * 1024
 };
 
 interface MCPContent {
-  type: string;
-  text?: string;
-  data?: string;
-  mimeType?: string;
+	type: string;
+	text?: string;
+	data?: string;
+	mimeType?: string;
 }
 
 function estimateTextSize(text: string): number {
-  return text.length * 2;
+	return new TextEncoder().encode(text).length;
 }
 
 function estimateImageSize(base64Data: string): number {
-  return Math.ceil(base64Data.length * 0.75);
+	return Math.ceil(base64Data.length * 0.75);
 }
 
 function truncateText(text: string, maxSize: number): string {
-  if (estimateTextSize(text) <= maxSize) return text;
-  const maxChars = Math.floor(maxSize / 2);
-  const truncationMessage = '\n\n[Content truncated due to size limit]';
-  const availableChars = maxChars - truncationMessage.length;
-  if (availableChars <= 0) return truncationMessage;
-  return text.substring(0, availableChars) + truncationMessage;
+	if (estimateTextSize(text) <= maxSize) return text;
+
+	const truncationMessage = '\n\n[Content truncated due to size limit]';
+	const messageSize = estimateTextSize(truncationMessage);
+	if (messageSize >= maxSize) return truncationMessage;
+
+	let low = 0;
+	let high = text.length;
+	while (low < high) {
+		const mid = Math.ceil((low + high) / 2);
+		const candidate = text.substring(0, mid) + truncationMessage;
+		if (estimateTextSize(candidate) <= maxSize) {
+			low = mid;
+		} else {
+			high = mid - 1;
+		}
+	}
+
+	return text.substring(0, low) + truncationMessage;
 }
 
 export function validateMcpOutput(content: MCPContent[], toolName: string): MCPContent[] {
-  if (!content || content.length === 0) return content;
+	if (!content || content.length === 0) return content;
 
-  let totalSize = 0;
-  const sanitized: MCPContent[] = [];
+	let totalSize = 0;
+	const sanitized: MCPContent[] = [];
 
-  for (const item of content) {
-    if (item.type === 'text' && item.text) {
-      const textSize = estimateTextSize(item.text);
-      totalSize += textSize;
-      if (textSize > LIMITS.maxTextSize) {
-        debug.warn('mcp', `Tool ${toolName} text output exceeded limit: ${(textSize / 1024 / 1024).toFixed(2)} MB > ${(LIMITS.maxTextSize / 1024 / 1024).toFixed(0)} MB`);
-        sanitized.push({ type: 'text', text: truncateText(item.text, LIMITS.maxTextSize) });
-      } else {
-        sanitized.push(item);
-      }
-    } else if (item.type === 'image' && item.data) {
-      const imageSize = estimateImageSize(item.data);
-      totalSize += imageSize;
-      if (imageSize > LIMITS.maxImageSize) {
-        debug.warn('mcp', `Tool ${toolName} image output exceeded limit: ${(imageSize / 1024 / 1024).toFixed(2)} MB > ${(LIMITS.maxImageSize / 1024 / 1024).toFixed(0)} MB`);
-        sanitized.push({ type: 'text', text: `[Image omitted: size ${(imageSize / 1024 / 1024).toFixed(2)} MB exceeds limit of ${(LIMITS.maxImageSize / 1024 / 1024).toFixed(0)} MB]` });
-      } else {
-        sanitized.push(item);
-      }
-    } else {
-      sanitized.push(item);
-    }
+	for (const item of content) {
+		let sanitizedItem: MCPContent = item;
+		let itemSize = 0;
 
-    if (totalSize > LIMITS.maxTotalSize) {
-      debug.warn('mcp', `Tool ${toolName} total output exceeded limit: ${(totalSize / 1024 / 1024).toFixed(2)} MB > ${(LIMITS.maxTotalSize / 1024 / 1024).toFixed(0)} MB`);
-      sanitized.push({ type: 'text', text: '\n\n[Additional content omitted due to total size limit]' });
-      break;
-    }
-  }
+		if (item.type === 'text' && item.text) {
+			const textSize = estimateTextSize(item.text);
+			if (textSize > LIMITS.maxTextSize) {
+				debug.warn('mcp', `Tool ${toolName} text output exceeded limit: ${(textSize / 1024 / 1024).toFixed(2)} MB > ${(LIMITS.maxTextSize / 1024 / 1024).toFixed(0)} MB`);
+				sanitizedItem = { type: 'text', text: truncateText(item.text, LIMITS.maxTextSize) };
+			}
+			itemSize = estimateTextSize(sanitizedItem.text ?? '');
+		} else if (item.type === 'image' && item.data) {
+			const imageSize = estimateImageSize(item.data);
+			if (imageSize > LIMITS.maxImageSize) {
+				debug.warn('mcp', `Tool ${toolName} image output exceeded limit: ${(imageSize / 1024 / 1024).toFixed(2)} MB > ${(LIMITS.maxImageSize / 1024 / 1024).toFixed(0)} MB`);
+				sanitizedItem = {
+					type: 'text',
+					text: `[Image omitted: size ${(imageSize / 1024 / 1024).toFixed(2)} MB exceeds limit of ${(LIMITS.maxImageSize / 1024 / 1024).toFixed(0)} MB]`
+				};
+				itemSize = estimateTextSize(sanitizedItem.text ?? '');
+			} else {
+				itemSize = imageSize;
+			}
+		}
 
-  return sanitized;
-}
+		totalSize += itemSize;
+		if (totalSize > LIMITS.maxTotalSize) {
+			debug.warn('mcp', `Tool ${toolName} total output exceeded limit: ${(totalSize / 1024 / 1024).toFixed(2)} MB > ${(LIMITS.maxTotalSize / 1024 / 1024).toFixed(0)} MB`);
+			sanitized.push({
+				type: 'text',
+				text: '\n\n[Additional content omitted due to total size limit]'
+			});
+			break;
+		}
 
-export function getMcpOutputLimits() {
-  return { ...LIMITS };
+		sanitized.push(sanitizedItem);
+	}
+
+	return sanitized;
 }

--- a/backend/mcp/output-validator.ts
+++ b/backend/mcp/output-validator.ts
@@ -1,0 +1,86 @@
+/**
+ * MCP Tool Output Validator
+ *
+ * Validates and sanitizes MCP tool outputs before forwarding to AI models.
+ * Prevents memory pressure from oversized tool responses.
+ *
+ * Limits:
+ *   - Text content: 10 MB per tool response
+ *   - Image content: 5 MB per image
+ *   - Total content array: 15 MB per tool call
+ */
+
+import { debug } from '$shared/utils/logger';
+
+const LIMITS = {
+  maxTextSize: 10 * 1024 * 1024,
+  maxImageSize: 5 * 1024 * 1024,
+  maxTotalSize: 15 * 1024 * 1024
+};
+
+interface MCPContent {
+  type: string;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+
+function estimateTextSize(text: string): number {
+  return text.length * 2;
+}
+
+function estimateImageSize(base64Data: string): number {
+  return Math.ceil(base64Data.length * 0.75);
+}
+
+function truncateText(text: string, maxSize: number): string {
+  if (estimateTextSize(text) <= maxSize) return text;
+  const maxChars = Math.floor(maxSize / 2);
+  const truncationMessage = '\n\n[Content truncated due to size limit]';
+  const availableChars = maxChars - truncationMessage.length;
+  if (availableChars <= 0) return truncationMessage;
+  return text.substring(0, availableChars) + truncationMessage;
+}
+
+export function validateMcpOutput(content: MCPContent[], toolName: string): MCPContent[] {
+  if (!content || content.length === 0) return content;
+
+  let totalSize = 0;
+  const sanitized: MCPContent[] = [];
+
+  for (const item of content) {
+    if (item.type === 'text' && item.text) {
+      const textSize = estimateTextSize(item.text);
+      totalSize += textSize;
+      if (textSize > LIMITS.maxTextSize) {
+        debug.warn('mcp', `Tool ${toolName} text output exceeded limit: ${(textSize / 1024 / 1024).toFixed(2)} MB > ${(LIMITS.maxTextSize / 1024 / 1024).toFixed(0)} MB`);
+        sanitized.push({ type: 'text', text: truncateText(item.text, LIMITS.maxTextSize) });
+      } else {
+        sanitized.push(item);
+      }
+    } else if (item.type === 'image' && item.data) {
+      const imageSize = estimateImageSize(item.data);
+      totalSize += imageSize;
+      if (imageSize > LIMITS.maxImageSize) {
+        debug.warn('mcp', `Tool ${toolName} image output exceeded limit: ${(imageSize / 1024 / 1024).toFixed(2)} MB > ${(LIMITS.maxImageSize / 1024 / 1024).toFixed(0)} MB`);
+        sanitized.push({ type: 'text', text: `[Image omitted: size ${(imageSize / 1024 / 1024).toFixed(2)} MB exceeds limit of ${(LIMITS.maxImageSize / 1024 / 1024).toFixed(0)} MB]` });
+      } else {
+        sanitized.push(item);
+      }
+    } else {
+      sanitized.push(item);
+    }
+
+    if (totalSize > LIMITS.maxTotalSize) {
+      debug.warn('mcp', `Tool ${toolName} total output exceeded limit: ${(totalSize / 1024 / 1024).toFixed(2)} MB > ${(LIMITS.maxTotalSize / 1024 / 1024).toFixed(0)} MB`);
+      sanitized.push({ type: 'text', text: '\n\n[Additional content omitted due to total size limit]' });
+      break;
+    }
+  }
+
+  return sanitized;
+}
+
+export function getMcpOutputLimits() {
+  return { ...LIMITS };
+}

--- a/backend/mcp/servers/helper.ts
+++ b/backend/mcp/servers/helper.ts
@@ -13,6 +13,7 @@ import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { z } from "zod";
 import { projectContextService } from '../project-context';
+import { validateMcpOutput } from '../output-validator';
 
 /**
  * Infer argument types from Zod schema
@@ -204,7 +205,11 @@ export function createRemoteMcpServer(
 						isError: true,
 					} as any;
 				}
-				return await def.handler(args) as any;
+				const result = await def.handler(args) as any;
+				if (result?.content) {
+					result.content = validateMcpOutput(result.content, toolName as string);
+				}
+				return result;
 			});
 		}
 	}


### PR DESCRIPTION
## The Problem

MCP tools run in-process and return arbitrary data from the filesystem, browser automation, or external APIs. There's currently no size check on tool outputs before they get forwarded to AI models. A tool that reads a large file, captures a high-res screenshot, or returns verbose debug data can push a single response past tens of megabytes.

This matters because the AI engine adapters (Codex, Claude, Copilot, Qwen, OpenCode) serialize these responses into their message streams. A single oversized tool output can cause memory pressure, slow down stream processing, or hit upstream API limits that the engine doesn't handle gracefully.

## The Fix

Added an output validator that runs inside `createRemoteMcpServer()` — the function that registers all MCP tools for the remote HTTP transport. Every tool handler's result passes through `validateMcpOutput()` before being returned to the engine.

The validator checks three limits:

| Content type | Limit | Action when exceeded |
|---|---|---|
| Text | 10 MB | Truncated with ellipsis and marker |
| Image (base64) | 5 MB | Replaced with text explaining what was omitted |
| Total per tool call | 15 MB | Remaining content dropped with marker |

Size estimation uses conservative heuristics: 2 bytes per character for text (UTF-8 worst case), and 75% of base64 string length for images (since base64 expands data by ~33%).

## Why These Limits

10 MB for text is generous — most tool outputs are under 100 KB. Even a full file listing of a large project rarely exceeds 1 MB. The 10 MB ceiling catches pathological cases (reading binary files as text, dumping entire logs) without blocking legitimate large outputs.

5 MB for images covers typical screenshots at reasonable resolutions. A 1920x1080 screenshot compressed as PNG is usually 200-500 KB. Even at 4K, you'd need a very detailed image to hit 5 MB.

15 MB total prevents the "death by a thousand cuts" scenario where many medium-sized outputs combine into a massive response.

## Edge Cases Handled

- Empty content arrays pass through unchanged
- Non-text/non-image content types (if any are added later) pass through without modification
- Truncation markers are appended so the AI model knows data was cut — it won't silently assume the output was complete
- The validator runs after the abort-signal check, so cancelled tools don't waste cycles on validation

## Files Changed

- `backend/mcp/output-validator.ts` — New module with `validateMcpOutput()` and `getMcpOutputLimits()`
- `backend/mcp/servers/helper.ts` — Wrapped tool handler output in `createRemoteMcpServer()` with validation

## Verification

- `bun tsc --noEmit` passes clean
- Applies to all MCP tools registered via the remote HTTP transport (browser automation, weather, and any future tools)
- Does not affect Claude Code's in-process MCP path (`createSdkMcpServer`) — that path uses the same tool definitions but a different registration flow. If validation is needed there too, it should be added at the SDK level or in a shared wrapper.