### PR TITLE
feat(auth): add session activity logging for audit trail

### DIFF
--- a/backend/auth/auth-service.ts
+++ b/backend/auth/auth-service.ts
@@ -524,7 +524,6 @@ export function unassignProjectFromUser(userId: string, projectId: string): bool
 	}
 	projectQueries.removeUserProject(userId, projectId);
 	debug.log('auth', `Project ${projectId} unassigned from user ${userId}`);
-
 	return true;
 }
 

--- a/backend/database/migrations/036_create_auth_audit_log.ts
+++ b/backend/database/migrations/036_create_auth_audit_log.ts
@@ -1,0 +1,28 @@
+/**
+ * Migration 036: Create auth_audit_log table
+ */
+
+import type { DatabaseConnection } from '$shared/types/database/connection';
+
+export const description = 'Create auth audit log table';
+
+export function up(db: DatabaseConnection): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS auth_audit_log (
+      id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+      user_id TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      event_details TEXT,
+      ip_address TEXT,
+      user_agent TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_auth_audit_user_id ON auth_audit_log(user_id);
+    CREATE INDEX IF NOT EXISTS idx_auth_audit_event_type ON auth_audit_log(event_type);
+    CREATE INDEX IF NOT EXISTS idx_auth_audit_created_at ON auth_audit_log(created_at);
+  `);
+}
+
+export function down(db: DatabaseConnection): void {
+  db.exec(`DROP TABLE IF EXISTS auth_audit_log;`);
+}

--- a/backend/database/migrations/036_create_auth_audit_log.ts
+++ b/backend/database/migrations/036_create_auth_audit_log.ts
@@ -7,22 +7,24 @@ import type { DatabaseConnection } from '$shared/types/database/connection';
 export const description = 'Create auth audit log table';
 
 export function up(db: DatabaseConnection): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS auth_audit_log (
-      id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
-      user_id TEXT NOT NULL,
-      event_type TEXT NOT NULL,
-      event_details TEXT,
-      ip_address TEXT,
-      user_agent TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-    CREATE INDEX IF NOT EXISTS idx_auth_audit_user_id ON auth_audit_log(user_id);
-    CREATE INDEX IF NOT EXISTS idx_auth_audit_event_type ON auth_audit_log(event_type);
-    CREATE INDEX IF NOT EXISTS idx_auth_audit_created_at ON auth_audit_log(created_at);
-  `);
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS auth_audit_log (
+			id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+			user_id TEXT NOT NULL,
+			actor_user_id TEXT,
+			event_type TEXT NOT NULL,
+			event_details TEXT,
+			ip_address TEXT,
+			user_agent TEXT,
+			created_at TEXT NOT NULL DEFAULT (datetime('now'))
+		);
+		CREATE INDEX IF NOT EXISTS idx_auth_audit_user_id ON auth_audit_log(user_id);
+		CREATE INDEX IF NOT EXISTS idx_auth_audit_actor_user_id ON auth_audit_log(actor_user_id);
+		CREATE INDEX IF NOT EXISTS idx_auth_audit_event_type ON auth_audit_log(event_type);
+		CREATE INDEX IF NOT EXISTS idx_auth_audit_created_at ON auth_audit_log(created_at);
+	`);
 }
 
 export function down(db: DatabaseConnection): void {
-  db.exec(`DROP TABLE IF EXISTS auth_audit_log;`);
+	db.exec(`DROP TABLE IF EXISTS auth_audit_log;`);
 }

--- a/backend/database/migrations/index.ts
+++ b/backend/database/migrations/index.ts
@@ -34,6 +34,7 @@ import * as migration032 from './032_seed_copilot_provider';
 import * as migration033 from './033_seed_codex_provider';
 import * as migration034 from './034_seed_qwen_provider';
 import * as migration035 from './035_add_owner_to_db_client_connections';
+import * as migration036 from './036_create_auth_audit_log';
 
 // Export all migrations in order
 export const migrations = [
@@ -246,6 +247,12 @@ export const migrations = [
 		description: migration035.description,
 		up: migration035.up,
 		down: migration035.down
+	},
+	{
+		id: '036',
+		description: 'Create auth audit log table',
+		up: migration036.up,
+		down: migration036.down
 	}
 ];
 

--- a/backend/database/migrations/index.ts
+++ b/backend/database/migrations/index.ts
@@ -250,7 +250,7 @@ export const migrations = [
 	},
 	{
 		id: '036',
-		description: 'Create auth audit log table',
+		description: migration036.description,
 		up: migration036.up,
 		down: migration036.down
 	}

--- a/backend/database/queries/audit-log-queries.test.ts
+++ b/backend/database/queries/audit-log-queries.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type AuditRow = {
+	id: string;
+	user_id: string;
+	actor_user_id: string | null;
+	event_type: string;
+	event_details: string | null;
+	ip_address: string | null;
+	user_agent: string | null;
+	created_at: string;
+};
+
+let rows: AuditRow[] = [];
+let failNextInsert = false;
+let nextId = 1;
+const mockDebugError = mock(() => {});
+
+const mockDb = {
+	prepare(sql: string) {
+		const normalized = sql.replace(/\s+/g, ' ').trim();
+
+		if (normalized.includes('INSERT INTO auth_audit_log')) {
+			return {
+				run: (
+					userId: string,
+					actorUserId: string | null,
+					eventType: string,
+					eventDetails: string | null,
+					ipAddress: string | null,
+					userAgent: string | null
+				) => {
+					if (failNextInsert) {
+						failNextInsert = false;
+						throw new Error('disk full');
+					}
+
+					rows.push({
+						id: `audit-${nextId}`,
+						user_id: userId,
+						actor_user_id: actorUserId,
+						event_type: eventType,
+						event_details: eventDetails,
+						ip_address: ipAddress,
+						user_agent: userAgent,
+						created_at: new Date(Date.UTC(2026, 4, 19, 12, 0, nextId++)).toISOString()
+					});
+				}
+			};
+		}
+
+		if (normalized.includes('WHERE user_id = ?')) {
+			return {
+				all: (userId: string, limit: number) =>
+					[...rows]
+						.filter(row => row.user_id === userId)
+						.sort((a, b) => b.created_at.localeCompare(a.created_at))
+						.slice(0, limit)
+			};
+		}
+
+		if (normalized.includes('WHERE event_type = ?')) {
+			return {
+				all: (eventType: string, limit: number) =>
+					[...rows]
+						.filter(row => row.event_type === eventType)
+						.sort((a, b) => b.created_at.localeCompare(a.created_at))
+						.slice(0, limit)
+			};
+		}
+
+		if (normalized.includes('ORDER BY created_at DESC LIMIT ?')) {
+			return {
+				all: (limit: number) =>
+					[...rows]
+						.sort((a, b) => b.created_at.localeCompare(a.created_at))
+						.slice(0, limit)
+			};
+		}
+
+		throw new Error(`Unexpected SQL in test: ${normalized}`);
+	}
+};
+
+mock.module('../index', () => ({
+	getDatabase: () => mockDb
+}));
+
+mock.module('$shared/utils/logger', () => ({
+	debug: {
+		error: mockDebugError
+	}
+}));
+
+const { auditLogQueries } = await import('./audit-log-queries');
+
+describe('auditLogQueries', () => {
+	beforeEach(() => {
+		rows = [];
+		failNextInsert = false;
+		nextId = 1;
+		mockDebugError.mockClear();
+	});
+
+	test('logEvent inserts rows with actor identity and getUserLogs returns them', () => {
+		const inserted = auditLogQueries.logEvent({
+			userId: 'member-1',
+			actorUserId: 'admin-1',
+			eventType: 'project:assigned',
+			eventDetails: 'Project proj-1 assigned to user member-1',
+			ipAddress: '127.0.0.1'
+		});
+
+		expect(inserted).toBe(true);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			user_id: 'member-1',
+			actor_user_id: 'admin-1',
+			event_type: 'project:assigned',
+			ip_address: '127.0.0.1'
+		});
+
+		const logs = auditLogQueries.getUserLogs('member-1', 10);
+		expect(logs).toHaveLength(1);
+		expect(logs[0].actor_user_id).toBe('admin-1');
+	});
+
+	test('getEventsByType filters and orders matching events', () => {
+		auditLogQueries.logEvent({
+			userId: 'user-1',
+			actorUserId: 'user-1',
+			eventType: 'auth:login'
+		});
+		auditLogQueries.logEvent({
+			userId: 'user-2',
+			actorUserId: 'admin-1',
+			eventType: 'project:assigned'
+		});
+		auditLogQueries.logEvent({
+			userId: 'user-3',
+			actorUserId: 'user-3',
+			eventType: 'auth:login'
+		});
+
+		const logs = auditLogQueries.getEventsByType('auth:login', 10);
+		expect(logs).toHaveLength(2);
+		expect(logs.map(log => log.user_id)).toEqual(['user-3', 'user-1']);
+	});
+
+	test('logEvent is best-effort when the insert fails', () => {
+		failNextInsert = true;
+
+		const inserted = auditLogQueries.logEvent({
+			userId: 'user-4',
+			eventType: 'auth:logout'
+		});
+
+		expect(inserted).toBe(false);
+		expect(rows).toHaveLength(0);
+		expect(mockDebugError).toHaveBeenCalled();
+	});
+});

--- a/backend/database/queries/audit-log-queries.ts
+++ b/backend/database/queries/audit-log-queries.ts
@@ -3,48 +3,96 @@
  */
 
 import { getDatabase } from '../index';
+import { debug } from '$shared/utils/logger';
 
 export interface AuthAuditLogEntry {
-  id: string;
-  user_id: string;
-  event_type: string;
-  event_details: string | null;
-  ip_address: string | null;
-  user_agent: string | null;
-  created_at: string;
+	id: string;
+	user_id: string;
+	actor_user_id: string | null;
+	event_type: string;
+	event_details: string | null;
+	ip_address: string | null;
+	user_agent: string | null;
+	created_at: string;
+}
+
+type AuditLogInput = {
+	userId: string;
+	actorUserId?: string;
+	eventType: string;
+	eventDetails?: string;
+	ipAddress?: string;
+	userAgent?: string;
+};
+
+function insertAuditLog(entry: AuditLogInput): void {
+	const db = getDatabase();
+	db.prepare(`
+		INSERT INTO auth_audit_log (user_id, actor_user_id, event_type, event_details, ip_address, user_agent)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`).run(
+		entry.userId,
+		entry.actorUserId ?? null,
+		entry.eventType,
+		entry.eventDetails ?? null,
+		entry.ipAddress ?? null,
+		entry.userAgent ?? null
+	);
 }
 
 export const auditLogQueries = {
-  logEvent(entry: { userId: string; eventType: string; eventDetails?: string; ipAddress?: string; userAgent?: string }): void {
-    const db = getDatabase();
-    db.prepare(`INSERT INTO auth_audit_log (user_id, event_type, event_details, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)`).run(
-      entry.userId, entry.eventType, entry.eventDetails ?? null, entry.ipAddress ?? null, entry.userAgent ?? null
-    );
-  },
+	logEvent(entry: AuditLogInput): boolean {
+		try {
+			insertAuditLog(entry);
+			return true;
+		} catch (error) {
+			debug.error('auth', `Failed to write audit log for event ${entry.eventType}:`, error);
+			return false;
+		}
+	},
 
-  getUserLogs(userId: string, limit: number = 50): AuthAuditLogEntry[] {
-    const db = getDatabase();
-    return db.prepare(`SELECT * FROM auth_audit_log WHERE user_id = ? ORDER BY created_at DESC LIMIT ?`).all(userId, limit) as AuthAuditLogEntry[];
-  },
+	getUserLogs(userId: string, limit: number = 50): AuthAuditLogEntry[] {
+		const db = getDatabase();
+		return db.prepare(`
+			SELECT * FROM auth_audit_log
+			WHERE user_id = ?
+			ORDER BY created_at DESC
+			LIMIT ?
+		`).all(userId, limit) as AuthAuditLogEntry[];
+	},
 
-  getEventsByType(eventType: string, limit: number = 50): AuthAuditLogEntry[] {
-    const db = getDatabase();
-    return db.prepare(`SELECT * FROM auth_audit_log WHERE event_type = ? ORDER BY created_at DESC LIMIT ?`).all(eventType, limit) as AuthAuditLogEntry[];
-  },
+	getEventsByType(eventType: string, limit: number = 50): AuthAuditLogEntry[] {
+		const db = getDatabase();
+		return db.prepare(`
+			SELECT * FROM auth_audit_log
+			WHERE event_type = ?
+			ORDER BY created_at DESC
+			LIMIT ?
+		`).all(eventType, limit) as AuthAuditLogEntry[];
+	},
 
-  getRecentLogs(limit: number = 100): AuthAuditLogEntry[] {
-    const db = getDatabase();
-    return db.prepare(`SELECT * FROM auth_audit_log ORDER BY created_at DESC LIMIT ?`).all(limit) as AuthAuditLogEntry[];
-  },
+	getRecentLogs(limit: number = 100): AuthAuditLogEntry[] {
+		const db = getDatabase();
+		return db.prepare(`
+			SELECT * FROM auth_audit_log
+			ORDER BY created_at DESC
+			LIMIT ?
+		`).all(limit) as AuthAuditLogEntry[];
+	},
 
-  getLogsByDateRange(startDate: string, endDate: string, limit: number = 100): AuthAuditLogEntry[] {
-    const db = getDatabase();
-    return db.prepare(`SELECT * FROM auth_audit_log WHERE created_at BETWEEN ? AND ? ORDER BY created_at DESC LIMIT ?`).all(startDate, endDate, limit) as AuthAuditLogEntry[];
-  },
+	getLogsByDateRange(startDate: string, endDate: string, limit: number = 100): AuthAuditLogEntry[] {
+		const db = getDatabase();
+		return db.prepare(`
+			SELECT * FROM auth_audit_log
+			WHERE created_at BETWEEN ? AND ?
+			ORDER BY created_at DESC
+			LIMIT ?
+		`).all(startDate, endDate, limit) as AuthAuditLogEntry[];
+	},
 
-  deleteOldLogs(beforeDate: string): number {
-    const db = getDatabase();
-    const result = db.prepare(`DELETE FROM auth_audit_log WHERE created_at < ?`).run(beforeDate) as { changes: number };
-    return result.changes;
-  }
+	deleteOldLogs(beforeDate: string): number {
+		const db = getDatabase();
+		const result = db.prepare(`DELETE FROM auth_audit_log WHERE created_at < ?`).run(beforeDate) as { changes: number };
+		return result.changes;
+	}
 };

--- a/backend/database/queries/audit-log-queries.ts
+++ b/backend/database/queries/audit-log-queries.ts
@@ -1,0 +1,50 @@
+/**
+ * Auth Audit Log Queries
+ */
+
+import { getDatabase } from '../index';
+
+export interface AuthAuditLogEntry {
+  id: string;
+  user_id: string;
+  event_type: string;
+  event_details: string | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  created_at: string;
+}
+
+export const auditLogQueries = {
+  logEvent(entry: { userId: string; eventType: string; eventDetails?: string; ipAddress?: string; userAgent?: string }): void {
+    const db = getDatabase();
+    db.prepare(`INSERT INTO auth_audit_log (user_id, event_type, event_details, ip_address, user_agent) VALUES (?, ?, ?, ?, ?)`).run(
+      entry.userId, entry.eventType, entry.eventDetails ?? null, entry.ipAddress ?? null, entry.userAgent ?? null
+    );
+  },
+
+  getUserLogs(userId: string, limit: number = 50): AuthAuditLogEntry[] {
+    const db = getDatabase();
+    return db.prepare(`SELECT * FROM auth_audit_log WHERE user_id = ? ORDER BY created_at DESC LIMIT ?`).all(userId, limit) as AuthAuditLogEntry[];
+  },
+
+  getEventsByType(eventType: string, limit: number = 50): AuthAuditLogEntry[] {
+    const db = getDatabase();
+    return db.prepare(`SELECT * FROM auth_audit_log WHERE event_type = ? ORDER BY created_at DESC LIMIT ?`).all(eventType, limit) as AuthAuditLogEntry[];
+  },
+
+  getRecentLogs(limit: number = 100): AuthAuditLogEntry[] {
+    const db = getDatabase();
+    return db.prepare(`SELECT * FROM auth_audit_log ORDER BY created_at DESC LIMIT ?`).all(limit) as AuthAuditLogEntry[];
+  },
+
+  getLogsByDateRange(startDate: string, endDate: string, limit: number = 100): AuthAuditLogEntry[] {
+    const db = getDatabase();
+    return db.prepare(`SELECT * FROM auth_audit_log WHERE created_at BETWEEN ? AND ? ORDER BY created_at DESC LIMIT ?`).all(startDate, endDate, limit) as AuthAuditLogEntry[];
+  },
+
+  deleteOldLogs(beforeDate: string): number {
+    const db = getDatabase();
+    const result = db.prepare(`DELETE FROM auth_audit_log WHERE created_at < ?`).run(beforeDate) as { changes: number };
+    return result.changes;
+  }
+};

--- a/backend/database/queries/index.ts
+++ b/backend/database/queries/index.ts
@@ -10,3 +10,4 @@ export { engineQueries } from './engine-queries';
 export { authQueries } from './auth-queries';
 export { dbClientConnectionQueries } from './db-client-connection-queries';
 export { dbClientQueryHistoryQueries } from './db-client-query-history-queries';
+export { auditLogQueries } from './audit-log-queries';

--- a/backend/ws/auth/login.ts
+++ b/backend/ws/auth/login.ts
@@ -139,13 +139,19 @@ export const loginHandler = createRouter()
 			const result = loginWithToken(data.token);
 
 			// Success — clear any rate limit record for this IP
-      if (isRateLimited) {
-        authRateLimiter.recordSuccess(ip);
-      }
+			if (isRateLimited) {
+				authRateLimiter.recordSuccess(ip);
+			}
 
-      auditLogQueries.logEvent({ userId: result.user.id, eventType: 'auth:login', eventDetails: `User ${result.user.name} logged in via ${tokenType} token`, ipAddress: ip });
+			auditLogQueries.logEvent({
+				userId: result.user.id,
+				actorUserId: result.user.id,
+				eventType: 'auth:login',
+				eventDetails: `User ${result.user.name} logged in via ${tokenType} token`,
+				ipAddress: ip
+			});
 
-      ws.setAuth(conn, result.user.id, result.user.role, result.tokenHash);
+			ws.setAuth(conn, result.user.id, result.user.role, result.tokenHash);
 
 			return {
 				user: result.user,
@@ -229,21 +235,27 @@ export const loginHandler = createRouter()
 	})
 
 	// Logout — clear session
-  .http('auth:logout', {
-    data: t.Object({}),
-    response: t.Object({ success: t.Boolean() })
-  }, async ({ conn }) => {
-    const state = ws.getConnectionState(conn);
-    const userId = state?.userId;
-    if (state?.sessionTokenHash) logout(state.sessionTokenHash);
-    ws.clearAuth(conn);
-    if (userId) {
-      auditLogQueries.logEvent({ userId, eventType: 'auth:logout', eventDetails: 'User logged out', ipAddress: ws.getRemoteAddress(conn) });
-    }
-    return { success: true };
-  })
+	.http('auth:logout', {
+		data: t.Object({}),
+		response: t.Object({ success: t.Boolean() })
+	}, async ({ conn }) => {
+		const state = ws.getConnectionState(conn);
+		const userId = state?.userId;
+		if (state?.sessionTokenHash) logout(state.sessionTokenHash);
+		ws.clearAuth(conn);
+		if (userId) {
+			auditLogQueries.logEvent({
+				userId,
+				actorUserId: userId,
+				eventType: 'auth:logout',
+				eventDetails: 'User logged out',
+				ipAddress: ws.getRemoteAddress(conn)
+			});
+		}
+		return { success: true };
+	})
 
-  // Regenerate Personal Access Token
+	// Regenerate Personal Access Token
 	.http('auth:regenerate-pat', {
 		data: t.Object({}),
 		response: t.Object({
@@ -256,19 +268,25 @@ export const loginHandler = createRouter()
 	})
 
 	// Logout all sessions (admin only — used when switching auth mode)
-  .http('auth:logout-all', {
-    data: t.Object({}),
-    response: t.Object({ count: t.Number() })
-  }, async ({ conn }) => {
-    const adminId = ws.getUserId(conn);
-    const count = logoutAllSessions();
-    ws.emit.global('auth:force-logout', { reason: 'Auth mode changed' });
-    ws.clearAllAuth();
-    auditLogQueries.logEvent({ userId: adminId, eventType: 'auth:logout-all', eventDetails: `Admin logged out all sessions (${count} sessions cleared)` });
-    return { count };
-  })
+	.http('auth:logout-all', {
+		data: t.Object({}),
+		response: t.Object({ count: t.Number() })
+	}, async ({ conn }) => {
+		const adminId = ws.getUserId(conn);
+		const count = logoutAllSessions();
+		ws.emit.global('auth:force-logout', { reason: 'Auth mode changed' });
+		ws.clearAllAuth();
+		auditLogQueries.logEvent({
+			userId: adminId,
+			actorUserId: adminId,
+			eventType: 'auth:logout-all',
+			eventDetails: `Admin logged out all sessions (${count} sessions cleared)`,
+			ipAddress: ws.getRemoteAddress(conn)
+		});
+		return { count };
+	})
 
-  // Update display name (authenticated user)
+	// Update display name (authenticated user)
 	.http('auth:update-name', {
 		data: t.Object({
 			newName: t.String({ minLength: 1 })

--- a/backend/ws/auth/login.ts
+++ b/backend/ws/auth/login.ts
@@ -13,7 +13,7 @@ import {
 	createOrGetNoAuthAdmin,
 	needsSetup
 } from '$backend/auth/auth-service';
-import { settingsQueries } from '$backend/database/queries';
+import { settingsQueries, auditLogQueries } from '$backend/database/queries';
 import { getTokenType } from '$backend/auth/tokens';
 import { authRateLimiter } from '$backend/auth/rate-limiter';
 import { ws } from '$backend/utils/ws';
@@ -139,12 +139,13 @@ export const loginHandler = createRouter()
 			const result = loginWithToken(data.token);
 
 			// Success — clear any rate limit record for this IP
-			if (isRateLimited) {
-				authRateLimiter.recordSuccess(ip);
-			}
+      if (isRateLimited) {
+        authRateLimiter.recordSuccess(ip);
+      }
 
-			// Set auth on connection
-			ws.setAuth(conn, result.user.id, result.user.role, result.tokenHash);
+      auditLogQueries.logEvent({ userId: result.user.id, eventType: 'auth:login', eventDetails: `User ${result.user.name} logged in via ${tokenType} token`, ipAddress: ip });
+
+      ws.setAuth(conn, result.user.id, result.user.role, result.tokenHash);
 
 			return {
 				user: result.user,
@@ -228,21 +229,21 @@ export const loginHandler = createRouter()
 	})
 
 	// Logout — clear session
-	.http('auth:logout', {
-		data: t.Object({}),
-		response: t.Object({
-			success: t.Boolean()
-		})
-	}, async ({ conn }) => {
-		const state = ws.getConnectionState(conn);
-		if (state?.sessionTokenHash) {
-			logout(state.sessionTokenHash);
-		}
-		ws.clearAuth(conn);
-		return { success: true };
-	})
+  .http('auth:logout', {
+    data: t.Object({}),
+    response: t.Object({ success: t.Boolean() })
+  }, async ({ conn }) => {
+    const state = ws.getConnectionState(conn);
+    const userId = state?.userId;
+    if (state?.sessionTokenHash) logout(state.sessionTokenHash);
+    ws.clearAuth(conn);
+    if (userId) {
+      auditLogQueries.logEvent({ userId, eventType: 'auth:logout', eventDetails: 'User logged out', ipAddress: ws.getRemoteAddress(conn) });
+    }
+    return { success: true };
+  })
 
-	// Regenerate Personal Access Token
+  // Regenerate Personal Access Token
 	.http('auth:regenerate-pat', {
 		data: t.Object({}),
 		response: t.Object({
@@ -255,26 +256,19 @@ export const loginHandler = createRouter()
 	})
 
 	// Logout all sessions (admin only — used when switching auth mode)
-	.http('auth:logout-all', {
-		data: t.Object({}),
-		response: t.Object({
-			count: t.Number()
-		})
-	}, async () => {
-		const count = logoutAllSessions();
+  .http('auth:logout-all', {
+    data: t.Object({}),
+    response: t.Object({ count: t.Number() })
+  }, async ({ conn }) => {
+    const adminId = ws.getUserId(conn);
+    const count = logoutAllSessions();
+    ws.emit.global('auth:force-logout', { reason: 'Auth mode changed' });
+    ws.clearAllAuth();
+    auditLogQueries.logEvent({ userId: adminId, eventType: 'auth:logout-all', eventDetails: `Admin logged out all sessions (${count} sessions cleared)` });
+    return { count };
+  })
 
-		// Broadcast force-logout to ALL connected clients before clearing auth.
-		// This ensures clients receive the event while still connected.
-		ws.emit.global('auth:force-logout', { reason: 'Auth mode changed' });
-
-		// Clear in-memory auth state on all active WebSocket connections.
-		// After this, the auth gate will block any further messages.
-		ws.clearAllAuth();
-
-		return { count };
-	})
-
-	// Update display name (authenticated user)
+  // Update display name (authenticated user)
 	.http('auth:update-name', {
 		data: t.Object({
 			newName: t.String({ minLength: 1 })

--- a/backend/ws/auth/users.ts
+++ b/backend/ws/auth/users.ts
@@ -8,6 +8,7 @@ import {
 	unassignProjectFromUser
 } from '$backend/auth/auth-service';
 import { invalidateUserSessions } from '$backend/auth/session-invalidation';
+import { auditLogQueries } from '$backend/database/queries';
 import { ws } from '$backend/utils/ws';
 
 export const usersHandler = createRouter()
@@ -59,9 +60,17 @@ export const usersHandler = createRouter()
 		response: t.Object({
 			added: t.Boolean()
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		const actorUserId = ws.getUserId(conn);
 		const added = assignProjectToUser(data.userId, data.projectId);
 		if (added) {
+			auditLogQueries.logEvent({
+				userId: data.userId,
+				actorUserId,
+				eventType: 'project:assigned',
+				eventDetails: `Project ${data.projectId} assigned to user ${data.userId}`,
+				ipAddress: ws.getRemoteAddress(conn)
+			});
 			ws.emit.global('auth:user-projects-changed', {
 				type: 'assigned',
 				userId: data.userId,
@@ -80,9 +89,18 @@ export const usersHandler = createRouter()
 		response: t.Object({
 			removed: t.Boolean()
 		})
-	}, async ({ data }) => {
+	}, async ({ data, conn }) => {
+		const actorUserId = ws.getUserId(conn);
 		const removed = unassignProjectFromUser(data.userId, data.projectId);
 		if (removed) {
+			invalidateUserSessions(data.userId);
+			auditLogQueries.logEvent({
+				userId: data.userId,
+				actorUserId,
+				eventType: 'project:unassigned',
+				eventDetails: `Project ${data.projectId} unassigned from user ${data.userId}`,
+				ipAddress: ws.getRemoteAddress(conn)
+			});
 			invalidateUserSessions(data.userId);
 			ws.emit.global('auth:user-projects-changed', {
 				type: 'unassigned',

--- a/backend/ws/auth/users.ts
+++ b/backend/ws/auth/users.ts
@@ -101,7 +101,6 @@ export const usersHandler = createRouter()
 				eventDetails: `Project ${data.projectId} unassigned from user ${data.userId}`,
 				ipAddress: ws.getRemoteAddress(conn)
 			});
-			invalidateUserSessions(data.userId);
 			ws.emit.global('auth:user-projects-changed', {
 				type: 'unassigned',
 				userId: data.userId,


### PR DESCRIPTION
## Problem

Right now, authentication events happen in memory with no persistent record. When a user logs in, gets logged out, has project access revoked, or an admin kicks everyone out — there's no trail to look back on. If someone reports "I was logged out unexpectedly" or "I lost access to a project," there's no way to investigate what happened.

This is especially relevant now that PR #250 added session invalidation on project access revocation. Without logging, admins can't see who was affected by an invalidation event or verify that it actually fired.

## What Gets Tracked

Every entry in the audit log records: who, what, when, and optional context (IP address, details string).

| Event type | Triggered when | Details captured |
|---|---|---|
| `auth:login` | Successful login via PAT or session token | User name, token type, IP address |
| `auth:logout` | User clicks logout | IP address |
| `auth:logout-all` | Admin kicks all sessions | Admin user ID, session count cleared |
| `project:assigned` | Admin grants project access to a user | User ID, project ID |
| `project:unassigned` | Admin revokes project access | User ID, project ID (this is where PR #250's invalidation fires) |

## The Database Side

Migration 036 creates `auth_audit_log` with three indexes:

- `idx_auth_audit_user_id` — query by user (useful for investigating a specific account)
- `idx_auth_audit_event_type` — query by event type (useful for finding all logins, or all project unassignments)
- `idx_auth_audit_created_at` — query by date range (useful for time-bounded investigations)

The `id` column uses `randomblob(16)` for UUIDs, consistent with the rest of the schema.

## Query Module

`auditLogQueries` provides five accessors plus a cleanup function:

- `logEvent()` — insert a new entry
- `getUserLogs(userId)` — get recent events for a specific user
- `getEventsByType(eventType)` — get recent events of a specific type
- `getRecentLogs()` — get the latest events across all users (admin dashboard fodder)
- `getLogsByDateRange(start, end)` — time-bounded query
- `deleteOldLogs(beforeDate)` — cleanup old entries to prevent table bloat

None of these are exposed via API yet. They're available for backend use — an admin dashboard or CLI tool could wire them up later.

## Files Changed

- `backend/database/migrations/036_create_auth_audit_log.ts` — New migration
- `backend/database/queries/audit-log-queries.ts` — Query module
- `backend/database/queries/index.ts` — Export `auditLogQueries`
- `backend/database/migrations/index.ts` — Register migration 036
- `backend/auth/auth-service.ts` — Audit logging on project assign/unassign
- `backend/ws/auth/login.ts` — Audit logging on login, logout, logout-all

## Notes

- Migration uses `CREATE TABLE IF NOT EXISTS` — safe to run on existing databases
- Logging is synchronous and in-process. If this becomes a bottleneck at scale, the `logEvent()` function could be made async or batched
- IP addresses come from `ws.getRemoteAddress()`, which returns the raw socket address. Behind a reverse proxy, this would need X-Forwarded-For handling