### PR TITLE
feat(navigator): add drag-and-drop project reordering with order persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,3 @@ temp-videos/
 # Terminal output cache
 .terminal-output-cache/
 
-# Geeto state files
-.geeto
-geeto*

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ temp-videos/
 
 # Terminal output cache
 .terminal-output-cache/
+
+# Geeto state files
+.geeto
+geeto*

--- a/backend/ws/user/crud.ts
+++ b/backend/ws/user/crud.ts
@@ -110,7 +110,8 @@ export const crudHandler = createRouter()
 			lastView: t.Union([t.String(), t.Null()]),
 			settings: t.Union([t.Any(), t.Null()]),
 			unreadSessions: t.Union([t.Any(), t.Null()]),
-			todoPanelState: t.Union([t.Any(), t.Null()])
+			todoPanelState: t.Union([t.Any(), t.Null()]),
+			projectOrder: t.Union([t.Array(t.String()), t.Null()])
 		})
 	}, async ({ conn }) => {
 		const userId = ws.getUserId(conn);
@@ -120,12 +121,14 @@ export const crudHandler = createRouter()
 		const userSettings = getUserState(userId, 'settings');
 		const unreadSessions = getUserState(userId, 'unreadSessions');
 		const todoPanelState = getUserState(userId, 'todoPanelState');
+		const projectOrder = getUserState(userId, 'projectOrder');
 
 		debug.log('user', `Restored state for ${userId}:`, {
 			currentProjectId,
 			lastView,
 			hasSettings: !!userSettings,
-			unreadSessionsCount: unreadSessions ? Object.keys(unreadSessions).length : 0
+			unreadSessionsCount: unreadSessions ? Object.keys(unreadSessions).length : 0,
+			projectOrderCount: Array.isArray(projectOrder) ? projectOrder.length : 0
 		});
 
 		return {
@@ -133,7 +136,8 @@ export const crudHandler = createRouter()
 			lastView: lastView ?? null,
 			settings: userSettings ?? null,
 			unreadSessions: unreadSessions ?? null,
-			todoPanelState: todoPanelState ?? null
+			todoPanelState: todoPanelState ?? null,
+			projectOrder: Array.isArray(projectOrder) ? projectOrder : null
 		};
 	})
 
@@ -150,7 +154,7 @@ export const crudHandler = createRouter()
 		const userId = ws.getUserId(conn);
 
 		// Validate allowed keys to prevent arbitrary data storage
-		const allowedKeys = ['currentProjectId', 'lastView', 'settings', 'unreadSessions', 'todoPanelState'];
+		const allowedKeys = ['currentProjectId', 'lastView', 'settings', 'unreadSessions', 'todoPanelState', 'projectOrder'];
 		if (!allowedKeys.includes(data.key)) {
 			throw new Error(`Invalid state key: ${data.key}. Allowed: ${allowedKeys.join(', ')}`);
 		}

--- a/frontend/components/workspace/DesktopNavigator.svelte
+++ b/frontend/components/workspace/DesktopNavigator.svelte
@@ -282,7 +282,7 @@
 							class="flex items-center gap-2.5 py-2.5 px-3 bg-transparent border-none rounded-lg text-slate-600 dark:text-slate-400 text-sm text-left cursor-pointer transition-all duration-150 relative group
 								hover:bg-violet-500/10
 								{draggedProjectId === project.id ? 'opacity-50' : ''}
-								{dragOverProjectId === project.id ? 'ring-1 ring-violet-400/60 bg-violet-500/10' : ''}
+								{dragOverProjectId === project.id ? 'ring-1 ring-inset ring-violet-400/60 bg-violet-500/10' : ''}
 								{currentProjectId === project.id
 								? 'bg-violet-500/10 dark:bg-violet-500/20 text-slate-900 dark:text-slate-100'
 								: ''}"
@@ -398,11 +398,11 @@
 						type="button"
 						class="flex items-center justify-center w-9 h-9 shrink-0 border-none rounded-lg cursor-pointer transition-all duration-150 relative font-semibold text-sm
 							{draggedProjectId === project.id ? 'opacity-50' : ''}
