### PR TITLE
fix(terminal): preserve terminal names and avoid duplicate PTY reconnects

### DIFF
--- a/backend/terminal/pty-session-manager.ts
+++ b/backend/terminal/pty-session-manager.ts
@@ -86,17 +86,7 @@ class PtySessionManager {
 		});
 
 		debug.log('terminal', `✅ PTY spawned with PID: ${pty.pid}`);
-
-		// CRITICAL: Send initial newline to trigger shell prompt display
-		// Without this, shell won't show prompt on first connection
-		setTimeout(() => {
-			try {
-				pty.write('\r');
-				debug.log('terminal', '📝 Sent initial newline to trigger prompt');
-			} catch (error) {
-				debug.error('terminal', 'Failed to send initial newline:', error);
-			}
-		}, 100);
+		let receivedInitialOutput = false;
 
 		// Create session
 		const session: PtySession = {
@@ -117,6 +107,7 @@ class PtySessionManager {
 
 		// Setup PTY event handlers with micro-task batching
 		pty.onData((data: string) => {
+			receivedInitialOutput = true;
 			session.lastActivityAt = new Date();
 
 			// IMPORTANT: Always persist output to stream manager FIRST
@@ -157,6 +148,22 @@ class PtySessionManager {
 				});
 			}
 		});
