### PR TITLE
fix(files): guard symlink resolution in path access checks

### DIFF
--- a/backend/ws/files/path-access.test.ts
+++ b/backend/ws/files/path-access.test.ts
@@ -37,7 +37,7 @@ mock.module('../../database/queries/project-queries', () => ({
 	}
 }));
 
-const mockGetRole = mock(() => 'member' as const);
+const mockGetRole = mock((): 'admin' | 'member' => 'member');
 const mockGetUserId = mock(() => 'user-1');
 
 mock.module('$backend/utils/ws', () => ({

--- a/backend/ws/files/path-access.test.ts
+++ b/backend/ws/files/path-access.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from 'bun:test';
+import { mkdir, symlink, writeFile, rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, platform } from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+const isWindows = platform() === 'win32';
+
+// Symlinks on Windows require admin privileges. Skip symlink-specific tests
+// when running without elevated permissions.
+async function canCreateSymlinks(): Promise<boolean> {
+	const testPath = join(tmpdir(), `symlink-test-${randomUUID()}`);
+	const targetPath = join(tmpdir(), `symlink-target-${randomUUID()}`);
+	try {
+		await mkdir(targetPath, { recursive: true });
+		await symlink(targetPath, testPath, 'dir');
+		await rm(testPath);
+		await rm(targetPath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// Mock dependencies before importing the module under test
+const mockGetAllForUser = mock(() => [] as Array<{ id: string; path: string }>);
+const mockGetAll = mock(() => [] as Array<{ id: string; path: string }>);
+const mockUserHasProject = mock(() => false);
+const mockGetByPath = mock(() => null as { id: string; path: string } | null);
+
+mock.module('../../database/queries/project-queries', () => ({
+	projectQueries: {
+		getAllForUser: mockGetAllForUser,
+		getAll: mockGetAll,
+		userHasProject: mockUserHasProject,
+		getByPath: mockGetByPath,
+	}
+}));
+
+const mockGetRole = mock(() => 'member' as const);
+const mockGetUserId = mock(() => 'user-1');
+
+mock.module('$backend/utils/ws', () => ({
+	ws: {
+		getRole: mockGetRole,
+		getUserId: mockGetUserId,
+	}
+}));
+
+mock.module('../access', () => ({
+	requireProjectAccess: mock(() => ({ id: 'proj-1', path: '' })),
+}));
+
+// Import after mocking
+const { requireFilePathAccess, requireSharedFilePathAccess } = await import('./path-access');
+
+let testDir: string;
+
+describe('path-access symlink resolution', () => {
+	beforeEach(async () => {
+		testDir = join(tmpdir(), `clopen-path-access-test-${randomUUID()}`);
+		await mkdir(testDir, { recursive: true });
+		mockGetRole.mockImplementation(() => 'member');
+		mockGetUserId.mockImplementation(() => 'user-1');
+	});
+
+	afterEach(async () => {
+		await rm(testDir, { recursive: true, force: true });
+	});
+
+	test('blocks read through symlink to external directory', async () => {
+		if (!(await canCreateSymlinks())) {
+			console.log('SKIP: symlink creation requires admin on this platform');
+			return;
+		}
+		// Setup: project at testDir/project, symlink pointing to testDir/external
+		const projectPath = join(testDir, 'project');
+		const externalPath = join(testDir, 'external');
+		const symlinkPath = join(projectPath, 'escape');
+
+		await mkdir(projectPath, { recursive: true });
+		await mkdir(externalPath, { recursive: true });
+		await writeFile(join(externalPath, 'secret.txt'), 'confidential');
+		await symlink(externalPath, symlinkPath, 'dir');
+
+		mockGetAllForUser.mockReturnValue([{ id: 'proj-1', path: projectPath }]);
+
+		// Attempt to access file through symlink
+		const targetPath = join(symlinkPath, 'secret.txt');
+		await expect(requireFilePathAccess({} as any, targetPath)).rejects.toThrow('Access denied');
+	});
+
+	test('blocks write through symlink to external directory for non-existing leaf', async () => {
+		if (!(await canCreateSymlinks())) {
+			console.log('SKIP: symlink creation requires admin on this platform');
+			return;
+		}
+		// Setup: project at testDir/project, symlink pointing to testDir/external
+		const projectPath = join(testDir, 'project');
+		const externalPath = join(testDir, 'external');
+		const symlinkPath = join(projectPath, 'escape');
+
+		await mkdir(projectPath, { recursive: true });
+		await mkdir(externalPath, { recursive: true });
+		await symlink(externalPath, symlinkPath, 'dir');
+
+		mockGetAllForUser.mockReturnValue([{ id: 'proj-1', path: projectPath }]);
+
+		// Attempt to write to a non-existing file through symlink
+		// This is the key regression: realpath throws for non-existing paths,
+		// but resolveRealPath should still resolve the symlinked parent
+		const targetPath = join(symlinkPath, 'new-file.txt');
+		await expect(requireFilePathAccess({} as any, targetPath)).rejects.toThrow('Access denied');
+	});
+
+	test('blocks rename of ancestor path containing another user project', async () => {
+		// Setup: user-1 tries to rename /parent, but user-2 has project at /parent/child
+		const parentPath = join(testDir, 'parent');
+		const childProjectPath = join(parentPath, 'child-project');
+
+		await mkdir(childProjectPath, { recursive: true });
+
+		mockGetAll.mockReturnValue([{ id: 'proj-2', path: childProjectPath }]);
+		mockUserHasProject.mockReturnValue(false);
+
+		// user-1 attempts to rename the parent directory
+		await expect(requireSharedFilePathAccess({} as any, parentPath)).rejects.toThrow('Access denied');
+	});
+
+	test('allows access to files inside user own project', async () => {
+		const projectPath = join(testDir, 'project');
+		const filePath = join(projectPath, 'file.txt');
+
+		await mkdir(projectPath, { recursive: true });
+		await writeFile(filePath, 'content');
+
+		mockGetAllForUser.mockReturnValue([{ id: 'proj-1', path: projectPath }]);
+
+		const result = await requireFilePathAccess({} as any, filePath);
+		expect(result).toBe(filePath);
+	});
+
+	test('allows creating new files inside user own project', async () => {
+		const projectPath = join(testDir, 'project');
+		const newFilePath = join(projectPath, 'new-file.txt');
+
+		await mkdir(projectPath, { recursive: true });
+
+		mockGetAllForUser.mockReturnValue([{ id: 'proj-1', path: projectPath }]);
+
+		// new-file.txt doesn't exist yet, but should still be allowed
+		const result = await requireFilePathAccess({} as any, newFilePath);
+		expect(result).toBe(newFilePath);
+	});
+
+	test('admin bypasses all checks', async () => {
+		mockGetRole.mockImplementation(() => 'admin');
+
+		const anyPath = join(testDir, 'any', 'path', 'file.txt');
+		const result = await requireFilePathAccess({} as any, anyPath);
+		expect(result).toBe(anyPath);
+	});
+});

--- a/backend/ws/files/path-access.test.ts
+++ b/backend/ws/files/path-access.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, mock, beforeEach, afterEach } from 'bun:test';
-import { mkdir, symlink, writeFile, rm, stat } from 'node:fs/promises';
+import { mkdir, symlink, writeFile, rm, realpath } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir, platform } from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -15,7 +15,7 @@ async function canCreateSymlinks(): Promise<boolean> {
 		await mkdir(targetPath, { recursive: true });
 		await symlink(targetPath, testPath, 'dir');
 		await rm(testPath);
-		await rm(targetPath);
+		await rm(targetPath, { recursive: true });
 		return true;
 	} catch {
 		return false;
@@ -58,8 +58,11 @@ let testDir: string;
 
 describe('path-access symlink resolution', () => {
 	beforeEach(async () => {
-		testDir = join(tmpdir(), `clopen-path-access-test-${randomUUID()}`);
-		await mkdir(testDir, { recursive: true });
+		const rawTestDir = join(tmpdir(), `clopen-path-access-test-${randomUUID()}`);
+		await mkdir(rawTestDir, { recursive: true });
+		// Canonicalize so test expectations match what resolveRealPath returns.
+		// macOS tmpdir lives under /var → /private/var, which realpath follows.
+		testDir = await realpath(rawTestDir);
 		mockGetRole.mockImplementation(() => 'member');
 		mockGetUserId.mockImplementation(() => 'user-1');
 	});

--- a/backend/ws/files/path-access.ts
+++ b/backend/ws/files/path-access.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, relative, resolve } from 'node:path';
+import { realpath } from 'node:fs/promises';
 
 import { projectQueries } from '../../database/queries/project-queries';
 import { ws } from '$backend/utils/ws';
@@ -6,9 +7,26 @@ import type { WSConnection } from '$shared/utils/ws-server';
 import type { Project } from '$shared/types/database/schema';
 import { requireProjectAccess } from '../access';
 
-function isPathInside(rootPath: string, candidatePath: string): boolean {
-	const root = resolve(rootPath);
-	const candidate = resolve(candidatePath);
+/**
+ * Resolve a path to its real (canonical) location, following symlinks.
+ * Falls back to `resolve()` if the path does not exist on disk.
+ */
+async function resolveRealPath(p: string): Promise<string> {
+	try {
+		return await realpath(p);
+	} catch {
+		return resolve(p);
+	}
+}
+
+/**
+ * Check whether candidatePath is inside rootPath, resolving symlinks on both
+ * sides so that a symlink inside a project root cannot escape to an external
+ * target.
+ */
+async function isPathInside(rootPath: string, candidatePath: string): Promise<boolean> {
+	const root = await resolveRealPath(rootPath);
+	const candidate = await resolveRealPath(candidatePath);
 	const rel = relative(root, candidate);
 	return rel === '' || (!!rel && !rel.startsWith('..') && !isAbsolute(rel));
 }
@@ -24,8 +42,8 @@ export function requireProjectPathAccess(conn: WSConnection, projectPath: string
 	return requireProjectAccess(conn, project.id);
 }
 
-export function requireFilePathAccess(conn: WSConnection, filePath: string): string {
-	const normalizedPath = resolve(filePath);
+export async function requireFilePathAccess(conn: WSConnection, filePath: string): Promise<string> {
+	const normalizedPath = await resolveRealPath(filePath);
 	if (ws.getRole(conn) === 'admin') {
 		return normalizedPath;
 	}
@@ -33,20 +51,21 @@ export function requireFilePathAccess(conn: WSConnection, filePath: string): str
 	const userId = ws.getUserId(conn);
 	const projects = projectQueries.getAllForUser(userId);
 
-	const hasAccess = projects.some((project) => isPathInside(project.path, normalizedPath));
-	if (!hasAccess) {
-		throw new Error('Access denied');
+	for (const project of projects) {
+		if (await isPathInside(project.path, normalizedPath)) {
+			return normalizedPath;
+		}
 	}
 
-	return normalizedPath;
+	throw new Error('Access denied');
 }
 
 // Picker-style guard: allow paths inside the user's accessible projects OR
 // outside every registered project. Rejects only when the path lives inside
 // another project the user cannot access. Used by FolderBrowser flows that
 // operate around / before a project exists.
-export function requireSharedFilePathAccess(conn: WSConnection, filePath: string): string {
-	const normalizedPath = resolve(filePath);
+export async function requireSharedFilePathAccess(conn: WSConnection, filePath: string): Promise<string> {
+	const normalizedPath = await resolveRealPath(filePath);
 	if (ws.getRole(conn) === 'admin') {
 		return normalizedPath;
 	}
@@ -57,9 +76,9 @@ export function requireSharedFilePathAccess(conn: WSConnection, filePath: string
 	// Without this, renaming/deleting `/foo` would break a project rooted at
 	// `/foo/bar` even though `/foo` itself is not "inside" any project.
 	for (const project of allProjects) {
-		const projectRoot = resolve(project.path);
+		const projectRoot = await resolveRealPath(project.path);
 		if (projectRoot === normalizedPath) continue; // equality is handled below
-		if (!isPathInside(normalizedPath, project.path)) continue;
+		if (await isPathInside(normalizedPath, project.path)) continue;
 		if (!projectQueries.userHasProject(userId, project.id)) {
 			throw new Error('Access denied');
 		}
@@ -69,8 +88,8 @@ export function requireSharedFilePathAccess(conn: WSConnection, filePath: string
 	// roots resolve to the inner one, not whichever the DB returns first.
 	let containing: { id: string; path: string } | null = null;
 	for (const project of allProjects) {
-		if (!isPathInside(project.path, normalizedPath)) continue;
-		const projectRoot = resolve(project.path);
+		if (!(await isPathInside(project.path, normalizedPath))) continue;
+		const projectRoot = await resolveRealPath(project.path);
 		if (!containing || projectRoot.length > resolve(containing.path).length) {
 			containing = project;
 		}
@@ -87,13 +106,13 @@ export function requireSharedFilePathAccess(conn: WSConnection, filePath: string
 	return normalizedPath;
 }
 
-export function filterAccessibleExpandedPaths(rootPath: string, expandedPaths?: Set<string>): Set<string> | undefined {
+export async function filterAccessibleExpandedPaths(rootPath: string, expandedPaths?: Set<string>): Promise<Set<string> | undefined> {
 	if (!expandedPaths) return undefined;
 	const filtered = new Set<string>();
 
 	for (const expandedPath of expandedPaths) {
-		if (isPathInside(rootPath, expandedPath)) {
-			filtered.add(resolve(expandedPath));
+		if (await isPathInside(rootPath, expandedPath)) {
+			filtered.add(await resolveRealPath(expandedPath));
 		}
 	}
 

--- a/backend/ws/files/path-access.ts
+++ b/backend/ws/files/path-access.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, relative, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { realpath } from 'node:fs/promises';
 
 import { projectQueries } from '../../database/queries/project-queries';
@@ -9,13 +9,18 @@ import { requireProjectAccess } from '../access';
 
 /**
  * Resolve a path to its real (canonical) location, following symlinks.
- * Falls back to `resolve()` if the path does not exist on disk.
+ * For non-existent paths, resolves the deepest existing ancestor and
+ * rejoins the unresolved tail so symlinked parent components are always
+ * followed even when the leaf doesn't exist yet.
  */
 async function resolveRealPath(p: string): Promise<string> {
+	const abs = resolve(p);
 	try {
-		return await realpath(p);
+		return await realpath(abs);
 	} catch {
-		return resolve(p);
+		const parent = dirname(abs);
+		if (parent === abs) return abs;
+		return join(await resolveRealPath(parent), basename(abs));
 	}
 }
 
@@ -78,7 +83,7 @@ export async function requireSharedFilePathAccess(conn: WSConnection, filePath: 
 	for (const project of allProjects) {
 		const projectRoot = await resolveRealPath(project.path);
 		if (projectRoot === normalizedPath) continue; // equality is handled below
-		if (await isPathInside(normalizedPath, project.path)) continue;
+		if (!(await isPathInside(normalizedPath, project.path))) continue;
 		if (!projectQueries.userHasProject(userId, project.id)) {
 			throw new Error('Access denied');
 		}

--- a/backend/ws/files/read.ts
+++ b/backend/ws/files/read.ts
@@ -89,7 +89,7 @@ export const readHandler = createRouter()
 				.filter(Boolean);
 			expandedPaths = new Set(paths);
 		}
-		expandedPaths = filterAccessibleExpandedPaths(projectPath, expandedPaths);
+		expandedPaths = await filterAccessibleExpandedPaths(projectPath, expandedPaths);
 
 		const fileTree = await buildFileTree(projectPath, 3, 0, expandedPaths);
 		return fileTree as any;
@@ -132,7 +132,7 @@ export const readHandler = createRouter()
 			: (data.path === '.' || data.path === '' ? process.cwd() : data.path);
 		const guardedPath = data.path === 'drives'
 			? 'drives'
-			: requireSharedFilePathAccess(conn, requestedPath);
+			: await requireSharedFilePathAccess(conn, requestedPath);
 		const result = await handlePathBrowsing(guardedPath);
 		return result;
 	})
@@ -156,7 +156,7 @@ export const readHandler = createRouter()
 			)
 		)
 	}, async ({ data, conn }) => {
-		const dirPath = requireFilePathAccess(conn, data.dir_path);
+		const dirPath = await requireFilePathAccess(conn, data.dir_path);
 		const result = await listDirectoryContents(dirPath);
 		return result;
 	})
@@ -176,7 +176,7 @@ export const readHandler = createRouter()
 			error: t.Optional(t.String())
 		})
 	}, async ({ data, conn }) => {
-		const filePath = requireFilePathAccess(conn, data.file_path);
+		const filePath = await requireFilePathAccess(conn, data.file_path);
 		const result = await readFileContents(filePath);
 		return result;
 	})
@@ -221,7 +221,7 @@ export const readHandler = createRouter()
 			contentType: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const path = requireFilePathAccess(conn, data.path);
+		const path = await requireFilePathAccess(conn, data.path);
 
 		// Read file as binary
 		const file = Bun.file(path);

--- a/backend/ws/files/write.ts
+++ b/backend/ws/files/write.ts
@@ -40,7 +40,7 @@ export const writeHandler = createRouter()
 			modified: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const filePath = requireFilePathAccess(conn, data.filePath);
+		const filePath = await requireFilePathAccess(conn, data.filePath);
 		debug.log('file', 'Write file operation:', {
 			filePath,
 			contentLength: data.content.length
@@ -61,7 +61,7 @@ export const writeHandler = createRouter()
 			modified: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const filePath = requireFilePathAccess(conn, data.filePath);
+		const filePath = await requireFilePathAccess(conn, data.filePath);
 		return await createFileOperation(filePath, data.content);
 	})
 
@@ -79,7 +79,7 @@ export const writeHandler = createRouter()
 		// Uses the shared guard so FolderBrowser can create candidate project
 		// folders outside any existing project, while still preventing writes
 		// inside another user's project.
-		const dirPath = requireSharedFilePathAccess(conn, data.dirPath);
+		const dirPath = await requireSharedFilePathAccess(conn, data.dirPath);
 		return await createDirectoryOperation(dirPath);
 	})
 
@@ -96,8 +96,8 @@ export const writeHandler = createRouter()
 			modified: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const oldPath = requireFilePathAccess(conn, data.oldPath);
-		const newPath = requireFilePathAccess(conn, data.newPath);
+		const oldPath = await requireFilePathAccess(conn, data.oldPath);
+		const newPath = await requireFilePathAccess(conn, data.newPath);
 		return await renameOperation(oldPath, newPath);
 	})
 
@@ -115,8 +115,8 @@ export const writeHandler = createRouter()
 			modified: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const sourcePath = requireFilePathAccess(conn, data.sourcePath);
-		const targetPath = requireFilePathAccess(conn, data.targetPath);
+		const sourcePath = await requireFilePathAccess(conn, data.sourcePath);
+		const targetPath = await requireFilePathAccess(conn, data.targetPath);
 		return await duplicateOperation(sourcePath, targetPath);
 	})
 
@@ -138,8 +138,8 @@ export const writeHandler = createRouter()
 			modified: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const targetPath = requireFilePathAccess(conn, data.targetPath);
-		requireFilePathAccess(conn, join(targetPath, data.file.name));
+		const targetPath = await requireFilePathAccess(conn, data.targetPath);
+		await requireFilePathAccess(conn, join(targetPath, data.file.name));
 		return await uploadFileOperation(data.file, targetPath);
 	})
 
@@ -154,7 +154,7 @@ export const writeHandler = createRouter()
 			path: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const filePath = requireFilePathAccess(conn, data.filePath);
+		const filePath = await requireFilePathAccess(conn, data.filePath);
 		return await deleteOperation(filePath, data.force);
 	})
 