-							{dragOverProjectId === project.id ? 'ring-1 ring-violet-400/60' : ''}
+							{dragOverProjectId === project.id ? 'ring-1 ring-inset ring-violet-400/60' : ''}
 							{currentProjectId === project.id
 							? 'bg-violet-500/10 dark:bg-violet-500/20 text-violet-700 dark:text-violet-300'
 							: 'bg-slate-200/50 dark:bg-slate-800/50 text-slate-600 dark:text-slate-400 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100'}"
-						draggable={projectState.projects.length > 1}
+						draggable={canReorderProjects()}
 						ondragstart={(event) => handleProjectDragStart(event, project.id)}
 						ondragover={(event) => handleProjectDragOver(event, project.id)}
 						ondragleave={() => handleProjectDragLeave(project.id)}

--- a/frontend/components/workspace/DesktopNavigator.svelte
+++ b/frontend/components/workspace/DesktopNavigator.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
 	import { fade } from 'svelte/transition';
 	import Icon from '$frontend/components/common/display/Icon.svelte';
-	import { projectState, setCurrentProject, removeProject, addProject } from '$frontend/stores/core/projects.svelte';
+	import {
+		projectState,
+		setCurrentProject,
+		removeProject,
+		addProject,
+		reorderProjects
+	} from '$frontend/stores/core/projects.svelte';
 	import { workspaceState, toggleNavigator } from '$frontend/stores/ui/workspace.svelte';
 	import { addNotification } from '$frontend/stores/ui/notification.svelte';
 	import { openSettingsModal } from '$frontend/stores/ui/settings-modal.svelte';
@@ -31,6 +37,8 @@
 	let hoveredProject = $state<Project | null>(null);
 	let tooltipY = $state(0);
 	let tooltipX = $state(0);
+	let draggedProjectId = $state<string | null>(null);
+	let dragOverProjectId = $state<string | null>(null);
 
 	// Derived
 	const isCollapsed = $derived(workspaceState.navigatorCollapsed);
@@ -150,6 +158,50 @@
 	function hideProjectTooltip() {
 		hoveredProject = null;
 	}
+
+	function canReorderProjects() {
+		return !searchQuery.trim() && projectState.projects.length > 1;
+	}
+
+	function handleProjectDragStart(event: DragEvent, projectId: string) {
+		if (!canReorderProjects()) {
+			event.preventDefault();
+			return;
+		}
+		draggedProjectId = projectId;
+		if (event.dataTransfer) {
+			event.dataTransfer.effectAllowed = 'move';
+			event.dataTransfer.setData('text/plain', projectId);
+		}
+	}
+
+	function handleProjectDragOver(event: DragEvent, projectId: string) {
+		if (!canReorderProjects() || draggedProjectId === projectId) return;
+		event.preventDefault();
+		if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+		dragOverProjectId = projectId;
+	}
+
+	function handleProjectDragLeave(projectId: string) {
+		if (dragOverProjectId === projectId) {
+			dragOverProjectId = null;
+		}
+	}
+
+	function handleProjectDrop(event: DragEvent, targetProjectId: string) {
+		if (!canReorderProjects()) return;
+		event.preventDefault();
+		const sourceProjectId = draggedProjectId;
+		draggedProjectId = null;
+		dragOverProjectId = null;
+		if (!sourceProjectId || sourceProjectId === targetProjectId) return;
+		reorderProjects(sourceProjectId, targetProjectId);
+	}
+
+	function handleProjectDragEnd() {
+		draggedProjectId = null;
+		dragOverProjectId = null;
+	}
 </script>
 
 <!-- Project Navigator Sidebar -->
@@ -229,19 +281,36 @@
 						<div
 							class="flex items-center gap-2.5 py-2.5 px-3 bg-transparent border-none rounded-lg text-slate-600 dark:text-slate-400 text-sm text-left cursor-pointer transition-all duration-150 relative group
 								hover:bg-violet-500/10
+								{draggedProjectId === project.id ? 'opacity-50' : ''}
+								{dragOverProjectId === project.id ? 'ring-1 ring-violet-400/60 bg-violet-500/10' : ''}
 								{currentProjectId === project.id
 								? 'bg-violet-500/10 dark:bg-violet-500/20 text-slate-900 dark:text-slate-100'
 								: ''}"
 							role="button"
 							title={project.path}
 							tabindex="0"
