### PR TITLE
fix(files): add file type validation on upload with extension blocklist

### DIFF
--- a/backend/http/file-type-validator.ts
+++ b/backend/http/file-type-validator.ts
@@ -1,0 +1,46 @@
+export const BLOCKED_EXTENSIONS = new Set([
+	'.exe', '.dll', '.com', '.bat', '.cmd', '.ps1', '.psm1', '.psd1',
+	'.vbs', '.vbe', '.jse', '.wsf', '.wsh', '.msi', '.msp',
+	'.scr', '.pif', '.scf', '.lnk', '.inf',
+	'.sh', '.bash', '.zsh', '.ksh', '.csh',
+	'.app', '.dmg', '.pkg',
+	'.elf', '.so', '.o', '.ko',
+	'.jar', '.class',
+	'.pyc', '.pyo',
+]);
+
+const MAGIC_BYTES: Record<string, Uint8Array[]> = {
+	png: [new Uint8Array([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])],
+	jpeg: [new Uint8Array([0xFF, 0xD8, 0xFF])],
+	webp: [new Uint8Array([0x52, 0x49, 0x46, 0x46])],
+	gif: [new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x37, 0x61]), new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61])],
+	pdf: [new Uint8Array([0x25, 0x50, 0x44, 0x46])],
+	zip: [new Uint8Array([0x50, 0x4B, 0x03, 0x04]), new Uint8Array([0x50, 0x4B, 0x05, 0x06]), new Uint8Array([0x50, 0x4B, 0x07, 0x08])],
+	gzip: [new Uint8Array([0x1F, 0x8B])],
+	bmp: [new Uint8Array([0x42, 0x4D])],
+	tiff: [new Uint8Array([0x49, 0x49, 0x2A, 0x00]), new Uint8Array([0x4D, 0x4D, 0x00, 0x2A])],
+	mp4: [new Uint8Array([0x00, 0x00, 0x00])],
+	mp3: [new Uint8Array([0x49, 0x44, 0x33])],
+	json: [new Uint8Array([0x7B]), new Uint8Array([0x5B])],
+	xml: [new Uint8Array([0x3C])],
+	svg: [new Uint8Array([0x3C, 0x73, 0x76, 0x67])],
+	html: [new Uint8Array([0x3C, 0x68, 0x74, 0x6D, 0x6C]), new Uint8Array([0x3C, 0x21, 0x44, 0x4F])],
+	txt: [],
+	md: [],
+	css: [new Uint8Array([0x2F, 0x2A])],
+};
+
+export function isBlockedExtension(fileName: string): boolean {
+	const ext = fileName.slice(fileName.lastIndexOf('.')).toLowerCase();
+	return BLOCKED_EXTENSIONS.has(ext);
+}
+
+export function matchesMagicByte(data: Uint8Array, extension: string): boolean {
+	const ext = extension.toLowerCase();
+	const magicList = MAGIC_BYTES[ext];
+	if (!magicList || magicList.length === 0) return true;
+	return magicList.some((magic) => {
+		if (data.length < magic.length) return false;
+		return magic.every((byte, i) => data[i] === byte);
+	});
+}

--- a/backend/http/files-upload.ts
+++ b/backend/http/files-upload.ts
@@ -24,6 +24,7 @@ import { authQueries, fileAuditLogQueries } from '../database/queries';
 import { findContainingProjectId, requireFilePathAccessFor } from '../ws/files/path-access';
 import { clientIpFromRequest } from '../utils/client-ip';
 import { validateFileSize } from '../files/file-size-limit';
+import { isBlockedExtension } from './file-type-validator';
 
 type AuthIdentity = { userId: string; role: string };
 
@@ -70,6 +71,10 @@ export const filesUploadRoute = new Elysia().post('/api/files/upload', async ({ 
 	}
 	if (!Number.isFinite(fileSizeParam) || fileSizeParam < 0) {
 		return new Response('Invalid fileSize query parameter', { status: 400 });
+	}
+
+	if (isBlockedExtension(fileNameParam)) {
+		return new Response(`File type "${fileNameParam.slice(fileNameParam.lastIndexOf('.'))}" is not allowed for upload`, { status: 400 });
 	}
 
 	const ipAddress = clientIpFromRequest(request, server);


### PR DESCRIPTION
## Summary

The file upload endpoint had no server-side validation for file types. You could upload anything — `.exe`, `.dll`, `.sh`, `.jar`, `.ps1`, `.class` — and the server would accept it, write it to disk, and serve it back. There was already client-side filtering in the UI, but that is trivially bypassed by sending a direct POST request.

This PR adds a two-layer file type validator that blocks dangerous uploads before they hit disk.

## New file: `backend/http/file-type-validator.ts`

**Layer 1 — Extension blocklist.**

A curated set of extensions that are never allowed through. The list covers executable formats (`.exe`, `.dll`, `.so`, `.dmg`), scripting runtimes (`.ps1`, `.sh`, `.bash`, `.vbs`), compiled bytecode (`.jar`, `.class`, `.pyc`), and Windows installer/shortcut formats (`.msi`, `.lnk`, `.scr`). The full set:

```
.exe .dll .com .bat .cmd .ps1 .psm1 .psd1 .vbs .vbe .jse .wsf .wsh
.msi .msp .scr .pif .scf .lnk .inf .sh .bash .zsh .ksh .csh
.app .dmg .pkg .elf .so .o .ko .jar .class .pyc .pyo
```

**Layer 2 — Magic byte verification (currently stubbed for future use).**

A mapping of known file signatures — PNG, JPEG, GIF, PDF, ZIP, and others — with their header bytes. The `matchesMagicByte` function lets you verify that the first few bytes of a file match its declared extension. This is not wired into the upload flow yet because it requires reading the beginning of the file stream before writing, which needs a small refactor in the upload pipeline. But the function and data are ready, and extending the check later is a one-line addition.

## Change in `backend/http/files-upload.ts`

A single guard at the top of the upload handler, right after the filename is extracted and before any file processing begins:

```ts
if (isBlockedExtension(fileNameParam)) {
    return new Response(`File type "${ext}" is not allowed for upload`, { status: 400 });
}
```

It runs before the temp file is created, before the writer stream opens, before any disk I/O happens. The rejection is instant.

## Why this matters

Without server-side validation, the upload endpoint is essentially a free file write primitive. A user with a valid session could upload executable content and then access it through the file serving path. This is especially relevant in a self-hosted multi-user setup where the server might also serve uploaded files over HTTP.

The blocklist approach was chosen over an allowlist because the workspace needs to accept arbitrary project files — source code, configs, assets, datasets — and an allowlist would be too restrictive. Blocking known-dangerous formats is the practical middle ground.

## What is intentionally not covered

Deep content inspection (e.g., scanning inside archives, stripping metadata from office documents) is out of scope. The goal here is to stop the obvious attacks cheaply, not to build a full antivirus.

## Validation

- `bun build --no-bundle backend/http/file-type-validator.ts` — compiles clean
- `bun run lint` — no warnings
- The check runs entirely synchronously with no I/O, so it adds zero latency to successful uploads