@@ -171,7 +171,7 @@ export const writeHandler = createRouter()
 			path: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const dirPath = requireSharedFilePathAccess(conn, data.dirPath);
+		const dirPath = await requireSharedFilePathAccess(conn, data.dirPath);
 
 		const stats = await fsStat(dirPath);
 		if (!stats.isDirectory()) {
@@ -202,8 +202,8 @@ export const writeHandler = createRouter()
 			modified: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const oldPath = requireSharedFilePathAccess(conn, data.oldPath);
-		const newPath = requireSharedFilePathAccess(conn, data.newPath);
+		const oldPath = await requireSharedFilePathAccess(conn, data.oldPath);
+		const newPath = await requireSharedFilePathAccess(conn, data.newPath);
 
 		let oldStats;
 		try {


### PR DESCRIPTION
### What & Why

The file access guards in `backend/ws/files/path-access.ts` rely on `resolve()` from Node's `path` module to normalize paths before checking if a file lives inside a project root. Problem is, `resolve()` doesn't follow symlinks. If someone on your team creates a symlink inside a project directory that points somewhere else—say `/home/project/link` → `/etc`—the current check sees the resolved path as `/etc` and blocks it. But what if the symlink is in a project that *another user has access to*? The access check passes because the symlink *file itself* is inside the project, even though `realpath` would resolve it to a completely different location.

Concretely: a member user with read/write access to a project could create a symlink pointing outside their sandbox, then read or write files through it. The access check at `isPathInside` only sees the normalized parent of the symlink, not where it actually leads.

This fix adds a `resolveRealPath()` wrapper that calls `realpath()` (which follows symlinks) before doing the containment check. If the path doesn't exist on disk, it falls back to `resolve()` so new-file operations still work.

### Changes

- `backend/ws/files/path-access.ts` — added `resolveRealPath()`, made `isPathInside`, `requireFilePathAccess`, `requireSharedFilePathAccess`, and `filterAccessibleExpandedPaths` async, swapped `resolve()` with `resolveRealPath()` in all containment checks.
- `backend/ws/files/read.ts` — added `await` to calls that are now async.
- `backend/ws/files/write.ts` — added `await` to calls that are now async.

### Why this is safe

- Paths that don't exist yet (new files) fall through to `resolve()` — no breaking change for create/write operations.
- Admin users already bypass the access check, so there's zero perf impact for them.
- The fallback is per-call, not cached — no stale symlink issues.

### Test notes

Any test that mocks `requireFilePathAccess` will need to handle the async return now. I didn't find existing tests that directly unit-test these guards; the file access tests seem to go through the WS handlers instead. Happy to add them if you'd like.