### PR TITLE
feat(mcp): add structured audit logging for tool invocations

### DIFF
--- a/backend/mcp/servers/helper.ts
+++ b/backend/mcp/servers/helper.ts
@@ -14,6 +14,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { z } from "zod";
 import { projectContextService } from '../project-context';
 import { validateMcpOutput } from '../output-validator';
+import { debug } from '$shared/utils/logger';
 
 /**
  * Infer argument types from Zod schema
@@ -158,6 +159,22 @@ export function buildServerRegistries<
 	};
 }
 
+const SENSITIVE_ARG_KEYS = new Set(['apiKey', 'api_key', 'token', 'secret', 'password', 'credential', 'key']);
+
+function sanitizeArgs(args: Record<string, unknown>): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(args)) {
+		if (SENSITIVE_ARG_KEYS.has(key)) {
+			result[key] = '[REDACTED]';
+		} else if (typeof value === 'string' && value.length > 200) {
+			result[key] = value.slice(0, 200) + '...';
+		} else {
+			result[key] = value;
+		}
+	}
+	return result;
+}
+
 // ============================================================================
 // Remote MCP Server for Open Code (HTTP transport, in-process execution)
 // ============================================================================
@@ -209,7 +226,12 @@ export function createRemoteMcpServer(
 						isError: true,
 					} as any;
 				}
+				const start = performance.now();
+				debug.log('mcp-tool', `Invoke ${String(srv.meta.name)}/${String(toolName)}`, sanitizeArgs(args));
 				const result = await def.handler(args) as any;
+				const elapsed = (performance.now() - start).toFixed(1);
+				const isError = result?.isError === true;
+				debug.log('mcp-tool', `Result ${String(srv.meta.name)}/${String(toolName)} — ${isError ? 'error' : 'ok'} (${elapsed}ms)`);
 				if (result?.content) {
 					result.content = validateMcpOutput(result.content, toolName as string);
 				}

--- a/shared/utils/logger.ts
+++ b/shared/utils/logger.ts
@@ -27,6 +27,7 @@ export type LogLabel =
 	// Communication
 	| 'websocket'
 	| 'mcp'
+	| 'mcp-tool'
 	| 'notification'
 	| 'rate-limit'
 	


### PR DESCRIPTION
## Problem

The MCP server infrastructure was running tools silently. When a tool was invoked, there was no record of which tool, what arguments were passed, how long it took, or whether it succeeded. That made debugging integration issues tedious — you had to add temporary log statements or reproduce the scenario while watching the network tab.

This PR adds structured audit logging around every MCP tool invocation.

## What changed in `backend/mcp/servers/helper.ts`

**`sanitizeArgs()`** — a helper that takes a tool's argument object and returns a redacted copy. It scrubs values for known sensitive keys (`apiKey`, `token`, `secret`, `password`, `credential`, `key`) and truncates any string longer than 200 characters. The idea is to make logs useful for debugging without accidentally leaking credentials into log files.

```ts
const SENSITIVE_ARG_KEYS = new Set(['apiKey', 'api_key', 'token', 'secret', 'password', 'credential', 'key']);
```

**Two log points wrapped around each tool call:**

1. **Before invocation** — logs the tool name and its sanitized arguments. This tells you what was requested and with what parameters.
2. **After completion** — logs the same identifier, whether it returned an error or success, and the elapsed time in milliseconds.

```
Invoke filesystem/list_files {"path":"/home/user/project"}
Result filesystem/list_files — ok (12.3ms)
```

The timing uses `performance.now()` for sub-millisecond precision, rounded to one decimal place.

## What this enables

- **Post-mortem debugging** — if a tool call fails intermittently, you can check the logs to see argument patterns or timing outliers.
- **Performance monitoring** — you can spot tools that are consistently slow without profiling each one individually.
- **Security audit trail** — even though arguments are redacted, you can see which tools were called and when, which is useful for investigating unexpected behavior.

## What it does not do

This is purely a logging change. No behavior is altered — tools execute exactly as they did before, return the same results, and fail with the same errors. The only difference is that there is now a record of what happened.

## Risk

Minimal. The `sanitizeArgs` function is best-effort — it checks exact key names, so a credential passed under a nonstandard key would still appear in logs. But covering the common cases covers the vast majority of real usage. The redaction set can be extended later if needed.

## Validation

- `bun build --no-bundle backend/mcp/servers/helper.ts` — compiles clean
- `bun run lint` — no new warnings
- Log output tested by inspecting the `debug('mcp-tool')` channel behavior