### PR TITLE
feat(git): add checkout commit and open commit on remote actions in history

### DIFF
--- a/backend/git/git-service.ts
+++ b/backend/git/git-service.ts
@@ -317,6 +317,14 @@ export class GitService {
 		}
 	}
 
+	async checkoutCommit(cwd: string, commitHash: string): Promise<void> {
+		assertSafeGitRevish(commitHash, 'commit hash');
+		const result = await execGit(['checkout', commitHash], cwd);
+		if (result.exitCode !== 0) {
+			throw new Error(`git checkout failed: ${result.stderr}`);
+		}
+	}
+
 	async deleteBranch(cwd: string, name: string, force = false): Promise<void> {
 		assertSafeGitRevish(name, 'branch name');
 		const flag = force ? '-D' : '-d';

--- a/backend/ws/git/branch.ts
+++ b/backend/ws/git/branch.ts
@@ -59,6 +59,18 @@ export const branchHandler = createRouter()
 		return { ok: true };
 	})
 
+	.http('git:checkout-commit', {
+		data: t.Object({
+			projectId: t.String(),
+			commitHash: t.String()
+		}),
+		response: t.Object({ ok: t.Boolean() })
+	}, async ({ data, conn }) => {
+		const project = requireProjectAccess(conn, data.projectId);
+		await gitService.checkoutCommit(project.path, data.commitHash);
+		return { ok: true };
+	})
+
 	.http('git:delete-branch', {
 		data: t.Object({
 			projectId: t.String(),

--- a/frontend/components/git/GitLog.svelte
+++ b/frontend/components/git/GitLog.svelte
@@ -212,6 +212,15 @@
 		return ref.substring(0, MAX_REF_LENGTH - 1) + '\u2026';
 	}
 
+	function formatRefs(refs: string[]): string {
+		const visible = refs.slice(0, MAX_VISIBLE_REFS).map(truncateRef);
+		if (refs.length <= MAX_VISIBLE_REFS) {
+			return visible.join('  ·  ');
+		}
+
+		return `${visible.join('  ·  ')}  ·  +${refs.length - MAX_VISIBLE_REFS}`;
+	}
+
 	function formatDate(dateStr: string): string {
 		const date = new Date(dateStr);
 		const now = new Date();
@@ -361,9 +370,9 @@
 					{/if}
 
 					<!-- Commit info (3-line layout) -->
-					<div class="flex-1 min-w-0 px-1.5 py-0.5 pr-2 group-hover:pr-14 group-focus-within:pr-14 flex flex-col justify-center overflow-hidden transition-[padding] duration-150">
+					<div class="flex-1 min-w-0 px-1.5 py-0.5 pr-2 group-hover:pr-10 group-focus-within:pr-10 flex flex-col justify-center overflow-hidden transition-[padding] duration-150">
 						<!-- Line 1: Message + Date -->
-						<div class="flex items-center gap-2">
+						<div class="flex min-w-0 items-center gap-2">
 							<p class="flex-1 min-w-0 text-sm text-slate-900 dark:text-slate-100 leading-tight truncate" title={commit.message}>
 								{commit.message}
 							</p>
@@ -385,23 +394,13 @@
 
 						<!-- Line 3: Refs -->
 						{#if commit.refs && commit.refs.length > 0}
-							<div class="flex min-w-0 items-center gap-1 mt-px overflow-hidden">
-								{#each commit.refs.slice(0, MAX_VISIBLE_REFS) as ref}
-									<span
-										class="text-3xs px-1 rounded bg-blue-500/10 text-blue-600 dark:text-blue-400 shrink min-w-0 truncate max-w-28 group-hover:max-w-22 group-focus-within:max-w-22"
-										title={ref}
-									>
-										{truncateRef(ref)}
-									</span>
-								{/each}
-								{#if commit.refs.length > MAX_VISIBLE_REFS}
-									<span
-										class="text-3xs px-1 py-px rounded bg-slate-500/10 text-slate-500 shrink-0 cursor-default"
-										title={commit.refs.slice(MAX_VISIBLE_REFS).join(', ')}
-									>
-										+{commit.refs.length - MAX_VISIBLE_REFS}
-									</span>
-								{/if}
+							<div class="min-w-0 mt-px max-w-[80%] overflow-hidden">
+								<span
+									class="block min-w-0 truncate text-3xs text-blue-600 dark:text-blue-400"
+									title={commit.refs.join(', ')}
+								>
+									{formatRefs(commit.refs)}
+								</span>
 							</div>
 						{/if}
 					</div>

--- a/frontend/components/git/GitLog.svelte
+++ b/frontend/components/git/GitLog.svelte
@@ -10,9 +10,10 @@
 		activeHash?: string | null;
 		onLoadMore: () => void;
 		onViewCommit: (hash: string) => void;
+		onCheckoutCommit: (hash: string) => void;
 	}
 
-	const { commits, isLoading, hasMore, activeHash = null, onLoadMore, onViewCommit }: Props = $props();
+	const { commits, isLoading, hasMore, activeHash = null, onLoadMore, onViewCommit, onCheckoutCommit }: Props = $props();
 
 	let selectedHash = $state('');
 	const effectiveActiveHash = $derived(activeHash ?? selectedHash);
@@ -229,6 +230,11 @@
 		onViewCommit(hash);
 	}
 
+	function handleCheckoutCommit(hash: string, e: MouseEvent) {
+		e.stopPropagation();
+		onCheckoutCommit(hash);
+	}
+
 	async function copyCommitHash(hash: string, e: MouseEvent) {
 		e.stopPropagation();
 		try {
@@ -256,7 +262,7 @@
 				{@const graph = graphRows[idx]}
 				{@const graphWidth = (graph ? graph.maxCol + 1 : 1) * LANE_WIDTH + GRAPH_PAD * 2}
 				<div
-					class="group flex items-stretch w-full text-left cursor-pointer transition-colors
+					class="group relative flex items-stretch w-full text-left cursor-pointer transition-colors
 						{effectiveActiveHash === commit.hash
 							? 'bg-violet-500/10 dark:bg-violet-500/15 text-slate-900 dark:text-slate-100'
 							: 'hover:bg-slate-50 dark:hover:bg-slate-800/40'}"
@@ -386,6 +392,17 @@
 								{/if}
 							</div>
 						{/if}
+					</div>
+					<div class="pointer-events-none absolute inset-y-0 right-0 flex w-12 items-center justify-center bg-white/45 opacity-0 backdrop-blur-sm transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 dark:bg-slate-900/45">
+						<button
+							type="button"
+							class="pointer-events-auto flex items-center justify-center w-6 h-6 rounded-md text-slate-500 transition-all hover:bg-violet-500/10 hover:text-violet-600 dark:text-slate-400 dark:hover:text-violet-400"
+							onclick={(e) => handleCheckoutCommit(commit.hash, e)}
+							title={`Checkout commit ${commit.hashShort}`}
+							aria-label={`Checkout commit ${commit.hashShort}`}
+						>
+							<Icon name="lucide:arrow-right-to-line" class="w-3.5 h-3.5" />
+						</button>
 					</div>
 				</div>
 			{/each}

--- a/frontend/components/git/GitLog.svelte
+++ b/frontend/components/git/GitLog.svelte
@@ -11,9 +11,10 @@
 		onLoadMore: () => void;
 		onViewCommit: (hash: string) => void;
 		onCheckoutCommit: (hash: string) => void;
+		getRemoteCommitUrl?: (hash: string) => string | null;
 	}
 
-	const { commits, isLoading, hasMore, activeHash = null, onLoadMore, onViewCommit, onCheckoutCommit }: Props = $props();
+	const { commits, isLoading, hasMore, activeHash = null, onLoadMore, onViewCommit, onCheckoutCommit, getRemoteCommitUrl }: Props = $props();
 
 	let selectedHash = $state('');
 	const effectiveActiveHash = $derived(activeHash ?? selectedHash);
@@ -244,6 +245,17 @@
 			addNotification({ type: 'error', title: 'Failed', message: 'Could not copy to clipboard', duration: 3000 });
 		}
 	}
+
+	function openCommitOnRemote(hash: string, e: MouseEvent) {
+		e.stopPropagation();
+		const remoteUrl = getRemoteCommitUrl?.(hash) ?? null;
+		if (!remoteUrl) {
+			addNotification({ type: 'error', title: 'No Remote URL', message: 'Could not build a remote commit URL', duration: 3000 });
+			return;
+		}
+
+		window.open(remoteUrl, '_blank', 'noopener,noreferrer');
+	}
 </script>
 
 <div class="flex-1 min-h-0 flex flex-col">
@@ -349,17 +361,17 @@
 					{/if}
 
 					<!-- Commit info (3-line layout) -->
-					<div class="flex-1 min-w-0 px-1.5 py-0.5 flex flex-col justify-center overflow-hidden">
+					<div class="flex-1 min-w-0 px-1.5 py-0.5 pr-2 group-hover:pr-14 group-focus-within:pr-14 flex flex-col justify-center overflow-hidden transition-[padding] duration-150">
 						<!-- Line 1: Message + Date -->
 						<div class="flex items-center gap-2">
 							<p class="flex-1 min-w-0 text-sm text-slate-900 dark:text-slate-100 leading-tight truncate" title={commit.message}>
 								{commit.message}
 							</p>
-							<span class="text-3xs text-slate-400 shrink-0">{formatDate(commit.date)}</span>
+							<span class="text-3xs text-slate-400 shrink-0 transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">{formatDate(commit.date)}</span>
 						</div>
 
 						<!-- Line 2: Hash + Author -->
-						<div class="flex items-center gap-1.5 mt-px">
+						<div class="flex min-w-0 items-center gap-1.5 mt-px">
 							<button
 								type="button"
 								class="text-xs font-mono text-violet-600 dark:text-violet-400 hover:text-violet-800 dark:hover:text-violet-300 bg-transparent border-none cursor-pointer p-0 shrink-0 transition-colors"
@@ -368,15 +380,15 @@
 							>
 								{commit.hashShort}
 							</button>
-							<span class="text-xs text-slate-500 truncate">{commit.author}</span>
+							<span class="flex-1 min-w-0 text-xs text-slate-500 truncate">{commit.author}</span>
 						</div>
 
 						<!-- Line 3: Refs -->
 						{#if commit.refs && commit.refs.length > 0}
-							<div class="flex items-center gap-1 mt-px overflow-hidden">
+							<div class="flex min-w-0 items-center gap-1 mt-px overflow-hidden">
 								{#each commit.refs.slice(0, MAX_VISIBLE_REFS) as ref}
 									<span
-										class="text-3xs px-1 rounded bg-blue-500/10 text-blue-600 dark:text-blue-400 shrink-0 truncate max-w-28"
+										class="text-3xs px-1 rounded bg-blue-500/10 text-blue-600 dark:text-blue-400 shrink min-w-0 truncate max-w-28 group-hover:max-w-22 group-focus-within:max-w-22"
 										title={ref}
 									>
 										{truncateRef(ref)}
@@ -393,7 +405,7 @@
 							</div>
 						{/if}
 					</div>
-					<div class="pointer-events-none absolute inset-y-0 right-0 flex w-12 items-center justify-center bg-white/45 opacity-0 backdrop-blur-sm transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 dark:bg-slate-900/45">
+					<div class="pointer-events-none absolute inset-y-0 right-0 flex items-center gap-1 pl-1 pr-2 bg-white/20 opacity-0 backdrop-blur-md supports-[backdrop-filter]:bg-white/10 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 dark:bg-slate-900/20 dark:supports-[backdrop-filter]:bg-slate-900/10">
 						<button
 							type="button"
 							class="pointer-events-auto flex items-center justify-center w-6 h-6 rounded-md text-slate-500 transition-all hover:bg-violet-500/10 hover:text-violet-600 dark:text-slate-400 dark:hover:text-violet-400"
@@ -402,6 +414,16 @@
 							aria-label={`Checkout commit ${commit.hashShort}`}
 						>
 							<Icon name="lucide:arrow-right-to-line" class="w-3.5 h-3.5" />
+						</button>
+						<button
+							type="button"
+							class="pointer-events-auto flex items-center justify-center w-6 h-6 rounded-md text-slate-500 transition-all hover:bg-violet-500/10 hover:text-violet-600 disabled:opacity-40 disabled:cursor-not-allowed dark:text-slate-400 dark:hover:text-violet-400"
+							onclick={(e) => openCommitOnRemote(commit.hash, e)}
+							disabled={!getRemoteCommitUrl?.(commit.hash)}
+							title={`Open commit ${commit.hashShort} on remote`}
+							aria-label={`Open commit ${commit.hashShort} on remote`}
+						>
+							<Icon name="lucide:globe" class="w-3.5 h-3.5" />
 						</button>
 					</div>
 				</div>

--- a/frontend/components/settings/system-tools/SystemToolsSettings.svelte
+++ b/frontend/components/settings/system-tools/SystemToolsSettings.svelte
@@ -49,7 +49,7 @@
 			<ToolInstallCard
 				tool="qwen"
 				title="Qwen Code CLI"
-				description="Used by clopen to run the Qwen Code engine. The CLI is bundled with the SDK — installing it standalone is only needed for shell use."
+				description="Used by clopen to run the Qwen Code engine."
 			/>
 		</div>
 	</section>

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -901,6 +901,7 @@
 			await ws.http('git:switch-branch', { projectId, name });
 			showBranchManager = false;
 			await loadAll();
+			if (activeView === 'log') await loadLog(true);
 		} catch (err) {
 			debug.error('git', 'Failed to switch branch:', err);
 			showError('Switch Branch Failed', err instanceof Error ? err.message : 'Unknown error');
@@ -923,6 +924,7 @@
 					openTabs = [];
 					activeTabId = null;
 					await loadAll();
+					if (activeView === 'log') await loadLog(true);
 					showInfo('Commit Checked Out', `Checked out ${shortHash}. HEAD is now detached.`);
 				} catch (err) {
 					debug.error('git', 'Failed to checkout commit:', err);

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -914,8 +914,43 @@
 		});
 	}
 
+	function getPreferredRemoteUrl(): string | null {
+		if (remotes.length === 0) return null;
+		return remotes.find(remote => remote.name === selectedRemote)?.fetchUrl
+			|| remotes.find(remote => remote.name === selectedRemote)?.pushUrl
+			|| remotes[0]?.fetchUrl
+			|| remotes[0]?.pushUrl
+			|| null;
+	}
+
+	function buildRemoteCommitUrl(hash: string): string | null {
+		const remoteUrl = getPreferredRemoteUrl();
+		if (!remoteUrl) return null;
+
+		let normalized = remoteUrl.trim();
+
+		if (normalized.startsWith('git@')) {
+			normalized = normalized.replace(/^git@([^:]+):/, 'https://$1/');
+		} else if (normalized.startsWith('ssh://git@')) {
+			normalized = normalized.replace(/^ssh:\/\/git@/, 'https://');
+		} else if (normalized.startsWith('ssh://')) {
+			normalized = normalized.replace(/^ssh:\/\//, 'https://');
+		}
+
+		normalized = normalized.replace(/\.git$/, '').replace(/\/+$/, '');
+
+		try {
+			const url = new URL(normalized);
+			const basePath = url.pathname.replace(/\/+$/, '');
+			const commitSegment = url.hostname.includes('bitbucket') ? 'commits' : 'commit';
+			return `${url.protocol}//${url.host}${basePath}/${commitSegment}/${hash}`;
+		} catch {
+			return null;
+		}
+	}
+
 	async function createBranch(name: string) {
-		if (!projectId) return;
+		if (!projectId) return false;
 		try {
 			await ws.http('git:create-branch', { projectId, name });
 			showBranchManager = false;
@@ -2011,6 +2046,7 @@ ${bodies}`;
 				onLoadMore={() => loadLog()}
 				onViewCommit={viewCommitDiff}
 				onCheckoutCommit={checkoutCommit}
+				getRemoteCommitUrl={buildRemoteCommitUrl}
 			/>
 		{/if}
 	{:else if activeView === 'stash'}

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -889,6 +889,31 @@
 		}
 	}
 
+	function checkoutCommit(hash: string) {
+		const commit = commits.find(item => item.hash === hash);
+		const shortHash = commit?.hashShort ?? hash.slice(0, 7);
+		requestConfirm({
+			title: 'Checkout Commit',
+			message: `Checkout commit ${shortHash}? This will detach HEAD. Create or switch to a branch before committing new work.`,
+			type: 'warning',
+			confirmText: 'Checkout',
+			onConfirm: async () => {
+				if (!projectId) return;
+				try {
+					await ws.http('git:checkout-commit', { projectId, commitHash: hash });
+					selectedCommit = null;
+					openTabs = [];
+					activeTabId = null;
+					await loadAll();
+					showInfo('Commit Checked Out', `Checked out ${shortHash}. HEAD is now detached.`);
+				} catch (err) {
+					debug.error('git', 'Failed to checkout commit:', err);
+					showError('Checkout Failed', err instanceof Error ? err.message : 'Unknown error');
+				}
+			}
+		});
+	}
+
 	async function createBranch(name: string) {
 		if (!projectId) return;
 		try {
@@ -1985,6 +2010,7 @@ ${bodies}`;
 				activeHash={activeTab?.commitHash ?? null}
 				onLoadMore={() => loadLog()}
 				onViewCommit={viewCommitDiff}
+				onCheckoutCommit={checkoutCommit}
 			/>
 		{/if}
 	{:else if activeView === 'stash'}


### PR DESCRIPTION
## Summary

This PR introduces two new actions to the Git log panel: checking out a commit (detached HEAD) and opening a commit on the remote repository (e.g., GitHub, Bitbucket).

 ## Changes

 - Added API and backend logic for checking out a specific commit by hash.
 - Exposed a new "Checkout commit" action in the Git log UI, with confirmation dialog.
 - Added logic to detect the remote URL and build links to a commit page (supports major hosts).
 - Added "Open commit on remote" action in the Git log UI; opens the commit in default browser.
 - Improved the log row's UI to show new action buttons on hover/focus.
 
 ## Preview
 
<img width="258" height="203" alt="image" src="https://github.com/user-attachments/assets/9a4b5d6d-4cea-40c2-8524-d4c640f1168c" />
