### PR TITLE
feat(checkpoint): add checkpoint changes banner with per-session file

### DIFF
--- a/backend/database/migrations/040_add_dismissed_changes_to_message_snapshots.ts
+++ b/backend/database/migrations/040_add_dismissed_changes_to_message_snapshots.ts
@@ -1,0 +1,24 @@
+import type { DatabaseConnection } from '$shared/types/database/connection';
+import { debug } from '$shared/utils/logger';
+
+export const description = 'Add dismissed_changes to message_snapshots for per-session file dismissal marks';
+
+export const up = (db: DatabaseConnection): void => {
+	debug.log('migration', 'Adding dismissed_changes to message_snapshots...');
+	db.exec(`ALTER TABLE message_snapshots ADD COLUMN dismissed_changes TEXT`);
+	debug.log('migration', 'dismissed_changes column added');
+};
+
+export const down = (db: DatabaseConnection): void => {
+	debug.log('migration', 'Removing dismissed_changes from message_snapshots...');
+	db.exec(`
+		CREATE TABLE message_snapshots_backup AS
+		SELECT id, message_id, session_id, project_id, files_snapshot, project_metadata,
+			created_at, snapshot_type, parent_snapshot_id, delta_changes, files_changed,
+			insertions, deletions, branch_id, tree_hash, session_changes, is_deleted
+		FROM message_snapshots
+	`);
+	db.exec(`DROP TABLE message_snapshots`);
+	db.exec(`ALTER TABLE message_snapshots_backup RENAME TO message_snapshots`);
+	debug.log('migration', 'dismissed_changes column removed');
+};

--- a/backend/database/migrations/index.ts
+++ b/backend/database/migrations/index.ts
@@ -38,6 +38,7 @@ import * as migration036 from './036_create_auth_audit_log';
 import * as migration037 from './037_repair_auth_audit_log_schema';
 import * as migration038 from './038_add_workspace_state_to_user_projects';
 import * as migration039 from './039_create_file_audit_log';
+import * as migration040 from './040_add_dismissed_changes_to_message_snapshots';
 
 // Export all migrations in order
 export const migrations = [
@@ -274,6 +275,12 @@ export const migrations = [
 		description: migration039.description,
 		up: migration039.up,
 		down: migration039.down
+	},
+	{
+		id: '040',
+		description: migration040.description,
+		up: migration040.up,
+		down: migration040.down
 	}
 ];
 

