### PR TITLE
fix(memory): clean up FileTree projectSearchStates on project remove

### DIFF
--- a/frontend/components/files/FileTree.svelte
+++ b/frontend/components/files/FileTree.svelte
@@ -1,6 +1,15 @@
 <script module lang="ts">
+	import { registerProjectCleanup } from '$frontend/utils/project-state-cleanup';
+
 	// Persistent state that survives component destruction (mobile/desktop switch)
 	const projectSearchStates = new Map<string, any>();
+
+	function cleanupFileTreeSearchState(projectId: string): void {
+		projectSearchStates.delete(projectId);
+	}
+
+	// Register once at module load to avoid duplicate closures on remount.
+	registerProjectCleanup(cleanupFileTreeSearchState);
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
## Summary

`frontend/components/files/FileTree.svelte:3` keeps a module-level `Map<projectId, searchState>` to preserve search UI state across mobile/desktop layout switches. It's never cleaned up when a project is removed — same shape as the four sites already covered by #252.

## Why

This is one adjacent site that #252 didn't sweep in. Pattern is identical to `projectFileStates` in `FilesPanel.svelte` from the same domain, so reusing the registry from `frontend/utils/project-state-cleanup.ts` is the consistent fix.

## Changes

- `frontend/components/files/FileTree.svelte:1` — register a named module-level cleanup function (`cleanupFileTreeSearchState`) with the project cleanup registry. Stable closure identity, registers once at module load.

## Notes

- `bun run check` and `bun run lint` pass clean.
- No new tests — same justification as #252: the cleanup function is a one-line `map.delete(key)` triggered from the centralized registry.

## Related

Builds on #252 by @DeryFerd — credits the pattern.