+
+		// Some shells do not paint the first prompt until they receive input.
+		// Only send a fallback newline if the PTY stayed completely silent after
+		// spawn; otherwise it duplicates the initial prompt on normal shells.
+		setTimeout(() => {
+			if (receivedInitialOutput) {
+				return;
+			}
+
+			try {
+				pty.write('\r');
+				debug.log('terminal', '📝 Sent fallback newline to trigger prompt');
+			} catch (error) {
+				debug.error('terminal', 'Failed to send fallback newline:', error);
+			}
+		}, 350);
 
 		pty.onExit((event: { exitCode: number; signal?: number | string }) => {
 			debug.log('terminal', `🏁 PTY session ${sessionId} exited with code: ${event.exitCode}`);

--- a/frontend/components/common/xterm/XTerm.svelte
+++ b/frontend/components/common/xterm/XTerm.svelte
@@ -47,9 +47,9 @@
 	const MAX_INIT_RETRIES = 5; // Max retry attempts
 	const keyboardEventHandler: ((e: KeyboardEvent) => void) | null = null; // Store event handler reference
 
-	// Track which sessions have connected to PTY in this browser session (after refresh)
-	// This prevents reconnection issues after browser refresh
-	const connectedSessions = new Set<string>();
+	function shouldConnectSession(sessionId: string): boolean {
+		return !terminalService.hasActiveListeners(sessionId);
+	}
 	
 	// Initialize terminal
 	async function initializeTerminal() {
@@ -60,14 +60,7 @@
 		await xtermService.initialize(terminalContainer);
 
 		if (xtermService.isInitialized && session) {
-			// CRITICAL: Mark session as connected BEFORE setting isInitialized
-			// This prevents the session change $effect from triggering a duplicate connection
-			// because $effect checks connectedSessions.has(session.id)
-			if (hasActiveProject && onExecuteCommand) {
-				connectedSessions.add(session.id);
-			}
-
-			// Update reactive state AFTER marking connected
+			// Update reactive state after initialization
 			isInitialized = xtermService.isInitialized;
 
 			// Setup input handling - forwards all keystrokes to PTY
@@ -91,26 +84,6 @@
 
 			// Mark terminal as ready immediately - shell handles prompts
 			isTerminalReady = true;
-
-			// CRITICAL: Auto-connect to PTY session right after initialization
-			// This opens the SSE stream to persistent PTY
-			if (hasActiveProject && onExecuteCommand && session) {
-				// IMPORTANT: Get actual terminal dimensions and pass to PTY
-				// This ensures PTY is created with correct size to prevent cursor positioning issues
-				let terminalSize: { cols: number; rows: number } | undefined;
-				if (xtermService.fitAddon && xtermService.terminal) {
-					// First fit to get proper dimensions
-					xtermService.fitAddon.fit();
-					const dims = xtermService.fitAddon.proposeDimensions();
-					if (dims) {
-						terminalSize = { cols: dims.cols, rows: dims.rows };
-					}
-				}
-
-				onExecuteCommand('', terminalSize).catch(() => {
-					// Silently handle connection errors
-				});
-			}
 		} else {
 			// Update reactive state even if not fully initialized
 			isInitialized = xtermService.isInitialized;
@@ -473,10 +446,8 @@
 				// This ensures PTY session is created on server for:
 				// 1. New tabs (session.lines.length === 0)
 				// 2. Restored sessions after browser refresh that haven't connected yet
-				const hasNotConnected = !connectedSessions.has(session.id);
+				const hasNotConnected = shouldConnectSession(session.id);
 				if (hasNotConnected && hasActiveProject && onExecuteCommand) {
-					// Session hasn't connected to PTY yet - create connection
-					connectedSessions.add(session.id);
 					setTimeout(() => {
 						// Get terminal dimensions for PTY size sync
 						let terminalSize: { cols: number; rows: number } | undefined;
@@ -585,13 +556,6 @@
 		// Remove keyboard event listener (must match capture phase)
 		if (keyboardEventHandler && xtermService.terminal?.element) {
 			xtermService.terminal.element.removeEventListener('keydown', keyboardEventHandler, true);
-		}
-
-		// CRITICAL: Clean up terminal service WebSocket listeners for the current session
-		// This prevents stale listeners from accumulating when XTerm is destroyed
-		// during project switches, which would cause duplicate output processing
-		if (lastSessionId) {
-			terminalService.cleanupListeners(lastSessionId);
 		}
 
 		xtermService.dispose();

--- a/frontend/components/terminal/Terminal.svelte
+++ b/frontend/components/terminal/Terminal.svelte
@@ -6,6 +6,7 @@
 	import { terminalStore } from '$frontend/stores/features/terminal.svelte';
 	import { projectState } from '$frontend/stores/core/projects.svelte';
 	import { terminalService } from '$frontend/services/terminal';
+	import { terminalProjectManager } from '$frontend/services/terminal';
 	import TerminalTabs from './TerminalTabs.svelte';
 	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import XTerm from '$frontend/components/common/xterm/XTerm.svelte';
@@ -223,6 +224,10 @@
 		}
 	}
 
+	function handleRenameSession(sessionId: string, name: string) {
+		terminalProjectManager.renameSession(sessionId, name);
+	}
+
 	// Format directory path for display in header
 	function formatDirectory(dir: string): string {
 		if (!dir || typeof dir !== 'string') return '~';
@@ -270,6 +275,7 @@
 			onSwitchSession={(sessionId) => terminalStore.switchToSession(sessionId)}
 			onCloseSession={handleCloseSession}
 			onNewSession={handleNewSession}
+			onRenameSession={handleRenameSession}
 		/>
 	</div>
 

--- a/frontend/components/terminal/TerminalTabs.svelte
+++ b/frontend/components/terminal/TerminalTabs.svelte
@@ -11,14 +11,44 @@
 		activeSessionId,
 		onSwitchSession,
 		onCloseSession,
-		onNewSession
+		onNewSession,
+		onRenameSession
 	}: {
 		sessions: TerminalSession[];
 		activeSessionId: string | null;
 		onSwitchSession?: (sessionId: string) => void;
 		onCloseSession?: (sessionId: string) => void;
 		onNewSession?: () => void;
+		onRenameSession?: (sessionId: string, name: string) => void;
 	} = $props();
+
+	let editingSessionId = $state<string | null>(null);
+	let draftName = $state('');
+
+	function focusAndSelect(node: HTMLInputElement) {
+		queueMicrotask(() => {
+			node.focus();
+			node.select();
+		});
+	}
+
+	function startRename(session: TerminalSession) {
+		editingSessionId = session.id;
+		draftName = session.name;
+	}
+
+	function cancelRename() {
+		editingSessionId = null;
+		draftName = '';
+	}
+
+	function saveRename(sessionId: string) {
+		const normalizedName = draftName.trim();
+		if (normalizedName) {
+			onRenameSession?.(sessionId, normalizedName);
+		}
+		cancelRename();
+	}
 
 	// Check for duplicate sessions (for debugging)
 	$effect(() => {
@@ -42,10 +72,31 @@
 					? 'text-violet-600 dark:text-violet-400'
 					: 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'}"
 			onclick={() => onSwitchSession?.(session.id)}
+			ondblclick={() => startRename(session)}
 			role="tab"
 			tabindex="0"
 		>
-			<span class="truncate max-w-28">{session.name}</span>
+			{#if editingSessionId === session.id}
+				<input
+					bind:value={draftName}
+					class="w-28 min-w-0 rounded border border-violet-300 bg-white/90 px-1.5 py-0.5 text-xs text-slate-800 outline-none dark:border-violet-500/60 dark:bg-slate-900 dark:text-slate-100"
+					onclick={(e) => e.stopPropagation()}
+					onblur={() => saveRename(session.id)}
+					onkeydown={(e) => {
+						e.stopPropagation();
+						if (e.key === 'Enter') {
+							e.preventDefault();
+							saveRename(session.id);
+						} else if (e.key === 'Escape') {
+							e.preventDefault();
+							cancelRename();
+						}
+					}}
+					use:focusAndSelect
+				/>
+			{:else}
+				<span class="truncate max-w-28">{session.name}</span>
+			{/if}
 			<!-- Close button -->
 			<span
 				role="button"
@@ -85,4 +136,3 @@
 		</button>
 	{/if}
 </div>
-

--- a/frontend/services/terminal/background/session-restore.ts
+++ b/frontend/services/terminal/background/session-restore.ts
@@ -107,7 +107,7 @@ class SessionRestoreService {
 
 			const restoredSession = {
 				id: persistedSession.sessionId,
-				name: `Terminal ${terminalNumber}`,
+				name: persistedSession.name || `Terminal ${terminalNumber}`,
 				directory: persistedSession.workingDirectory,
 				lines: persistedSession.lines || [],
 				commandHistory: persistedSession.commandHistory || [],

--- a/frontend/services/terminal/persistence.service.ts
+++ b/frontend/services/terminal/persistence.service.ts
@@ -11,6 +11,7 @@ import { debug } from '$shared/utils/logger';
 
 export interface PersistedTerminalSession {
 	sessionId: string;
+	name: string;
 	projectId?: string;
 	projectPath?: string;
 	workingDirectory: string;
@@ -57,6 +58,7 @@ class TerminalPersistenceManager {
 		this.persistedData = {
 			sessions: sessions.map(session => ({
 				sessionId: session.id,
+				name: session.name,
 				projectId: session.projectId,
 				projectPath: session.projectPath,
 				workingDirectory: session.directory,

--- a/frontend/services/terminal/project.service.ts
+++ b/frontend/services/terminal/project.service.ts
@@ -23,6 +23,7 @@ interface ProjectTerminalContext {
 	sessionIds: string[];
 	activeSessionId: string | null;
 	lastActiveAt: Date;
+	sessionNames: Map<string, string>;
 	// Store terminal output per session for this project
 	sessionOutputs: Map<string, Array<{ content: string; type: string; timestamp: Date }>>;
 	// Store command history per session for this project
@@ -55,7 +56,8 @@ class TerminalProjectManager {
 				: context.activeSessionId;
 		return {
 			sessionIds: [...context.sessionIds],
-			activeSessionId: activeSessionId ?? context.sessionIds[0] ?? null
+			activeSessionId: activeSessionId ?? context.sessionIds[0] ?? null,
+			sessionNames: Object.fromEntries(context.sessionNames)
 		};
 	}
 
@@ -72,6 +74,7 @@ class TerminalProjectManager {
 				sessionIds: [],
 				activeSessionId: null,
 				lastActiveAt: new Date(),
+				sessionNames: new Map(),
 				sessionOutputs: new Map(),
 				sessionCommandHistories: new Map()
 			};
@@ -130,6 +133,7 @@ class TerminalProjectManager {
 			if (restored && restored.sessionIds.length > 0) {
 				context.sessionIds = [...restored.sessionIds];
 				context.activeSessionId = restored.activeSessionId ?? restored.sessionIds[0] ?? null;
+				context.sessionNames = new Map(Object.entries(restored.sessionNames || {}));
 			}
 		}
 
@@ -190,7 +194,7 @@ class TerminalProjectManager {
 
 				const terminalSession: TerminalSession = {
 					id: backendSession.sessionId,
-					name: `Terminal ${terminalNumber}`,
+					name: context.sessionNames.get(backendSession.sessionId) || `Terminal ${terminalNumber}`,
 					directory: backendSession.cwd || projectPath,
 					lines: [],
 					commandHistory: [],
@@ -206,6 +210,7 @@ class TerminalProjectManager {
 				terminalStore.addSession(terminalSession);
 				terminalSessionManager.createSession(backendSession.sessionId, projectId, projectPath, backendSession.cwd || projectPath);
 				context.sessionIds.push(backendSession.sessionId);
+				context.sessionNames.set(backendSession.sessionId, terminalSession.name);
 
 				// Update nextSessionId to avoid ID conflicts
 				const match = backendSession.sessionId.match(/terminal-(\d+)/);
@@ -238,6 +243,7 @@ class TerminalProjectManager {
 		const session = terminalStore.getSession(sessionId);
 		if (session) {
 			session.directory = projectPath;
+			context.sessionNames.set(sessionId, session.name);
 		}
 
 		terminalSessionManager.createSession(sessionId, projectId, projectPath, projectPath);
@@ -303,7 +309,7 @@ class TerminalProjectManager {
 
 				const terminalSession: TerminalSession = {
 					id: sessionId,
-					name: `Terminal ${terminalNumber}`,
+					name: context.sessionNames.get(sessionId) || `Terminal ${terminalNumber}`,
 					directory: context.projectPath, // Always use the project path as base directory
 					lines: [],
 					commandHistory: [],
@@ -483,7 +489,7 @@ class TerminalProjectManager {
 		
 		const terminalSession: TerminalSession = {
 			id: managerSession.id,
-			name: `Terminal ${terminalNumber}`,
+			name: projectContext?.sessionNames.get(managerSession.id) || `Terminal ${terminalNumber}`,
 			directory: correctDirectory,
 			lines: [],
 			commandHistory: managerSession.commandHistory || [],
@@ -557,6 +563,7 @@ class TerminalProjectManager {
 					context.sessionCommandHistories.set(sessionId, session.commandHistory);
 					// Saved command history items for session
 				}
+				context.sessionNames.set(sessionId, session.name);
 				
 				// Update session metadata in manager
 				terminalSessionManager.updateSession(sessionId, {
@@ -642,6 +649,7 @@ class TerminalProjectManager {
 		const session = terminalStore.getSession(sessionId);
 		if (session) {
 			session.directory = context.projectPath;
+			context.sessionNames.set(sessionId, session.name);
 		}
 		
 		// Create corresponding session in manager with correct project association
@@ -707,6 +715,7 @@ class TerminalProjectManager {
 				context.sessionOutputs.delete(sessionId);
 				context.sessionOutputs.delete(`${sessionId}-metadata`);
 				context.sessionCommandHistories.delete(sessionId);
+				context.sessionNames.delete(sessionId);
 
 				// Update active session if needed
 				if (context.activeSessionId === sessionId) {
@@ -736,6 +745,21 @@ class TerminalProjectManager {
 	getProjectSessions(projectId: string): string[] {
 		const context = this.projectContexts.get(projectId);
 		return context?.sessionIds || [];
+	}
+
+	renameSession(sessionId: string, name: string): void {
+		const normalizedName = name.trim();
+		if (!normalizedName) return;
+
+		terminalStore.renameSession(sessionId, normalizedName);
+
+		for (const context of this.projectContexts.values()) {
+			if (!context.sessionIds.includes(sessionId)) continue;
+			context.sessionNames.set(sessionId, normalizedName);
+			this.persistContexts();
+			markTerminalDirty();
+			return;
+		}
 	}
 
 	/**
@@ -868,7 +892,7 @@ class TerminalProjectManager {
 
 				const terminalSession: TerminalSession = {
 					id: data.sessionId,
-					name: `Terminal ${terminalNumber}`,
+					name: context.sessionNames.get(data.sessionId) || `Terminal ${terminalNumber}`,
 					directory: data.currentDirectory,
 					lines: [],
 					commandHistory: [],
@@ -884,6 +908,7 @@ class TerminalProjectManager {
 				// Add to store and context
 				terminalStore.addSession(terminalSession);
 				context.sessionIds.push(data.sessionId);
+				context.sessionNames.set(data.sessionId, terminalSession.name);
 
 				// Create in session manager
 				terminalSessionManager.createSession(

--- a/frontend/services/terminal/terminal.service.ts
+++ b/frontend/services/terminal/terminal.service.ts
@@ -31,45 +31,17 @@ export class TerminalService {
 	private resizeEndpointAvailable: boolean | null = true; // WebSocket always available
 	private activeListeners = new Map<string, Array<() => void>>();
 	private lastOutputSeq = new Map<string, number>();
+	private connectingSessions = new Set<string>();
 
-	/**
-	 * Connect to persistent PTY session with streaming output via WebSocket
-	 */
-	async connectToSession(
-		options: TerminalConnectOptions,
+	private attachSessionListeners(
+		sessionId: string,
 		onData: (data: StreamingResponse) => void
-	): Promise<void> {
-		const { sessionId, workingDirectory, projectPath, projectId, terminalSize } = options;
-
-		debug.log('terminal', `🔌 Connecting to PTY session via WebSocket: ${sessionId}`);
-
-		// CRITICAL: Cleanup existing listeners BEFORE creating new ones
-		// This prevents duplicate event handlers when reconnecting to the same session
-		// (e.g., when switching between projects and coming back)
-		this.cleanupListeners(sessionId);
-
-		// Reset sequence tracking for fresh deduplication
-		this.lastOutputSeq.delete(sessionId);
-
-		// Get or create session state
-		const session = terminalSessionManager.getOrCreateSession(
-			sessionId,
-			projectId,
-			projectPath,
-			workingDirectory
-		);
-
-		// Create unique stream ID for this connection
-		const streamId = `${sessionId}-${Date.now()}`;
-
-		// Setup WebSocket listeners for this session
+	): void {
 		const listeners: Array<() => void> = [];
 
-		// Listen for ready event
 		const unsubReady = ws.on('terminal:ready', (data) => {
 			if (data.sessionId === sessionId) {
 				debug.log('terminal', `✅ PTY session ready: ${sessionId} (PID: ${data.pid})`);
-				// Update session state with stream ID
 				terminalSessionManager.updateSession(sessionId, {
 					streamId: data.streamId,
 					processId: data.pid,
@@ -79,12 +51,8 @@ export class TerminalService {
 		});
 		listeners.push(unsubReady);
 
-		// Listen for output (with sequence-based deduplication)
 		const unsubOutput = ws.on('terminal:output', (data) => {
 			if (data.sessionId === sessionId) {
-				// Deduplicate: skip if we've already seen this sequence number
-				// Multiple WS connections in the same project room can deliver
-				// the same terminal:output event multiple times
 				if (data.seq !== undefined && data.seq !== null) {
 					const lastSeq = this.lastOutputSeq.get(sessionId) || 0;
 					if (data.seq <= lastSeq) return;
@@ -102,7 +70,6 @@ export class TerminalService {
 		});
 		listeners.push(unsubOutput);
 
-		// Listen for directory changes
 		const unsubDirectory = ws.on('terminal:directory', (data) => {
 			if (data.sessionId === sessionId) {
 				terminalSessionManager.updateWorkingDirectory(sessionId, data.newDirectory);
@@ -115,12 +82,10 @@ export class TerminalService {
 		});
 		listeners.push(unsubDirectory);
 
-		// Listen for exit
 		const unsubExit = ws.on('terminal:exit', (data) => {
 			if (data.sessionId === sessionId) {
 				debug.log('terminal', `🏁 PTY session exited: ${sessionId} (code: ${data.exitCode})`);
 
-				// Clear stream info
 				backgroundTerminalService.endStream(sessionId, true);
 
 				onData({
@@ -129,13 +94,11 @@ export class TerminalService {
 					sessionId: data.sessionId
 				});
 
-				// Cleanup listeners
 				this.cleanupListeners(sessionId);
 			}
 		});
 		listeners.push(unsubExit);
 
-		// Listen for errors
 		const unsubError = ws.on('terminal:error', (data) => {
 			if (data.sessionId === sessionId) {
 				debug.error('terminal', `❌ PTY error for ${sessionId}:`, data.error);
@@ -148,8 +111,53 @@ export class TerminalService {
 		});
 		listeners.push(unsubError);
 
-		// Store listeners for cleanup
 		this.activeListeners.set(sessionId, listeners);
+	}
+
+	/**
+	 * Connect to persistent PTY session with streaming output via WebSocket
+	 */
+	async connectToSession(
+		options: TerminalConnectOptions,
+		onData: (data: StreamingResponse) => void
+	): Promise<void> {
+		const { sessionId, workingDirectory, projectPath, projectId, terminalSize } = options;
+
+		if (this.connectingSessions.has(sessionId)) {
+			debug.log('terminal', `⏳ Connection already in progress for: ${sessionId}`);
+			return;
+		}
+
+		if (this.activeListeners.has(sessionId)) {
+			debug.log('terminal', `⏭️ Reusing existing terminal listeners for: ${sessionId}`);
+			return;
+		}
+
+		debug.log('terminal', `🔌 Connecting to PTY session via WebSocket: ${sessionId}`);
+		this.connectingSessions.add(sessionId);
+
+		// Reset sequence tracking for fresh deduplication
+		this.lastOutputSeq.delete(sessionId);
+
+		// Get or create session state
+		const session = terminalSessionManager.getOrCreateSession(
+			sessionId,
+			projectId,
+			projectPath,
+			workingDirectory
+		);
+
+		const hasLivePty = Boolean(session.processId || session.streamId);
+
+		// Create unique stream ID for this connection
+		const streamId = `${sessionId}-${Date.now()}`;
+		this.attachSessionListeners(sessionId, onData);
+
+		if (hasLivePty) {
+			debug.log('terminal', `🔁 Reattached listeners to existing PTY session: ${sessionId}`);
+			this.connectingSessions.delete(sessionId);
+			return;
+		}
 
 		// Create terminal session (now using HTTP pattern)
 		try {
@@ -175,6 +183,8 @@ export class TerminalService {
 			// Cleanup listeners on error
 			this.cleanupListeners(sessionId);
 			throw error;
+		} finally {
+			this.connectingSessions.delete(sessionId);
 		}
 	}
 
@@ -360,6 +370,11 @@ export class TerminalService {
 			this.lastOutputSeq.delete(sessionId);
 			debug.log('terminal', `🧹 Cleaned up listeners for ${sessionId}`);
 		}
+		this.connectingSessions.delete(sessionId);
+	}
+
+	hasActiveListeners(sessionId: string): boolean {
+		return this.activeListeners.has(sessionId) || this.connectingSessions.has(sessionId);
 	}
 
 	/**

--- a/frontend/services/terminal/terminal.service.ts
+++ b/frontend/services/terminal/terminal.service.ts
@@ -147,17 +147,18 @@ export class TerminalService {
 			workingDirectory
 		);
 
-		const hasLivePty = Boolean(session.processId || session.streamId);
-
 		// Create unique stream ID for this connection
 		const streamId = `${sessionId}-${Date.now()}`;
 		this.attachSessionListeners(sessionId, onData);
 
-		if (hasLivePty) {
-			debug.log('terminal', `🔁 Reattached listeners to existing PTY session: ${sessionId}`);
-			this.connectingSessions.delete(sessionId);
-			return;
-		}
+		// Always (re)issue create-session even when the PTY is already live on the
+		// server. The handler is idempotent — it reuses the running PTY, clears any
+		// stale listeners, and replays the serialized scrollback. That replay is what
+		// repaints the terminal after a project switch, where the store's session
+		// lines were intentionally reset to []. Skipping it here left the terminal
+		// blank until a browser refresh. Duplicate connects are already prevented by
+		// the connectingSessions / activeListeners guards above and XTerm's
+		// shouldConnectSession check.
 
 		// Create terminal session (now using HTTP pattern)
 		try {

--- a/frontend/stores/features/terminal-workspace.svelte.ts
+++ b/frontend/stores/features/terminal-workspace.svelte.ts
@@ -28,6 +28,7 @@ import { debug } from '$shared/utils/logger';
 export interface TerminalSlice {
 	sessionIds: string[];
 	activeSessionId: string | null;
+	sessionNames?: Record<string, string>;
 }
 
 // Slices the coordinator restored from the blob, awaiting the terminal manager
@@ -76,7 +77,8 @@ registerDock({
 			const s = slice as TerminalSlice;
 			restoredSlices.set(projectId, {
 				sessionIds: [...s.sessionIds],
-				activeSessionId: s.activeSessionId ?? s.sessionIds[0] ?? null
+				activeSessionId: s.activeSessionId ?? s.sessionIds[0] ?? null,
+				sessionNames: s.sessionNames ? { ...s.sessionNames } : undefined
 			});
 		} else {
 			restoredSlices.delete(projectId);

--- a/frontend/stores/features/terminal.svelte.ts
+++ b/frontend/stores/features/terminal.svelte.ts
@@ -5,6 +5,7 @@
 
 import type { TerminalSession, TerminalLine, TerminalCommand } from '$shared/types/terminal';
 import { terminalService, type StreamingResponse } from '$frontend/services/terminal';
+import { terminalSessionManager } from '$frontend/services/terminal';
 import { addNotification } from '../ui/notification.svelte';
 import { markTerminalDirty } from './terminal-workspace.svelte';
 import ws from '$frontend/utils/ws';
@@ -59,7 +60,22 @@ export const terminalStore = {
 			throw new Error('ProjectId is required to create a terminal session');
 		}
 		
-		const sessionNumber = terminalState.nextSessionId++;
+		const existingNumbers = new Set(
+			terminalState.sessions
+				.filter((session) => session.projectId === projectId)
+				.map((session) => {
+					const match = session.id.match(/terminal-(\d+)$/);
+					return match ? parseInt(match[1], 10) : null;
+				})
+				.filter((value): value is number => value !== null)
+		);
+
+		let sessionNumber = 1;
+		while (existingNumbers.has(sessionNumber)) {
+			sessionNumber++;
+		}
+
+		terminalState.nextSessionId = sessionNumber + 1;
 		// Always include projectId in sessionId to ensure uniqueness across projects
 		const sanitizedProjectId = projectId.replace(/[^a-zA-Z0-9]/g, '').substring(0, 8);
 		const sessionId = `${sanitizedProjectId}-terminal-${sessionNumber}`;
@@ -71,6 +87,12 @@ export const terminalStore = {
 		if (terminalState.sessions.find(s => s.id === sessionId)) {
 			return this.createNewSession(directory, projectPath, projectId);
 		}
+
+		// Reused tab numbers can recreate a previous session ID (e.g. close
+		// Terminal 2, then open a new tab back into slot 2). Make absolutely sure
+		// no stale frontend listener/session metadata survives for that ID.
+		terminalService.cleanupListeners(sessionId);
+		terminalSessionManager.removeSession(sessionId);
 		
 		// Clear any existing buffer for this session
 		terminalState.lineBuffers.delete(sessionId);
@@ -242,6 +264,12 @@ export const terminalStore = {
 		terminalState.sessions = terminalState.sessions.filter(session => session.id !== sessionId);
 		debug.log('terminal', `🔴 [closeSession] Session removed from state. Remaining sessions: ${terminalState.sessions.length}`);
 
+		// When the last tab is closed, reset numbering so the next created tab
+		// starts again from "Terminal 1" instead of continuing the old counter.
+		if (terminalState.sessions.length === 0) {
+			terminalState.nextSessionId = 1;
+		}
+
 		// If we closed the active session, switch to another one (if available)
 		if (sessionId === terminalState.activeSessionId) {
 			const newActiveSession = terminalState.sessions[0];
@@ -265,6 +293,21 @@ export const terminalStore = {
 			// DO NOT update historical input lines - they should preserve their original directory
 			// Historical prompts should show the directory at the time the command was executed
 		}
+	},
+
+	renameSession(sessionId: string, name: string): void {
+		const normalizedName = name.trim();
+		if (!normalizedName) {
+			return;
+		}
+
+		terminalState.sessions = terminalState.sessions.map((session) =>
+			session.id === sessionId
+				? { ...session, name: normalizedName, lastUsedAt: new Date() }
+				: session
+		);
+
+		markTerminalDirty();
 	},
 
 	// Connect to PTY session (for initial auto-connect)


### PR DESCRIPTION
# Preserve terminal tab names and prevent duplicate PTY reconnects

## Summary

This PR improves terminal session handling by preserving custom tab names across restarts and prevents duplicate PTY connections, avoiding redundant prompts and event listeners.

## Changes

- Terminal tab names are now editable and saved; they persist across sessions and reloads.
- Tab renaming UI added to `TerminalTabs.svelte`, allowing rename via double-click.
- Session persistence now saves and restores the terminal name.
- Avoids sending a duplicate initial newline to the PTY, sending it only as a fallback if the prompt doesn't display.
- Removed browser-side logic that caused duplicate PTY connections and output streams after refreshes.
- Improved PTY session cleanup to avoid multiple active listeners when switching projects or sessions.

## Preview 

<img width="502" height="277" alt="image" src="https://github.com/user-attachments/assets/9cd13249-602a-4145-8dcc-9b447c139f84" />
