### PR TITLE
fix(files): cap animated image frame count to prevent resource exhaustion

### DIFF
--- a/backend/files/image-processing.test.ts
+++ b/backend/files/image-processing.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// Stub sharp before importing the module under test so no real image I/O
+// happens during unit tests. mockPages is set per-test to control metadata.
+let mockPages: number | undefined;
+
+await mock.module('sharp', () => ({
+	default: (_input: unknown, _opts?: unknown) => ({
+		metadata: () =>
+			Promise.resolve({
+				width: 100,
+				height: 100,
+				format: 'gif',
+				pages: mockPages,
+			}),
+	}),
+}));
+
+// Stub file-size-limit so the database is never touched.
+await mock.module('./file-size-limit', () => ({
+	validateFileSize: () => {},
+}));
+
+const { processImageEdit } = await import('./image-processing');
+
+const RECIPE = { output: { format: 'gif' as const } };
+
+describe('processImageEdit — animation frame limit', () => {
+	test('rejects when frame count exceeds the 100-frame limit', async () => {
+		mockPages = 101;
+		await expect(processImageEdit('/dev/null', RECIPE)).rejects.toThrow(
+			'Cannot process animated image: 101 frames exceeds the limit of 100'
+		);
+	});
+
+	test('error message includes the actual and maximum frame counts', async () => {
+		mockPages = 500;
+		await expect(processImageEdit('/dev/null', RECIPE)).rejects.toThrow(
+			'Cannot process animated image: 500 frames exceeds the limit of 100'
+		);
+	});
+
+	test('allows animated images at exactly 100 frames', async () => {
+		mockPages = 100;
+		await expect(processImageEdit('/dev/null', RECIPE)).resolves.toBeDefined();
+	});
+
+	test('allows static images with no pages field', async () => {
+		mockPages = undefined;
+		await expect(processImageEdit('/dev/null', RECIPE)).resolves.toBeDefined();
+	});
+});

--- a/backend/files/image-processing.ts
+++ b/backend/files/image-processing.ts
@@ -27,6 +27,9 @@ export interface ProcessedImage {
 	size: number;
 }
 
+/** Hard cap on animation frames — prevents resource exhaustion via GIF bomb. */
+const MAX_ANIMATION_FRAMES = 100;
+
 /** Clamp a value into [min, max], rounding to an integer. */
 function clampInt(value: number, min: number, max: number): number {
 	return Math.max(min, Math.min(max, Math.round(value)));
@@ -193,6 +196,13 @@ export async function processImageEdit(
 		throw new Error('Source file is not a readable image');
 	}
 
+	const frameCount = srcMeta.pages ?? 1;
+	if (frameCount > MAX_ANIMATION_FRAMES) {
+		throw new Error(
+			`Cannot process animated image: ${frameCount} frames exceeds the limit of ${MAX_ANIMATION_FRAMES}`
+		);
+	}
+
 	// Nothing to do: not compressing, no edits, and the format is unchanged →
 	// return the original bytes verbatim so an untouched file stays identical.
 	const compress = recipe.output.compress ?? false;
@@ -208,7 +218,7 @@ export async function processImageEdit(
 		};
 	}
 
-	const animated = (srcMeta.pages ?? 1) > 1;
+	const animated = frameCount > 1;
 	const rotate = recipe.rotate ?? 0;
 
 	let pipeline: Sharp;


### PR DESCRIPTION
### Problem

This one came out of a threat model exercise around the image processing pipeline. The `processImageEdit` function uses `sharp` under the hood, and while `sharp` is generally well-behaved, it will happily decode every single frame of an animated file you throw at it. GIF bombs are a known attack vector — you feed a server a small animated GIF with hundreds of frames, and each frame gets decoded, composited, and processed separately. Memory usage multiplies with frame count.

The fix is straightforward: a hard cap on animation frames before any processing begins.

### What changed in `backend/files/image-processing.ts`

**New constant at the top of the file:**

```ts
const MAX_ANIMATION_FRAMES = 100;
```

**A guard clause right after metadata is read:**

```ts
const frameCount = srcMeta.pages ?? 1;
if (frameCount > MAX_ANIMATION_FRAMES) {
    throw new Error(
        `Cannot process animated image: ${frameCount} frames exceeds the limit of ${MAX_ANIMATION_FRAMES}`
    );
}
```

This runs before any pixel-level operations — before `sharp` starts decoding frames, before memory is allocated for compositing, before anything expensive happens. The rejection happens at the metadata read stage, which is cheap.

**One cleanup:** the `animated` variable on line 208 was recalculating `(srcMeta.pages ?? 1) > 1`. I replaced it with `frameCount > 1` since the value is already computed and stored.

### Why 100?

100 frames is generous enough for almost any real-world animated asset — short animations, UI mockups, memes, screen recordings trimmed to reasonable length. A 100-frame GIF at 10fps gives you 10 seconds of animation. Anything beyond that is unusual for web upload scenarios and starts looking deliberate.

For reference, a GIF bomb with 1000+ frames can easily consume 500MB+ of RAM during processing depending on resolution and edit operations applied. 100 keeps the ceiling manageable.

### Risk

This is a `Code-only` change with essentially zero risk. The guard runs before any processing, throws a clear error message, and the existing error handler in the calling code (`files-upload.ts`) translates exceptions into HTTP 400 responses. Users who happen to have a legitimate animated file over 100 frames will see a clear error message telling them exactly why it was rejected.

### Validation

- `bun build --no-bundle backend/files/image-processing.ts` — compiles clean
- The logic is entirely additive — existing behavior is preserved for every file under 101 frames
- The metadata read (`sharp(...).metadata()`) was already happening before this change, so no new I/O penalty