### PR TITLE
fix(files): stream zip extraction with output cap to block zip bombs

### DIFF
--- a/backend/files/file-archive.test.ts
+++ b/backend/files/file-archive.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Stub settingsQueries before importing the module under test so the file-size
+// limit is controllable and never touches a real database during unit tests.
+let mockSettingsRow: { key: string; value: string; updated_at: string } | null = null;
+await mock.module('../database/queries', () => ({
+	settingsQueries: {
+		get: (_key: string) => mockSettingsRow,
+		getAll: () => [],
+		set: () => {},
+		delete: () => {}
+	}
+}));
+
+const { extractZipOperation } = await import('./file-archive');
+
+function setLimitMB(mb: number): void {
+	mockSettingsRow = {
+		key: 'system:settings',
+		value: JSON.stringify({ maxFileSizeMB: mb }),
+		updated_at: ''
+	};
+}
+
+function writeU32(buf: Uint8Array, off: number, val: number): void {
+	buf[off] = val & 0xff;
+	buf[off + 1] = (val >>> 8) & 0xff;
+	buf[off + 2] = (val >>> 16) & 0xff;
+	buf[off + 3] = (val >>> 24) & 0xff;
+}
+
+function readU32(buf: Uint8Array, off: number): number {
+	return (buf[off] | (buf[off + 1] << 8) | (buf[off + 2] << 16) | (buf[off + 3] << 24)) >>> 0;
+}
+
+// Overwrite the uncompressed-size fields in a single-file zip's local and
+// central headers with a forged (tiny) value, leaving the compressed data and
+// compressed-size fields intact. Models an attacker lying about extracted size
+// to slip past any check that trusts the zip metadata. Assumes no archive
+// comment (true for fflate's zipSync output).
+function forgeUncompressedSizes(zip: Uint8Array, fakeSize: number): Uint8Array {
+	const out = zip.slice();
+	const eocd = out.length - 22;
+	const cdOffset = readU32(out, eocd + 16);
+	writeU32(out, cdOffset + 24, fakeSize); // central directory header
+	writeU32(out, 22, fakeSize); // local file header (single file at offset 0)
+	return out;
+}
+
+describe('extractZipOperation — output-size cap', () => {
+	let testDir: string;
+
+	beforeEach(async () => {
+		mockSettingsRow = null;
+		testDir = join(tmpdir(), `clopen-archive-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		await mkdir(testDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		mockSettingsRow = null;
+		await rm(testDir, { recursive: true, force: true });
+	});
+
+	test('extracts a normal archive and writes its contents', async () => {
+		const { zipSync } = await import('fflate');
+		const zip = zipSync(
+			{
+				'file1.txt': new TextEncoder().encode('Hello world, this is a test file'),
+				'file2.txt': new TextEncoder().encode('Another test file with some content')
+			},
+			{ level: 6 }
+		);
+		const archivePath = join(testDir, 'normal.zip');
+		const extractDir = join(testDir, 'extracted');
+		await Bun.write(archivePath, zip);
+
+		const result = await extractZipOperation(archivePath, extractDir);
+
+		expect(result.entries).toBe(2);
+		expect(await Bun.file(join(extractDir, 'file1.txt')).text()).toBe('Hello world, this is a test file');
+		expect(await Bun.file(join(extractDir, 'file2.txt')).text()).toBe('Another test file with some content');
+	});
+
+	test('rejects when actual decompressed output exceeds the limit', async () => {
+		// 4MB of zeros compresses to a few KB, so the compressed archive sails
+		// past the compressed-size guard — only the streaming output cap catches it.
+		setLimitMB(1);
+		const { zipSync } = await import('fflate');
+		const zip = zipSync({ 'big.bin': new Uint8Array(4 * 1024 * 1024) }, { level: 9 });
+		const archivePath = join(testDir, 'big.zip');
+		await Bun.write(archivePath, zip);
+
+		expect(zip.byteLength).toBeLessThan(1024 * 1024); // compressed archive is under the limit
+
+		await expect(extractZipOperation(archivePath, join(testDir, 'out'))).rejects.toThrow(
+			/exceeds maximum allowed size/
+		);
+	});
+
+	test('rejects even when the zip metadata forges a tiny uncompressed size', async () => {
+		// The whole point of the reshape: the cap counts ACTUAL decompressed
+		// bytes, so lying about the size in the central directory cannot bypass it.
+		setLimitMB(1);
+		const { zipSync } = await import('fflate');
+		const honest = zipSync({ 'bomb.bin': new Uint8Array(4 * 1024 * 1024) }, { level: 9 });
+		const forged = forgeUncompressedSizes(honest, 10);
+
+		const eocd = forged.length - 22;
+		const cdOffset = readU32(forged, eocd + 16);
+		expect(readU32(forged, cdOffset + 24)).toBe(10); // metadata now claims 10 bytes
+
+		const archivePath = join(testDir, 'forged.zip');
+		await Bun.write(archivePath, forged);
+
+		await expect(extractZipOperation(archivePath, join(testDir, 'out'))).rejects.toThrow(
+			/exceeds maximum allowed size/
+		);
+	});
+
+	test('rejects path-traversal entries before writing them', async () => {
+		const { zipSync } = await import('fflate');
+		const zip = zipSync({ '../escape.txt': new TextEncoder().encode('nope') }, { level: 6 });
+		const archivePath = join(testDir, 'traversal.zip');
+		await Bun.write(archivePath, zip);
+
+		await expect(extractZipOperation(archivePath, join(testDir, 'out'))).rejects.toThrow(/Unsafe path/);
+	});
+});

--- a/backend/files/file-archive.ts
+++ b/backend/files/file-archive.ts
@@ -1,6 +1,6 @@
 import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path';
 import { mkdir, readdir, stat, writeFile } from 'node:fs/promises';
-import { zipSync, unzipSync } from 'fflate';
+import { zipSync, Unzip, UnzipInflate, UnzipPassThrough } from 'fflate';
 
 import { debug } from '$shared/utils/logger';
 import { getMaxFileSize, validateFileSize } from './file-size-limit';
@@ -139,33 +139,7 @@ export async function extractZipOperation(archivePath: string, targetDir: string
 		}
 
 		const data = new Uint8Array(await archiveFile.arrayBuffer());
-		const unzipped = unzipSync(data);
-
-		let totalBytes = 0;
-		for (const buf of Object.values(unzipped)) {
-			totalBytes += buf.byteLength;
-			if (totalBytes > limit) {
-				throw new Error(`Extracted content exceeds maximum allowed size of ${limitMB}MB`);
-			}
-		}
-
-		let entryCount = 0;
-		for (const [entryPath, content] of Object.entries(unzipped)) {
-			if (!isSafeEntryPath(entryPath, targetDir)) {
-				throw new Error(`Unsafe path in archive: ${entryPath}`);
-			}
-			const normalized = entryPath.replace(/\\/g, '/');
-			const isDirEntry = normalized.endsWith('/');
-			const fullPath = join(targetDir, normalized.split('/').join(sep));
-
-			if (isDirEntry) {
-				await mkdir(fullPath, { recursive: true });
-				continue;
-			}
-			await mkdir(dirname(fullPath), { recursive: true });
-			await writeFile(fullPath, content);
-			entryCount++;
-		}
+		const entryCount = await extractWithinLimit(data, targetDir, limit, limitMB);
 
 		const targetStats = await stat(targetDir);
 		return {
@@ -187,5 +161,92 @@ export async function extractZipOperation(archivePath: string, targetDir: string
 		}
 		throw new Error('Failed to extract archive');
 	}
+}
+
+const STREAM_CHUNK_SIZE = 64 * 1024;
+
+function concatChunks(chunks: Uint8Array[], total: number): Uint8Array {
+	const out = new Uint8Array(total);
+	let pos = 0;
+	for (const chunk of chunks) {
+		out.set(chunk, pos);
+		pos += chunk.length;
+	}
+	return out;
+}
+
+async function writeEntry(fullPath: string, content: Uint8Array): Promise<void> {
+	await mkdir(dirname(fullPath), { recursive: true });
+	await writeFile(fullPath, content);
+}
+
+/**
+ * Stream-extract a ZIP, aborting as soon as the running total of *actual*
+ * decompressed bytes exceeds the limit. Feeding the compressed data in small
+ * chunks bounds how much a single decode step can emit, so a crafted archive
+ * cannot allocate more than the limit before being rejected — unlike trusting
+ * the uncompressed-size fields in the central directory, which an attacker
+ * controls and can forge to defeat a pre-decompression size check.
+ */
+async function extractWithinLimit(
+	data: Uint8Array,
+	targetDir: string,
+	limit: number,
+	limitMB: number
+): Promise<number> {
+	let totalBytes = 0;
+	let entryCount = 0;
+	let failure: Error | null = null;
+	const writes: Promise<void>[] = [];
+
+	const unzipper = new Unzip((file) => {
+		if (failure) return;
+
+		if (!isSafeEntryPath(file.name, targetDir)) {
+			failure = new Error(`Unsafe path in archive: ${file.name}`);
+			return;
+		}
+
+		const normalized = file.name.replace(/\\/g, '/');
+		const fullPath = join(targetDir, normalized.split('/').join(sep));
+
+		if (normalized.endsWith('/')) {
+			writes.push(mkdir(fullPath, { recursive: true }).then(() => undefined));
+			return;
+		}
+
+		const chunks: Uint8Array[] = [];
+		let fileBytes = 0;
+		file.ondata = (err, chunk, final) => {
+			if (failure) return;
+			if (err) {
+				failure = err;
+				return;
+			}
+			totalBytes += chunk.length;
+			if (totalBytes > limit) {
+				failure = new Error(`Extracted content exceeds maximum allowed size of ${limitMB}MB`);
+				return;
+			}
+			chunks.push(chunk);
+			fileBytes += chunk.length;
+			if (final) {
+				writes.push(writeEntry(fullPath, concatChunks(chunks, fileBytes)));
+				entryCount++;
+			}
+		};
+		file.start();
+	});
+	unzipper.register(UnzipInflate);
+	unzipper.register(UnzipPassThrough);
+
+	for (let offset = 0; offset < data.length && !failure; offset += STREAM_CHUNK_SIZE) {
+		const end = Math.min(offset + STREAM_CHUNK_SIZE, data.length);
+		unzipper.push(data.subarray(offset, end), end >= data.length);
+	}
+
+	if (failure) throw failure;
+	await Promise.all(writes);
+	return entryCount;
 }
 


### PR DESCRIPTION
## Summary

Stream-extract uploaded ZIP archives and abort as soon as the *actual* decompressed output exceeds the configured file-size limit, instead of decompressing the whole archive into memory first. Closes the zip-bomb DoS vector on the extract path.

## Why

`extractZipOperation` read the entire archive and called `unzipSync(data)` with no bound on decompressed output. A user uploading a small, highly-compressible archive through the WS extract path (`backend/ws/files/write.ts`) could expand it to gigabytes and OOM the backend, taking down every active session — the compressed-size guard only bounds the *input*, not the output.

Checking the uncompressed size declared in the ZIP central directory before decompressing does **not** fix this: that field is written by whoever created the archive, so an attacker forges a tiny value while the real DEFLATE stream expands without limit. The defense has to count actual decompressed bytes.

## Changes

- `backend/files/file-archive.ts` — `extractZipOperation` now decompresses through fflate's streaming `Unzip` (`UnzipInflate` + `UnzipPassThrough`), feeding the compressed bytes in 64 KB chunks. A running total of real output is checked in each file's `ondata` handler; the moment it crosses the limit, extraction aborts before the offending data is retained. Path-safety (`isSafeEntryPath`) now runs in the `onfile` callback, before any decompression or write.
- `backend/files/file-archive.test.ts` — regression coverage: forged-metadata bypass (tiny declared uncompressed size, large real stream → still rejected), actual-output cap, honest multi-file extraction, and path-traversal rejection.

## Security impact

- **Attacker:** any authenticated user who can upload an archive and trigger extraction.
- **Before:** a crafted small archive expands unbounded in memory at `unzipSync`, OOM-ing the shared backend process (DoS affecting all sessions). A central-directory size check is bypassable by forging the declared size.
- **After:** memory is bounded by the file-size limit plus at most one decode step's output, regardless of what the archive metadata claims. The forged-metadata regression test pins this.

## Related

Replaces #280 by @DeryFerd, reshaped after review: the original checked the central-directory uncompressed size and a compression ratio before decompressing, both of which trust attacker-controlled metadata. This counts actual decompressed bytes instead. Credit to @DeryFerd for surfacing the gap (`Co-authored-by` on the commit).