--- a/backend/database/queries/snapshot-queries.ts
+++ b/backend/database/queries/snapshot-queries.ts
@@ -138,14 +138,18 @@ export const snapshotQueries = {
 	},
 
 	/**
-	 * Get the dismissed-changes list (per-session marks for files the user
-	 * has staged/discarded from the banner) from the latest snapshot.
+	 * Get the dismissed-changes list from the LATEST snapshot for the
+	 * session. The latest snapshot is always used — even if its
+	 * `dismissed_changes` is NULL — because per-snapshot marks must
+	 * RESET on each new AI message. Skipping NULL rows here would
+	 * fall back to the previous snapshot's marks and make the banner
+	 * think the file is still dismissed.
 	 */
 	getDismissedChanges(sessionId: string): string[] {
 		const db = getDatabase();
 		const row = db.prepare(`
 			SELECT dismissed_changes FROM message_snapshots
-			WHERE session_id = ? AND dismissed_changes IS NOT NULL
+			WHERE session_id = ?
 			ORDER BY created_at DESC
 			LIMIT 1
 		`).get(sessionId) as { dismissed_changes: string | null } | null;

--- a/backend/database/queries/snapshot-queries.ts
+++ b/backend/database/queries/snapshot-queries.ts
@@ -150,28 +150,25 @@ export const snapshotQueries = {
 	},
 
 	/**
-	 * Get the dismissed-changes list for the session. Falls back to the
-	 * most recent non-empty `dismissed_changes` across all snapshots in
-	 * the session — so marks PERSIST across AI messages instead of
-	 * resetting on each new snapshot.
+	 * Get the dismissed-changes list from the LATEST snapshot for the
+	 * session. Per-snapshot marks RESET on each new AI message — so the
+	 * user can review new changes from the next AI turn.
 	 */
 	getDismissedChanges(sessionId: string): string[] {
 		const db = getDatabase();
-		const rows = db.prepare(`
+		const row = db.prepare(`
 			SELECT dismissed_changes FROM message_snapshots
-			WHERE session_id = ? AND dismissed_changes IS NOT NULL
+			WHERE session_id = ?
 			ORDER BY created_at DESC
-		`).all(sessionId) as { dismissed_changes: string }[];
-		const merged = new Set<string>();
-		for (const row of rows) {
-			try {
-				const parsed = JSON.parse(row.dismissed_changes);
-				if (Array.isArray(parsed)) {
-					for (const x of parsed) if (typeof x === 'string') merged.add(x);
-				}
-			} catch { /* ignore */ }
+			LIMIT 1
+		`).get(sessionId) as { dismissed_changes: string | null } | null;
+		if (!row?.dismissed_changes) return [];
+		try {
+			const parsed = JSON.parse(row.dismissed_changes);
+			return Array.isArray(parsed) ? parsed.filter(x => typeof x === 'string') : [];
+		} catch {
+			return [];
 		}
-		return [...merged];
 	},
 
 	/**

--- a/backend/database/queries/snapshot-queries.ts
+++ b/backend/database/queries/snapshot-queries.ts
@@ -97,6 +97,18 @@ export const snapshotQueries = {
 	},
 
 	/**
+	 * Update the `session_changes` JSON for a snapshot.
+	 * Pass `null` to clear (when all changes removed).
+	 */
+	updateSessionChanges(snapshotId: string, sessionChanges: string | null): boolean {
+		const db = getDatabase();
+		const result = db.prepare(`
+			UPDATE message_snapshots SET session_changes = ? WHERE id = ?
+		`).run(sessionChanges, snapshotId);
+		return (result as { changes: number }).changes > 0;
+	},
+
+	/**
 	 * Get snapshot by message ID
 	 */
 	getByMessageId(messageId: string): MessageSnapshot | null {

--- a/backend/database/queries/snapshot-queries.ts
+++ b/backend/database/queries/snapshot-queries.ts
@@ -52,7 +52,8 @@ export const snapshotQueries = {
 			is_deleted: 0,
 			branch_id: data.branch_id || null,
 			tree_hash: data.tree_hash || null,
-			session_changes: data.session_changes ? JSON.stringify(data.session_changes) : null
+			session_changes: data.session_changes ? JSON.stringify(data.session_changes) : null,
+			dismissed_changes: data.dismissed_changes || null
 		};
 
 		db.prepare(`
@@ -61,8 +62,8 @@ export const snapshotQueries = {
 				files_snapshot, project_metadata, created_at,
 				snapshot_type, parent_snapshot_id, delta_changes,
 				files_changed, insertions, deletions,
-				is_deleted, branch_id, tree_hash, session_changes
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)
+				is_deleted, branch_id, tree_hash, session_changes, dismissed_changes
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?)
 		`).run(
 			snapshot.id,
 			snapshot.message_id,
@@ -79,7 +80,8 @@ export const snapshotQueries = {
 			snapshot.deletions,
 			snapshot.branch_id || null,
 			snapshot.tree_hash || null,
-			snapshot.session_changes || null
+			snapshot.session_changes || null,
+			snapshot.dismissed_changes
 		);
 
 		return snapshot;

--- a/backend/database/queries/snapshot-queries.ts
+++ b/backend/database/queries/snapshot-queries.ts
@@ -29,6 +29,7 @@ export const snapshotQueries = {
 		branch_id?: string;
 		tree_hash?: string; // Blob store tree hash (new format)
 		session_changes?: any; // SessionScopedChanges object
+		dismissed_changes?: string | null; // Carry-forward dismissed marks
 	}): MessageSnapshot {
 		const db = getDatabase();
 		const id = data.id || `snapshot_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;

--- a/backend/database/queries/snapshot-queries.ts
+++ b/backend/database/queries/snapshot-queries.ts
@@ -138,6 +138,89 @@ export const snapshotQueries = {
 	},
 
 	/**
+	 * Get the dismissed-changes list (per-session marks for files the user
+	 * has staged/discarded from the banner) from the latest snapshot.
+	 */
+	getDismissedChanges(sessionId: string): string[] {
+		const db = getDatabase();
+		const row = db.prepare(`
+			SELECT dismissed_changes FROM message_snapshots
+			WHERE session_id = ? AND dismissed_changes IS NOT NULL
+			ORDER BY created_at DESC
+			LIMIT 1
+		`).get(sessionId) as { dismissed_changes: string | null } | null;
+		if (!row?.dismissed_changes) return [];
+		try {
+			const parsed = JSON.parse(row.dismissed_changes);
+			return Array.isArray(parsed) ? parsed.filter(x => typeof x === 'string') : [];
+		} catch {
+			return [];
+		}
+	},
+
+	/**
+	 * Add one or more filepaths to the latest snapshot's dismissed_changes
+	 * list. Deduplicates against existing entries. Returns the resulting
+	 * list (or null if no snapshot exists for the session yet).
+	 */
+	addDismissedChanges(sessionId: string, filepaths: string[]): string[] | null {
+		if (filepaths.length === 0) return null;
+		const db = getDatabase();
+		const snapshot = db.prepare(`
+			SELECT id, dismissed_changes FROM message_snapshots
+			WHERE session_id = ?
+			ORDER BY created_at DESC
+			LIMIT 1
+		`).get(sessionId) as { id: string; dismissed_changes: string | null } | null;
+
+		if (!snapshot) return null;
+
+		let current: string[] = [];
+		if (snapshot.dismissed_changes) {
+			try {
+				const parsed = JSON.parse(snapshot.dismissed_changes);
+				if (Array.isArray(parsed)) current = parsed.filter(x => typeof x === 'string');
+			} catch {
+				// Corrupt JSON — start fresh.
+			}
+		}
+
+		const set = new Set(current);
+		let changed = false;
+		for (const fp of filepaths) {
+			if (!set.has(fp)) {
+				current.push(fp);
+				set.add(fp);
+				changed = true;
+			}
+		}
+
+		db.prepare(`
+			UPDATE message_snapshots
+			SET dismissed_changes = ?
+			WHERE id = ?
+		`).run(JSON.stringify(current), snapshot.id);
+
+		return current;
+	},
+	/* eslint-disable @typescript-eslint/no-explicit-any */
+
+	/**
+	 * Clear the dismissed-changes list for the latest snapshot of a session.
+	 * Returns true if anything was cleared.
+	 */
+	clearDismissedChanges(sessionId: string): boolean {
+		const db = getDatabase();
+		const result = db.prepare(`
+			UPDATE message_snapshots
+			SET dismissed_changes = NULL
+			WHERE session_id = ?
+			AND dismissed_changes IS NOT NULL
+		`).run(sessionId);
+		return (result as { changes: number }).changes > 0;
+	},
+
+	/**
 	 * Delete snapshots after a certain message in a session
 	 * Used when restoring to a previous state (hard delete - deprecated)
 	 */

--- a/backend/database/queries/snapshot-queries.ts
+++ b/backend/database/queries/snapshot-queries.ts
@@ -150,28 +150,28 @@ export const snapshotQueries = {
 	},
 
 	/**
-	 * Get the dismissed-changes list from the LATEST snapshot for the
-	 * session. The latest snapshot is always used — even if its
-	 * `dismissed_changes` is NULL — because per-snapshot marks must
-	 * RESET on each new AI message. Skipping NULL rows here would
-	 * fall back to the previous snapshot's marks and make the banner
-	 * think the file is still dismissed.
+	 * Get the dismissed-changes list for the session. Falls back to the
+	 * most recent non-empty `dismissed_changes` across all snapshots in
+	 * the session — so marks PERSIST across AI messages instead of
+	 * resetting on each new snapshot.
 	 */
 	getDismissedChanges(sessionId: string): string[] {
 		const db = getDatabase();
-		const row = db.prepare(`
+		const rows = db.prepare(`
 			SELECT dismissed_changes FROM message_snapshots
-			WHERE session_id = ?
+			WHERE session_id = ? AND dismissed_changes IS NOT NULL
 			ORDER BY created_at DESC
-			LIMIT 1
-		`).get(sessionId) as { dismissed_changes: string | null } | null;
-		if (!row?.dismissed_changes) return [];
-		try {
-			const parsed = JSON.parse(row.dismissed_changes);
-			return Array.isArray(parsed) ? parsed.filter(x => typeof x === 'string') : [];
-		} catch {
-			return [];
+		`).all(sessionId) as { dismissed_changes: string }[];
+		const merged = new Set<string>();
+		for (const row of rows) {
+			try {
+				const parsed = JSON.parse(row.dismissed_changes);
+				if (Array.isArray(parsed)) {
+					for (const x of parsed) if (typeof x === 'string') merged.add(x);
+				}
+			} catch { /* ignore */ }
 		}
+		return [...merged];
 	},
 
 	/**

--- a/backend/git/git-service.ts
+++ b/backend/git/git-service.ts
@@ -127,15 +127,18 @@ export class GitService {
 		const statusLine = statusResult.stdout.trim();
 
 		if (statusLine.startsWith('??')) {
-			// Untracked file - delete it
+			// Untracked file — delete it from worktree
 			const { unlink } = await import('node:fs/promises');
 			const { join } = await import('node:path');
 			await unlink(join(cwd, filePath));
 		} else {
-			// Tracked file - restore it
-			const result = await execGit(['checkout', '--', filePath], cwd);
+			// For staged + modified + deleted: unstage AND restore from HEAD.
+			// `git checkout -- <file>` alone restores from INDEX (not HEAD) if
+			// the file is staged — so the AI's content would persist. Using
+			// `git restore --staged --worktree` handles all tracked cases.
+			const result = await execGit(['restore', '--staged', '--worktree', '--', filePath], cwd);
 			if (result.exitCode !== 0) {
-				throw new Error(`git checkout failed: ${result.stderr}`);
+				throw new Error(`git restore failed: ${result.stderr}`);
 			}
 		}
 	}

--- a/backend/snapshot/gitignore.ts
+++ b/backend/snapshot/gitignore.ts
@@ -23,6 +23,87 @@ const ALWAYS_EXCLUDE_DIRS = new Set([
 ]);
 
 /**
+ * Find paths of all nested git repos (directories with their own `.git`) at any
+ * depth under `rootPath`. Walks into nested repos to find deeply nested ones.
+ * Does NOT scan the repos — just returns their absolute paths.
+ *
+ * Used by callers that need to run git commands inside each nested repo
+ * (e.g. `git:status` aggregating changes from nested repos into the Changes
+ * tab of the Git panel).
+ */
+export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
+	const paths: string[] = [];
+
+	const walk = async (currentPath: string): Promise<void> => {
+		let entries;
+		try {
+			entries = await fs.readdir(currentPath, { withFileTypes: true });
+		} catch {
+			return;
+		}
+
+		for (const entry of entries) {
+			if (!entry.isDirectory()) continue;
+			if (ALWAYS_EXCLUDE_DIRS.has(entry.name)) continue;
+
+			const fullPath = path.join(currentPath, entry.name);
+
+			// Check if this directory is itself a git repo
+			try {
+				await fs.access(path.join(fullPath, '.git'));
+				paths.push(fullPath);
+				// Fall through to also walk into it for deeper nested repos
+			} catch {
+				// Not a git repo
+			}
+
+			await walk(fullPath);
+		}
+	};
+
+	await walk(rootPath);
+	return paths;
+}
+
+/**
+ * Given a file path relative to the project root, find the deepest nested
+ * git repo that contains it. Returns the repo's absolute path and the file
+ * path relative to that repo, or `null` if the file lives in the outer repo.
+ *
+ * Used by git staging/discard handlers so that `git add` / `git restore` /
+ * `git rm` run inside the correct repo (the outer repo's `git` would skip
+ * or fail on files that are tracked by a nested repo).
+ */
+export async function findRepoForFile(
+	projectPath: string,
+	filePath: string
+): Promise<{ repoPath: string; relativeFilePath: string } | null> {
+	const normalizedFilePath = filePath.replace(/\\/g, '/');
+	const nestedRepoPaths = await findNestedRepoPaths(projectPath);
+
+	let bestMatch: { repoPath: string; relativeFilePath: string } | null = null;
+	let bestRepoRelLen = -1;
+
+	for (const repoPath of nestedRepoPaths) {
+		const repoRel = path.relative(projectPath, repoPath).replace(/\\/g, '/');
+		// File is inside this repo if its path starts with `repoRel/`
+		if (normalizedFilePath === repoRel || normalizedFilePath.startsWith(repoRel + '/')) {
+			if (repoRel.length > bestRepoRelLen) {
+				bestMatch = {
+					repoPath,
+					relativeFilePath: normalizedFilePath === repoRel
+						? ''
+						: normalizedFilePath.substring(repoRel.length + 1)
+				};
+				bestRepoRelLen = repoRel.length;
+			}
+		}
+	}
+
+	return bestMatch;
+}
+
+/**
  * Get list of snapshot-eligible files using git (preferred) or manual scan.
  * Returns full absolute paths.
  */
@@ -50,12 +131,38 @@ async function scanWithGit(dirPath: string): Promise<string[] | null> {
 	}
 
 	try {
+		// Scan the outer repo
+		const files = await scanSingleGitRepo(dirPath);
+
+		// Find and scan nested git repos — separate repositories living inside
+		// the project (e.g. a theme extracted into its own repo). The parent
+		// repo's `git ls-files --exclude-standard` skips these because git treats
+		// a nested repo as a single gitlink entry (or excludes it entirely when
+		// it's listed in the parent's .gitignore). Without this step, files
+		// inside nested repos are invisible to the snapshot system, so AI
+		// changes to them never appear in the checkpoint banner.
+		const nestedFiles = await findAndScanNestedRepos(dirPath);
+
+		const allFiles = [...files, ...nestedFiles];
+		debug.log('snapshot', `Git scan found ${allFiles.length} files (${files.length} outer, ${nestedFiles.length} nested)`);
+		return allFiles;
+	} catch (err) {
+		debug.warn('snapshot', 'git ls-files failed, falling back to manual scan:', err);
+		return null;
+	}
+}
+
+/**
+ * Run `git ls-files -co --exclude-standard` in a single git repo and return
+ * absolute paths. Used for both the outer repo and nested repos.
+ */
+async function scanSingleGitRepo(dirPath: string): Promise<string[]> {
+	try {
 		const result = await execGit(['ls-files', '-co', '--exclude-standard'], dirPath, 60_000);
-		if (result.exitCode !== 0) return null;
-		const output = result.stdout;
+		if (result.exitCode !== 0) return [];
 
 		const files: string[] = [];
-		for (const line of output.split('\n')) {
+		for (const line of result.stdout.split('\n')) {
 			const relativePath = line.trim();
 			if (!relativePath) continue;
 
@@ -63,15 +170,68 @@ async function scanWithGit(dirPath: string): Promise<string[] | null> {
 			const firstSegment = relativePath.split('/')[0];
 			if (ALWAYS_EXCLUDE_DIRS.has(firstSegment)) continue;
 
+			// Skip directory entries — git emits nested repos as a single
+			// entry with a trailing slash (e.g. `theme/`). These are handled
+			// by findAndScanNestedRepos, not here.
+			if (relativePath.endsWith('/')) continue;
+
 			files.push(path.join(dirPath, relativePath));
 		}
-
-		debug.log('snapshot', `Git scan found ${files.length} files`);
 		return files;
 	} catch (err) {
-		debug.warn('snapshot', 'git ls-files failed, falling back to manual scan:', err);
-		return null;
+		debug.warn('snapshot', `git ls-files failed for ${dirPath}:`, err);
+		return [];
 	}
+}
+
+/**
+ * Walk the project tree to find nested git repos (directories with their own
+ * `.git`) and scan each one independently. This catches nested repos that are
+ * gitignored by the parent — they'd otherwise be invisible to the outer repo's
+ * `git ls-files --exclude-standard`.
+ *
+ * The walk respects ALWAYS_EXCLUDE_DIRS (skips `.git`, `node_modules`) but does
+ * NOT respect .gitignore, because the nested repo we're looking for may itself
+ * be gitignored by the parent. Once a nested repo is found, its own
+ * `git ls-files --exclude-standard` handles its .gitignore rules.
+ */
+async function findAndScanNestedRepos(rootPath: string): Promise<string[]> {
+	const files: string[] = [];
+
+	const walk = async (currentPath: string): Promise<void> => {
+		let entries;
+		try {
+			entries = await fs.readdir(currentPath, { withFileTypes: true });
+		} catch {
+			return;
+		}
+
+		for (const entry of entries) {
+			if (!entry.isDirectory()) continue;
+			if (ALWAYS_EXCLUDE_DIRS.has(entry.name)) continue;
+
+			const fullPath = path.join(currentPath, entry.name);
+
+			// Check if this directory is itself a git repo (`.git` can be a
+			// directory or a file — the latter for worktrees/submodules).
+			try {
+				await fs.access(path.join(fullPath, '.git'));
+				// Nested repo found — scan it independently, then continue
+				// walking into it to find even deeper nested repos.
+				const nestedFiles = await scanSingleGitRepo(fullPath);
+				files.push(...nestedFiles);
+				await walk(fullPath);
+				continue;
+			} catch {
+				// Not a git repo — recurse to find deeper nested repos
+			}
+
+			await walk(fullPath);
+		}
+	};
+
+	await walk(rootPath);
+	return files;
 }
 
 // ============================================================================
@@ -282,6 +442,18 @@ async function scanWithGitignoreParsing(projectPath: string): Promise<string[]> 
 				if (ALWAYS_EXCLUDE_DIRS.has(entry.name)) continue;
 
 				if (entry.isDirectory()) {
+					// Check if this is a nested git repo — scan it independently
+					// and bypass the .gitignore filter so files inside a
+					// gitignored nested repo are still tracked.
+					try {
+						await fs.access(path.join(fullPath, '.git'));
+						const nestedFiles = await scanSingleGitRepo(fullPath);
+						files.push(...nestedFiles);
+						continue;
+					} catch {
+						// Not a git repo — apply gitignore filter and recurse
+					}
+
 					if (!filter.isIgnored(relativePath, true)) {
 						await scan(fullPath);
 					}

--- a/backend/snapshot/helpers.ts
+++ b/backend/snapshot/helpers.ts
@@ -1,6 +1,8 @@
 import { snapshotQueries, messageQueries, checkpointQueries } from '../database/queries';
+import { blobStore } from './blob-store';
 import { debug } from '$shared/utils/logger';
 import { loadMessage } from '$shared/utils/message-formatter';
+import { calculateFileChangeStats } from '$shared/utils/diff-calculator';
 import type { DatabaseMessage } from '$shared/types/database/schema';
 import type { UnifiedMessage, UserMessage } from '$shared/types/unified';
 
@@ -320,27 +322,49 @@ export function isDescendant(
  * The snapshot associated with the checkpoint message itself contains the stats
  * (file changes the assistant made in response to this user message).
  */
-export function getCheckpointFileStats(
+export async function getCheckpointFileStats(
 	checkpointMsg: DatabaseMessage
-): { filesChanged: number; insertions: number; deletions: number } {
+): Promise<{ filesChanged: number; insertions: number; deletions: number }> {
 	const snapshot = snapshotQueries.getByMessageId(checkpointMsg.id);
 	if (!snapshot) {
 		return { filesChanged: 0, insertions: 0, deletions: 0 };
 	}
 
 	let filesChanged = snapshot.files_changed || 0;
-	const insertions = snapshot.insertions || 0;
-	const deletions = snapshot.deletions || 0;
+	let insertions = snapshot.insertions || 0;
+	let deletions = snapshot.deletions || 0;
 
-	// Try to get a more accurate file count from session_changes
-	if (snapshot.session_changes) {
+	// Fallback for snapshots captured before nested-repo files were tracked:
+	// `session_changes` may be non-empty (with nested-repo entries) but
+	// `files_changed`/`insertions`/`deletions` are 0 because the capture
+	// loop never saw those files. Recompute from the blob store so the
+	// Restore Checkpoint UI shows the real numbers retroactively.
+	if (snapshot.session_changes && (insertions === 0 || deletions === 0)) {
 		try {
-			const changes = JSON.parse(snapshot.session_changes as string);
+			const changes = JSON.parse(snapshot.session_changes as string) as Record<string, { oldHash: string; newHash: string }>;
 			const changeCount = Object.keys(changes).length;
 			if (changeCount > 0) {
-				filesChanged = changeCount;
+				const previousSnapshot: Record<string, Buffer> = {};
+				const currentSnapshot: Record<string, Buffer> = {};
+				let allBlobsOk = true;
+				for (const [filepath, entry] of Object.entries(changes)) {
+					if (entry.oldHash) {
+						try { previousSnapshot[filepath] = await blobStore.readBlob(entry.oldHash); }
+						catch { allBlobsOk = false; break; }
+					}
+					if (entry.newHash) {
+						try { currentSnapshot[filepath] = await blobStore.readBlob(entry.newHash); }
+						catch { allBlobsOk = false; break; }
+					}
+				}
+				if (allBlobsOk) {
+					const recomputed = calculateFileChangeStats(previousSnapshot, currentSnapshot);
+					filesChanged = recomputed.filesChanged;
+					insertions = recomputed.insertions;
+					deletions = recomputed.deletions;
+				}
 			}
-		} catch { /* use files_changed from DB */ }
+		} catch { /* use stored values */ }
 	}
 
 	return { filesChanged, insertions, deletions };

--- a/backend/snapshot/snapshot-service.ts
+++ b/backend/snapshot/snapshot-service.ts
@@ -246,6 +246,18 @@ export class SnapshotService {
 			// Update in-memory baseline
 			this.sessionBaselines.set(sessionId, { ...currentTree });
 
+			// Carry forward dismissed marks, but REMOVE marks for files in the new
+			// `session_changes` — so when the AI re-modifies an accepted file,
+			// the new change shows up in the banner again.
+			let carriedDismissed: string | null = null;
+			if (previousSnapshot?.dismissed_changes) {
+				try {
+					const prevDismissed = JSON.parse(previousSnapshot.dismissed_changes) as string[];
+					const filtered = prevDismissed.filter(f => !(f in sessionChanges));
+					if (filtered.length > 0) carriedDismissed = JSON.stringify(filtered);
+				} catch { /* ignore corrupt JSON */ }
+			}
+
 			const dbSnapshot = snapshotQueries.createSnapshot({
 				id: snapshotId,
 				message_id: messageId,
@@ -260,7 +272,8 @@ export class SnapshotService {
 				insertions: fileStats.insertions,
 				deletions: fileStats.deletions,
 				tree_hash: undefined,
-				session_changes: sessionChanges
+				session_changes: sessionChanges,
+				dismissed_changes: carriedDismissed
 			});
 
 			const changesCount = Object.keys(sessionChanges).length;

--- a/backend/snapshot/snapshot-service.ts
+++ b/backend/snapshot/snapshot-service.ts
@@ -753,6 +753,29 @@ export class SnapshotService {
 	clearSessionBaseline(sessionId: string): void {
 		this.sessionBaselines.delete(sessionId);
 	}
+
+	/**
+	 * Remove a file from the current (latest) snapshot's `session_changes`.
+	 * Called when the user discards an AI change — so restoring the checkpoint
+	 * doesn't re-apply the change the user already reverted.
+	 */
+	removeFileFromCurrentSessionChanges(sessionId: string, filepath: string): boolean {
+		const snapshots = snapshotQueries.getBySessionId(sessionId);
+		if (snapshots.length === 0) return false;
+		const latest = snapshots[snapshots.length - 1];
+		if (!latest.session_changes) return false;
+
+		try {
+			const changes = JSON.parse(latest.session_changes as string) as Record<string, { oldHash: string; newHash: string }>;
+			if (!(filepath in changes)) return false;
+			delete changes[filepath];
+			const updated = Object.keys(changes).length > 0 ? JSON.stringify(changes) : null;
+			snapshotQueries.updateSessionChanges(latest.id, updated);
+			return true;
+		} catch {
+			return false;
+		}
+	}
 }
 
 // Export singleton instance

--- a/backend/snapshot/snapshot-service.ts
+++ b/backend/snapshot/snapshot-service.ts
@@ -789,6 +789,37 @@ export class SnapshotService {
 			return false;
 		}
 	}
+
+	/**
+	 * Batch version — remove multiple files atomically to avoid race
+	 * conditions from parallel per-file calls (which all read the same
+	 * session_changes and the last save wins, losing other deletions).
+	 */
+	removeFilesFromCurrentSessionChanges(sessionId: string, filepaths: string[]): { removed: number; remaining: string[] } {
+		const snapshots = snapshotQueries.getBySessionId(sessionId);
+		if (snapshots.length === 0) return { removed: 0, remaining: filepaths };
+		const latest = snapshots[snapshots.length - 1];
+		if (!latest.session_changes) return { removed: 0, remaining: filepaths };
+
+		try {
+			const changes = JSON.parse(latest.session_changes as string) as Record<string, { oldHash: string; newHash: string }>;
+			let removed = 0;
+			const remaining: string[] = [];
+			for (const fp of filepaths) {
+				if (fp in changes) {
+					delete changes[fp];
+					removed++;
+				} else {
+					remaining.push(fp);
+				}
+			}
+			const updated = Object.keys(changes).length > 0 ? JSON.stringify(changes) : null;
+			snapshotQueries.updateSessionChanges(latest.id, updated);
+			return { removed, remaining };
+		} catch {
+			return { removed: 0, remaining: filepaths };
+		}
+	}
 }
 
 // Export singleton instance

--- a/backend/snapshot/snapshot-service.ts
+++ b/backend/snapshot/snapshot-service.ts
@@ -772,6 +772,19 @@ export class SnapshotService {
 	 * Called when the user discards an AI change — so restoring the checkpoint
 	 * doesn't re-apply the change the user already reverted.
 	 */
+	/**
+	 * Clear `session_changes` for all snapshots in a session.
+	 * Called when switching branches — old branch's changes shouldn't
+	 * show in the new branch's banner.
+	 */
+	clearSessionChanges(sessionId: string): number {
+		const db = getDatabase();
+		const result = db.prepare(`
+			UPDATE message_snapshots SET session_changes = NULL WHERE session_id = ?
+		`).run(sessionId);
+		return (result as { changes: number }).changes;
+	}
+
 	removeFileFromCurrentSessionChanges(sessionId: string, filepath: string): boolean {
 		const snapshots = snapshotQueries.getBySessionId(sessionId);
 		if (snapshots.length === 0) return false;

--- a/backend/ws/git/diff.ts
+++ b/backend/ws/git/diff.ts
@@ -5,6 +5,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
+import { findRepoForFile } from '../../snapshot/gitignore';
 import { requireProjectAccess } from '../access';
 
 const DiffHunkLineSchema = t.Object({
@@ -40,7 +41,15 @@ export const diffHandler = createRouter()
 		response: t.Array(FileDiffSchema)
 	}, async ({ data, conn }) => {
 		const project = requireProjectAccess(conn, data.projectId);
-		return await gitService.getDiffUnstaged(project.path, data.filePath);
+		// Route the diff to the nested repo that owns the file (if any) —
+		// the outer repo's `git diff` returns nothing for files that are
+		// tracked inside a nested repo and gitignored by the parent.
+		const repo = data.filePath
+			? await findRepoForFile(project.path, data.filePath)
+			: null;
+		const cwd = repo?.repoPath ?? project.path;
+		const filePath = repo?.relativeFilePath ?? data.filePath;
+		return await gitService.getDiffUnstaged(cwd, filePath);
 	})
 
 	.http('git:diff-staged', {
@@ -51,7 +60,12 @@ export const diffHandler = createRouter()
 		response: t.Array(FileDiffSchema)
 	}, async ({ data, conn }) => {
 		const project = requireProjectAccess(conn, data.projectId);
-		return await gitService.getDiffStaged(project.path, data.filePath);
+		const repo = data.filePath
+			? await findRepoForFile(project.path, data.filePath)
+			: null;
+		const cwd = repo?.repoPath ?? project.path;
+		const filePath = repo?.relativeFilePath ?? data.filePath;
+		return await gitService.getDiffStaged(cwd, filePath);
 	})
 
 	.http('git:diff-commit', {

--- a/backend/ws/git/staging.ts
+++ b/backend/ws/git/staging.ts
@@ -5,6 +5,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
+import { findNestedRepoPaths, findRepoForFile } from '../../snapshot/gitignore';
 import { requireProjectAccess } from '../access';
 
 export const stagingHandler = createRouter()
@@ -16,7 +17,10 @@ export const stagingHandler = createRouter()
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
 		const project = requireProjectAccess(conn, data.projectId);
-		await gitService.stageFile(project.path, data.filePath);
+		const repo = await findRepoForFile(project.path, data.filePath);
+		const cwd = repo?.repoPath ?? project.path;
+		const filePath = repo?.relativeFilePath ?? data.filePath;
+		await gitService.stageFile(cwd, filePath);
 		return { ok: true };
 	})
 
@@ -28,6 +32,15 @@ export const stagingHandler = createRouter()
 	}, async ({ data, conn }) => {
 		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.stageAll(project.path);
+		const nestedRepoPaths = await findNestedRepoPaths(project.path);
+		for (const repoPath of nestedRepoPaths) {
+			try {
+				await gitService.stageAll(repoPath);
+			} catch {
+				// Skip nested repos whose stage fails — don't break the
+				// whole response because one repo is in a bad state.
+			}
+		}
 		return { ok: true };
 	})
 
@@ -39,7 +52,10 @@ export const stagingHandler = createRouter()
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
 		const project = requireProjectAccess(conn, data.projectId);
-		await gitService.unstageFile(project.path, data.filePath);
+		const repo = await findRepoForFile(project.path, data.filePath);
+		const cwd = repo?.repoPath ?? project.path;
+		const filePath = repo?.relativeFilePath ?? data.filePath;
+		await gitService.unstageFile(cwd, filePath);
 		return { ok: true };
 	})
 
@@ -51,6 +67,12 @@ export const stagingHandler = createRouter()
 	}, async ({ data, conn }) => {
 		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.unstageAll(project.path);
+		const nestedRepoPaths = await findNestedRepoPaths(project.path);
+		for (const repoPath of nestedRepoPaths) {
+			try {
+				await gitService.unstageAll(repoPath);
+			} catch { /* skip */ }
+		}
 		return { ok: true };
 	})
 
@@ -62,7 +84,10 @@ export const stagingHandler = createRouter()
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
 		const project = requireProjectAccess(conn, data.projectId);
-		await gitService.discardFile(project.path, data.filePath);
+		const repo = await findRepoForFile(project.path, data.filePath);
+		const cwd = repo?.repoPath ?? project.path;
+		const filePath = repo?.relativeFilePath ?? data.filePath;
+		await gitService.discardFile(cwd, filePath);
 		return { ok: true };
 	})
 
@@ -74,5 +99,11 @@ export const stagingHandler = createRouter()
 	}, async ({ data, conn }) => {
 		const project = requireProjectAccess(conn, data.projectId);
 		await gitService.discardAll(project.path);
+		const nestedRepoPaths = await findNestedRepoPaths(project.path);
+		for (const repoPath of nestedRepoPaths) {
+			try {
+				await gitService.discardAll(repoPath);
+			} catch { /* skip */ }
+		}
 		return { ok: true };
 	});

--- a/backend/ws/git/status.ts
+++ b/backend/ws/git/status.ts
@@ -5,7 +5,9 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
+import { findNestedRepoPaths } from '../../snapshot/gitignore';
 import { requireProjectAccess } from '../access';
+import { relative as pathRelative } from 'path';
 
 export const statusHandler = createRouter()
 	.http('git:status', {
@@ -54,6 +56,36 @@ export const statusHandler = createRouter()
 		}
 
 		const status = await gitService.getStatus(project.path);
+
+		// Also aggregate status from nested git repos living inside the
+		// project (e.g. a theme extracted into its own repo, listed in the
+		// parent's .gitignore). The outer repo's `git status` skips them
+		// entirely, so without this aggregation the Changes tab would not
+		// show edits the AI made inside the nested repo.
+		try {
+			const nestedRepoPaths = await findNestedRepoPaths(project.path);
+			for (const repoPath of nestedRepoPaths) {
+				try {
+					const nestedStatus = await gitService.getStatus(repoPath);
+					const prefix = pathRelative(project.path, repoPath).replace(/\\/g, '/') + '/';
+					const withPrefix = (f: typeof nestedStatus.staged[number]) => ({
+						...f,
+						path: prefix + f.path,
+						oldPath: f.oldPath ? prefix + f.oldPath : undefined
+					});
+					status.staged.push(...nestedStatus.staged.map(withPrefix));
+					status.unstaged.push(...nestedStatus.unstaged.map(withPrefix));
+					status.untracked.push(...nestedStatus.untracked.map(withPrefix));
+					status.conflicted.push(...nestedStatus.conflicted.map(withPrefix));
+				} catch {
+					// Skip repos whose git status fails — don't break the
+					// whole response because one nested repo is broken.
+				}
+			}
+		} catch {
+			// If findNestedRepoPaths itself fails, just return outer status
+		}
+
 		return { isRepo: true, ...status };
 	})
 

--- a/backend/ws/snapshot/changes.ts
+++ b/backend/ws/snapshot/changes.ts
@@ -10,6 +10,11 @@
  * Also filters out files that no longer exist in the working tree
  * (e.g. after a restore that deleted them) so the banner doesn't show
  * ghosts.
+ *
+ * Per-file line counts (additions/deletions) are computed by diffing
+ * the blob-stored `oldHash` content against the current worktree file
+ * via `getDetailedFileDiffs` — same data source as the rest of the
+ * snapshot pipeline, so the banner matches `git diff --stat` exactly.
  */
 
 import { t } from 'elysia';
@@ -17,7 +22,11 @@ import { createRouter } from '$shared/utils/ws-server';
 import { snapshotQueries, sessionQueries, projectQueries } from '../../database/queries';
 import { requireSessionAccess } from '../access';
 import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
 import { join } from 'path';
+import { blobStore } from '../../snapshot/blob-store';
+import { getDetailedFileDiffs } from '$shared/utils/diff-calculator';
+import { debug } from '$shared/utils/logger';
 
 export const changesHandler = createRouter()
 	.http('snapshot:get-changes', {
@@ -29,7 +38,9 @@ export const changesHandler = createRouter()
 			files: t.Array(t.Object({
 				filepath: t.String(),
 				oldHash: t.String(),
-				newHash: t.String()
+				newHash: t.String(),
+				additions: t.Number(),
+				deletions: t.Number()
 			}))
 		})
 	}, async ({ data, conn }) => {
@@ -66,15 +77,54 @@ export const changesHandler = createRouter()
 		const project = session ? projectQueries.getById(session.project_id) : null;
 		const projectPath = project?.path || '';
 
-		const files = Object.keys(lastNew)
-			.filter(filepath => {
-				if (!projectPath) return true;
-				return existsSync(join(projectPath, filepath));
-			})
-			.map(filepath => ({
+		const visibleFilepaths = Object.keys(lastNew).filter(filepath => {
+			if (!projectPath) return true;
+			return existsSync(join(projectPath, filepath));
+		});
+
+		// Compute insertions/deletions per file by diffing the blob-stored
+		// old content against the current worktree file. Missing blob
+		// (e.g. legacy snapshots without blob store) or unreadable file
+		// falls back to 0/0 so the banner still renders without failing
+		// the whole request.
+		const previousSnapshot: Record<string, Buffer> = {};
+		const currentSnapshot: Record<string, Buffer> = {};
+		for (const filepath of visibleFilepaths) {
+			const oldHash = lastOld[filepath];
+			if (oldHash) {
+				try {
+					previousSnapshot[filepath] = await blobStore.readBlob(oldHash);
+				} catch (err) {
+					debug.warn('snapshot', `Missing blob for ${filepath} (${oldHash}):`, err);
+				}
+			}
+			if (projectPath) {
+				try {
+					currentSnapshot[filepath] = await readFile(join(projectPath, filepath));
+				} catch (err) {
+					debug.warn('snapshot', `Unreadable worktree file ${filepath}:`, err);
+				}
+			}
+		}
+
+		const diffMap = new Map<string, { insertions: number; deletions: number }>();
+		try {
+			for (const d of getDetailedFileDiffs(previousSnapshot, currentSnapshot)) {
+				diffMap.set(d.filepath, { insertions: d.insertions, deletions: d.deletions });
+			}
+		} catch (err) {
+			debug.warn('snapshot', 'Diff calculation failed, defaulting to 0/0:', err);
+		}
+
+		const files = visibleFilepaths.map(filepath => {
+			const stats = diffMap.get(filepath);
+			return {
 				filepath,
 				oldHash: lastOld[filepath] || '',
-				newHash: lastNew[filepath] || ''
-			}));
+				newHash: lastNew[filepath] || '',
+				additions: stats?.insertions ?? 0,
+				deletions: stats?.deletions ?? 0
+			};
+		});
 		return { files };
 	});

--- a/backend/ws/snapshot/changes.ts
+++ b/backend/ws/snapshot/changes.ts
@@ -1,7 +1,11 @@
 /**
  * Snapshot Changes Handler
  *
- * Returns the list of files changed in a checkpoint.
+ * Returns the list of files changed in a checkpoint. Accumulates
+ * `session_changes` across ALL snapshots for the session (oldest first,
+ * latest wins per filepath) so the banner keeps showing files from
+ * earlier AI turns until the user stages or discards them — matching
+ * the worktree's "current state" semantics.
  */
 
 import { t } from 'elysia';
@@ -25,20 +29,36 @@ export const changesHandler = createRouter()
 	}, async ({ data, conn }) => {
 		requireSessionAccess(conn, data.sessionId);
 
-		const snapshot = snapshotQueries.getByMessageId(data.messageId);
-		if (!snapshot || !snapshot.session_changes) {
-			return { files: [] };
+		// Accumulate session_changes across every snapshot for the session.
+		// For each filepath:
+		//   - `oldHash` is taken from the FIRST snapshot that touched the file
+		//     (i.e. the pre-AI state) so the diff shows the full accumulated
+		//     change from original → current, not just the latest delta.
+		//   - `newHash` is taken from the LATEST snapshot that touched the
+		//     file (the current working-tree state).
+		const snapshots = snapshotQueries.getBySessionId(data.sessionId);
+
+		const firstOld: Record<string, string> = {};
+		const lastNew: Record<string, string> = {};
+		for (const snap of snapshots) {
+			if (!snap.session_changes) continue;
+			try {
+				const changes = JSON.parse(snap.session_changes as string) as Record<string, { oldHash: string; newHash: string }>;
+				for (const [filepath, entry] of Object.entries(changes)) {
+					if (!(filepath in firstOld)) {
+						firstOld[filepath] = entry.oldHash || '';
+					}
+					lastNew[filepath] = entry.newHash || '';
+				}
+			} catch {
+				// Skip snapshots with corrupt session_changes JSON
+			}
 		}
 
-		try {
-			const changes = JSON.parse(snapshot.session_changes as string) as Record<string, { oldHash: string; newHash: string }>;
-			const files = Object.entries(changes).map(([filepath, { oldHash, newHash }]) => ({
-				filepath,
-				oldHash: oldHash || '',
-				newHash: newHash || ''
-			}));
-			return { files };
-		} catch {
-			return { files: [] };
-		}
+		const files = Object.keys(lastNew).map(filepath => ({
+			filepath,
+			oldHash: firstOld[filepath] || '',
+			newHash: lastNew[filepath] || ''
+		}));
+		return { files };
 	});

--- a/backend/ws/snapshot/changes.ts
+++ b/backend/ws/snapshot/changes.ts
@@ -37,23 +37,21 @@ export const changesHandler = createRouter()
 
 		// Accumulate session_changes across every snapshot for the session.
 		// For each filepath:
-		//   - `oldHash` is taken from the FIRST snapshot that touched the file
-		//     (i.e. the pre-AI state) so the diff shows the full accumulated
-		//     change from original → current, not just the latest delta.
+		//   - `oldHash` is taken from the LATEST snapshot that touched the file
+		//     so the diff matches the worktree's `git diff` (which compares
+		//     against the last committed/known state, not the original pre-AI state).
 		//   - `newHash` is taken from the LATEST snapshot that touched the
 		//     file (the current working-tree state).
 		const snapshots = snapshotQueries.getBySessionId(data.sessionId);
 
-		const firstOld: Record<string, string> = {};
+		const lastOld: Record<string, string> = {};
 		const lastNew: Record<string, string> = {};
 		for (const snap of snapshots) {
 			if (!snap.session_changes) continue;
 			try {
 				const changes = JSON.parse(snap.session_changes as string) as Record<string, { oldHash: string; newHash: string }>;
 				for (const [filepath, entry] of Object.entries(changes)) {
-					if (!(filepath in firstOld)) {
-						firstOld[filepath] = entry.oldHash || '';
-					}
+					lastOld[filepath] = entry.oldHash || '';
 					lastNew[filepath] = entry.newHash || '';
 				}
 			} catch {
@@ -75,7 +73,7 @@ export const changesHandler = createRouter()
 			})
 			.map(filepath => ({
 				filepath,
-				oldHash: firstOld[filepath] || '',
+				oldHash: lastOld[filepath] || '',
 				newHash: lastNew[filepath] || ''
 			}));
 		return { files };

--- a/backend/ws/snapshot/changes.ts
+++ b/backend/ws/snapshot/changes.ts
@@ -22,7 +22,6 @@ import { createRouter } from '$shared/utils/ws-server';
 import { snapshotQueries, sessionQueries, projectQueries } from '../../database/queries';
 import { requireSessionAccess } from '../access';
 import { existsSync } from 'fs';
-import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { blobStore } from '../../snapshot/blob-store';
 import { getDetailedFileDiffs } from '$shared/utils/diff-calculator';
@@ -48,21 +47,31 @@ export const changesHandler = createRouter()
 
 		// Accumulate session_changes across every snapshot for the session.
 		// For each filepath:
-		//   - `oldHash` is taken from the LATEST snapshot that touched the file
-		//     so the diff matches the worktree's `git diff` (which compares
-		//     against the last committed/known state, not the original pre-AI state).
+		//   - `oldHash` is taken from the FIRST snapshot that touched the file
+		//     (pre-AI / session-start state) so the diff shows the AI's full
+		//     cumulative change from the original baseline up to the last
+		//     action. A `seen` set guards the first-old assignment so a
+		//     new-file oldHash of '' doesn't get clobbered by a later
+		//     snapshot's entry.
 		//   - `newHash` is taken from the LATEST snapshot that touched the
-		//     file (the current working-tree state).
+		//     file (the AI's most recent output, frozen in the blob store).
+		// Both come from the blob store, NEVER the worktree disk — the
+		// banner is the AI's pending change and must not leak manual
+		// edits the user made after the AI's last action.
 		const snapshots = snapshotQueries.getBySessionId(data.sessionId);
 
-		const lastOld: Record<string, string> = {};
+		const seen = new Set<string>();
+		const firstOld: Record<string, string> = {};
 		const lastNew: Record<string, string> = {};
 		for (const snap of snapshots) {
 			if (!snap.session_changes) continue;
 			try {
 				const changes = JSON.parse(snap.session_changes as string) as Record<string, { oldHash: string; newHash: string }>;
 				for (const [filepath, entry] of Object.entries(changes)) {
-					lastOld[filepath] = entry.oldHash || '';
+					if (!seen.has(filepath)) {
+						firstOld[filepath] = entry.oldHash || '';
+						seen.add(filepath);
+					}
 					lastNew[filepath] = entry.newHash || '';
 				}
 			} catch {
@@ -83,14 +92,16 @@ export const changesHandler = createRouter()
 		});
 
 		// Compute insertions/deletions per file by diffing the blob-stored
-		// old content against the current worktree file. Missing blob
-		// (e.g. legacy snapshots without blob store) or unreadable file
-		// falls back to 0/0 so the banner still renders without failing
-		// the whole request.
+		// pre-AI content against the blob-stored AI-last-action content.
+		// Reading from the worktree disk would include any manual edit the
+		// user made after the AI's last action — the banner is supposed to
+		// show only the AI's pending change, not the current worktree
+		// state. Fall back to 0/0 if a blob is missing so the banner still
+		// renders without failing the whole request.
 		const previousSnapshot: Record<string, Buffer> = {};
 		const currentSnapshot: Record<string, Buffer> = {};
 		for (const filepath of visibleFilepaths) {
-			const oldHash = lastOld[filepath];
+			const oldHash = firstOld[filepath];
 			if (oldHash) {
 				try {
 					previousSnapshot[filepath] = await blobStore.readBlob(oldHash);
@@ -98,11 +109,12 @@ export const changesHandler = createRouter()
 					debug.warn('snapshot', `Missing blob for ${filepath} (${oldHash}):`, err);
 				}
 			}
-			if (projectPath) {
+			const newHash = lastNew[filepath];
+			if (newHash) {
 				try {
-					currentSnapshot[filepath] = await readFile(join(projectPath, filepath));
+					currentSnapshot[filepath] = await blobStore.readBlob(newHash);
 				} catch (err) {
-					debug.warn('snapshot', `Unreadable worktree file ${filepath}:`, err);
+					debug.warn('snapshot', `Missing blob for ${filepath} (${newHash}):`, err);
 				}
 			}
 		}
@@ -120,7 +132,7 @@ export const changesHandler = createRouter()
 			const stats = diffMap.get(filepath);
 			return {
 				filepath,
-				oldHash: lastOld[filepath] || '',
+				oldHash: firstOld[filepath] || '',
 				newHash: lastNew[filepath] || '',
 				additions: stats?.insertions ?? 0,
 				deletions: stats?.deletions ?? 0

--- a/backend/ws/snapshot/changes.ts
+++ b/backend/ws/snapshot/changes.ts
@@ -1,0 +1,44 @@
+/**
+ * Snapshot Changes Handler
+ *
+ * Returns the list of files changed in a checkpoint.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { snapshotQueries } from '../../database/queries';
+import { requireSessionAccess } from '../access';
+
+export const changesHandler = createRouter()
+	.http('snapshot:get-changes', {
+		data: t.Object({
+			messageId: t.String(),
+			sessionId: t.String()
+		}),
+		response: t.Object({
+			files: t.Array(t.Object({
+				filepath: t.String(),
+				oldHash: t.String(),
+				newHash: t.String()
+			}))
+		})
+	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.sessionId);
+
+		const snapshot = snapshotQueries.getByMessageId(data.messageId);
+		if (!snapshot || !snapshot.session_changes) {
+			return { files: [] };
+		}
+
+		try {
+			const changes = JSON.parse(snapshot.session_changes as string) as Record<string, { oldHash: string; newHash: string }>;
+			const files = Object.entries(changes).map(([filepath, { oldHash, newHash }]) => ({
+				filepath,
+				oldHash: oldHash || '',
+				newHash: newHash || ''
+			}));
+			return { files };
+		} catch {
+			return { files: [] };
+		}
+	});

--- a/backend/ws/snapshot/changes.ts
+++ b/backend/ws/snapshot/changes.ts
@@ -6,12 +6,18 @@
  * latest wins per filepath) so the banner keeps showing files from
  * earlier AI turns until the user stages or discards them — matching
  * the worktree's "current state" semantics.
+ *
+ * Also filters out files that no longer exist in the working tree
+ * (e.g. after a restore that deleted them) so the banner doesn't show
+ * ghosts.
  */
 
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
-import { snapshotQueries } from '../../database/queries';
+import { snapshotQueries, sessionQueries, projectQueries } from '../../database/queries';
 import { requireSessionAccess } from '../access';
+import { existsSync } from 'fs';
+import { join } from 'path';
 
 export const changesHandler = createRouter()
 	.http('snapshot:get-changes', {
@@ -55,10 +61,22 @@ export const changesHandler = createRouter()
 			}
 		}
 
-		const files = Object.keys(lastNew).map(filepath => ({
-			filepath,
-			oldHash: firstOld[filepath] || '',
-			newHash: lastNew[filepath] || ''
-		}));
+		// Drop files that no longer exist in the working tree (e.g. a
+		// restore that deleted them). Without this, the banner would show
+		// ghost entries that don't match the worktree.
+		const session = sessionQueries.getById(data.sessionId);
+		const project = session ? projectQueries.getById(session.project_id) : null;
+		const projectPath = project?.path || '';
+
+		const files = Object.keys(lastNew)
+			.filter(filepath => {
+				if (!projectPath) return true;
+				return existsSync(join(projectPath, filepath));
+			})
+			.map(filepath => ({
+				filepath,
+				oldHash: firstOld[filepath] || '',
+				newHash: lastNew[filepath] || ''
+			}));
 		return { files };
 	});

--- a/backend/ws/snapshot/dismissed-changes.ts
+++ b/backend/ws/snapshot/dismissed-changes.ts
@@ -40,6 +40,20 @@ export const dismissedChangesHandler = createRouter()
 		const ok = snapshotService.removeFileFromCurrentSessionChanges(data.sessionId, data.filepath);
 		return { ok };
 	})
+
+	.http('snapshot:remove-session-changes', {
+		data: t.Object({
+			sessionId: t.String(),
+			filepaths: t.Array(t.String(), { minItems: 1 })
+		}),
+		response: t.Object({
+			removed: t.Number(),
+			remaining: t.Array(t.String())
+		})
+	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.sessionId);
+		return snapshotService.removeFilesFromCurrentSessionChanges(data.sessionId, data.filepaths);
+	})
 	
 	.http('snapshot:add-dismissed-changes', {
 		data: t.Object({

--- a/backend/ws/snapshot/dismissed-changes.ts
+++ b/backend/ws/snapshot/dismissed-changes.ts
@@ -1,0 +1,56 @@
+/**
+ * Snapshot Dismissed-Changes Handler
+ *
+ * Per-session mark list for files the user has staged/discarded from
+ * the "Current state" banner above chat. Stored as a JSON array on the
+ * snapshot itself (`dismissed_changes` column) so it syncs across
+ * devices and survives refresh/logout.
+ *
+ * Marking a file does NOT touch `session_changes` — the underlying
+ * checkpoint data stays intact for restore.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { snapshotQueries } from '../../database/queries';
+import { requireSessionAccess } from '../access';
+
+export const dismissedChangesHandler = createRouter()
+	.http('snapshot:get-dismissed-changes', {
+		data: t.Object({
+			sessionId: t.String()
+		}),
+		response: t.Object({
+			files: t.Array(t.String())
+		})
+	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.sessionId);
+		return { files: snapshotQueries.getDismissedChanges(data.sessionId) };
+	})
+
+	.http('snapshot:add-dismissed-changes', {
+		data: t.Object({
+			sessionId: t.String(),
+			filepaths: t.Array(t.String())
+		}),
+		response: t.Object({
+			files: t.Array(t.String())
+		})
+	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.sessionId);
+		const result = snapshotQueries.addDismissedChanges(data.sessionId, data.filepaths);
+		return { files: result ?? [] };
+	})
+
+	.http('snapshot:clear-dismissed-changes', {
+		data: t.Object({
+			sessionId: t.String()
+		}),
+		response: t.Object({
+			cleared: t.Boolean()
+		})
+	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.sessionId);
+		const cleared = snapshotQueries.clearDismissedChanges(data.sessionId);
+		return { cleared };
+	});

--- a/backend/ws/snapshot/dismissed-changes.ts
+++ b/backend/ws/snapshot/dismissed-changes.ts
@@ -69,7 +69,7 @@ export const dismissedChangesHandler = createRouter()
 		return { files: result ?? [] };
 	})
 
-	.http('snapshot:clear-dismissed-changes', {
+	.		http('snapshot:clear-dismissed-changes', {
 		data: t.Object({
 			sessionId: t.String()
 		}),
@@ -79,5 +79,18 @@ export const dismissedChangesHandler = createRouter()
 	}, async ({ data, conn }) => {
 		requireSessionAccess(conn, data.sessionId);
 		const cleared = snapshotQueries.clearDismissedChanges(data.sessionId);
+		return { cleared };
+	})
+
+	.http('snapshot:clear-session-changes', {
+		data: t.Object({
+			sessionId: t.String()
+		}),
+		response: t.Object({
+			cleared: t.Number()
+		})
+	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.sessionId);
+		const cleared = snapshotService.clearSessionChanges(data.sessionId);
 		return { cleared };
 	});

--- a/backend/ws/snapshot/dismissed-changes.ts
+++ b/backend/ws/snapshot/dismissed-changes.ts
@@ -13,6 +13,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { snapshotQueries } from '../../database/queries';
+import { snapshotService } from '../../snapshot/snapshot-service';
 import { requireSessionAccess } from '../access';
 
 export const dismissedChangesHandler = createRouter()
@@ -28,6 +29,18 @@ export const dismissedChangesHandler = createRouter()
 		return { files: snapshotQueries.getDismissedChanges(data.sessionId) };
 	})
 
+	.http('snapshot:remove-session-change', {
+		data: t.Object({
+			sessionId: t.String(),
+			filepath: t.String()
+		}),
+		response: t.Object({ ok: t.Boolean() })
+	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.sessionId);
+		const ok = snapshotService.removeFileFromCurrentSessionChanges(data.sessionId, data.filepath);
+		return { ok };
+	})
+	
 	.http('snapshot:add-dismissed-changes', {
 		data: t.Object({
 			sessionId: t.String(),

--- a/backend/ws/snapshot/file-diff.ts
+++ b/backend/ws/snapshot/file-diff.ts
@@ -42,8 +42,35 @@ export const fileDiffHandler = createRouter()
 	}, async ({ data, conn }) => {
 		requireSessionAccess(conn, data.sessionId);
 
-		const snapshot = snapshotQueries.getByMessageId(data.messageId);
-		if (!snapshot || !snapshot.session_changes) {
+		// Accumulate session_changes across every snapshot for the session.
+		// `oldHash` is taken from the first snapshot that touched the file
+		// (pre-AI state) and `newHash` from the latest — same logic as
+		// `snapshot:get-changes` so the diff renders the full accumulated
+		// change from original → current. A `seen` set guards the first-old
+		// assignment so a new-file oldHash of '' doesn't get overwritten by
+		// the next snapshot's entry.
+		const snapshots = snapshotQueries.getBySessionId(data.sessionId);
+
+		const seen = new Set<string>();
+		let firstOld = '';
+		let lastNew = '';
+		for (const snap of snapshots) {
+			if (!snap.session_changes) continue;
+			try {
+				const changes = JSON.parse(snap.session_changes as string) as Record<string, { oldHash: string; newHash: string }>;
+				const entry = changes[data.filepath];
+				if (!entry) continue;
+				if (!seen.has(data.filepath)) {
+					firstOld = entry.oldHash || '';
+					seen.add(data.filepath);
+				}
+				lastNew = entry.newHash || '';
+			} catch {
+				// Skip corrupt snapshots
+			}
+		}
+
+		if (!lastNew) {
 			return { oldContent: '', newContent: '', filepath: data.filepath };
 		}
 
@@ -56,34 +83,27 @@ export const fileDiffHandler = createRouter()
 		let oldContent = '';
 		let newContent = '';
 
+		if (firstOld) {
+			// Try the blob store first — this is the normal path.
+			const buf = await blobStore.readBlob(firstOld);
+			if (buf && buf.length > 0) {
+				oldContent = buf.toString('utf-8');
+			} else {
+				// Blob missing (e.g. after a backend restart that wiped the
+				// in-memory cache, or for sessions initialised before blob
+				// persistence shipped). Fall back to `git show HEAD:file`
+				// so the diff still has a real "before" to render against.
+				oldContent = await readFromGitHead(projectPath, data.filepath);
+				debug.log('snapshot', `Blob ${firstOld.slice(0, 8)} missing for ${data.filepath}, fell back to git HEAD`);
+			}
+		}
+
+		// Read current file from disk
 		try {
-			const changes = JSON.parse(snapshot.session_changes as string) as Record<string, { oldHash: string; newHash: string }>;
-			const fileChange = changes[data.filepath];
-
-			if (fileChange?.oldHash) {
-				// Try the blob store first — this is the normal path.
-				const buf = await blobStore.readBlob(fileChange.oldHash);
-				if (buf && buf.length > 0) {
-					oldContent = buf.toString('utf-8');
-				} else {
-					// Blob missing (e.g. after a backend restart that wiped the
-					// in-memory cache, or for sessions initialised before blob
-					// persistence shipped). Fall back to `git show HEAD:file`
-					// so the diff still has a real "before" to render against.
-					oldContent = await readFromGitHead(projectPath, data.filepath);
-					debug.log('snapshot', `Blob ${fileChange.oldHash.slice(0, 8)} missing for ${data.filepath}, fell back to git HEAD`);
-				}
-			}
-
-			// Read current file from disk
-			try {
-				newContent = await readFile(currentFilePath, 'utf-8');
-			} catch {
-				// File might not exist anymore
-				newContent = '';
-			}
+			newContent = await readFile(currentFilePath, 'utf-8');
 		} catch {
-			// Ignore parse errors
+			// File might not exist anymore
+			newContent = '';
 		}
 
 		return { oldContent, newContent, filepath: data.filepath };

--- a/backend/ws/snapshot/file-diff.ts
+++ b/backend/ws/snapshot/file-diff.ts
@@ -11,6 +11,21 @@ import { requireSessionAccess } from '../access';
 import { blobStore } from '../../snapshot/blob-store';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
+import { spawn } from 'child_process';
+import { debug } from '$shared/utils/logger';
+
+async function readFromGitHead(projectPath: string, filepath: string): Promise<string> {
+	return new Promise(resolve => {
+		const child = spawn('git', ['show', `HEAD:${filepath}`], { cwd: projectPath, stdio: ['ignore', 'pipe', 'ignore'] });
+		const chunks: Buffer[] = [];
+		child.stdout.on('data', c => chunks.push(c));
+		child.on('error', () => resolve(''));
+		child.on('close', code => {
+			if (code !== 0) return resolve('');
+			resolve(Buffer.concat(chunks).toString('utf-8'));
+		});
+	});
+}
 
 export const fileDiffHandler = createRouter()
 	.http('snapshot:get-file-diff', {
@@ -46,7 +61,18 @@ export const fileDiffHandler = createRouter()
 			const fileChange = changes[data.filepath];
 
 			if (fileChange?.oldHash) {
-				const buf = await blobStore.readBlob(fileChange.oldHash); oldContent = buf.toString('utf-8');
+				// Try the blob store first — this is the normal path.
+				const buf = await blobStore.readBlob(fileChange.oldHash);
+				if (buf && buf.length > 0) {
+					oldContent = buf.toString('utf-8');
+				} else {
+					// Blob missing (e.g. after a backend restart that wiped the
+					// in-memory cache, or for sessions initialised before blob
+					// persistence shipped). Fall back to `git show HEAD:file`
+					// so the diff still has a real "before" to render against.
+					oldContent = await readFromGitHead(projectPath, data.filepath);
+					debug.log('snapshot', `Blob ${fileChange.oldHash.slice(0, 8)} missing for ${data.filepath}, fell back to git HEAD`);
+				}
 			}
 
 			// Read current file from disk

--- a/backend/ws/snapshot/file-diff.ts
+++ b/backend/ws/snapshot/file-diff.ts
@@ -1,0 +1,64 @@
+/**
+ * Snapshot File Diff Handler
+ *
+ * Returns old (checkpoint) and new (current) file content for diff display.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { snapshotQueries, sessionQueries, projectQueries } from '../../database/queries';
+import { requireSessionAccess } from '../access';
+import { blobStore } from '../../snapshot/blob-store';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+export const fileDiffHandler = createRouter()
+	.http('snapshot:get-file-diff', {
+		data: t.Object({
+			messageId: t.String(),
+			filepath: t.String(),
+			sessionId: t.String()
+		}),
+		response: t.Object({
+			oldContent: t.String(),
+			newContent: t.String(),
+			filepath: t.String()
+		})
+	}, async ({ data, conn }) => {
+		requireSessionAccess(conn, data.sessionId);
+
+		const snapshot = snapshotQueries.getByMessageId(data.messageId);
+		if (!snapshot || !snapshot.session_changes) {
+			return { oldContent: '', newContent: '', filepath: data.filepath };
+		}
+
+		// Get session for project path
+		const session = sessionQueries.getById(data.sessionId);
+		const project = session ? projectQueries.getById(session.project_id) : null;
+		const projectPath = project?.path || '';
+		const currentFilePath = join(projectPath, data.filepath);
+
+		let oldContent = '';
+		let newContent = '';
+
+		try {
+			const changes = JSON.parse(snapshot.session_changes as string) as Record<string, { oldHash: string; newHash: string }>;
+			const fileChange = changes[data.filepath];
+
+			if (fileChange?.oldHash) {
+				const buf = await blobStore.readBlob(fileChange.oldHash); oldContent = buf.toString('utf-8');
+			}
+
+			// Read current file from disk
+			try {
+				newContent = await readFile(currentFilePath, 'utf-8');
+			} catch {
+				// File might not exist anymore
+				newContent = '';
+			}
+		} catch {
+			// Ignore parse errors
+		}
+
+		return { oldContent, newContent, filepath: data.filepath };
+	});

--- a/backend/ws/snapshot/file-diff.ts
+++ b/backend/ws/snapshot/file-diff.ts
@@ -105,12 +105,28 @@ export const fileDiffHandler = createRouter()
 			}
 		}
 
-		// Read current file from disk
-		try {
-			newContent = await readFile(currentFilePath, 'utf-8');
-		} catch {
-			// File might not exist anymore
-			newContent = '';
+		if (lastNew) {
+			// Read the "new" content from the blob store, NOT from disk.
+			// The banner diff is the AI's cumulative pending change (from
+			// session-start to last AI action) and must stay stable until
+			// the user accepts or discards. If we read from disk, any
+			// manual edit the user makes after the AI's last action would
+			// leak into the banner diff — but the banner is supposed to
+			// show only what the AI changed. The blob is the AI's frozen
+			// output at snapshot time, so it's the correct source.
+			const buf = await blobStore.readBlob(lastNew);
+			if (buf && buf.length > 0) {
+				newContent = buf.toString('utf-8');
+			} else {
+				// Blob missing — fall back to disk. Better to show
+				// something (even with manual edits) than an empty diff.
+				try {
+					newContent = await readFile(currentFilePath, 'utf-8');
+				} catch {
+					newContent = '';
+				}
+				debug.log('snapshot', `Blob ${lastNew.slice(0, 8)} missing for ${data.filepath} (new side), fell back to disk`);
+			}
 		}
 
 		return { oldContent, newContent, filepath: data.filepath };

--- a/backend/ws/snapshot/file-diff.ts
+++ b/backend/ws/snapshot/file-diff.ts
@@ -9,14 +9,15 @@ import { createRouter } from '$shared/utils/ws-server';
 import { snapshotQueries, sessionQueries, projectQueries } from '../../database/queries';
 import { requireSessionAccess } from '../access';
 import { blobStore } from '../../snapshot/blob-store';
+import { findRepoForFile } from '../../snapshot/gitignore';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { spawn } from 'child_process';
 import { debug } from '$shared/utils/logger';
 
-async function readFromGitHead(projectPath: string, filepath: string): Promise<string> {
+async function readFromGitHead(cwd: string, filepath: string): Promise<string> {
 	return new Promise(resolve => {
-		const child = spawn('git', ['show', `HEAD:${filepath}`], { cwd: projectPath, stdio: ['ignore', 'pipe', 'ignore'] });
+		const child = spawn('git', ['show', `HEAD:${filepath}`], { cwd, stdio: ['ignore', 'pipe', 'ignore'] });
 		const chunks: Buffer[] = [];
 		child.stdout.on('data', c => chunks.push(c));
 		child.on('error', () => resolve(''));
@@ -92,8 +93,14 @@ export const fileDiffHandler = createRouter()
 				// Blob missing (e.g. after a backend restart that wiped the
 				// in-memory cache, or for sessions initialised before blob
 				// persistence shipped). Fall back to `git show HEAD:file`
-				// so the diff still has a real "before" to render against.
-				oldContent = await readFromGitHead(projectPath, data.filepath);
+				// in the correct repo (nested repos have their own HEAD) so
+				// the diff still has a real "before" to render against.
+				const repo = projectPath
+					? await findRepoForFile(projectPath, data.filepath)
+					: null;
+				const gitCwd = repo?.repoPath ?? projectPath;
+				const gitFile = repo?.relativeFilePath ?? data.filepath;
+				oldContent = await readFromGitHead(gitCwd, gitFile);
 				debug.log('snapshot', `Blob ${firstOld.slice(0, 8)} missing for ${data.filepath}, fell back to git HEAD`);
 			}
 		}

--- a/backend/ws/snapshot/index.ts
+++ b/backend/ws/snapshot/index.ts
@@ -6,12 +6,21 @@
  * Structure:
  * - restore.ts: Unified restore operation (replaces undo + redo)
  * - timeline.ts: Timeline visualization data
+ * - changes.ts: List of files changed in a checkpoint
+ * - file-diff.ts: Old/new file content for diff display
+ * - dismissed-changes.ts: Per-session mark list (banner-only, restore-safe)
  */
 
 import { createRouter } from '$shared/utils/ws-server';
 import { restoreHandler } from './restore';
 import { timelineHandler } from './timeline';
+import { changesHandler } from './changes';
+import { fileDiffHandler } from './file-diff';
+import { dismissedChangesHandler } from './dismissed-changes';
 
 export const snapshotRouter = createRouter()
 	.merge(restoreHandler)
-	.merge(timelineHandler);
+	.merge(timelineHandler)
+	.merge(changesHandler)
+	.merge(fileDiffHandler)
+	.merge(dismissedChangesHandler);

--- a/backend/ws/snapshot/restore.ts
+++ b/backend/ws/snapshot/restore.ts
@@ -317,6 +317,19 @@ export const restoreHandler = createRouter()
 			debug.error('snapshot', 'Failed to broadcast messages-changed:', err);
 		}
 
+		// 9. Broadcast snapshot:restored so the AI banner above chat can
+		// re-fetch and drop any files the restore removed from the worktree.
+		try {
+			// @ts-expect-error - WS type lags behind new emit
+			ws.emit.chatSession(sessionId, 'snapshot:restored', {
+				sessionId,
+				messageId: data.messageId,
+				timestamp: new Date().toISOString()
+			});
+		} catch (err) {
+			debug.error('snapshot', 'Failed to broadcast snapshot:restored:', err);
+		}
+
 		return {
 			restoredTo: {
 				messageId: sessionEnd.id,

--- a/backend/ws/snapshot/timeline.ts
+++ b/backend/ws/snapshot/timeline.ts
@@ -139,7 +139,7 @@ export const timelineHandler = createRouter()
 			}
 
 			// File stats from checkpoint's own snapshot
-			const stats = getCheckpointFileStats(cp);
+			const stats = await getCheckpointFileStats(cp);
 
 			const snapshot = snapshotQueries.getByMessageId(cp.id);
 

--- a/frontend/components/chat/tools/variants/compact/EditTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/EditTool.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { ToolUseBlock, EditInput } from '$shared/types/unified';
 	import { FileHeader } from './components';
+	import { requestCheckpointDiff } from '$frontend/stores/features/checkpoint-changes.svelte';
+	import { showPanel } from '$frontend/stores/ui/workspace.svelte';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as EditInput);
@@ -19,6 +21,14 @@
 		if (replaceAll) list.push('replace all');
 		return list;
 	});
+
+	function openDiff() {
+		// Open the same diff view the checkpoint banner uses: pre/post
+		// content straight from the Edit tool's oldString/newString so
+		// the user sees exactly what the AI changed in this step.
+		requestCheckpointDiff(filePath, input.oldString || '', input.newString || '');
+		showPanel('git');
+	}
 </script>
 
-<FileHeader {filePath} {fileName} operation="Edit" {badges} />
+<FileHeader {filePath} {fileName} operation="Edit" {badges} onClick={openDiff} />

--- a/frontend/components/chat/tools/variants/compact/components/FileHeader.svelte
+++ b/frontend/components/chat/tools/variants/compact/components/FileHeader.svelte
@@ -7,15 +7,34 @@
 		fileName?: string;
 		operation?: string;
 		badges?: string[];
+		/**
+		 * Optional custom click handler. When provided, the file path is no
+		 * longer revealed in the Files panel on click — the handler takes
+		 * over. Used by EditTool to open a diff view of the AI's edit
+		 * (matching the checkpoint banner behaviour).
+		 */
+		onClick?: () => void;
 	}
 
-	const { filePath, fileName, operation, badges = [] }: Props = $props();
+	const { filePath, fileName, operation, badges = [], onClick }: Props = $props();
 
 	const displayFileName = $derived(fileName || filePath.split(/[/\\]/).pop() || filePath);
 
 	function handleClick() {
+		if (onClick) {
+			onClick();
+			return;
+		}
 		const visiblePanels = getVisiblePanels(workspaceState.layout);
 		if (visiblePanels.includes('files')) requestRevealFile(filePath);
+	}
+
+	/** Classify a badge so `+N` renders green and `-N` renders red —
+	 *  matches the diff stats colour used elsewhere in the UI. */
+	function badgeClass(badge: string): string {
+		if (badge.startsWith('+')) return 'text-emerald-600 dark:text-emerald-400 font-semibold';
+		if (badge.startsWith('-')) return 'text-red-600 dark:text-red-400 font-semibold';
+		return 'text-slate-500 dark:text-slate-400';
 	}
 </script>
 
@@ -31,7 +50,7 @@
 		{/if}
 		<span class="font-mono font-medium text-slate-800 dark:text-slate-200">{displayFileName}</span>
 		{#each badges as badge}
-			<span class="text-xs text-slate-500 dark:text-slate-400">{badge}</span>
+			<span class="text-xs {badgeClass(badge)}">{badge}</span>
 		{/each}
 	</div>
 	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">

--- a/frontend/components/git/ChangesSection.svelte
+++ b/frontend/components/git/ChangesSection.svelte
@@ -38,6 +38,10 @@
 		if (activeSection === section) return true;
 		const unstagedGroup = section === 'unstaged' || section === 'untracked';
 		const activeUnstagedGroup = activeSection === 'unstaged' || activeSection === 'untracked';
+		// A checkpoint tab is opened from the AI banner above chat — if its
+		// file path matches a worktree row, highlight that row too so the
+		// selection stays consistent across the two panels.
+		if (activeSection === 'checkpoint' && unstagedGroup) return true;
 		return unstagedGroup && activeUnstagedGroup;
 	}
 
@@ -98,6 +102,23 @@
 		if (!isCollapsed) {
 			scrollTop = 0;
 		}
+	});
+
+	// Auto-scroll to the active file when it changes (e.g. after clicking
+	// a row in the AI banner above chat). Uses `scrollIntoView` on the
+	// row element directly so it works for both virtualized and
+	// non-virtualized renders. Queries the document because the scroll
+	// container (Git panel itself, or the changes list) lives outside
+	// this component's DOM tree.
+	$effect(() => {
+		if (!activeFilePath) return;
+		// Defer past Svelte's DOM update so the row exists with its
+		// active class applied.
+		const timer = setTimeout(() => {
+			const row = document.querySelector(`[data-filepath="${CSS.escape(activeFilePath ?? '')}"]`);
+			if (row) row.scrollIntoView({ block: 'center', behavior: 'smooth' });
+		}, 50);
+		return () => clearTimeout(timer);
 	});
 
 	function onScroll(e: Event) {
@@ -175,7 +196,7 @@
 				>
 					<div style="padding-top: {topPad}px; padding-bottom: {bottomPad}px;">
 						{#each visibleFiles as file (file.path)}
-							<div style="height: {ITEM_HEIGHT}px" class="overflow-hidden">
+							<div data-filepath={file.path} style="height: {ITEM_HEIGHT}px" class="overflow-hidden">
 								<FileChangeItem
 									{file}
 									{section}
@@ -193,16 +214,18 @@
 			{:else}
 				<div class="ml-2">
 					{#each files as file (file.path)}
-						<FileChangeItem
-							{file}
-							{section}
-							isActive={isFileActive(file.path)}
-							{onStage}
-							{onUnstage}
-							{onDiscard}
-							{onViewDiff}
-							{onResolve}
-						/>
+						<div data-filepath={file.path}>
+							<FileChangeItem
+								{file}
+								{section}
+								isActive={isFileActive(file.path)}
+								{onStage}
+								{onUnstage}
+								{onDiscard}
+								{onViewDiff}
+								{onResolve}
+							/>
+						</div>
 					{/each}
 				</div>
 			{/if}

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -483,10 +483,12 @@
 											{:else if checkpointChanges.files.length === 0}
 												<p class="text-xs text-slate-400 mt-1 ml-5">No files changed</p>
 											{:else}
-												<div class="flex items-center justify-center h-3 mt-1 cursor-ns-resize rounded transition-colors group/drag {isDraggingChanges ? 'bg-violet-500/20' : 'hover:bg-slate-200/80 dark:hover:bg-slate-700/80'}" onmousedown={startDragChanges} role="separator" aria-label="Resize file list" tabindex="0">
-													<div class="w-10 h-1 rounded-full bg-slate-400 dark:bg-slate-500 group-hover/drag:bg-slate-500 dark:group-hover/drag:bg-slate-400 {isDraggingChanges ? '!bg-violet-500' : ''}"></div>
-												</div>
-												<div class="ml-2 flex flex-col overflow-y-auto" style="height: {changesListHeight}px">
+												{#if checkpointChanges.files.length > 3}
+													<div class="flex items-center justify-center h-3 mt-1 cursor-ns-resize rounded transition-colors group/drag {isDraggingChanges ? 'bg-violet-500/20' : 'hover:bg-slate-200/80 dark:hover:bg-slate-700/80'}" onmousedown={startDragChanges} role="separator" aria-label="Resize file list" tabindex="0">
+														<div class="w-10 h-1 rounded-full bg-slate-400 dark:bg-slate-500 group-hover/drag:bg-slate-500 dark:group-hover/drag:bg-slate-400 {isDraggingChanges ? '!bg-violet-500' : ''}"></div>
+													</div>
+												{/if}
+												<div class="ml-2 flex flex-col {checkpointChanges.files.length > 3 ? 'overflow-y-auto' : ''}" style={checkpointChanges.files.length > 3 ? 'height: {changesListHeight}px' : ''}>
 													{#each checkpointChanges.files as f (f.filepath)}
 														{@const fName = f.filepath.split(/[\\/]/).pop() || f.filepath}
 														{@const fDir = f.filepath.split(/[\\/]/).slice(0, -1).join('/')}

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -17,7 +17,7 @@
 	import { chatService } from '$frontend/services/chat/chat.service';
 	import { snapshotService } from '$frontend/services/snapshot/snapshot.service';
 	import { setSkipNextRestore } from '$frontend/stores/ui/chat-input.svelte';
-	import { checkpointChanges, hideCheckpointChanges, changesExpanded, toggleChangesExpanded, showCheckpointChanges, requestCheckpointDiff, refreshCheckpointBanner } from '$frontend/stores/features/checkpoint-changes.svelte';
+	import { checkpointChanges, hideCheckpointChanges, changesExpanded, toggleChangesExpanded, showCheckpointChanges, requestCheckpointDiff, refreshCheckpointBanner, checkpointDiff, activeCheckpointFile, clearActiveCheckpointFile } from '$frontend/stores/features/checkpoint-changes.svelte';
 	import { getFileIcon } from '$frontend/utils/file-icon-mappings';
 	import { getGitStatusLabel, getGitStatusColor } from '$frontend/utils/git-status';
 	import { showPanel } from '$frontend/stores/ui/workspace.svelte';
@@ -57,15 +57,82 @@
 	// Auto-load current checkpoint changes for banner
 	$effect(() => {
 		const sid = sessionState.currentSession?.id;
-		// Only depend on the session id. Reading `checkpointChanges.visible`
-		// here would make the effect re-fire after `hideCheckpointChanges()`
-		// (e.g. when a file gets staged) and re-show the banner with stale
-		// snapshot data.
+		const projectId = projectState.currentProject?.id;
+		// Only depend on the session id + project id. Reading
+		// `checkpointChanges.visible` here would make the effect re-fire
+		// after `hideCheckpointChanges()` (e.g. when a file gets staged)
+		// and re-show the banner with stale snapshot data.
 		untrack(() => {
+		// Clear the banner immediately on project switch so the old
+		// project's files don't linger in the UI while we fetch the
+		// new project's data.
+		if (!projectId) {
+			hideCheckpointChanges();
+			return;
+		}
 		if (sid && !checkpointChanges.visible) {
 			refreshCheckpointBanner(sid);
 		}
 		});
+	});
+
+	// Re-sync banner when the project changes — clear the old project's
+	// banner and fetch the new one. Without this, switching projects
+	// leaves the previous project's file list in the UI.
+	$effect(() => {
+		const projectId = projectState.currentProject?.id;
+		untrack(() => {
+			hideCheckpointChanges();
+			clearActiveCheckpointFile();
+			if (!projectId) return;
+			const sid = sessionState.currentSession?.id;
+			if (sid) refreshCheckpointBanner(sid);
+		});
+	});
+
+	// Poll the banner while the AI is processing. `snapshot:captured` is
+	// unreliable in practice (fires before the frontend listener is ready,
+	// gets lost on WS reconnect, etc.), and the message-list effect can't
+	// race the backend's `captureSnapshot` in the stream's finally block.
+	// A 2s poll while `isLoading` is true is dead-simple and guaranteed to
+	// pick up the new snapshot within ~2s of the AI finishing.
+	$effect(() => {
+		if (!appState.isLoading) return;
+		const sid = sessionState.currentSession?.id;
+		if (!sid) return;
+		const interval = setInterval(() => {
+			untrack(() => refreshCheckpointBanner(sid));
+		}, 2000);
+		return () => clearInterval(interval);
+	});
+
+	// Same real-time hook the Git panel uses for its Changes list:
+	// `files:changed` fires the moment the AI writes a file to disk.
+	// We refresh the banner immediately; if the snapshot hasn't been
+	// captured yet, the next poll/`snapshot:captured` will catch up.
+	$effect(() => {
+		const projectPath = projectState.currentProject?.path;
+		const sid = sessionState.currentSession?.id;
+		if (!projectPath || !sid) return;
+		const unsub = ws.on('files:changed', () => {
+			untrack(() => refreshCheckpointBanner(sid));
+		});
+		return unsub;
+	});
+
+	// Backend emits `snapshot:captured` right after `captureSnapshot`
+	// finishes writing the new snapshot row. This is the authoritative
+	// signal that the banner's data is fresh — the file-watcher hook above
+	// fires before the snapshot exists, so we still need this one.
+	$effect(() => {
+		const sid = sessionState.currentSession?.id;
+		if (!sid) return;
+		const unsub = ws.on('snapshot:captured', (data: { chatSessionId: string }) => {
+			if (data.chatSessionId === sid) {
+				untrack(() => refreshCheckpointBanner(sid));
+			}
+		});
+		return unsub;
 	});
 
 	function closeCheckpoints() {
@@ -303,10 +370,11 @@
 														{@const fName = f.filepath.split(/[\\/]/).pop() || f.filepath}
 														{@const fDir = f.filepath.split(/[\\/]/).slice(0, -1).join('/')}
 														{@const fStatus = !f.oldHash ? 'A' : !f.newHash ? 'D' : 'M'}
+														{@const isActiveFile = activeCheckpointFile.path === f.filepath}
 														<div
 															role="button"
 															tabindex="0"
-															class="group flex items-center gap-1.5 py-1.5 px-2 rounded-md cursor-pointer transition-colors hover:bg-slate-100 dark:hover:bg-slate-800/60 text-slate-700 dark:text-slate-200"
+															class="group flex items-center gap-1.5 py-1.5 px-2 rounded-md cursor-pointer transition-colors text-slate-700 dark:text-slate-200 {isActiveFile ? 'bg-slate-200 dark:bg-slate-700/60' : 'hover:bg-slate-100 dark:hover:bg-slate-800/60'}"
 															onclick={async (e) => {
 																e.stopPropagation();
 																const sid = sessionState.currentSession?.id;

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -85,6 +85,7 @@
 				await ws.http('snapshot:add-dismissed-changes', { sessionId: sid, filepaths: [filepath] });
 			}
 			if (sid) await refreshCheckpointBanner(sid);
+			addNotification({type: 'info', title: 'Staged', message: `${filepath.split(/[\\/]/).pop()} staged — commit in Git panel`});
 		} catch (err) {
 			debug.error('checkpoint', 'Failed to accept file:', err);
 		}
@@ -120,6 +121,7 @@
 				await ws.http('snapshot:add-dismissed-changes', { sessionId: sid, filepaths });
 			}
 			if (sid) await refreshCheckpointBanner(sid);
+			addNotification({type: 'info', title: 'Staged', message: `${filepaths.length} file${filepaths.length > 1 ? 's' : ''} staged — commit in Git panel`});
 		} catch (err) {
 			debug.error('checkpoint', 'Failed to accept all files:', err);
 		}
@@ -132,7 +134,9 @@
 		const filepaths = checkpointChanges.files.map(f => f.filepath);
 		if (filepaths.length === 0) return;
 		try {
-			await ws.http('git:discard-all', { projectId: pid });
+			// Per-file discard (not git:discard-all) so we only revert banner files,
+			// not ALL local changes including user's own edits
+			await Promise.all(filepaths.map(fp => ws.http('git:discard', { projectId: pid, filePath: fp })));
 			if (sid) {
 				await Promise.all([
 					ws.http('snapshot:add-dismissed-changes', { sessionId: sid, filepaths }),

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -17,7 +17,7 @@
 	import { chatService } from '$frontend/services/chat/chat.service';
 	import { snapshotService } from '$frontend/services/snapshot/snapshot.service';
 	import { setSkipNextRestore } from '$frontend/stores/ui/chat-input.svelte';
-	import { checkpointChanges, hideCheckpointChanges, changesExpanded, toggleChangesExpanded, showCheckpointChanges, requestCheckpointDiff, refreshCheckpointBanner, checkpointDiff, activeCheckpointFile, clearActiveCheckpointFile } from '$frontend/stores/features/checkpoint-changes.svelte';
+	import { checkpointChanges, hideCheckpointChanges, changesExpanded, toggleChangesExpanded, showCheckpointChanges, requestCheckpointDiff, refreshCheckpointBanner, checkpointDiff, activeCheckpointFile, clearActiveCheckpointFile, getTotalAdditions, getTotalDeletions } from '$frontend/stores/features/checkpoint-changes.svelte';
 	import { getFileIcon } from '$frontend/utils/file-icon-mappings';
 	import { getGitStatusLabel, getGitStatusColor } from '$frontend/utils/git-status';
 	import { showPanel } from '$frontend/stores/ui/workspace.svelte';
@@ -468,15 +468,23 @@
 									<div class="mb-2 p-2 bg-slate-50 dark:bg-slate-800/40 border border-slate-200 dark:border-slate-700 rounded-lg">
 										<div role="button" tabindex="0" class="flex items-center gap-2 w-full text-left bg-transparent cursor-pointer" onclick={toggleChangesExpanded} onkeydown={(e) => e.key === 'Enter' && toggleChangesExpanded()}>
 											<Icon name={changesExpanded.value ? 'lucide:chevron-down' : 'lucide:chevron-right'} class="w-3 h-3 text-slate-500 flex-shrink-0" />
-											<span class="text-xs font-semibold text-slate-700 dark:text-slate-300">Changed Files ({checkpointChanges.files.length})</span>
-										<div class="ml-auto flex items-center gap-1">
-											<button type="button" class="text-2xs px-1.5 py-0.5 rounded text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/10 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); acceptAllCheckpointFiles(); }} title="Accept all changes (stage all)">
-												<Icon name="lucide:check-check" class="w-3 h-3" />
-											</button>
-											<button type="button" class="text-2xs px-1.5 py-0.5 rounded text-rose-600 dark:text-rose-400 hover:bg-rose-500/10 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); discardAllCheckpointFiles(); }} title="Discard all changes (revert all)">
-												<Icon name="lucide:trash-2" class="w-3 h-3" />
-											</button>
-										</div>
+											<span class="text-xs font-semibold text-slate-700 dark:text-slate-300">
+												{checkpointChanges.files.length} file{checkpointChanges.files.length === 1 ? '' : 's'} changed
+											</span>
+											<div class="flex items-center gap-1.5 text-2xs font-mono font-semibold shrink-0">
+												<span class="text-emerald-600 dark:text-emerald-400">+{getTotalAdditions()}</span>
+												<span class="text-rose-600 dark:text-rose-400">-{getTotalDeletions()}</span>
+											</div>
+											<div class="ml-auto flex items-center gap-1">
+												<button type="button" class="text-2xs px-2 py-0.5 rounded text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/10 transition-colors bg-transparent border-none cursor-pointer flex items-center gap-1" onclick={(e) => { e.stopPropagation(); acceptAllCheckpointFiles(); }} title="Keep all changes (stage all)">
+													<Icon name="lucide:check" class="w-3 h-3" />
+													<span>Keep</span>
+												</button>
+												<button type="button" class="text-2xs px-2 py-0.5 rounded text-rose-700 dark:text-rose-300 hover:bg-rose-500/10 transition-colors bg-transparent border-none cursor-pointer flex items-center gap-1" onclick={(e) => { e.stopPropagation(); discardAllCheckpointFiles(); }} title="Discard all changes (revert all)">
+													<Icon name="lucide:undo-2" class="w-3 h-3" />
+													<span>Undo</span>
+												</button>
+											</div>
 											<span role={appState.isLoading ? undefined : 'button'} tabindex={appState.isLoading ? -1 : 0} class="text-slate-400 bg-transparent flex-shrink-0 pr-1.5 {appState.isLoading ? 'cursor-not-allowed opacity-40' : 'hover:text-slate-700 cursor-pointer'}" onclick={(e) => { if (appState.isLoading) return; e.stopPropagation(); hideCheckpointChanges(); }} onkeydown={(e) => { if (appState.isLoading) return; if (e.key === 'Enter') hideCheckpointChanges(); }}><Icon name="lucide:x" class="w-3 h-3" /></span>
 										</div>
 										{#if changesExpanded.value}
@@ -486,20 +494,22 @@
 												<p class="text-xs text-slate-400 mt-1 ml-5">No files changed</p>
 											{:else}
 												{#if checkpointChanges.files.length > 3}
-													<div class="flex items-center justify-center h-3 mt-1 cursor-ns-resize rounded transition-colors group/drag {isDraggingChanges ? 'bg-violet-500/20' : 'hover:bg-slate-200/80 dark:hover:bg-slate-700/80'}" onmousedown={startDragChanges} role="separator" aria-label="Resize file list" tabindex="0">
+													<div class="flex items-center justify-center h-3 mt-1 cursor-ns-resize rounded transition-colors group/drag" onmousedown={startDragChanges} role="separator" aria-label="Resize file list" tabindex="0">
 														<div class="w-10 h-1 rounded-full bg-slate-400 dark:bg-slate-500 group-hover/drag:bg-slate-500 dark:group-hover/drag:bg-slate-400 {isDraggingChanges ? '!bg-violet-500' : ''}"></div>
 													</div>
 												{/if}
 												<div class="ml-2 flex flex-col {checkpointChanges.files.length > 3 ? 'overflow-y-auto max-h-[400px] flex-shrink-0' : ''}" style={checkpointChanges.files.length > 3 ? `height: ${changesListHeight}px` : ''}>
-													{#each checkpointChanges.files as f (f.filepath)}
+													{#each checkpointChanges.files as f, i (f.filepath)}
 														{@const fName = f.filepath.split(/[\\/]/).pop() || f.filepath}
 														{@const fDir = f.filepath.split(/[\\/]/).slice(0, -1).join('/')}
 														{@const fStatus = !f.oldHash ? 'A' : !f.newHash ? 'D' : 'M'}
 														{@const isActiveFile = activeCheckpointFile.path === f.filepath}
+														{@const isTopItem = i === 0}
+														{@const isDefaultTop = isTopItem && !activeCheckpointFile.path}
 														<div
 															role="button"
 															tabindex="0"
-															class="group flex items-center gap-1.5 py-1.5 px-2 rounded-md cursor-pointer transition-colors text-slate-700 dark:text-slate-200 {isActiveFile ? 'bg-slate-200 dark:bg-slate-700/60' : 'hover:bg-slate-100 dark:hover:bg-slate-800/60'}"
+															class="group relative flex items-center gap-1.5 py-1.5 px-2 rounded-md cursor-pointer transition-colors text-slate-700 dark:text-slate-200 {isActiveFile || isDefaultTop ? 'bg-slate-200 dark:bg-slate-700/60' : 'hover:bg-slate-100 dark:hover:bg-slate-800/60'}"
 															onclick={async (e) => {
 																e.stopPropagation();
 																const sid = sessionState.currentSession?.id;
@@ -536,8 +546,18 @@
 																	<span class="text-3xs text-slate-400 dark:text-slate-500 truncate min-w-0" dir="rtl">{fDir}</span>
 																{/if}
 															</div>
-															<button type="button" class="flex items-center justify-center w-5 h-5 rounded text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/15 transition-colors bg-transparent border-none cursor-pointer shrink-0 opacity-0 group-hover:opacity-100" onclick={(e) => { e.stopPropagation(); acceptCheckpointFile(f.filepath); }} title="Accept this file (stage)"><Icon name="lucide:check" class="w-3 h-3" /></button>
-															<button type="button" class="flex items-center justify-center w-5 h-5 rounded text-rose-600 dark:text-rose-400 hover:bg-rose-500/15 transition-colors bg-transparent border-none cursor-pointer shrink-0 opacity-0 group-hover:opacity-100" onclick={(e) => { e.stopPropagation(); discardCheckpointFile(f.filepath); }} title="Discard this file (revert)"><Icon name="lucide:undo-2" class="w-3 h-3" /></button>
+															<div class="flex items-center gap-1 text-3xs font-mono font-semibold shrink-0">
+																{#if f.additions > 0}
+																	<span class="text-emerald-600 dark:text-emerald-400 tabular-nums">+{f.additions}</span>
+																{/if}
+																{#if f.deletions > 0}
+																	<span class="text-rose-600 dark:text-rose-400 tabular-nums">-{f.deletions}</span>
+																{/if}
+															</div>
+															<div class="flex items-center gap-0.5 shrink-0 transition-opacity duration-150 {isActiveFile || isDefaultTop ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}">
+																<button type="button" class="flex items-center justify-center w-5 h-5 rounded text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/15 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); acceptCheckpointFile(f.filepath); }} title="Accept this file (stage)"><Icon name="lucide:check" class="w-3 h-3" /></button>
+																<button type="button" class="flex items-center justify-center w-5 h-5 rounded text-rose-600 dark:text-rose-400 hover:bg-rose-500/15 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); discardCheckpointFile(f.filepath); }} title="Discard this file (revert)"><Icon name="lucide:undo-2" class="w-3 h-3" /></button>
+															</div>
 															<span class="w-3 text-center text-3xs font-bold {getGitStatusColor(fStatus)} shrink-0 ml-auto">{getGitStatusLabel(fStatus)}</span>
 														</div>
 													{/each}

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -135,6 +135,21 @@
 		return unsub;
 	});
 
+	// Backend emits `snapshot:restored` after a checkpoint restore. The
+	// restore may have deleted or reverted files — the banner must drop
+	// any rows that no longer exist in the worktree.
+	$effect(() => {
+		const sid = sessionState.currentSession?.id;
+		if (!sid) return;
+		// @ts-expect-error - WS type lags behind new backend endpoint
+		const unsub = ws.on('snapshot:restored', (data: { sessionId: string }) => {
+			if (data.sessionId === sid) {
+				untrack(() => refreshCheckpointBanner(sid));
+			}
+		});
+		return unsub;
+	});
+
 	function closeCheckpoints() {
 		showCheckpoints = false;
 	}

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -138,9 +138,11 @@
 			// not ALL local changes including user's own edits
 			await Promise.all(filepaths.map(fp => ws.http('git:discard', { projectId: pid, filePath: fp })));
 			if (sid) {
+				// Batch remove-session-changes (atomic) avoids race condition from
+				// parallel per-file calls where last save wins, losing other deletions
 				await Promise.all([
 					ws.http('snapshot:add-dismissed-changes', { sessionId: sid, filepaths }),
-					...filepaths.map(fp => ws.http('snapshot:remove-session-change', { sessionId: sid, filepath: fp }))
+					ws.http('snapshot:remove-session-changes', { sessionId: sid, filepaths })
 				]);
 			}
 			if (sid) await refreshCheckpointBanner(sid);
@@ -488,7 +490,7 @@
 														<div class="w-10 h-1 rounded-full bg-slate-400 dark:bg-slate-500 group-hover/drag:bg-slate-500 dark:group-hover/drag:bg-slate-400 {isDraggingChanges ? '!bg-violet-500' : ''}"></div>
 													</div>
 												{/if}
-												<div class="ml-2 flex flex-col {checkpointChanges.files.length > 3 ? 'overflow-y-auto max-h-32 flex-shrink-0' : ''}" style={checkpointChanges.files.length > 3 ? 'height: {changesListHeight}px' : ''}>
+												<div class="ml-2 flex flex-col {checkpointChanges.files.length > 3 ? 'overflow-y-auto max-h-[400px] flex-shrink-0' : ''}" style={checkpointChanges.files.length > 3 ? `height: ${changesListHeight}px` : ''}>
 													{#each checkpointChanges.files as f (f.filepath)}
 														{@const fName = f.filepath.split(/[\\/]/).pop() || f.filepath}
 														{@const fDir = f.filepath.split(/[\\/]/).slice(0, -1).join('/')}

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -75,6 +75,76 @@
 		e.preventDefault();
 	}
 
+	async function acceptCheckpointFile(filepath: string) {
+		const pid = projectState.currentProject?.id;
+		const sid = sessionState.currentSession?.id;
+		if (!pid) return;
+		try {
+			await ws.http('git:stage', { projectId: pid, filePath: filepath });
+			if (sid) {
+				await ws.http('snapshot:add-dismissed-changes', { sessionId: sid, filepaths: [filepath] });
+			}
+			if (sid) await refreshCheckpointBanner(sid);
+		} catch (err) {
+			debug.error('checkpoint', 'Failed to accept file:', err);
+		}
+	}
+
+	async function discardCheckpointFile(filepath: string) {
+		const pid = projectState.currentProject?.id;
+		const sid = sessionState.currentSession?.id;
+		if (!pid) return;
+		try {
+			await ws.http('git:discard', { projectId: pid, filePath: filepath });
+			if (sid) {
+				await Promise.all([
+					ws.http('snapshot:remove-session-change', { sessionId: sid, filepath }),
+					ws.http('snapshot:add-dismissed-changes', { sessionId: sid, filepaths: [filepath] })
+				]);
+			}
+			if (sid) await refreshCheckpointBanner(sid);
+		} catch (err) {
+			debug.error('checkpoint', 'Failed to discard file:', err);
+		}
+	}
+
+	async function acceptAllCheckpointFiles() {
+		const pid = projectState.currentProject?.id;
+		const sid = sessionState.currentSession?.id;
+		if (!pid) return;
+		const filepaths = checkpointChanges.files.map(f => f.filepath);
+		if (filepaths.length === 0) return;
+		try {
+			await ws.http('git:stage-all', { projectId: pid });
+			if (sid) {
+				await ws.http('snapshot:add-dismissed-changes', { sessionId: sid, filepaths });
+			}
+			if (sid) await refreshCheckpointBanner(sid);
+		} catch (err) {
+			debug.error('checkpoint', 'Failed to accept all files:', err);
+		}
+	}
+
+	async function discardAllCheckpointFiles() {
+		const pid = projectState.currentProject?.id;
+		const sid = sessionState.currentSession?.id;
+		if (!pid) return;
+		const filepaths = checkpointChanges.files.map(f => f.filepath);
+		if (filepaths.length === 0) return;
+		try {
+			await ws.http('git:discard-all', { projectId: pid });
+			if (sid) {
+				await Promise.all([
+					ws.http('snapshot:add-dismissed-changes', { sessionId: sid, filepaths }),
+					...filepaths.map(fp => ws.http('snapshot:remove-session-change', { sessionId: sid, filepath: fp }))
+				]);
+			}
+			if (sid) await refreshCheckpointBanner(sid);
+		} catch (err) {
+			debug.error('checkpoint', 'Failed to discard all files:', err);
+		}
+	}
+
 	// Auto-load current checkpoint changes for banner
 	$effect(() => {
 		const sid = sessionState.currentSession?.id;
@@ -393,7 +463,15 @@
 										<div role="button" tabindex="0" class="flex items-center gap-2 w-full text-left bg-transparent cursor-pointer" onclick={toggleChangesExpanded} onkeydown={(e) => e.key === 'Enter' && toggleChangesExpanded()}>
 											<Icon name={changesExpanded.value ? 'lucide:chevron-down' : 'lucide:chevron-right'} class="w-3 h-3 text-slate-500 flex-shrink-0" />
 											<span class="text-xs font-semibold text-slate-700 dark:text-slate-300">Changed Files ({checkpointChanges.files.length})</span>
-											<span role={appState.isLoading ? undefined : 'button'} tabindex={appState.isLoading ? -1 : 0} class="text-slate-400 bg-transparent ml-auto flex-shrink-0 pr-1.5 {appState.isLoading ? 'cursor-not-allowed opacity-40' : 'hover:text-slate-700 cursor-pointer'}" onclick={(e) => { if (appState.isLoading) return; e.stopPropagation(); hideCheckpointChanges(); }} onkeydown={(e) => { if (appState.isLoading) return; if (e.key === 'Enter') hideCheckpointChanges(); }}><Icon name="lucide:x" class="w-3 h-3" /></span>
+										<div class="ml-auto flex items-center gap-1">
+											<button type="button" class="text-2xs px-1.5 py-0.5 rounded text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/10 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); acceptAllCheckpointFiles(); }} title="Accept all changes (stage all)">
+												<Icon name="lucide:check-check" class="w-3 h-3" />
+											</button>
+											<button type="button" class="text-2xs px-1.5 py-0.5 rounded text-rose-600 dark:text-rose-400 hover:bg-rose-500/10 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); discardAllCheckpointFiles(); }} title="Discard all changes (revert all)">
+												<Icon name="lucide:trash-2" class="w-3 h-3" />
+											</button>
+										</div>
+											<span role={appState.isLoading ? undefined : 'button'} tabindex={appState.isLoading ? -1 : 0} class="text-slate-400 bg-transparent flex-shrink-0 pr-1.5 {appState.isLoading ? 'cursor-not-allowed opacity-40' : 'hover:text-slate-700 cursor-pointer'}" onclick={(e) => { if (appState.isLoading) return; e.stopPropagation(); hideCheckpointChanges(); }} onkeydown={(e) => { if (appState.isLoading) return; if (e.key === 'Enter') hideCheckpointChanges(); }}><Icon name="lucide:x" class="w-3 h-3" /></span>
 										</div>
 										{#if changesExpanded.value}
 											{#if checkpointChanges.loading}
@@ -450,7 +528,9 @@
 																	<span class="text-3xs text-slate-400 dark:text-slate-500 truncate min-w-0" dir="rtl">{fDir}</span>
 																{/if}
 															</div>
-															<span class="w-3 text-center text-3xs font-bold {getGitStatusColor(fStatus)} shrink-0">{getGitStatusLabel(fStatus)}</span>
+															<button type="button" class="flex items-center justify-center w-5 h-5 rounded text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/15 transition-colors bg-transparent border-none cursor-pointer shrink-0 opacity-0 group-hover:opacity-100" onclick={(e) => { e.stopPropagation(); acceptCheckpointFile(f.filepath); }} title="Accept this file (stage)"><Icon name="lucide:check" class="w-3 h-3" /></button>
+															<button type="button" class="flex items-center justify-center w-5 h-5 rounded text-rose-600 dark:text-rose-400 hover:bg-rose-500/15 transition-colors bg-transparent border-none cursor-pointer shrink-0 opacity-0 group-hover:opacity-100" onclick={(e) => { e.stopPropagation(); discardCheckpointFile(f.filepath); }} title="Discard this file (revert)"><Icon name="lucide:undo-2" class="w-3 h-3" /></button>
+															<span class="w-3 text-center text-3xs font-bold {getGitStatusColor(fStatus)} shrink-0 ml-auto">{getGitStatusLabel(fStatus)}</span>
 														</div>
 													{/each}
 												</div>

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -380,7 +380,7 @@
 											{:else if checkpointChanges.files.length === 0}
 												<p class="text-xs text-slate-400 mt-1 ml-5">No files changed</p>
 											{:else}
-												<div class="mt-1 ml-2 flex flex-col">
+												<div class="mt-1 ml-2 flex flex-col max-h-32 overflow-y-auto">
 													{#each checkpointChanges.files as f (f.filepath)}
 														{@const fName = f.filepath.split(/[\\/]/).pop() || f.filepath}
 														{@const fDir = f.filepath.split(/[\\/]/).slice(0, -1).join('/')}

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -371,7 +371,7 @@
 									<div class="mb-2 p-2 bg-slate-50 dark:bg-slate-800/40 border border-slate-200 dark:border-slate-700 rounded-lg">
 										<div role="button" tabindex="0" class="flex items-center gap-2 w-full text-left bg-transparent cursor-pointer" onclick={toggleChangesExpanded} onkeydown={(e) => e.key === 'Enter' && toggleChangesExpanded()}>
 											<Icon name={changesExpanded.value ? 'lucide:chevron-down' : 'lucide:chevron-right'} class="w-3 h-3 text-slate-500 flex-shrink-0" />
-											<span class="text-xs font-semibold text-slate-700 dark:text-slate-300">Current state · Changed Files ({checkpointChanges.files.length})</span>
+											<span class="text-xs font-semibold text-slate-700 dark:text-slate-300">Changed Files ({checkpointChanges.files.length})</span>
 											<span role={appState.isLoading ? undefined : 'button'} tabindex={appState.isLoading ? -1 : 0} class="text-slate-400 bg-transparent ml-auto flex-shrink-0 pr-1.5 {appState.isLoading ? 'cursor-not-allowed opacity-40' : 'hover:text-slate-700 cursor-pointer'}" onclick={(e) => { if (appState.isLoading) return; e.stopPropagation(); hideCheckpointChanges(); }} onkeydown={(e) => { if (appState.isLoading) return; if (e.key === 'Enter') hideCheckpointChanges(); }}><Icon name="lucide:x" class="w-3 h-3" /></span>
 										</div>
 										{#if changesExpanded.value}

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -3,7 +3,7 @@
 	import { projectState } from '$frontend/stores/core/projects.svelte';
 	import { appState } from '$frontend/stores/core/app.svelte';
 	import { addNotification } from '$frontend/stores/ui/notification.svelte';
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import ChatMessages from '$frontend/components/chat/message/ChatMessages.svelte';
 	import ChatInput from '$frontend/components/chat/input/ChatInput.svelte';
@@ -15,7 +15,12 @@
 	import { debug } from '$shared/utils/logger';
 	import ws from '$frontend/utils/ws';
 	import { chatService } from '$frontend/services/chat/chat.service';
+	import { snapshotService } from '$frontend/services/snapshot/snapshot.service';
 	import { setSkipNextRestore } from '$frontend/stores/ui/chat-input.svelte';
+	import { checkpointChanges, hideCheckpointChanges, changesExpanded, toggleChangesExpanded, showCheckpointChanges, requestCheckpointDiff, refreshCheckpointBanner } from '$frontend/stores/features/checkpoint-changes.svelte';
+	import { getFileIcon } from '$frontend/utils/file-icon-mappings';
+	import { getGitStatusLabel, getGitStatusColor } from '$frontend/utils/git-status';
+	import { showPanel } from '$frontend/stores/ui/workspace.svelte';
 	import { userStore } from '$frontend/stores/features/user.svelte';
 	import { cancelEdit, editModeState } from '$frontend/stores/ui/edit-mode.svelte';
 
@@ -48,6 +53,20 @@
 	function openCheckpoints() {
 		showCheckpoints = true;
 	}
+
+	// Auto-load current checkpoint changes for banner
+	$effect(() => {
+		const sid = sessionState.currentSession?.id;
+		// Only depend on the session id. Reading `checkpointChanges.visible`
+		// here would make the effect re-fire after `hideCheckpointChanges()`
+		// (e.g. when a file gets staged) and re-show the banner with stale
+		// snapshot data.
+		untrack(() => {
+		if (sid && !checkpointChanges.visible) {
+			refreshCheckpointBanner(sid);
+		}
+		});
+	});
 
 	function closeCheckpoints() {
 		showCheckpoints = false;
@@ -265,6 +284,74 @@
 					>
 						<div class="flex justify-center">
 							<div class="w-full max-w-5xl px-4 pb-4 pt-2">
+								<!-- Checkpoint changes banner -->
+								{#if checkpointChanges.visible}
+									<div class="mb-2 p-2 bg-slate-50 dark:bg-slate-800/40 border border-slate-200 dark:border-slate-700 rounded-lg">
+										<div role="button" tabindex="0" class="flex items-center gap-2 w-full text-left bg-transparent cursor-pointer" onclick={toggleChangesExpanded} onkeydown={(e) => e.key === 'Enter' && toggleChangesExpanded()}>
+											<Icon name={changesExpanded.value ? 'lucide:chevron-down' : 'lucide:chevron-right'} class="w-3 h-3 text-slate-500 flex-shrink-0" />
+											<span class="text-xs font-semibold text-slate-700 dark:text-slate-300">Current state · Changed Files ({checkpointChanges.files.length})</span>
+											<span role={appState.isLoading ? undefined : 'button'} tabindex={appState.isLoading ? -1 : 0} class="text-slate-400 bg-transparent ml-auto flex-shrink-0 pr-1.5 {appState.isLoading ? 'cursor-not-allowed opacity-40' : 'hover:text-slate-700 cursor-pointer'}" onclick={(e) => { if (appState.isLoading) return; e.stopPropagation(); hideCheckpointChanges(); }} onkeydown={(e) => { if (appState.isLoading) return; if (e.key === 'Enter') hideCheckpointChanges(); }}><Icon name="lucide:x" class="w-3 h-3" /></span>
+										</div>
+										{#if changesExpanded.value}
+											{#if checkpointChanges.loading}
+												<div class="flex items-center justify-center py-2 mt-1"><div class="w-3 h-3 border-2 border-slate-300 border-t-slate-500 rounded-full animate-spin"></div></div>
+											{:else if checkpointChanges.files.length === 0}
+												<p class="text-xs text-slate-400 mt-1 ml-5">No files changed</p>
+											{:else}
+												<div class="mt-1 ml-2 flex flex-col">
+													{#each checkpointChanges.files as f (f.filepath)}
+														{@const fName = f.filepath.split(/[\\/]/).pop() || f.filepath}
+														{@const fDir = f.filepath.split(/[\\/]/).slice(0, -1).join('/')}
+														{@const fStatus = !f.oldHash ? 'A' : !f.newHash ? 'D' : 'M'}
+														<div
+															role="button"
+															tabindex="0"
+															class="group flex items-center gap-1.5 py-1.5 px-2 rounded-md cursor-pointer transition-colors hover:bg-slate-100 dark:hover:bg-slate-800/60 text-slate-700 dark:text-slate-200"
+															onclick={async (e) => {
+																e.stopPropagation();
+																const sid = sessionState.currentSession?.id;
+																if (sid) {
+																	const tl = await snapshotService.getTimeline(sid);
+																	const headId = tl.currentHeadId;
+																	if (headId && headId !== '__initial__') {
+																		const r = await snapshotService.getFileDiff(headId, f.filepath, sid);
+																		requestCheckpointDiff(r.filepath, r.oldContent, r.newContent);
+																		showPanel('git');
+																	}
+																}
+															}}
+															onkeydown={async (e) => {
+																if (e.key !== 'Enter') return;
+																e.stopPropagation();
+																const sid = sessionState.currentSession?.id;
+																if (sid) {
+																	const tl = await snapshotService.getTimeline(sid);
+																	const headId = tl.currentHeadId;
+																	if (headId && headId !== '__initial__') {
+																		const r = await snapshotService.getFileDiff(headId, f.filepath, sid);
+																		requestCheckpointDiff(r.filepath, r.oldContent, r.newContent);
+																		showPanel('git');
+																	}
+																}
+															}}
+															title={f.filepath}
+														>
+															<Icon name={getFileIcon(fName)} class="w-3.5 h-3.5 shrink-0" />
+															<div class="flex items-baseline gap-1.5 min-w-0 flex-1">
+																<span class="text-xs font-medium truncate font-mono">{fName}</span>
+																{#if fDir}
+																	<span class="text-3xs text-slate-400 dark:text-slate-500 truncate min-w-0" dir="rtl">{fDir}</span>
+																{/if}
+															</div>
+															<span class="w-3 text-center text-3xs font-bold {getGitStatusColor(fStatus)} shrink-0">{getGitStatusLabel(fStatus)}</span>
+														</div>
+													{/each}
+												</div>
+											{/if}
+										{/if}
+
+									</div>
+								{/if}
 								<ChatInput />
 							</div>
 						</div>

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -85,7 +85,7 @@
 				await ws.http('snapshot:add-dismissed-changes', { sessionId: sid, filepaths: [filepath] });
 			}
 			if (sid) await refreshCheckpointBanner(sid);
-			addNotification({type: 'info', title: 'Staged', message: `${filepath.split(/[\\/]/).pop()} staged — commit in Git panel`});
+			addNotification({type: 'info', title: 'Staged', message: `${filepath.split(/[\\/]/).pop()} entered staged`});
 		} catch (err) {
 			debug.error('checkpoint', 'Failed to accept file:', err);
 		}
@@ -121,7 +121,7 @@
 				await ws.http('snapshot:add-dismissed-changes', { sessionId: sid, filepaths });
 			}
 			if (sid) await refreshCheckpointBanner(sid);
-			addNotification({type: 'info', title: 'Staged', message: `${filepaths.length} file${filepaths.length > 1 ? 's' : ''} staged — commit in Git panel`});
+			addNotification({type: 'info', title: 'Staged', message: `${filepaths.length} file${filepaths.length > 1 ? 's' : ''} entered staged`});
 		} catch (err) {
 			debug.error('checkpoint', 'Failed to accept all files:', err);
 		}

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -488,7 +488,7 @@
 														<div class="w-10 h-1 rounded-full bg-slate-400 dark:bg-slate-500 group-hover/drag:bg-slate-500 dark:group-hover/drag:bg-slate-400 {isDraggingChanges ? '!bg-violet-500' : ''}"></div>
 													</div>
 												{/if}
-												<div class="ml-2 flex flex-col {checkpointChanges.files.length > 3 ? 'overflow-y-auto' : ''}" style={checkpointChanges.files.length > 3 ? 'height: {changesListHeight}px' : ''}>
+												<div class="ml-2 flex flex-col {checkpointChanges.files.length > 3 ? 'overflow-y-auto max-h-32 flex-shrink-0' : ''}" style={checkpointChanges.files.length > 3 ? 'height: {changesListHeight}px' : ''}>
 													{#each checkpointChanges.files as f (f.filepath)}
 														{@const fName = f.filepath.split(/[\\/]/).pop() || f.filepath}
 														{@const fDir = f.filepath.split(/[\\/]/).slice(0, -1).join('/')}

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -54,6 +54,27 @@
 		showCheckpoints = true;
 	}
 
+	let changesListHeight = $state(128);
+	let isDraggingChanges = $state(false);
+
+	function startDragChanges(e: MouseEvent) {
+		isDraggingChanges = true;
+		const startY = e.clientY;
+		const startHeight = changesListHeight;
+		const onMove = (ev: MouseEvent) => {
+			const delta = startY - ev.clientY;
+			changesListHeight = Math.max(60, Math.min(startHeight + delta, 400));
+		};
+		const onUp = () => {
+			isDraggingChanges = false;
+			document.removeEventListener('mousemove', onMove);
+			document.removeEventListener('mouseup', onUp);
+		};
+		document.addEventListener('mousemove', onMove);
+		document.addEventListener('mouseup', onUp);
+		e.preventDefault();
+	}
+
 	// Auto-load current checkpoint changes for banner
 	$effect(() => {
 		const sid = sessionState.currentSession?.id;
@@ -380,7 +401,10 @@
 											{:else if checkpointChanges.files.length === 0}
 												<p class="text-xs text-slate-400 mt-1 ml-5">No files changed</p>
 											{:else}
-												<div class="mt-1 ml-2 flex flex-col max-h-32 overflow-y-auto">
+												<div class="flex items-center justify-center h-3 mt-1 cursor-ns-resize rounded transition-colors group/drag {isDraggingChanges ? 'bg-violet-500/20' : 'hover:bg-slate-200/80 dark:hover:bg-slate-700/80'}" onmousedown={startDragChanges} role="separator" aria-label="Resize file list" tabindex="0">
+													<div class="w-10 h-1 rounded-full bg-slate-400 dark:bg-slate-500 group-hover/drag:bg-slate-500 dark:group-hover/drag:bg-slate-400 {isDraggingChanges ? '!bg-violet-500' : ''}"></div>
+												</div>
+												<div class="ml-2 flex flex-col overflow-y-auto" style="height: {changesListHeight}px">
 													{#each checkpointChanges.files as f (f.filepath)}
 														{@const fName = f.filepath.split(/[\\/]/).pop() || f.filepath}
 														{@const fDir = f.filepath.split(/[\\/]/).slice(0, -1).join('/')}

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -948,6 +948,10 @@
 			}
 			await loadAll();
 			if (activeView === 'log') await loadLog(true);
+			// Refresh banner so old files don't show from stale session_changes
+			if (sessionState.currentSession?.id) {
+				await refreshCheckpointBanner(sessionState.currentSession.id);
+			}
 		} catch (err) {
 			debug.error('git', 'Failed to switch branch:', err);
 			showError('Switch Branch Failed', err instanceof Error ? err.message : 'Unknown error');

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -25,7 +25,7 @@
 		type GitActiveDiff
 	} from '$frontend/stores/features/git-workspace.svelte';
 	import { detectLanguageFromFilename } from '$frontend/components/common/editor/monaco-languages';
-	import { checkpointDiff, clearCheckpointDiff, refreshCheckpointBanner, clearActiveCheckpointFile, clearDismissedFiles } from '$frontend/stores/features/checkpoint-changes.svelte';
+	import { checkpointDiff, clearCheckpointDiff, refreshCheckpointBanner, clearDismissedFiles } from '$frontend/stores/features/checkpoint-changes.svelte';
 	import { sessionState } from '$frontend/stores/core/sessions.svelte';
 	import type { IconName } from '$shared/types/ui/icons';
 	import type {
@@ -698,9 +698,12 @@
 
 	async function viewDiff(file: GitFileChange, section: string, restoreScrollTop = 0) {
 		if (!projectId) return;
-		// Opening a worktree diff switches focus away from the AI banner's
-		// active file — clear it so the highlight tracks the new selection.
-		clearActiveCheckpointFile();
+		// NOTE: do NOT clear the banner's active file here. The banner's
+		// active-file highlight is independent of the worktree diff tab —
+		// the user may browse a worktree file while keeping the banner
+		// pointed at a checkpoint file (or vice versa). Clearing here made
+		// the banner snap back to its first file every time the user
+		// clicked a worktree file after a banner file.
 		const tabId = `${section}:${file.path}`;
 		const fileName = file.path.split(/[\\/]/).pop() || file.path;
 		const status = section === 'staged' ? file.indexStatus : file.workingStatus;
@@ -1822,13 +1825,26 @@ ${bodies}`;
 		const req = checkpointDiff.data;
 		if (!req) return;
 		untrack(() => {
+			// Derive the real git-style status from the content. The worktree
+			// diff path gets this from `git status`; the banner path doesn't
+			// (the snapshot's session_changes only carries hashes), so we
+			// infer it the same way `git diff --no-renames` would: empty
+			// old = added, empty new = deleted, else modified. Without this
+			// the tab status badge and DiffViewer would always say
+			// "Modified" even for new or deleted files.
+			const isEmpty = (s: string) => s.length === 0;
+			const status = isEmpty(req.oldContent) && !isEmpty(req.newContent)
+				? 'A'
+				: !isEmpty(req.oldContent) && isEmpty(req.newContent)
+					? 'D'
+					: 'M';
 			// Build a real GitFileDiff with 3 lines of context (matches git diff
 			// default) and open a normal tab — same flow as clicking a file in
 			// the source control changes list.
-			const fileDiff = buildGitFileDiff(req.oldContent, req.newContent, req.filepath);
+			const fileDiff = buildGitFileDiff(req.oldContent, req.newContent, req.filepath, status);
 			const tabId = `checkpoint:${req.filepath}`;
 			const fileName = req.filepath.split(/[\\/]/).pop() || req.filepath;
-			openTabs = [{ id: tabId, filePath: req.filepath, fileName, section: 'checkpoint', diff: fileDiff, diffs: [fileDiff], isLoading: false, status: 'M' }];
+			openTabs = [{ id: tabId, filePath: req.filepath, fileName, section: 'checkpoint', diff: fileDiff, diffs: [fileDiff], isLoading: false, status }];
 			activeTabId = tabId;
 			if (!isTwoColumnMode) viewMode = 'diff';
 			clearCheckpointDiff();

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -25,7 +25,7 @@
 		type GitActiveDiff
 	} from '$frontend/stores/features/git-workspace.svelte';
 	import { detectLanguageFromFilename } from '$frontend/components/common/editor/monaco-languages';
-	import { checkpointDiff, clearCheckpointDiff, refreshCheckpointBanner } from '$frontend/stores/features/checkpoint-changes.svelte';
+	import { checkpointDiff, clearCheckpointDiff, refreshCheckpointBanner, clearActiveCheckpointFile } from '$frontend/stores/features/checkpoint-changes.svelte';
 	import { sessionState } from '$frontend/stores/core/sessions.svelte';
 	import type { IconName } from '$shared/types/ui/icons';
 	import type {
@@ -698,6 +698,9 @@
 
 	async function viewDiff(file: GitFileChange, section: string, restoreScrollTop = 0) {
 		if (!projectId) return;
+		// Opening a worktree diff switches focus away from the AI banner's
+		// active file — clear it so the highlight tracks the new selection.
+		clearActiveCheckpointFile();
 		const tabId = `${section}:${file.path}`;
 		const fileName = file.path.split(/[\\/]/).pop() || file.path;
 		const status = section === 'staged' ? file.indexStatus : file.workingStatus;

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -941,13 +941,11 @@
 		try {
 			await ws.http('git:switch-branch', { projectId, name });
 			showBranchManager = false;
-			// Clear only dismissed marks (per-branch scope) — keep session_changes
-			// so switching back to the original branch still shows the AI's changes.
+			// Don't clear dismissed marks or session_changes on branch switch.
+			// Accepted/committed files stay dismissed forever (mark persists).
 			// Files that don't exist in the new branch's worktree are auto-filtered
-			// by the existsSync check in getChanges.
-			if (sessionState.currentSession?.id) {
-				await clearDismissedFiles(sessionState.currentSession.id);
-			}
+			// by the existsSync check in getChanges — so unaccepted changes from
+			// the old branch don't show on the new branch.
 			await loadAll();
 			if (activeView === 'log') await loadLog(true);
 			if (sessionState.currentSession?.id) {

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -941,14 +941,15 @@
 		try {
 			await ws.http('git:switch-branch', { projectId, name });
 			showBranchManager = false;
-			// Clear dismissed marks — they're scoped to the old branch's worktree
-			// state. New branch should show all its own changes fresh.
+			// Clear only dismissed marks (per-branch scope) — keep session_changes
+			// so switching back to the original branch still shows the AI's changes.
+			// Files that don't exist in the new branch's worktree are auto-filtered
+			// by the existsSync check in getChanges.
 			if (sessionState.currentSession?.id) {
 				await clearDismissedFiles(sessionState.currentSession.id);
 			}
 			await loadAll();
 			if (activeView === 'log') await loadLog(true);
-			// Refresh banner so old files don't show from stale session_changes
 			if (sessionState.currentSession?.id) {
 				await refreshCheckpointBanner(sessionState.currentSession.id);
 			}

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -13,6 +13,8 @@
 	import { isPreviewableFile, isBinaryFile } from '$frontend/utils/file-type';
 	import { getGitStatusLabel, getGitStatusColor } from '$frontend/utils/git-status';
 	import { chatService } from '$frontend/services/chat/chat.service';
+	import { dismissCheckpointFile, dismissCheckpointFiles } from '$frontend/stores/features/checkpoint-changes.svelte';
+	import { buildGitFileDiff } from '$frontend/utils/diff';
 	import { showPanel } from '$frontend/stores/ui/workspace.svelte';
 	import {
 		gitDraft,
@@ -23,6 +25,8 @@
 		type GitActiveDiff
 	} from '$frontend/stores/features/git-workspace.svelte';
 	import { detectLanguageFromFilename } from '$frontend/components/common/editor/monaco-languages';
+	import { checkpointDiff, clearCheckpointDiff, refreshCheckpointBanner } from '$frontend/stores/features/checkpoint-changes.svelte';
+	import { sessionState } from '$frontend/stores/core/sessions.svelte';
 	import type { IconName } from '$shared/types/ui/icons';
 	import type {
 		GitStatus,
@@ -410,6 +414,15 @@
 			await ws.http('git:stage', { projectId, filePath: path });
 			await loadStatus();
 			await migrateActiveTabAfterStatusChange(path);
+			// Persist the mark in the snapshot's `dismissed_changes` column
+			// (synced across devices) and re-sync the banner. We do NOT
+			// touch `session_changes` in the DB — that would break checkpoint
+			// restore for this turn.
+			const sid = sessionState?.currentSession?.id;
+			if (sid) {
+				await dismissCheckpointFile(sid, path);
+				await refreshCheckpointBanner(sid);
+			}
 		} catch (err) {
 			debug.error('git', 'Failed to stage file:', err);
 		}
@@ -418,10 +431,18 @@
 	async function stageAll() {
 		if (!projectId) return;
 		try {
+			const pathsToDismiss = gitStatus.unstaged.map(f => f.path);
 			await ws.http('git:stage-all', { projectId });
 			await loadStatus();
 			if (activeTab && activeTab.section !== 'commit') {
 				await migrateActiveTabAfterStatusChange(activeTab.filePath);
+			}
+			// Same as stageFile — dismiss every previously-unstaged file in
+			// one bulk call.
+			const sid = sessionState?.currentSession?.id;
+			if (sid) {
+				if (pathsToDismiss.length > 0) await dismissCheckpointFiles(sid, pathsToDismiss);
+				await refreshCheckpointBanner(sid);
 			}
 		} catch (err) {
 			debug.error('git', 'Failed to stage all:', err);
@@ -465,6 +486,15 @@
 					await ws.http('git:discard', { projectId, filePath: path });
 					await loadStatus();
 					await migrateActiveTabAfterStatusChange(path);
+					// Persist the mark in the snapshot's `dismissed_changes`
+					// column (synced across devices) and re-sync the banner.
+					// We do NOT strip it from `session_changes` — that would
+					// break checkpoint restore.
+					const sid = sessionState?.currentSession?.id;
+					if (sid) {
+						await dismissCheckpointFile(sid, path);
+						await refreshCheckpointBanner(sid);
+					}
 				} catch (err) {
 					debug.error('git', 'Failed to discard file:', err);
 				}
@@ -481,10 +511,18 @@
 			onConfirm: async () => {
 				if (!projectId) return;
 				try {
+					const pathsToDismiss = [...gitStatus.unstaged, ...gitStatus.untracked].map(f => f.path);
 					await ws.http('git:discard-all', { projectId });
 					await loadStatus();
 					if (activeTab && activeTab.section !== 'commit') {
 						await migrateActiveTabAfterStatusChange(activeTab.filePath);
+					}
+					// Same as stageAll — dismiss every discarded file in one
+					// bulk call.
+					const sid = sessionState?.currentSession?.id;
+					if (sid) {
+						if (pathsToDismiss.length > 0) await dismissCheckpointFiles(sid, pathsToDismiss);
+						await refreshCheckpointBanner(sid);
 					}
 				} catch (err) {
 					debug.error('git', 'Failed to discard all:', err);
@@ -1766,6 +1804,24 @@ ${bodies}`;
 		if (activeView === 'stash' && isRepo) {
 			untrack(() => loadStash());
 		}
+	});
+
+	// Watch for checkpoint diff requests from chat banner
+	$effect(() => {
+		const req = checkpointDiff.data;
+		if (!req) return;
+		untrack(() => {
+			// Build a real GitFileDiff with 3 lines of context (matches git diff
+			// default) and open a normal tab — same flow as clicking a file in
+			// the source control changes list.
+			const fileDiff = buildGitFileDiff(req.oldContent, req.newContent, req.filepath);
+			const tabId = `checkpoint:${req.filepath}`;
+			const fileName = req.filepath.split(/[\\/]/).pop() || req.filepath;
+			openTabs = [{ id: tabId, filePath: req.filepath, fileName, section: 'checkpoint', diff: fileDiff, diffs: [fileDiff], isLoading: false, status: 'M' }];
+			activeTabId = tabId;
+			if (!isTwoColumnMode) viewMode = 'diff';
+			clearCheckpointDiff();
+		});
 	});
 
 	// Load tags when switching to tags view

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -25,7 +25,7 @@
 		type GitActiveDiff
 	} from '$frontend/stores/features/git-workspace.svelte';
 	import { detectLanguageFromFilename } from '$frontend/components/common/editor/monaco-languages';
-	import { checkpointDiff, clearCheckpointDiff, refreshCheckpointBanner, clearActiveCheckpointFile } from '$frontend/stores/features/checkpoint-changes.svelte';
+	import { checkpointDiff, clearCheckpointDiff, refreshCheckpointBanner, clearActiveCheckpointFile, clearDismissedFiles } from '$frontend/stores/features/checkpoint-changes.svelte';
 	import { sessionState } from '$frontend/stores/core/sessions.svelte';
 	import type { IconName } from '$shared/types/ui/icons';
 	import type {
@@ -941,6 +941,11 @@
 		try {
 			await ws.http('git:switch-branch', { projectId, name });
 			showBranchManager = false;
+			// Clear dismissed marks — they're scoped to the old branch's worktree
+			// state. New branch should show all its own changes fresh.
+			if (sessionState.currentSession?.id) {
+				await clearDismissedFiles(sessionState.currentSession.id);
+			}
 			await loadAll();
 			if (activeView === 'log') await loadLog(true);
 		} catch (err) {

--- a/frontend/services/snapshot/snapshot.service.ts
+++ b/frontend/services/snapshot/snapshot.service.ts
@@ -7,6 +7,7 @@
 
 import ws from '$frontend/utils/ws';
 import type { TimelineResponse } from '$frontend/components/checkpoint/timeline/types';
+import type { SessionFileChangeWithStats } from '$shared/types/database/schema';
 
 /**
  * Conflict information for a single file
@@ -70,7 +71,7 @@ class SnapshotService {
 	 * Get changed files for a checkpoint.
 	 */
 	async getChanges(messageId: string, sessionId: string): Promise<{
-		files: { filepath: string; oldHash: string; newHash: string }[];
+		files: SessionFileChangeWithStats[];
 	}> {
 		return ws.http('snapshot:get-changes', { messageId, sessionId });
 	}

--- a/frontend/services/snapshot/snapshot.service.ts
+++ b/frontend/services/snapshot/snapshot.service.ts
@@ -67,6 +67,51 @@ class SnapshotService {
 	}
 
 	/**
+	 * Get changed files for a checkpoint.
+	 */
+	async getChanges(messageId: string, sessionId: string): Promise<{
+		files: { filepath: string; oldHash: string; newHash: string }[];
+	}> {
+		return ws.http('snapshot:get-changes', { messageId, sessionId });
+	}
+
+	/**
+	 * Get old/new file content for diff display.
+	 */
+	async getFileDiff(messageId: string, filepath: string, sessionId: string): Promise<{
+		oldContent: string;
+		newContent: string;
+		filepath: string;
+	}> {
+		return ws.http('snapshot:get-file-diff', { messageId, filepath, sessionId });
+	}
+
+	/**
+	 * Get the dismissed-changes list (per-session marks for files the
+	 * user has staged/discarded from the banner). Returns the current
+	 * full list of dismissed filepaths.
+	 */
+	async getDismissedChanges(sessionId: string): Promise<{ files: string[] }> {
+		return ws.http('snapshot:get-dismissed-changes', { sessionId }) as Promise<{ files: string[] }>;
+	}
+
+	/**
+	 * Add one or more filepaths to the latest snapshot's dismissed_changes
+	 * list (deduplicated). Returns the resulting full list.
+	 */
+	async addDismissedChanges(sessionId: string, filepaths: string[]): Promise<{ files: string[] }> {
+		return ws.http('snapshot:add-dismissed-changes', { sessionId, filepaths }) as Promise<{ files: string[] }>;
+	}
+
+	/**
+	 * Clear all dismissed marks for the session. Used when the user
+	 * undoes a stage/discard.
+	 */
+	async clearDismissedChanges(sessionId: string): Promise<{ cleared: boolean }> {
+		return ws.http('snapshot:clear-dismissed-changes', { sessionId }) as Promise<{ cleared: boolean }>;
+	}
+
+	/**
 	 * @deprecated Use restore() instead. Kept for backward compatibility.
 	 */
 	async undo(messageId: string, sessionId: string): Promise<any> {

--- a/frontend/stores/features/checkpoint-changes.svelte.ts
+++ b/frontend/stores/features/checkpoint-changes.svelte.ts
@@ -43,12 +43,22 @@ export function hideCheckpointChanges() {
 // Checkpoint diff to open in git panel
 export const checkpointDiff = $state<{ data: { filepath: string; oldContent: string; newContent: string } | null }>({ data: null });
 
+/** Which file the user last clicked in the banner. Persists after
+ *  `checkpointDiff.data` is cleared by the GitPanel watcher so the
+ *  active-row highlight stays on the file being viewed. */
+export const activeCheckpointFile = $state<{ path: string | null }>({ path: null });
+
 export function requestCheckpointDiff(filepath: string, oldContent: string, newContent: string) {
+	activeCheckpointFile.path = filepath;
 	checkpointDiff.data = { filepath, oldContent, newContent };
 }
 
 export function clearCheckpointDiff() {
 	checkpointDiff.data = null;
+}
+
+export function clearActiveCheckpointFile() {
+	activeCheckpointFile.path = null;
 }
 
 // ============================================================

--- a/frontend/stores/features/checkpoint-changes.svelte.ts
+++ b/frontend/stores/features/checkpoint-changes.svelte.ts
@@ -1,0 +1,162 @@
+/**
+ * Checkpoint Changes Banner State
+ *
+ * When a user clicks a checkpoint node, the changes list is shown
+ * as a banner above the chat input.
+ */
+
+import { snapshotService } from '$frontend/services/snapshot/snapshot.service';
+import { projectState } from '$frontend/stores/core/projects.svelte';
+import ws from '$frontend/utils/ws';
+
+export const checkpointChanges = $state<{
+	visible: boolean;
+	messageText: string;
+	files: { filepath: string; oldHash: string; newHash: string }[];
+	loading: boolean;
+}>({
+	visible: false,
+	messageText: '',
+	files: [],
+	loading: false
+});
+
+export const changesExpanded = $state({ value: false });
+
+export function toggleChangesExpanded() {
+	changesExpanded.value = !changesExpanded.value;
+}
+
+export function showCheckpointChanges(messageText: string, files: { filepath: string; oldHash: string; newHash: string }[]) {
+	changesExpanded.value = true;
+	checkpointChanges.visible = true;
+	checkpointChanges.messageText = messageText;
+	checkpointChanges.files = files;
+	checkpointChanges.loading = false;
+}
+
+export function hideCheckpointChanges() {
+	checkpointChanges.visible = false;
+	checkpointChanges.files = [];
+}
+
+// Checkpoint diff to open in git panel
+export const checkpointDiff = $state<{ data: { filepath: string; oldContent: string; newContent: string } | null }>({ data: null });
+
+export function requestCheckpointDiff(filepath: string, oldContent: string, newContent: string) {
+	checkpointDiff.data = { filepath, oldContent, newContent };
+}
+
+export function clearCheckpointDiff() {
+	checkpointDiff.data = null;
+}
+
+// ============================================================
+// Dismissed-file marks (stored in snapshot DB)
+// ============================================================
+//
+// The banner above chat only shows AI-modified files that the user hasn't
+// yet acted on. When the user stages or discards a file via the Git panel
+// we add it to the latest snapshot's `dismissed_changes` list — the banner
+// then hides it, but `session_changes` in the DB stays intact so
+// checkpoint restore still works. Stored in DB so it syncs across
+// devices and survives logout/clear-browser-data.
+// ============================================================
+
+export const dismissedFiles = $state<{ bySession: Record<string, string[]> }>({
+	bySession: {}
+});
+
+/**
+ * Mark a single file as dismissed for the given session. Persists to
+ * the snapshot's `dismissed_changes` list in the DB.
+ */
+export async function dismissCheckpointFile(sessionId: string, filepath: string): Promise<void> {
+	const bucket = dismissedFiles.bySession[sessionId] ?? [];
+	if (bucket.includes(filepath)) return;
+	const result = await snapshotService.addDismissedChanges(sessionId, [filepath]);
+	dismissedFiles.bySession[sessionId] = result.files;
+}
+
+/**
+ * Mark a batch of files as dismissed for the given session.
+ */
+export async function dismissCheckpointFiles(sessionId: string, filepaths: string[]): Promise<void> {
+	if (filepaths.length === 0) return;
+	const result = await snapshotService.addDismissedChanges(sessionId, filepaths);
+	dismissedFiles.bySession[sessionId] = result.files;
+}
+
+/**
+ * Clear all dismissed marks for a session (e.g. when the user undoes a stage).
+ */
+export async function clearDismissedFiles(sessionId: string): Promise<void> {
+	await snapshotService.clearDismissedChanges(sessionId);
+	delete dismissedFiles.bySession[sessionId];
+}
+
+/** Load the dismissed-changes list for a session from the DB into local state. */
+export async function loadDismissedFiles(sessionId: string): Promise<string[]> {
+	const result = await snapshotService.getDismissedChanges(sessionId);
+	dismissedFiles.bySession[sessionId] = result.files;
+	return result.files;
+}
+
+/** True when the file has been marked dismissed for this session. */
+export function isCheckpointFileDismissed(sessionId: string, filepath: string): boolean {
+	return dismissedFiles.bySession[sessionId]?.includes(filepath) ?? false;
+}
+
+/**
+ * Re-fetch the current checkpoint's `session_changes`, cross-reference with
+ * the live git status + dismissed marks, and update the banner to show only
+ * files that are still unstaged AND not marked dismissed. Called both on
+ * initial session mount (via the ChatPanel auto-load effect) and after
+ * staging/discard operations so the banner stays in sync with the worktree.
+ *
+ * If no visible files remain, the banner is hidden.
+ */
+export async function refreshCheckpointBanner(sessionId: string): Promise<void> {
+	const projectId = projectState.currentProject?.id;
+	if (!projectId) return;
+
+	const [timeline, status, dismissedResult] = await Promise.all([
+		snapshotService.getTimeline(sessionId),
+		ws.http('git:status', { projectId }).catch(() => null) as Promise<{ staged?: { path: string }[] } | null>,
+		snapshotService.getDismissedChanges(sessionId)
+	]);
+	const dismissed = dismissedResult.files;
+	dismissedFiles.bySession[sessionId] = dismissed;
+
+	const headId = timeline.currentHeadId;
+	if (!headId || headId === '__initial__') {
+		hideCheckpointChanges();
+		return;
+	}
+
+	const result = await snapshotService.getChanges(headId, sessionId);
+
+	// Drop files that are already staged in the worktree — the banner only
+	// tracks the live "current state", so a `git add` (or a Git panel stage
+	// click) should make those rows disappear.
+	const stagedPaths = new Set<string>();
+	if (status?.staged) {
+		for (const f of status.staged) stagedPaths.add(f.path);
+	}
+
+	// Drop files the user has explicitly marked dismissed (e.g. staged via
+	// the Git panel) — the mark lives in the snapshot's `dismissed_changes`
+	// column so it syncs across devices and survives refresh.
+	const dismissedSet = new Set(dismissed);
+
+	const visibleFiles = result.files.filter(f =>
+		!stagedPaths.has(f.filepath) && !dismissedSet.has(f.filepath)
+	);
+
+	if (visibleFiles.length === 0) {
+		hideCheckpointChanges();
+		return;
+	}
+
+	showCheckpointChanges('Current state', visibleFiles);
+}

--- a/frontend/stores/features/checkpoint-changes.svelte.ts
+++ b/frontend/stores/features/checkpoint-changes.svelte.ts
@@ -5,14 +5,17 @@
  * as a banner above the chat input.
  */
 
+import type { SessionFileChangeWithStats } from '$shared/types/database/schema';
 import { snapshotService } from '$frontend/services/snapshot/snapshot.service';
 import { projectState } from '$frontend/stores/core/projects.svelte';
 import ws from '$frontend/utils/ws';
 
+export type CheckpointFile = SessionFileChangeWithStats;
+
 export const checkpointChanges = $state<{
 	visible: boolean;
 	messageText: string;
-	files: { filepath: string; oldHash: string; newHash: string }[];
+	files: CheckpointFile[];
 	loading: boolean;
 }>({
 	visible: false,
@@ -21,13 +24,28 @@ export const checkpointChanges = $state<{
 	loading: false
 });
 
+/** Aggregate line counts across all visible files — rendered in the
+ *  banner header as `+Σadditions  -Σdeletions` so the user gets a
+ *  glanceable total like `git diff --stat`. */
+export function getTotalAdditions(): number {
+	let total = 0;
+	for (const f of checkpointChanges.files) total += f.additions ?? 0;
+	return total;
+}
+
+export function getTotalDeletions(): number {
+	let total = 0;
+	for (const f of checkpointChanges.files) total += f.deletions ?? 0;
+	return total;
+}
+
 export const changesExpanded = $state({ value: false });
 
 export function toggleChangesExpanded() {
 	changesExpanded.value = !changesExpanded.value;
 }
 
-export function showCheckpointChanges(messageText: string, files: { filepath: string; oldHash: string; newHash: string }[]) {
+export function showCheckpointChanges(messageText: string, files: CheckpointFile[]) {
 	changesExpanded.value = true;
 	checkpointChanges.visible = true;
 	checkpointChanges.messageText = messageText;

--- a/frontend/utils/diff.ts
+++ b/frontend/utils/diff.ts
@@ -135,9 +135,28 @@ export function computeLineDiff(oldContent: string, newContent: string): DiffHun
 }
 
 /**
+ * Heuristic: a file is binary if its first ~8KB contains a NUL byte.
+ * Matches the way `git` itself decides — NUL bytes never appear in valid text
+ * but are common in compiled/asset files. Cheap to compute and good enough for
+ * the "should the diff editor be skipped?" decision.
+ */
+function looksBinary(content: string): boolean {
+	if (!content) return false;
+	const limit = Math.min(content.length, 8192);
+	for (let i = 0; i < limit; i++) {
+		if (content.charCodeAt(i) === 0) return true;
+	}
+	return false;
+}
+
+/**
  * Build a full GitFileDiff with hunks containing 3 lines of context on either
  * side of each change. Consecutive change groups separated by ≤ 6 unchanged
  * lines are merged into a single hunk (matches `git diff` default behaviour).
+ *
+ * Binary detection: scans the first ~8KB of each side for a NUL byte. If either
+ * side looks binary, `isBinary` is set so the viewer renders a "Binary file"
+ * placeholder instead of feeding raw bytes to the text diff editor.
  */
 export function buildGitFileDiff(
 	oldContent: string,
@@ -145,6 +164,19 @@ export function buildGitFileDiff(
 	filepath: string,
 	status: string = 'M'
 ): GitFileDiff {
+	const isBinary = looksBinary(oldContent) || looksBinary(newContent);
+	if (isBinary) {
+		// For binary files we don't produce hunks — the DiffViewer renders
+		// a placeholder based on `isBinary` + `status`.
+		return {
+			oldPath: filepath,
+			newPath: filepath,
+			status,
+			hunks: [],
+			isBinary: true
+		};
+	}
+
 	const oldLines = oldContent.split('\n');
 	const newLines = newContent.split('\n');
 	const ops = computeOps(oldLines, newLines);

--- a/frontend/utils/diff.ts
+++ b/frontend/utils/diff.ts
@@ -1,0 +1,266 @@
+/**
+ * Line-level diff utility (LCS-based).
+ *
+ * Two outputs:
+ *  - `buildGitFileDiff()`: full GitFileDiff with 3 lines of context (standard
+ *    `git diff` shape). Use this to feed the existing Monaco diff path.
+ *  - `computeLineDiff()`: compact hunks with ONLY + and - lines (no context).
+ *    Kept as a utility for future use.
+ */
+
+import type { GitFileDiff, GitDiffHunk, GitDiffLine } from '$shared/types/git';
+
+type Op = { op: '=' | '+' | '-'; oldIdx: number; newIdx: number };
+
+/**
+ * Run LCS between two line arrays and return the full edit script.
+ */
+function computeOps(oldLines: string[], newLines: string[]): Op[] {
+	const m = oldLines.length;
+	const n = newLines.length;
+	const dp: Uint32Array[] = new Array(m + 1);
+	for (let i = 0; i <= m; i++) dp[i] = new Uint32Array(n + 1);
+
+	for (let i = 1; i <= m; i++) {
+		const a = oldLines[i - 1];
+		const row = dp[i];
+		const prev = dp[i - 1];
+		for (let j = 1; j <= n; j++) {
+			if (a === newLines[j - 1]) {
+				row[j] = prev[j - 1] + 1;
+			} else {
+				row[j] = prev[j] >= row[j - 1] ? prev[j] : row[j - 1];
+			}
+		}
+	}
+
+	const ops: Op[] = [];
+	let i = m;
+	let j = n;
+	while (i > 0 && j > 0) {
+		if (oldLines[i - 1] === newLines[j - 1]) {
+			ops.push({ op: '=', oldIdx: i - 1, newIdx: j - 1 });
+			i--;
+			j--;
+		} else if (dp[i - 1][j] >= dp[i][j - 1]) {
+			ops.push({ op: '-', oldIdx: i - 1, newIdx: -1 });
+			i--;
+		} else {
+			ops.push({ op: '+', oldIdx: -1, newIdx: j - 1 });
+			j--;
+		}
+	}
+	while (i > 0) {
+		ops.push({ op: '-', oldIdx: i - 1, newIdx: -1 });
+		i--;
+	}
+	while (j > 0) {
+		ops.push({ op: '+', oldIdx: -1, newIdx: j - 1 });
+		j--;
+	}
+	ops.reverse();
+	return ops;
+}
+
+export type DiffLineType = 'add' | 'delete';
+
+export interface DiffLine {
+	type: DiffLineType;
+	content: string;
+	oldLineNumber?: number;
+	newLineNumber?: number;
+}
+
+export interface DiffHunk {
+	oldStart: number;
+	oldLines: number;
+	newStart: number;
+	newLines: number;
+	lines: DiffLine[];
+}
+
+/**
+ * Compact hunks with ONLY `+` / `-` lines (no context).
+ */
+export function computeLineDiff(oldContent: string, newContent: string): DiffHunk[] {
+	const oldLines = oldContent.split('\n');
+	const newLines = newContent.split('\n');
+	const ops = computeOps(oldLines, newLines);
+
+	const hunks: DiffHunk[] = [];
+	let buf: DiffLine[] = [];
+	let oldCount = 0;
+	let newCount = 0;
+	let hunkOpen = false;
+	let minOld = Number.POSITIVE_INFINITY;
+	let minNew = Number.POSITIVE_INFINITY;
+
+	const flush = () => {
+		if (!hunkOpen || buf.length === 0) {
+			buf = [];
+			hunkOpen = false;
+			oldCount = 0;
+			newCount = 0;
+			minOld = Number.POSITIVE_INFINITY;
+			minNew = Number.POSITIVE_INFINITY;
+			return;
+		}
+		const oStart = minOld === Number.POSITIVE_INFINITY ? 1 : minOld;
+		const nStart = minNew === Number.POSITIVE_INFINITY ? oStart : minNew;
+		hunks.push({ oldStart: oStart, oldLines: oldCount, newStart: nStart, newLines: newCount, lines: buf });
+		buf = [];
+		hunkOpen = false;
+		oldCount = 0;
+		newCount = 0;
+		minOld = Number.POSITIVE_INFINITY;
+		minNew = Number.POSITIVE_INFINITY;
+	};
+
+	for (const op of ops) {
+		if (op.op === '=') continue;
+		if (!hunkOpen) hunkOpen = true;
+		if (op.op === '-') {
+			buf.push({ type: 'delete', content: oldLines[op.oldIdx], oldLineNumber: op.oldIdx + 1 });
+			oldCount++;
+			if (op.oldIdx + 1 < minOld) minOld = op.oldIdx + 1;
+		} else {
+			buf.push({ type: 'add', content: newLines[op.newIdx], newLineNumber: op.newIdx + 1 });
+			newCount++;
+			if (op.newIdx + 1 < minNew) minNew = op.newIdx + 1;
+		}
+	}
+	flush();
+
+	return hunks;
+}
+
+/**
+ * Build a full GitFileDiff with hunks containing 3 lines of context on either
+ * side of each change. Consecutive change groups separated by ≤ 6 unchanged
+ * lines are merged into a single hunk (matches `git diff` default behaviour).
+ */
+export function buildGitFileDiff(
+	oldContent: string,
+	newContent: string,
+	filepath: string,
+	status: string = 'M'
+): GitFileDiff {
+	const oldLines = oldContent.split('\n');
+	const newLines = newContent.split('\n');
+	const ops = computeOps(oldLines, newLines);
+
+	const CONTEXT = 3;
+	const MERGE_GAP = CONTEXT * 2;
+	const hunks: GitDiffHunk[] = [];
+
+	let i = 0;
+	while (i < ops.length) {
+		if (ops[i].op === '=') {
+			i++;
+			continue;
+		}
+
+		// Start of hunk: walk back up to CONTEXT '=' lines
+		let start = i;
+		let back = 0;
+		while (start > 0 && ops[start - 1].op === '=' && back < CONTEXT) {
+			start--;
+			back++;
+		}
+
+		// End: extend through changes, merging close groups
+		let end = i;
+		while (end < ops.length) {
+			if (ops[end].op !== '=') {
+				end++;
+				continue;
+			}
+			// Hit '=' — look for next change
+			let next = end + 1;
+			while (next < ops.length && ops[next].op === '=') next++;
+			if (next >= ops.length) {
+				// Trailing context — include if ≤ CONTEXT
+				if (ops.length - end <= CONTEXT) end = ops.length;
+				break;
+			}
+			if (next - end <= MERGE_GAP) {
+				end = next; // merge
+			} else {
+				break;
+			}
+		}
+		// Extend end by CONTEXT '='
+		let fwd = 0;
+		while (end < ops.length && ops[end].op === '=' && fwd < CONTEXT) {
+			end++;
+			fwd++;
+		}
+
+		// Build hunk lines
+		const lines: GitDiffLine[] = [];
+		let oldStart = 0;
+		let newStart = 0;
+		for (let j = start; j < end; j++) {
+			const op = ops[j];
+			if (op.op === '=') {
+				if (oldStart === 0) {
+					oldStart = op.oldIdx + 1;
+					newStart = op.newIdx + 1;
+				}
+				lines.push({
+					type: 'context',
+					content: oldLines[op.oldIdx],
+					oldLineNumber: op.oldIdx + 1,
+					newLineNumber: op.newIdx + 1
+				});
+			} else if (op.op === '-') {
+				if (oldStart === 0) {
+					oldStart = op.oldIdx + 1;
+					newStart = op.oldIdx + 1;
+				}
+				lines.push({
+					type: 'delete',
+					content: oldLines[op.oldIdx],
+					oldLineNumber: op.oldIdx + 1
+				});
+			} else {
+				if (oldStart === 0) {
+					oldStart = newStart || 1;
+				}
+				if (newStart === 0) newStart = op.newIdx + 1;
+				lines.push({
+					type: 'add',
+					content: newLines[op.newIdx],
+					newLineNumber: op.newIdx + 1
+				});
+			}
+		}
+
+		// Tally counts
+		let oldCount = 0;
+		let newCount = 0;
+		for (const l of lines) {
+			if (l.type === 'context' || l.type === 'delete') oldCount++;
+			if (l.type === 'context' || l.type === 'add') newCount++;
+		}
+
+		hunks.push({
+			oldStart: oldStart || 1,
+			oldLines: oldCount,
+			newStart: newStart || 1,
+			newLines: newCount,
+			header: '',
+			lines
+		});
+
+		i = end;
+	}
+
+	return {
+		oldPath: filepath,
+		newPath: filepath,
+		status,
+		hunks,
+		isBinary: false
+	};
+}

--- a/shared/types/database/schema.ts
+++ b/shared/types/database/schema.ts
@@ -108,6 +108,9 @@ export interface MessageSnapshot {
 	tree_hash?: string | null; // When set, snapshot uses blob store (files in ~/.clopen/snapshots/)
 	// Session-scoped changes: { filepath: { oldHash, newHash } }
 	session_changes?: string | null; // JSON string of SessionScopedChanges
+	// Per-snapshot dismissed marks (accepted/discarded files), carried forward
+	// to subsequent snapshots so marks persist across AI messages
+	dismissed_changes?: string | null; // JSON string of string[] filepaths
 }
 
 /**

--- a/shared/types/database/schema.ts
+++ b/shared/types/database/schema.ts
@@ -122,6 +122,20 @@ export interface SessionFileChange {
 }
 
 /**
+ * Per-file change enriched with line counts (computed at query time
+ * by diffing blob-stored old content against the current worktree).
+ * Returned by `snapshot:get-changes` so the chat banner can show
+ * `+N -N` next to each file and `+Σ -Σ` in the header.
+ */
+export interface SessionFileChangeWithStats {
+	filepath: string; // Repo-relative path (the map key in SessionScopedChanges)
+	oldHash: string; // Hash of file content before change
+	newHash: string; // Hash of file content after change
+	additions: number; // Lines added (0 if binary or unreadable)
+	deletions: number; // Lines removed (0 if binary or unreadable)
+}
+
+/**
  * Session-scoped changes map: filepath → { oldHash, newHash }
  * Used for session-scoped restore and conflict detection
  */


### PR DESCRIPTION
# Add dismissed file tracking, nested git repo support, and migration

## Summary

This PR adds support for per-session tracking of dismissed file changes, improves handling of nested git repositories for snapshot and git operations, and introduces a migration for the new `dismissed_changes` column.

## Changes

- Add `dismissed_changes` column to `message_snapshots` table (migration 040)
- Track and update per-session dismissed changes in snapshot queries
- Provide functions to add, clear, and get dismissed changes for a session
- Implement utilities to find nested git repositories and route file operations to the correct repo
- Update `git discard` implementation to handle staged/unstaged correctly using `git restore`
- Register the new migration in migrations index