### PR TITLE
fix(db-client): add query validation to prevent SQL injection and dangerous operations

### DIFF
--- a/backend/db-client/query-validator.test.ts
+++ b/backend/db-client/query-validator.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from 'bun:test';
+import { validateQuery, validateSqlQuery, validateMongoQuery, validateRedisCommand } from './query-validator';
+
+describe('SQL Query Validation', () => {
+	test('should allow safe SELECT queries', () => {
+		const result = validateSqlQuery('postgres', 'SELECT * FROM users WHERE id = $1', [123]);
+		expect(result.safe).toBe(true);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	test('should block xp_cmdshell attempts', () => {
+		const result = validateSqlQuery('mysql', "SELECT * FROM users; EXEC xp_cmdshell('dir')");
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should block COPY FROM PROGRAM attempts', () => {
+		const result = validateSqlQuery('postgres', "COPY users FROM PROGRAM 'cat /etc/passwd'");
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should block INTO OUTFILE attempts', () => {
+		const result = validateSqlQuery('mysql', "SELECT * FROM users INTO OUTFILE '/tmp/users.txt'");
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should block stacked DROP queries', () => {
+		const result = validateSqlQuery('postgres', 'SELECT * FROM users; DROP TABLE users');
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should block UNION-based information_schema injection', () => {
+		const result = validateSqlQuery('mysql', 'SELECT * FROM users UNION SELECT * FROM information_schema.tables');
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should warn about inline string values', () => {
+		const result = validateSqlQuery('postgres', "SELECT * FROM users WHERE name = 'admin'");
+		expect(result.safe).toBe(true);
+		expect(result.warnings.length).toBeGreaterThan(0);
+	});
+
+	test('should warn about inline numeric values', () => {
+		const result = validateSqlQuery('mysql', 'SELECT * FROM users WHERE id = 123');
+		expect(result.safe).toBe(true);
+		expect(result.warnings.length).toBeGreaterThan(0);
+	});
+
+	test('should warn about SLEEP function', () => {
+		const result = validateSqlQuery('mysql', 'SELECT * FROM users WHERE id = 1 AND SLEEP(5)');
+		expect(result.safe).toBe(true);
+		expect(result.warnings.length).toBeGreaterThan(0);
+	});
+
+	test('should block excessively long queries', () => {
+		const longQuery = 'SELECT * FROM users WHERE ' + 'id = 1 OR '.repeat(20000) + 'id = 2';
+		const result = validateSqlQuery('postgres', longQuery);
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should warn about excessive nesting', () => {
+		const nestedQuery = 'SELECT * FROM users WHERE id IN (' + '('.repeat(60) + '1' + ')'.repeat(60) + ')';
+		const result = validateSqlQuery('postgres', nestedQuery);
+		expect(result.warnings.length).toBeGreaterThan(0);
+	});
+});
+
+describe('MongoDB Query Validation', () => {
+	test('should allow safe find queries', () => {
+		const result = validateMongoQuery('{"op":"find","filter":{"name":"test"}}');
+		expect(result.safe).toBe(true);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	test('should block $where operator', () => {
+		const result = validateMongoQuery('{"op":"find","filter":{"$where":"this.name == \'admin\'"}}');
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should block mapReduce operation', () => {
+		const result = validateMongoQuery('{"op":"mapReduce","map":"function() {}","reduce":"function() {}"}');
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should block $function operator', () => {
+		const result = validateMongoQuery('{"op":"aggregate","pipeline":[{"$addFields":{"result":{"$function":{"body":"function() { return 1; }","args":[],"lang":"js"}}}}]}');
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should reject invalid JSON', () => {
+		const result = validateMongoQuery('not valid json');
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+});
+
+describe('Redis Command Validation', () => {
+	test('should allow safe GET commands', () => {
+		const result = validateRedisCommand('GET mykey');
+		expect(result.safe).toBe(true);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	test('should allow safe SET commands', () => {
+		const result = validateRedisCommand('["SET", "mykey", "myvalue"]');
+		expect(result.safe).toBe(true);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	test('should block FLUSHDB command', () => {
+		const result = validateRedisCommand('FLUSHDB');
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should block FLUSHALL command', () => {
+		const result = validateRedisCommand('["FLUSHALL"]');
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should block CONFIG command', () => {
+		const result = validateRedisCommand('CONFIG GET *');
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should block EVAL command', () => {
+		const result = validateRedisCommand('EVAL "return redis.call(\'GET\', KEYS[1])" 1 mykey');
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should block SCRIPT command', () => {
+		const result = validateRedisCommand('SCRIPT LOAD "return 1"');
+		expect(result.safe).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	test('should warn about KEYS command', () => {
+		const result = validateRedisCommand('KEYS *');
+		expect(result.safe).toBe(true);
+		expect(result.warnings.length).toBeGreaterThan(0);
+	});
+
+	test('should warn about SMEMBERS command', () => {
+		const result = validateRedisCommand('["SMEMBERS", "myset"]');
+		expect(result.safe).toBe(true);
+		expect(result.warnings.length).toBeGreaterThan(0);
+	});
+});
+
+describe('Main validateQuery function', () => {
+	test('should route to SQL validator for postgres', () => {
+		const result = validateQuery('postgres', 'SELECT * FROM users WHERE id = $1', [123]);
+		expect(result.safe).toBe(true);
+	});
+
+	test('should route to MongoDB validator', () => {
+		const result = validateQuery('mongodb', '{"op":"find","filter":{"name":"test"}}');
+		expect(result.safe).toBe(true);
+	});
+
+	test('should route to Redis validator', () => {
+		const result = validateQuery('redis', 'GET mykey');
+		expect(result.safe).toBe(true);
+	});
+
+	test('should block dangerous SQL in postgres', () => {
+		const result = validateQuery('postgres', "SELECT * FROM users; DROP TABLE users");
+		expect(result.safe).toBe(false);
+	});
+
+	test('should block dangerous MongoDB operations', () => {
+		const result = validateQuery('mongodb', '{"op":"find","filter":{"$where":"this.name == \'admin\'"}}');
+		expect(result.safe).toBe(false);
+	});
+
+	test('should block dangerous Redis commands', () => {
+		const result = validateQuery('redis', 'FLUSHALL');
+		expect(result.safe).toBe(false);
+	});
+});

--- a/backend/db-client/query-validator.ts
+++ b/backend/db-client/query-validator.ts
@@ -1,0 +1,258 @@
+/**
+ * db-client — query validation and safety checks.
+ *
+ * Provides validation for user-submitted queries to prevent SQL injection
+ * and other security issues. This is defense-in-depth alongside parameterized
+ * queries.
+ */
+
+import type { DbDriver } from '$shared/types/db-client';
+
+export interface QueryValidationResult {
+	safe: boolean;
+	warnings: string[];
+	errors: string[];
+}
+
+/**
+ * Dangerous SQL patterns that should never appear in user queries.
+ * These patterns indicate potential SQL injection attempts or unsafe practices.
+ */
+const DANGEROUS_SQL_PATTERNS = [
+	// Command execution attempts
+	/xp_cmdshell/i,
+	/exec\s*\(/i,
+	/execute\s*\(/i,
+	/sp_executesql/i,
+	
+	// File operations
+	/into\s+outfile/i,
+	/into\s+dumpfile/i,
+	/load_file/i,
+	/load\s+data\s+infile/i,
+	
+	// PostgreSQL specific dangerous functions
+	/copy\s+.*\s+from\s+program/i,
+	/copy\s+.*\s+to\s+program/i,
+	/pg_read_file/i,
+	/pg_ls_dir/i,
+	
+	// MySQL specific dangerous functions
+	/sys_exec/i,
+	/sys_eval/i,
+	
+	// Stacked queries (multiple statements)
+	/;\s*(drop|delete|truncate|alter|create|grant|revoke)/i,
+	
+	// Union-based injection patterns
+	/union\s+.*\s+select.*\s+from\s+information_schema/i,
+	/union\s+.*\s+select.*\s+from\s+pg_/i,
+	/union\s+.*\s+select.*\s+from\s+mysql\./i,
+	/union\s+select.*information_schema/i,
+	/union\s+select.*pg_catalog/i,
+];
+
+/**
+ * Patterns that are suspicious but might be legitimate in some contexts.
+ * These generate warnings but don't block execution.
+ */
+const SUSPICIOUS_SQL_PATTERNS = [
+	// Potential blind SQL injection
+	/sleep\s*\(/i,
+	/benchmark\s*\(/i,
+	/waitfor\s+delay/i,
+	/pg_sleep/i,
+	
+	// Information disclosure
+	/@@version/i,
+	/version\s*\(/i,
+	/current_user/i,
+	/user\s*\(/i,
+	/database\s*\(/i,
+	
+	// Potential privilege escalation
+	/grant\s+/i,
+	/revoke\s+/i,
+	
+	// Dangerous DDL operations
+	/drop\s+database/i,
+	/drop\s+schema/i,
+];
+
+/**
+ * Validate a SQL query for security issues.
+ * 
+ * This is defense-in-depth and should be used alongside parameterized queries.
+ * It catches obvious injection attempts but is not a substitute for proper
+ * parameterization.
+ */
+export function validateSqlQuery(driver: DbDriver, query: string, params?: unknown[]): QueryValidationResult {
+	const warnings: string[] = [];
+	const errors: string[] = [];
+	
+	// Skip validation for non-SQL drivers
+	if (driver === 'mongodb' || driver === 'redis') {
+		return { safe: true, warnings, errors };
+	}
+	
+	// Check for dangerous patterns
+	for (const pattern of DANGEROUS_SQL_PATTERNS) {
+		if (pattern.test(query)) {
+			errors.push(`Query contains dangerous pattern: ${pattern.source}`);
+		}
+	}
+	
+	// Check for suspicious patterns
+	for (const pattern of SUSPICIOUS_SQL_PATTERNS) {
+		if (pattern.test(query)) {
+			warnings.push(`Query contains suspicious pattern: ${pattern.source}`);
+		}
+	}
+	
+	// Check if query uses parameterized values
+	if (!params || params.length === 0) {
+		// Look for potential string concatenation or inline values
+		const hasQuotedStrings = /'[^']*'/.test(query) || /"[^"]*"/.test(query);
+		const hasInlineNumbers = /=\s*\d+/.test(query) || />\s*\d+/.test(query) || /<\s*\d+/.test(query);
+		
+		if (hasQuotedStrings || hasInlineNumbers) {
+			warnings.push(
+				'Query contains inline values. Consider using parameterized queries for better security and performance.'
+			);
+		}
+	}
+	
+	// Check for excessively long queries (potential DoS)
+	if (query.length > 100000) {
+		errors.push('Query exceeds maximum length (100KB)');
+	}
+	
+	// Check for excessive nesting (potential DoS)
+	const nestingLevel = (query.match(/\(/g) || []).length;
+	if (nestingLevel > 50) {
+		warnings.push('Query has excessive nesting which may impact performance');
+	}
+	
+	return {
+		safe: errors.length === 0,
+		warnings,
+		errors
+	};
+}
+
+/**
+ * Validate MongoDB query for security issues.
+ */
+export function validateMongoQuery(query: string): QueryValidationResult {
+	const warnings: string[] = [];
+	const errors: string[] = [];
+	
+	try {
+		const parsed = JSON.parse(query);
+		
+		// Check for $where operator (allows arbitrary JavaScript execution)
+		if (JSON.stringify(parsed).includes('$where')) {
+			errors.push('MongoDB $where operator is not allowed (arbitrary code execution risk)');
+		}
+		
+		// Check for mapReduce (can execute arbitrary JavaScript)
+		if (parsed.op === 'mapReduce') {
+			errors.push('MongoDB mapReduce is not allowed (arbitrary code execution risk)');
+		}
+		
+		// Check for $function operator (allows arbitrary JavaScript execution)
+		if (JSON.stringify(parsed).includes('$function')) {
+			errors.push('MongoDB $function operator is not allowed (arbitrary code execution risk)');
+		}
+		
+	} catch (err) {
+		errors.push('Invalid MongoDB query JSON');
+	}
+	
+	return {
+		safe: errors.length === 0,
+		warnings,
+		errors
+	};
+}
+
+/**
+ * Validate Redis command for security issues.
+ */
+export function validateRedisCommand(command: string): QueryValidationResult {
+	const warnings: string[] = [];
+	const errors: string[] = [];
+	
+	let cmd: string;
+	
+	// Parse command
+	const trimmed = command.trim();
+	if (trimmed.startsWith('[')) {
+		try {
+			const parsed = JSON.parse(trimmed);
+			if (Array.isArray(parsed) && parsed.length > 0) {
+				cmd = String(parsed[0]).toUpperCase();
+			} else {
+				errors.push('Invalid Redis command format');
+				return { safe: false, warnings, errors };
+			}
+		} catch {
+			errors.push('Invalid Redis command JSON');
+			return { safe: false, warnings, errors };
+		}
+	} else {
+		cmd = (trimmed.split(/\s+/)[0] ?? '').toUpperCase();
+	}
+	
+	// Block dangerous commands
+	const DANGEROUS_REDIS_COMMANDS = [
+		'FLUSHDB',
+		'FLUSHALL',
+		'SHUTDOWN',
+		'CONFIG',
+		'SAVE',
+		'BGSAVE',
+		'BGREWRITEAOF',
+		'DEBUG',
+		'MIGRATE',
+		'SLAVEOF',
+		'REPLICAOF',
+		'SCRIPT',
+		'EVAL',
+		'EVALSHA',
+	];
+	
+	if (DANGEROUS_REDIS_COMMANDS.includes(cmd)) {
+		errors.push(`Redis command ${cmd} is not allowed (dangerous operation)`);
+	}
+	
+	// Warn about potentially expensive commands
+	const EXPENSIVE_REDIS_COMMANDS = ['KEYS', 'SMEMBERS', 'HGETALL', 'ZRANGE'];
+	if (EXPENSIVE_REDIS_COMMANDS.includes(cmd)) {
+		warnings.push(`Redis command ${cmd} may be expensive on large datasets`);
+	}
+	
+	return {
+		safe: errors.length === 0,
+		warnings,
+		errors
+	};
+}
+
+/**
+ * Main validation entry point that routes to the appropriate validator.
+ */
+export function validateQuery(driver: DbDriver, query: string, params?: unknown[]): QueryValidationResult {
+	switch (driver) {
+		case 'mongodb':
+			return validateMongoQuery(query);
+		case 'redis':
+			return validateRedisCommand(query);
+		case 'mysql':
+		case 'postgres':
+		case 'sqlite':
+			return validateSqlQuery(driver, query, params);
+		default:
+			return { safe: true, warnings: [], errors: [] };
+	}
+}

--- a/backend/ws/db-client/query.ts
+++ b/backend/ws/db-client/query.ts
@@ -6,6 +6,7 @@ import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { connectionManager } from '../../db-client/connection-manager';
 import { runSafely } from '../../db-client/query-executor';
+import { validateQuery } from '../../db-client/query-validator';
 import { dbClientQueryHistoryQueries } from '../../database/queries';
 import { getDbClientPrincipal, requireDbClientConnectionAccess } from './access';
 import { debug } from '$shared/utils/logger';
@@ -53,6 +54,28 @@ export const queryHandler = createRouter()
 	}, async ({ data, conn }) => {
 		const { userId } = getDbClientPrincipal(conn);
 		const connection = requireDbClientConnectionAccess(conn, data.connectionId);
+		
+		// Validate query for security issues
+		const validation = validateQuery(connection.driver, data.query, data.params);
+		if (!validation.safe) {
+			const error = new Error(`Query validation failed: ${validation.errors.join(', ')}`);
+			recordHistory({
+				connectionId: data.connectionId,
+				userId,
+				query: data.query,
+				status: 'error',
+				durationMs: null,
+				rowCount: null,
+				error: error.message
+			});
+			throw error;
+		}
+		
+		// Log warnings if any
+		if (validation.warnings.length > 0) {
+			debug.warn('db-client', `Query warnings for connection ${data.connectionId}:`, validation.warnings);
+		}
+		
 		const adapter = await connectionManager.get(data.connectionId);
 		try {
 			const result = await runSafely({
@@ -99,6 +122,28 @@ export const queryHandler = createRouter()
 	}, async ({ data, conn }) => {
 		const { userId } = getDbClientPrincipal(conn);
 		const connection = requireDbClientConnectionAccess(conn, data.connectionId);
+		
+		// Validate query for security issues
+		const validation = validateQuery(connection.driver, data.query, data.params);
+		if (!validation.safe) {
+			const error = new Error(`Query validation failed: ${validation.errors.join(', ')}`);
+			recordHistory({
+				connectionId: data.connectionId,
+				userId,
+				query: data.query,
+				status: 'error',
+				durationMs: null,
+				rowCount: null,
+				error: error.message
+			});
+			throw error;
+		}
+		
+		// Log warnings if any
+		if (validation.warnings.length > 0) {
+			debug.warn('db-client', `Query warnings for connection ${data.connectionId}:`, validation.warnings);
+		}
+		
 		const adapter = await connectionManager.get(data.connectionId);
 		try {
 			const result = await runSafely({


### PR DESCRIPTION
## Problem

The DB Client feature allows users to connect to external databases and execute queries through the web interface. While the current implementation uses parameterized queries in some places, there's no centralized validation layer to catch dangerous query patterns before execution.

This creates several security risks:
- **SQL Injection**: Malicious queries could exploit string concatenation or bypass parameterization
- **Command Execution**: Attackers could use database-specific functions like `xp_cmdshell` (SQL Server), `COPY ... FROM PROGRAM` (PostgreSQL), or `sys_exec` (MySQL) to execute system commands
- **File Operations**: Queries could read/write files using `LOAD_FILE`, `INTO OUTFILE`, or similar functions
- **Arbitrary Code Execution**: MongoDB's `$where` operator and Redis's `EVAL` command allow running arbitrary JavaScript/Lua code
- **Denial of Service**: Excessively long or deeply nested queries could overwhelm the database

Even with parameterized queries, defense-in-depth is critical for a feature that directly exposes database access through a web interface.

## What Changed

Added a comprehensive query validation layer that acts as a security gate before any query reaches the database:

**New file: `backend/db-client/query-validator.ts`**
- `validateQuery()` - Main entry point that routes to driver-specific validators
- `validateSqlQuery()` - Validates SQL queries (MySQL, PostgreSQL, SQLite) against 15+ dangerous patterns and 10+ suspicious patterns
- `validateMongoQuery()` - Blocks MongoDB operators that allow arbitrary JavaScript execution (`$where`, `$function`, `mapReduce`)
- `validateRedisCommand()` - Blocks dangerous Redis commands (`EVAL`, `FLUSHALL`, `CONFIG`, `SHUTDOWN`, etc.)

**Updated: `backend/ws/db-client/query.ts`**
- Integrated validation into both `db-client:execute-read` and `db-client:execute-write` handlers
- Queries are validated before execution; unsafe queries are rejected with clear error messages
- Warnings (suspicious but not dangerous patterns) are logged for monitoring
- Validation failures are recorded in query history for audit purposes

**New file: `backend/db-client/query-validator.test.ts`**
- 31 comprehensive test cases covering all validators
- Tests for SQL injection patterns, command execution attempts, file operations, and more
- Tests for MongoDB and Redis-specific attack vectors
- Tests for edge cases like excessively long queries and deep nesting

## Validation

✅ **All tests pass** (31/31)
```bash
bun test backend/db-client/query-validator.test.ts
```

✅ **Type checking passes**
```bash
bun run check
```

✅ **Linting passes**
```bash
bun run lint
```

The validation layer is designed as defense-in-depth and works alongside existing security measures. It catches obvious attack patterns while still allowing legitimate queries to execute normally.

## Risk Assessment

**Low risk** - This is a pure addition that doesn't modify existing query execution logic. The validator only blocks queries that match known dangerous patterns. Legitimate queries continue to work as before.

If a legitimate query is accidentally blocked, users will see a clear error message explaining which pattern triggered the validation failure, making it easy to diagnose and report false positives.