+							draggable={canReorderProjects()}
+							ondragstart={(event) => handleProjectDragStart(event, project.id)}
+							ondragover={(event) => handleProjectDragOver(event, project.id)}
+							ondragleave={() => handleProjectDragLeave(project.id)}
+							ondrop={(event) => handleProjectDrop(event, project.id)}
+							ondragend={handleProjectDragEnd}
 							onclick={() => selectProject(project)}
 							onkeydown={(e) => e.key === 'Enter' && selectProject(project)}
 						>
 							<div class="relative shrink-0">
-								<Icon name="lucide:folder" class="w-4 h-4" />
+								<Icon
+									name="lucide:folder"
+									class="w-4 h-4 {canReorderProjects() ? 'group-hover:hidden' : ''}"
+								/>
+								{#if canReorderProjects()}
+									<Icon
+										name="lucide:grip-vertical"
+										class="hidden w-4 h-4 group-hover:block"
+									/>
+								{/if}
 								<span
-									class="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-slate-50 dark:border-slate-900/95 {getProjectStatusColor(project.id ?? '')}"
+									class="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-slate-50 dark:border-slate-900/95 {canReorderProjects() ? 'group-hover:hidden' : ''} {getProjectStatusColor(project.id ?? '')}"
 								></span>
 							</div>
 
@@ -328,9 +397,17 @@
 					<button
 						type="button"
 						class="flex items-center justify-center w-9 h-9 shrink-0 border-none rounded-lg cursor-pointer transition-all duration-150 relative font-semibold text-sm
+							{draggedProjectId === project.id ? 'opacity-50' : ''}
+							{dragOverProjectId === project.id ? 'ring-1 ring-violet-400/60' : ''}
 							{currentProjectId === project.id
 							? 'bg-violet-500/10 dark:bg-violet-500/20 text-violet-700 dark:text-violet-300'
 							: 'bg-slate-200/50 dark:bg-slate-800/50 text-slate-600 dark:text-slate-400 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100'}"
+						draggable={projectState.projects.length > 1}
+						ondragstart={(event) => handleProjectDragStart(event, project.id)}
+						ondragover={(event) => handleProjectDragOver(event, project.id)}
+						ondragleave={() => handleProjectDragLeave(project.id)}
+						ondrop={(event) => handleProjectDrop(event, project.id)}
+						ondragend={handleProjectDragEnd}
 						onclick={() => selectProject(project)}
 						onmouseenter={(e) => showProjectTooltip(project, e)}
 						onmouseleave={hideProjectTooltip}

--- a/frontend/components/workspace/WorkspaceLayout.svelte
+++ b/frontend/components/workspace/WorkspaceLayout.svelte
@@ -23,7 +23,7 @@
 	// Services
 	import { initializeTheme } from '$frontend/utils/theme';
 	import { initializeStore } from '$frontend/stores/core/app.svelte';
-	import { initializeProjects } from '$frontend/stores/core/projects.svelte';
+	import { initializeProjects, restoreProjectOrder } from '$frontend/stores/core/projects.svelte';
 	import { initializeSessions } from '$frontend/stores/core/sessions.svelte';
 	import { initializeNotifications, notificationStore } from '$frontend/stores/ui/notification.svelte';
 	import { applyServerSettings, loadSystemSettings } from '$frontend/stores/features/settings.svelte';
@@ -78,7 +78,14 @@
 
 			// Step 3: Restore user state from server
 			setProgress(30, 'Restoring state...');
-			let serverState: { currentProjectId: string | null; lastView: string | null; settings: any; unreadSessions: any; todoPanelState: any } | null = null;
+			let serverState: {
+				currentProjectId: string | null;
+				lastView: string | null;
+				settings: any;
+				unreadSessions: any;
+				todoPanelState: any;
+				projectOrder: string[] | null;
+			} | null = null;
 			try {
 				serverState = await ws.http('user:restore-state', {});
 				debug.log('workspace', 'Server state restored:', serverState);
@@ -94,6 +101,7 @@
 			applyTodoPanelState(serverState?.todoPanelState);
 			restoreLastView(serverState?.lastView);
 			restoreUnreadSessions(serverState?.unreadSessions);
+			restoreProjectOrder(serverState?.projectOrder);
 			await loadSystemSettings();
 			initPresence();
 

--- a/frontend/stores/core/projects.svelte.ts
+++ b/frontend/stores/core/projects.svelte.ts
@@ -36,6 +36,7 @@ interface ProjectState {
 	projects: Project[];
 	currentProject: Project | null;
 	recentProjects: Project[];
+	projectOrder: string[];
 	isLoading: boolean;
 	error: string | null;
 }
@@ -45,6 +46,7 @@ export const projectState = $state<ProjectState>({
 	projects: [],
 	currentProject: null,
 	recentProjects: [],
+	projectOrder: [],
 	isLoading: false,
 	error: null
 });
@@ -230,6 +232,8 @@ export async function setCurrentProject(project: Project | null) {
 
 export function addProject(project: Project) {
 	projectState.projects.push(project);
+	projectState.projectOrder = projectState.projects.map((p) => p.id);
+	persistProjectOrder();
 	updateRecentProjects();
 }
 
@@ -252,6 +256,8 @@ export function removeProject(projectId: string) {
 	const projectPath = projectToRemove?.path || '';
 
 	projectState.projects = projectState.projects.filter(p => p.id !== projectId);
+	projectState.projectOrder = projectState.projects.map((p) => p.id);
+	persistProjectOrder();
 
 	// Clear current project if it's being removed
 	if (projectState.currentProject?.id === projectId) {
@@ -261,6 +267,59 @@ export function removeProject(projectId: string) {
 	// Clean up in-memory state to prevent memory leaks
 	cleanupProjectState(projectId, projectPath);
 
+	updateRecentProjects();
+}
+
+function persistProjectOrder() {
+	ws.http('user:save-state', { key: 'projectOrder', value: [...projectState.projectOrder] }).catch((err) => {
+		debug.error('project', 'Error saving project order to server:', err);
+	});
+}
+
+function applyProjectOrder(projects: Project[], order: string[]): Project[] {
+	if (order.length === 0) return projects;
+
+	const projectMap = new Map(projects.map((project) => [project.id, project]));
+	const orderedProjects: Project[] = [];
+
+	for (const id of order) {
+		const project = projectMap.get(id);
+		if (!project) continue;
+		orderedProjects.push(project);
+		projectMap.delete(id);
+	}
+
+	for (const project of projects) {
+		if (projectMap.has(project.id)) {
+			orderedProjects.push(project);
+		}
+	}
+
+	return orderedProjects;
+}
+
+export function restoreProjectOrder(order: string[] | null | undefined) {
+	projectState.projectOrder = Array.isArray(order) ? [...order] : [];
+	if (projectState.projects.length > 0) {
+		projectState.projects = applyProjectOrder(projectState.projects, projectState.projectOrder);
+		projectState.projectOrder = projectState.projects.map((project) => project.id);
+	}
+}
+
+export function reorderProjects(sourceProjectId: string, targetProjectId: string) {
+	if (sourceProjectId === targetProjectId) return;
+
+	const projects = [...projectState.projects];
+	const sourceIndex = projects.findIndex((project) => project.id === sourceProjectId);
+	const targetIndex = projects.findIndex((project) => project.id === targetProjectId);
+	if (sourceIndex === -1 || targetIndex === -1) return;
+
+	const [movedProject] = projects.splice(sourceIndex, 1);
+	projects.splice(targetIndex, 0, movedProject);
+
+	projectState.projects = projects;
+	projectState.projectOrder = projects.map((project) => project.id);
+	persistProjectOrder();
 	updateRecentProjects();
 }
 
@@ -281,7 +340,8 @@ export async function loadProjects(restoreProjectId?: string | null) {
 		const projects = await ws.http('projects:list');
 
 		if (projects) {
-			projectState.projects = projects;
+			projectState.projects = applyProjectOrder(projects, projectState.projectOrder);
+			projectState.projectOrder = projectState.projects.map((project) => project.id);
 			updateRecentProjects();
 
 			// Restore current project from server-provided ID if not already set


### PR DESCRIPTION
## Summary
   
This PR introduces drag-and-drop reordering to the project navigator, allowing users to rearrange their projects and persist the order across sessions.
 
## Changes
   
- Add drag-and-drop functionality to project navigator in `DesktopNavigator.svelte`
- Persist custom project order in user state on backend (`projectOrder`)
- Restore and apply project order on workspace initialization
- Update project store to handle reordering, adding, and removing consistently
- Visual drag indicators and "grip" icon for reordering

## Preview 

<img width="229" height="289" alt="image" src="https://github.com/user-attachments/assets/f1bf8339-6b70-4ca5-9bdf-3488c7c33e0f" />
