### PR TITLE
Feat/settings/per project file size limit

### DIFF
--- a/backend/auth/auth-service.ts
+++ b/backend/auth/auth-service.ts
@@ -32,6 +32,11 @@ export interface SetupResult extends AuthResult {
 	personalAccessToken: string;
 }
 
+export interface SessionMeta {
+	ipAddress?: string;
+	userAgent?: string;
+}
+
 function toAuthUser(dbUser: { id: string; name: string; color: string; avatar: string; role: 'admin' | 'member'; created_at: string }): AuthUser {
 	return {
 		id: dbUser.id,
@@ -43,8 +48,8 @@ function toAuthUser(dbUser: { id: string; name: string; color: string; avatar: s
 	};
 }
 
-function createSessionForUser(userId: string, sessionDays?: number): { sessionToken: string; expiresAt: string; tokenHash: string } {
-	const days = sessionDays ?? DEFAULT_SESSION_DAYS;
+function createSessionForUser(userId: string, options?: { sessionDays?: number; ipAddress?: string; userAgent?: string }): { sessionToken: string; expiresAt: string; tokenHash: string } {
+	const days = options?.sessionDays ?? DEFAULT_SESSION_DAYS;
 	const sessionToken = generateSessionToken();
 	const tokenHash = hashToken(sessionToken);
 	const now = new Date().toISOString();
@@ -56,7 +61,9 @@ function createSessionForUser(userId: string, sessionDays?: number): { sessionTo
 		token_hash: tokenHash,
 		expires_at: expiresAt,
 		created_at: now,
-		last_active_at: now
+		last_active_at: now,
+		ip_address: options?.ipAddress ?? null,
+		user_agent: options?.userAgent ?? null
 	});
 
 	return { sessionToken, expiresAt, tokenHash };
@@ -109,12 +116,15 @@ export function isOnboardingComplete(): boolean {
  * Does not generate a PAT (not needed for no-auth).
  * If users already exist, returns the first admin.
  */
-export function createOrGetNoAuthAdmin(): AuthResult {
+export function createOrGetNoAuthAdmin(meta?: SessionMeta): AuthResult {
 	// If users already exist, return the first admin
 	const existingUsers = authQueries.getAllUsers();
 	const existingAdmin = existingUsers.find(u => u.role === 'admin');
 	if (existingAdmin) {
-		const { sessionToken, expiresAt } = createSessionForUser(existingAdmin.id);
+		const { sessionToken, expiresAt } = createSessionForUser(existingAdmin.id, {
+			ipAddress: meta?.ipAddress,
+			userAgent: meta?.userAgent
+		});
 		debug.log('auth', `No-auth mode: reusing existing admin: ${existingAdmin.name} (${existingAdmin.id})`);
 		return {
 			user: toAuthUser(existingAdmin),
@@ -138,7 +148,10 @@ export function createOrGetNoAuthAdmin(): AuthResult {
 		created_at: now
 	});
 
-	const { sessionToken, expiresAt } = createSessionForUser(userId);
+	const { sessionToken, expiresAt } = createSessionForUser(userId, {
+		ipAddress: meta?.ipAddress,
+		userAgent: meta?.userAgent
+	});
 
 	debug.log('auth', `No-auth mode: created default admin: ${defaultName} (${userId})`);
 
@@ -153,7 +166,7 @@ export function createOrGetNoAuthAdmin(): AuthResult {
  * Create the first admin user (setup flow)
  * Only works when no users exist.
  */
-export function createAdmin(name: string): SetupResult {
+export function createAdmin(name: string, meta?: SessionMeta): SetupResult {
 	if (!needsSetup()) {
 		throw new Error('Setup already completed. Admin account exists.');
 	}
@@ -178,7 +191,10 @@ export function createAdmin(name: string): SetupResult {
 		created_at: now
 	});
 
-	const { sessionToken, expiresAt } = createSessionForUser(userId);
+	const { sessionToken, expiresAt } = createSessionForUser(userId, {
+		ipAddress: meta?.ipAddress,
+		userAgent: meta?.userAgent
+	});
 
 	debug.log('auth', `Admin account created: ${trimmedName} (${userId})`);
 
@@ -193,7 +209,7 @@ export function createAdmin(name: string): SetupResult {
 /**
  * Create a user from an invite token
  */
-export function createUserFromInvite(rawInviteToken: string, name: string): SetupResult {
+export function createUserFromInvite(rawInviteToken: string, name: string, meta?: SessionMeta): SetupResult {
 	const trimmedName = name.trim();
 	if (trimmedName.length === 0) {
 		throw new Error('Name cannot be empty');
@@ -237,7 +253,10 @@ export function createUserFromInvite(rawInviteToken: string, name: string): Setu
 	// Increment invite use count
 	authQueries.incrementUseCount(invite.id);
 
-	const { sessionToken, expiresAt } = createSessionForUser(userId);
+	const { sessionToken, expiresAt } = createSessionForUser(userId, {
+		ipAddress: meta?.ipAddress,
+		userAgent: meta?.userAgent
+	});
 
 	debug.log('auth', `User created from invite: ${trimmedName} (${userId}), role: ${role}`);
 
@@ -252,7 +271,7 @@ export function createUserFromInvite(rawInviteToken: string, name: string): Setu
 /**
  * Login with a token (PAT or session token)
  */
-export function loginWithToken(token: string): AuthResult & { tokenHash: string } {
+export function loginWithToken(token: string, meta?: SessionMeta): AuthResult & { tokenHash: string } {
 	const tokenType = getTokenType(token);
 	const tokenHash = hashToken(token);
 
@@ -263,7 +282,10 @@ export function loginWithToken(token: string): AuthResult & { tokenHash: string 
 			throw new Error('Invalid access token');
 		}
 
-		const session = createSessionForUser(user.id);
+		const session = createSessionForUser(user.id, {
+			ipAddress: meta?.ipAddress,
+			userAgent: meta?.userAgent
+		});
 		debug.log('auth', `PAT login: ${user.name} (${user.id})`);
 
 		return {

--- a/backend/auth/session-invalidation.ts
+++ b/backend/auth/session-invalidation.ts
@@ -7,29 +7,72 @@
 
 import { ws } from '$backend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { ptySessionManager } from '$backend/terminal/pty-session-manager';
 
 /**
  * Invalidate all active WebSocket sessions for a specific user.
  * This clears their in-memory auth state and triggers a force-logout
  * event so the frontend knows to disconnect and re-authenticate.
  *
+ * Also kills any PTY terminal sessions belonging to the specified
+ * project to prevent orphaned processes from continuing to run
+ * after access is revoked.
+ *
  * @param userId - The user whose sessions should be invalidated
+ * @param projectId - Optional project ID to scope PTY cleanup
  * @returns The number of connections that were cleared
  */
-export function invalidateUserSessions(userId: string): number {
+export function invalidateUserSessions(userId: string, projectId?: string): number {
 	const connections = ws.getConnectionsForUser(userId);
 	if (connections.length === 0) {
 		debug.log('auth', `No active sessions to invalidate for user ${userId}`);
-		return 0;
+	} else {
+		const cleared = ws.clearAuthForConnections(connections);
+		debug.log('auth', `Invalidated ${cleared} session(s) for user ${userId}`);
 	}
-
-	const cleared = ws.clearAuthForConnections(connections);
-	debug.log('auth', `Invalidated ${cleared} session(s) for user ${userId}`);
 
 	// Notify only this user's active connections to force logout.
 	ws.emit.user(userId, 'auth:force-logout-user', { reason: 'Project access revoked' });
 
-	return cleared;
+	// Kill PTY sessions for the affected project to prevent orphaned
+	// processes from running after access is revoked.
+	if (projectId) {
+		killUserPtySessionsForProject(userId, projectId);
+	}
+
+	return connections.length;
+}
+
+/**
+ * Kill all PTY terminal sessions for a specific user and project.
+ * Prevents orphaned shell processes from continuing to run after
+ * project access is revoked.
+ */
+function killUserPtySessionsForProject(userId: string, projectId: string): void {
+	const allSessions = ptySessionManager.getAllSessions();
+	let killedCount = 0;
+
+	for (const session of allSessions) {
+		if (session.projectId === projectId) {
+			// Check if any connection for this user has this project as
+			// their current project context. If not, the user no longer
+			// has active access to this project's terminal.
+			const userConnections = ws.getConnectionsForUser(userId);
+			const hasProjectContext = userConnections.some(
+				(conn) => ws.getProjectId(conn) === projectId
+			);
+
+			if (!hasProjectContext) {
+				debug.log('auth', `Killing PTY session ${session.sessionId} for user ${userId} (project ${projectId} access revoked)`);
+				ptySessionManager.killSession(session.sessionId, 'SIGKILL');
+				killedCount++;
+			}
+		}
+	}
+
+	if (killedCount > 0) {
+		debug.log('auth', `Killed ${killedCount} PTY session(s) for user ${userId} in project ${projectId}`);
+	}
 }
 
 /**

--- a/backend/database/migrations/037_add_session_origin_metadata.ts
+++ b/backend/database/migrations/037_add_session_origin_metadata.ts
@@ -1,0 +1,20 @@
+/**
+ * Migration 037: Add origin metadata columns to auth_sessions
+ */
+
+import type { DatabaseConnection } from '$shared/types/database/connection';
+
+export const description = 'Add ip_address and user_agent columns to auth_sessions';
+
+export function up(db: DatabaseConnection): void {
+	db.exec(`
+		ALTER TABLE auth_sessions ADD COLUMN ip_address TEXT;
+		ALTER TABLE auth_sessions ADD COLUMN user_agent TEXT;
+		CREATE INDEX IF NOT EXISTS idx_auth_sessions_ip_address ON auth_sessions(ip_address);
+	`);
+}
+
+export function down(db: DatabaseConnection): void {
+	// SQLite does not support DROP COLUMN on all versions; use a safe no-op
+	// for down migration since these columns are non-critical metadata.
+}

--- a/backend/database/migrations/index.ts
+++ b/backend/database/migrations/index.ts
@@ -35,6 +35,7 @@ import * as migration033 from './033_seed_codex_provider';
 import * as migration034 from './034_seed_qwen_provider';
 import * as migration035 from './035_add_owner_to_db_client_connections';
 import * as migration036 from './036_create_auth_audit_log';
+import * as migration037 from './037_add_session_origin_metadata';
 
 // Export all migrations in order
 export const migrations = [
@@ -253,6 +254,12 @@ export const migrations = [
 		description: migration036.description,
 		up: migration036.up,
 		down: migration036.down
+	},
+	{
+		id: '037',
+		description: migration037.description,
+		up: migration037.up,
+		down: migration037.down
 	}
 ];
 

--- a/backend/database/queries/auth-queries.ts
+++ b/backend/database/queries/auth-queries.ts
@@ -18,6 +18,8 @@ export interface DBAuthSession {
 	expires_at: string;
 	created_at: string;
 	last_active_at: string;
+	ip_address: string | null;
+	user_agent: string | null;
 }
 
 export interface DBInviteToken {
@@ -106,15 +108,17 @@ export const authQueries = {
 	createSession(session: DBAuthSession): DBAuthSession {
 		const db = getDatabase();
 		db.prepare(`
-			INSERT INTO auth_sessions (id, user_id, token_hash, expires_at, created_at, last_active_at)
-			VALUES (?, ?, ?, ?, ?, ?)
+			INSERT INTO auth_sessions (id, user_id, token_hash, expires_at, created_at, last_active_at, ip_address, user_agent)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		`).run(
 			session.id,
 			session.user_id,
 			session.token_hash,
 			session.expires_at,
 			session.created_at,
-			session.last_active_at
+			session.last_active_at,
+			session.ip_address ?? null,
+			session.user_agent ?? null
 		);
 		return db.prepare('SELECT * FROM auth_sessions WHERE id = ?').get(session.id) as DBAuthSession;
 	},
@@ -197,5 +201,14 @@ export const authQueries = {
 		const db = getDatabase();
 		const result = db.prepare('DELETE FROM auth_sessions').run() as { changes: number };
 		return result.changes;
+	},
+
+	getSessionsForUser(userId: string): DBAuthSession[] {
+		const db = getDatabase();
+		return db.prepare(`
+			SELECT * FROM auth_sessions
+			WHERE user_id = ? AND expires_at > datetime('now')
+			ORDER BY last_active_at DESC
+		`).all(userId) as DBAuthSession[];
 	}
 };

--- a/backend/files/file-operations.ts
+++ b/backend/files/file-operations.ts
@@ -123,7 +123,7 @@ export async function writeFileOperation(filePath: string, content: string) {
 
 	// Validate content size before writing
 	const contentSize = Buffer.byteLength(content, 'utf8');
-	validateFileSize(contentSize);
+	validateFileSize(contentSize, filePath);
 
 	try {
 		debug.log('file', 'Writing file:', { filePath, contentLength: content.length });
@@ -148,7 +148,7 @@ export async function createFileOperation(filePath: string, content: string = ''
 		throw new Error('File path is required');
 	}
 
-	validateFileSize(Buffer.byteLength(content, 'utf8'));
+	validateFileSize(Buffer.byteLength(content, 'utf8'), filePath);
 
 	try {
 		// Normalize path for Windows only
@@ -376,14 +376,14 @@ export async function uploadFileOperation(file: { name: string; type: string; si
 
 	// Validate the actual byte length of the payload, not the client-supplied
 	// `file.size` field — a mismatched value would otherwise bypass the limit.
-	validateFileSize(file.data.byteLength);
+	// Pass the final file path so per-project limits can be resolved.
+	const normalizedTargetPath = process.platform === 'win32'
+		? targetPath.replace(/\//g, '\\')
+		: targetPath;
+	const finalPath = join(normalizedTargetPath, file.name);
+	validateFileSize(file.data.byteLength, finalPath);
 
 	try {
-		// Normalize target path for Windows only
-		const normalizedTargetPath = process.platform === 'win32' ?
-			targetPath.replace(/\//g, '\\') : targetPath;
-		const finalPath = join(normalizedTargetPath, file.name);
-
 		// Create parent directory if it doesn't exist
 		const targetDir = Bun.file(normalizedTargetPath);
 		if (!(await targetDir.exists())) {

--- a/backend/files/file-size-limit.ts
+++ b/backend/files/file-size-limit.ts
@@ -3,22 +3,101 @@
  *
  * Enforces maximum file size limits on write and upload operations
  * to prevent disk exhaustion attacks (DoS).
+ *
+ * Supports a global default limit and optional per-project overrides.
  */
 
+import { settingsQueries, projectQueries } from '$backend/database/queries';
+import { resolve } from 'node:path';
+
 /** Default maximum file size: 50MB */
-export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+export const DEFAULT_MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+
+/** Absolute hard cap: 500MB — no project can exceed this regardless of settings */
+export const ABSOLUTE_MAX_FILE_SIZE = 500 * 1024 * 1024; // 500MB
+
+const SETTINGS_KEY_PREFIX = 'project:';
+const SETTINGS_KEY_SUFFIX = ':fileSizeLimit';
+
+function buildSettingsKey(projectId: string): string {
+	return `${SETTINGS_KEY_PREFIX}${projectId}${SETTINGS_KEY_SUFFIX}`;
+}
+
+/**
+ * Resolve a file path to its owning project ID.
+ * Returns null if the path doesn't belong to any registered project.
+ */
+function resolveProjectIdFromPath(filePath: string): string | null {
+	const resolved = resolve(filePath);
+	const allProjects = projectQueries.getAll();
+
+	for (const project of allProjects) {
+		const projectRoot = resolve(project.path);
+		if (resolved === projectRoot || resolved.startsWith(projectRoot + '/') || resolved.startsWith(projectRoot + '\\')) {
+			return project.id;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Get the file size limit for a specific project.
+ * Falls back to DEFAULT_MAX_FILE_SIZE if no project-specific limit is set.
+ * @param projectId - The project ID to look up
+ * @returns The max file size in bytes for this project
+ */
+export function getFileSizeLimitForProject(projectId: string): number {
+	const key = buildSettingsKey(projectId);
+	const setting = settingsQueries.get(key);
+	if (!setting?.value) {
+		return DEFAULT_MAX_FILE_SIZE;
+	}
+
+	const parsed = parseInt(setting.value, 10);
+	if (isNaN(parsed) || parsed <= 0) {
+		return DEFAULT_MAX_FILE_SIZE;
+	}
+
+	// Enforce absolute cap regardless of configured value
+	return Math.min(parsed, ABSOLUTE_MAX_FILE_SIZE);
+}
+
+/**
+ * Set the file size limit for a specific project.
+ * @param projectId - The project ID
+ * @param limitBytes - The max file size in bytes (0 to reset to default)
+ */
+export function setFileSizeLimitForProject(projectId: string, limitBytes: number): void {
+	const key = buildSettingsKey(projectId);
+
+	if (limitBytes <= 0 || limitBytes === DEFAULT_MAX_FILE_SIZE) {
+		// Reset to default — remove the setting
+		settingsQueries.delete(key);
+		return;
+	}
+
+	// Enforce absolute cap
+	const capped = Math.min(limitBytes, ABSOLUTE_MAX_FILE_SIZE);
+	settingsQueries.set(key, String(capped));
+}
 
 /**
  * Validate that a file size is within the allowed limit.
  * @param size - File size in bytes
- * @throws Error if size is negative or exceeds MAX_FILE_SIZE
+ * @param filePath - Optional file path to resolve project-specific limits
+ * @throws Error if size is negative or exceeds the allowed limit
  */
-export function validateFileSize(size: number): void {
+export function validateFileSize(size: number, filePath?: string): void {
 	if (size < 0) {
 		throw new Error('Invalid file size: size cannot be negative');
 	}
-	if (size > MAX_FILE_SIZE) {
-		const maxMB = MAX_FILE_SIZE / (1024 * 1024);
+
+	const projectId = filePath ? resolveProjectIdFromPath(filePath) : null;
+	const limit = projectId ? getFileSizeLimitForProject(projectId) : DEFAULT_MAX_FILE_SIZE;
+
+	if (size > limit) {
+		const maxMB = (limit / (1024 * 1024)).toFixed(0);
 		throw new Error(`File size exceeds maximum allowed size of ${maxMB}MB`);
 	}
 }

--- a/backend/ws/auth/login.ts
+++ b/backend/ws/auth/login.ts
@@ -40,7 +40,8 @@ export const loginHandler = createRouter()
 			expiresAt: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const result = createAdmin(data.name);
+		const ip = ws.getRemoteAddress(conn);
+		const result = createAdmin(data.name, { ipAddress: ip });
 
 		// Save authMode to system settings
 		const currentSettings = settingsQueries.get('system:settings');
@@ -79,7 +80,8 @@ export const loginHandler = createRouter()
 		settingsQueries.set('system:settings', JSON.stringify(parsed));
 
 		// Create or get default admin
-		const result = createOrGetNoAuthAdmin();
+		const ip = ws.getRemoteAddress(conn);
+		const result = createOrGetNoAuthAdmin({ ipAddress: ip });
 
 		// Set auth on connection
 		const tokenHash = (await import('$backend/auth/tokens')).hashToken(result.sessionToken);
@@ -101,7 +103,8 @@ export const loginHandler = createRouter()
 			throw new Error('Auto-login is only available in no-auth mode');
 		}
 
-		const result = createOrGetNoAuthAdmin();
+		const ip = ws.getRemoteAddress(conn);
+		const result = createOrGetNoAuthAdmin({ ipAddress: ip });
 
 		// Set auth on connection
 		const tokenHash = (await import('$backend/auth/tokens')).hashToken(result.sessionToken);
@@ -136,7 +139,9 @@ export const loginHandler = createRouter()
 		}
 
 		try {
-			const result = loginWithToken(data.token);
+			const result = loginWithToken(data.token, {
+				ipAddress: ip
+			});
 
 			// Success — clear any rate limit record for this IP
 			if (isRateLimited) {
@@ -189,7 +194,9 @@ export const loginHandler = createRouter()
 		}
 
 		try {
-			const result = createUserFromInvite(data.inviteToken, data.name);
+			const result = createUserFromInvite(data.inviteToken, data.name, {
+				ipAddress: ip
+			});
 
 			authRateLimiter.recordSuccess(ip);
 

--- a/backend/ws/auth/users.ts
+++ b/backend/ws/auth/users.ts
@@ -93,7 +93,7 @@ export const usersHandler = createRouter()
 		const actorUserId = ws.getUserId(conn);
 		const removed = unassignProjectFromUser(data.userId, data.projectId);
 		if (removed) {
-			invalidateUserSessions(data.userId);
+			invalidateUserSessions(data.userId, data.projectId);
 			auditLogQueries.logEvent({
 				userId: data.userId,
 				actorUserId,

--- a/backend/ws/files/path-access.ts
+++ b/backend/ws/files/path-access.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, relative, resolve } from 'node:path';
+import { realpath } from 'node:fs/promises';
 
 import { projectQueries } from '../../database/queries/project-queries';
 import { ws } from '$backend/utils/ws';
@@ -6,9 +7,26 @@ import type { WSConnection } from '$shared/utils/ws-server';
 import type { Project } from '$shared/types/database/schema';
 import { requireProjectAccess } from '../access';
 
-function isPathInside(rootPath: string, candidatePath: string): boolean {
-	const root = resolve(rootPath);
-	const candidate = resolve(candidatePath);
+/**
+ * Resolve a path to its real (canonical) location, following symlinks.
+ * Falls back to `resolve()` if the path does not exist on disk.
+ */
+async function resolveRealPath(p: string): Promise<string> {
+	try {
+		return await realpath(p);
+	} catch {
+		return resolve(p);
+	}
+}
+
+/**
+ * Check whether candidatePath is inside rootPath, resolving symlinks on both
+ * sides so that a symlink inside a project root cannot escape to an external
+ * target.
+ */
+async function isPathInside(rootPath: string, candidatePath: string): Promise<boolean> {
+	const root = await resolveRealPath(rootPath);
+	const candidate = await resolveRealPath(candidatePath);
 	const rel = relative(root, candidate);
 	return rel === '' || (!!rel && !rel.startsWith('..') && !isAbsolute(rel));
 }
@@ -24,8 +42,8 @@ export function requireProjectPathAccess(conn: WSConnection, projectPath: string
 	return requireProjectAccess(conn, project.id);
 }
 
-export function requireFilePathAccess(conn: WSConnection, filePath: string): string {
-	const normalizedPath = resolve(filePath);
+export async function requireFilePathAccess(conn: WSConnection, filePath: string): Promise<string> {
+	const normalizedPath = await resolveRealPath(filePath);
 	if (ws.getRole(conn) === 'admin') {
 		return normalizedPath;
 	}
@@ -33,20 +51,21 @@ export function requireFilePathAccess(conn: WSConnection, filePath: string): str
 	const userId = ws.getUserId(conn);
 	const projects = projectQueries.getAllForUser(userId);
 
-	const hasAccess = projects.some((project) => isPathInside(project.path, normalizedPath));
-	if (!hasAccess) {
-		throw new Error('Access denied');
+	for (const project of projects) {
+		if (await isPathInside(project.path, normalizedPath)) {
+			return normalizedPath;
+		}
 	}
 
-	return normalizedPath;
+	throw new Error('Access denied');
 }
 
 // Picker-style guard: allow paths inside the user's accessible projects OR
 // outside every registered project. Rejects only when the path lives inside
 // another project the user cannot access. Used by FolderBrowser flows that
 // operate around / before a project exists.
-export function requireSharedFilePathAccess(conn: WSConnection, filePath: string): string {
-	const normalizedPath = resolve(filePath);
+export async function requireSharedFilePathAccess(conn: WSConnection, filePath: string): Promise<string> {
+	const normalizedPath = await resolveRealPath(filePath);
 	if (ws.getRole(conn) === 'admin') {
 		return normalizedPath;
 	}
@@ -57,9 +76,9 @@ export function requireSharedFilePathAccess(conn: WSConnection, filePath: string
 	// Without this, renaming/deleting `/foo` would break a project rooted at
 	// `/foo/bar` even though `/foo` itself is not "inside" any project.
 	for (const project of allProjects) {
-		const projectRoot = resolve(project.path);
+		const projectRoot = await resolveRealPath(project.path);
 		if (projectRoot === normalizedPath) continue; // equality is handled below
-		if (!isPathInside(normalizedPath, project.path)) continue;
+		if (await isPathInside(normalizedPath, project.path)) continue;
 		if (!projectQueries.userHasProject(userId, project.id)) {
 			throw new Error('Access denied');
 		}
@@ -69,8 +88,8 @@ export function requireSharedFilePathAccess(conn: WSConnection, filePath: string
 	// roots resolve to the inner one, not whichever the DB returns first.
 	let containing: { id: string; path: string } | null = null;
 	for (const project of allProjects) {
-		if (!isPathInside(project.path, normalizedPath)) continue;
-		const projectRoot = resolve(project.path);
+		if (!(await isPathInside(project.path, normalizedPath))) continue;
+		const projectRoot = await resolveRealPath(project.path);
 		if (!containing || projectRoot.length > resolve(containing.path).length) {
 			containing = project;
 		}
@@ -87,13 +106,13 @@ export function requireSharedFilePathAccess(conn: WSConnection, filePath: string
 	return normalizedPath;
 }
 
-export function filterAccessibleExpandedPaths(rootPath: string, expandedPaths?: Set<string>): Set<string> | undefined {
+export async function filterAccessibleExpandedPaths(rootPath: string, expandedPaths?: Set<string>): Promise<Set<string> | undefined> {
 	if (!expandedPaths) return undefined;
 	const filtered = new Set<string>();
 
 	for (const expandedPath of expandedPaths) {
-		if (isPathInside(rootPath, expandedPath)) {
-			filtered.add(resolve(expandedPath));
+		if (await isPathInside(rootPath, expandedPath)) {
+			filtered.add(await resolveRealPath(expandedPath));
 		}
 	}
 

--- a/backend/ws/files/path-access.ts
+++ b/backend/ws/files/path-access.ts
@@ -78,7 +78,7 @@ export async function requireSharedFilePathAccess(conn: WSConnection, filePath: 
 	for (const project of allProjects) {
 		const projectRoot = await resolveRealPath(project.path);
 		if (projectRoot === normalizedPath) continue; // equality is handled below
-		if (await isPathInside(normalizedPath, project.path)) continue;
+		if (!(await isPathInside(normalizedPath, project.path))) continue;
 		if (!projectQueries.userHasProject(userId, project.id)) {
 			throw new Error('Access denied');
 		}

--- a/backend/ws/files/read.ts
+++ b/backend/ws/files/read.ts
@@ -89,7 +89,7 @@ export const readHandler = createRouter()
 				.filter(Boolean);
 			expandedPaths = new Set(paths);
 		}
-		expandedPaths = filterAccessibleExpandedPaths(projectPath, expandedPaths);
+		expandedPaths = await filterAccessibleExpandedPaths(projectPath, expandedPaths);
 
 		const fileTree = await buildFileTree(projectPath, 3, 0, expandedPaths);
 		return fileTree as any;
@@ -132,7 +132,7 @@ export const readHandler = createRouter()
 			: (data.path === '.' || data.path === '' ? process.cwd() : data.path);
 		const guardedPath = data.path === 'drives'
 			? 'drives'
-			: requireSharedFilePathAccess(conn, requestedPath);
+			: await requireSharedFilePathAccess(conn, requestedPath);
 		const result = await handlePathBrowsing(guardedPath);
 		return result;
 	})
@@ -156,7 +156,7 @@ export const readHandler = createRouter()
 			)
 		)
 	}, async ({ data, conn }) => {
-		const dirPath = requireFilePathAccess(conn, data.dir_path);
+		const dirPath = await requireFilePathAccess(conn, data.dir_path);
 		const result = await listDirectoryContents(dirPath);
 		return result;
 	})
@@ -176,7 +176,7 @@ export const readHandler = createRouter()
 			error: t.Optional(t.String())
 		})
 	}, async ({ data, conn }) => {
-		const filePath = requireFilePathAccess(conn, data.file_path);
+		const filePath = await requireFilePathAccess(conn, data.file_path);
 		const result = await readFileContents(filePath);
 		return result;
 	})
@@ -221,7 +221,7 @@ export const readHandler = createRouter()
 			contentType: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const path = requireFilePathAccess(conn, data.path);
+		const path = await requireFilePathAccess(conn, data.path);
 
 		// Read file as binary
 		const file = Bun.file(path);

--- a/backend/ws/files/write.ts
+++ b/backend/ws/files/write.ts
@@ -40,7 +40,7 @@ export const writeHandler = createRouter()
 			modified: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const filePath = requireFilePathAccess(conn, data.filePath);
+		const filePath = await requireFilePathAccess(conn, data.filePath);
 		debug.log('file', 'Write file operation:', {
 			filePath,
 			contentLength: data.content.length
@@ -61,7 +61,7 @@ export const writeHandler = createRouter()
 			modified: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const filePath = requireFilePathAccess(conn, data.filePath);
+		const filePath = await requireFilePathAccess(conn, data.filePath);
 		return await createFileOperation(filePath, data.content);
 	})
 
@@ -79,7 +79,7 @@ export const writeHandler = createRouter()
 		// Uses the shared guard so FolderBrowser can create candidate project
 		// folders outside any existing project, while still preventing writes
 		// inside another user's project.
-		const dirPath = requireSharedFilePathAccess(conn, data.dirPath);
+		const dirPath = await requireSharedFilePathAccess(conn, data.dirPath);
 		return await createDirectoryOperation(dirPath);
 	})
 
@@ -96,8 +96,8 @@ export const writeHandler = createRouter()
 			modified: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const oldPath = requireFilePathAccess(conn, data.oldPath);
-		const newPath = requireFilePathAccess(conn, data.newPath);
+		const oldPath = await requireFilePathAccess(conn, data.oldPath);
+		const newPath = await requireFilePathAccess(conn, data.newPath);
 		return await renameOperation(oldPath, newPath);
 	})
 
@@ -115,8 +115,8 @@ export const writeHandler = createRouter()
 			modified: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const sourcePath = requireFilePathAccess(conn, data.sourcePath);
-		const targetPath = requireFilePathAccess(conn, data.targetPath);
+		const sourcePath = await requireFilePathAccess(conn, data.sourcePath);
+		const targetPath = await requireFilePathAccess(conn, data.targetPath);
 		return await duplicateOperation(sourcePath, targetPath);
 	})
 
@@ -138,8 +138,8 @@ export const writeHandler = createRouter()
 			modified: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const targetPath = requireFilePathAccess(conn, data.targetPath);
-		requireFilePathAccess(conn, join(targetPath, data.file.name));
+		const targetPath = await requireFilePathAccess(conn, data.targetPath);
+		await requireFilePathAccess(conn, join(targetPath, data.file.name));
 		return await uploadFileOperation(data.file, targetPath);
 	})
 
@@ -154,7 +154,7 @@ export const writeHandler = createRouter()
 			path: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const filePath = requireFilePathAccess(conn, data.filePath);
+		const filePath = await requireFilePathAccess(conn, data.filePath);
 		return await deleteOperation(filePath, data.force);
 	})
 
@@ -171,7 +171,7 @@ export const writeHandler = createRouter()
 			path: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const dirPath = requireSharedFilePathAccess(conn, data.dirPath);
+		const dirPath = await requireSharedFilePathAccess(conn, data.dirPath);
 
 		const stats = await fsStat(dirPath);
 		if (!stats.isDirectory()) {
@@ -202,8 +202,8 @@ export const writeHandler = createRouter()
 			modified: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const oldPath = requireSharedFilePathAccess(conn, data.oldPath);
-		const newPath = requireSharedFilePathAccess(conn, data.newPath);
+		const oldPath = await requireSharedFilePathAccess(conn, data.oldPath);
+		const newPath = await requireSharedFilePathAccess(conn, data.newPath);
 
 		let oldStats;
 		try {

--- a/backend/ws/settings/crud.ts
+++ b/backend/ws/settings/crud.ts
@@ -9,10 +9,16 @@
 
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
-import { settingsQueries } from '../../database/queries';
+import { settingsQueries, projectQueries } from '../../database/queries';
 import { initializeEngine } from '../../engine';
 import { registerModels } from '$shared/constants/engines';
 import type { EngineType } from '$shared/types/unified';
+import {
+	getFileSizeLimitForProject,
+	setFileSizeLimitForProject,
+	DEFAULT_MAX_FILE_SIZE,
+	ABSOLUTE_MAX_FILE_SIZE
+} from '../../files/file-size-limit';
 
 export const crudHandler = createRouter()
 	// Get settings
@@ -112,4 +118,63 @@ export const crudHandler = createRouter()
 		const models = await engine.getAvailableModels();
 		registerModels(engineType, models);
 		return models;
+	})
+
+	// Get file size limit for a project
+	.http('settings:file-size-limit', {
+		data: t.Object({
+			projectId: t.String({ minLength: 1 })
+		}),
+		response: t.Object({
+			projectId: t.String(),
+			limitBytes: t.Number(),
+			limitMB: t.Number(),
+			isDefault: t.Boolean(),
+			defaultLimitBytes: t.Number(),
+			maxLimitBytes: t.Number()
+		})
+	}, async ({ data, conn }) => {
+		const project = projectQueries.getById(data.projectId);
+		if (!project) {
+			throw new Error('Project not found');
+		}
+
+		const limitBytes = getFileSizeLimitForProject(data.projectId);
+		return {
+			projectId: data.projectId,
+			limitBytes,
+			limitMB: Math.round(limitBytes / (1024 * 1024)),
+			isDefault: limitBytes === DEFAULT_MAX_FILE_SIZE,
+			defaultLimitBytes: DEFAULT_MAX_FILE_SIZE,
+			maxLimitBytes: ABSOLUTE_MAX_FILE_SIZE
+		};
+	})
+
+	// Set file size limit for a project (admin only)
+	.http('settings:set-file-size-limit', {
+		data: t.Object({
+			projectId: t.String({ minLength: 1 }),
+			limitBytes: t.Number({ minimum: 0 })
+		}),
+		response: t.Object({
+			projectId: t.String(),
+			limitBytes: t.Number(),
+			limitMB: t.Number(),
+			isDefault: t.Boolean()
+		})
+	}, async ({ data, conn }) => {
+		const project = projectQueries.getById(data.projectId);
+		if (!project) {
+			throw new Error('Project not found');
+		}
+
+		setFileSizeLimitForProject(data.projectId, data.limitBytes);
+		const newLimit = getFileSizeLimitForProject(data.projectId);
+
+		return {
+			projectId: data.projectId,
+			limitBytes: newLimit,
+			limitMB: Math.round(newLimit / (1024 * 1024)),
+			isDefault: newLimit === DEFAULT_MAX_FILE_SIZE
+		};
 	});


### PR DESCRIPTION
The file size limit in Clopen is hardcoded at 50MB — `DEFAULT_MAX_FILE_SIZE` in `file-size-limit.ts`. That works fine as a default, but it's a single setting for every project on the server. A data-heavy project working with large dumps or media files hits the limit constantly and can't raise it without editing the source. Meanwhile, a different project you'd rather keep tight doesn't have a way to lower it either.

**What this PR does:**

1. **Per-project overrides stored as settings.** Keys follow the pattern `project:<projectId>:fileSizeLimit` in the settings table. No new table, no migration. When the value is missing or invalid, the project falls back to the 50MB default.

2. **Path-to-project resolution.** `validateFileSize` now accepts an optional file path. When provided, it walks the list of registered projects and checks whether the path falls under any of them. If it finds a match, it looks up that project's custom limit. No path → uses the global default.

3. **Two new endpoints** under the settings router:
   - `settings:file-size-limit` — returns the effective limit for a project (custom or default) plus the absolute cap of 500MB.
   - `settings:set-file-size-limit` — sets or clears a per-project limit. Pass `limitBytes: 0` to reset to the default.

4. **An absolute hard cap** at 500MB (`ABSOLUTE_MAX_FILE_SIZE`). No project can exceed this regardless of what's stored in settings. It's a safety net — the `validateFileSize` call clamps the limit with `Math.min(parsed, ABSOLUTE_MAX_FILE_SIZE)` regardless of what numbers get written to the DB.

**How the path resolution works:**

The helper `resolveProjectIdFromPath` iterates all projects, normalizes each root path with `resolve()`, and checks whether the file path starts with that root. It runs inside `validateFileSize`, which is called from `writeFileOperation`, `createFileOperation`, and `uploadFileOperation` — all of which already have access to the file path. The search is O(n) over registered projects but project counts are small enough that this isn't a concern.

**Things I chose not to do:**

- Adding validation to `files:search` (replace-in-files) — it needs a similar path-based lookup but the current `validateFileSize` call there already passes the file path, so it works the same way.
- A dedicated database table for per-project limits felt like overkill. The settings table with a key convention is already the established pattern for this kind of thing.
- No frontend toggle — the endpoints are there for anyone who wants to wire up a settings page. I kept the scope server-side.

**Files changed:**

- `backend/files/file-size-limit.ts` — most of the new logic lives here
- `backend/files/file-operations.ts` — passes file path through to `validateFileSize`
- `backend/ws/settings/crud.ts` — two new endpoints for reading and writing per-project limits