### PR TITLE
fix(mcp): send bridge auth token from non-claude engines

### DIFF
--- a/backend/engine/adapters/opencode/server.ts
+++ b/backend/engine/adapters/opencode/server.ts
@@ -125,25 +125,30 @@ async function init(): Promise<void> {
 	if (!command) throw new Error('opencode binary not found on PATH');
 	const args = [command, 'serve', `--hostname=${OPENCODE_HOST}`, '--port=0'];
 
-	// Build MCP config — but only inject if the MCP endpoint is actually reachable.
-	// The opencode binary may initialize MCP connections synchronously before printing
-	// "opencode server listening", so an unreachable/slow MCP endpoint can stall startup.
-	let mcpConfig = getOpenCodeMcpConfig();
+	// Build MCP config — but only inject remote servers whose endpoint is
+	// actually reachable. The opencode binary may initialize MCP connections
+	// synchronously before printing "opencode server listening", so an
+	// unreachable/slow remote endpoint can stall startup. Drop ONLY the
+	// unreachable remote entries; stdio/local servers (no `url`) are independent
+	// of the HTTP bridge and must always survive — they were previously thrown
+	// out together with the bridge when it wasn't reachable yet.
+	const mcpConfig = getOpenCodeMcpConfig();
 	if (Object.keys(mcpConfig).length > 0) {
-		const mcpUrls = Object.values(mcpConfig).map(c => (c as any).url).filter(Boolean);
-		const reachable = await Promise.all(
-			mcpUrls.map(url => isServerAlive(url))
+		const entries = Object.entries(mcpConfig);
+		const reachability = await Promise.all(
+			entries.map(([, c]) => {
+				const url = (c as any).url as string | undefined;
+				return url ? isServerAlive(url) : Promise.resolve(true);
+			})
 		);
-
-		if (reachable.every(Boolean)) {
-			debug.log('engine', `Open Code server: injecting ${Object.keys(mcpConfig).length} MCP server(s)`);
-			for (const [name, config] of Object.entries(mcpConfig)) {
-				debug.log('engine', `  → ${name}: ${config.type} (${(config as any).url || (config as any).command?.join(' ')})`);
+		entries.forEach(([name, config], i) => {
+			if (reachability[i]) {
+				debug.log('engine', `Open Code server: injecting MCP server → ${name}: ${config.type} (${(config as any).url || (config as any).command?.join(' ')})`);
+			} else {
+				debug.warn('engine', `Open Code server: MCP endpoint for "${name}" not reachable, skipping it`);
+				delete mcpConfig[name];
 			}
-		} else {
-			debug.warn('engine', 'Open Code server: MCP endpoint not reachable, starting without MCP');
-			mcpConfig = {};
-		}
+		});
 	}
 
 	// Build provider config from DB (enabled providers + env vars)

--- a/backend/mcp/internal/config.ts
+++ b/backend/mcp/internal/config.ts
@@ -18,6 +18,7 @@ import { debug } from '$shared/utils/logger';
 import { SERVER_ENV } from '../../utils/env';
 import { validateMcpOutput } from './output-validator';
 import { MCP_TOOL_CALL_TIMEOUT_MS } from '../shared/constants';
+import { getMcpServiceToken } from './service-token';
 
 /**
  * User-defined MCP Servers Configuration
@@ -445,6 +446,7 @@ export function getOpenCodeMcpConfig(): Record<string, McpRemoteConfig> {
 			url: `http://localhost:${port}/mcp`,
 			enabled: true,
 			timeout: MCP_TOOL_CALL_TIMEOUT_MS,
+			headers: { Authorization: `Bearer ${getMcpServiceToken()}` },
 		},
 	};
 }
@@ -462,6 +464,7 @@ export function getOpenCodeMcpConfig(): Record<string, McpRemoteConfig> {
  */
 type CodexMcpServerConfig = {
 	url: string;
+	http_headers?: Record<string, string>;
 	tools?: Record<string, { approval_mode: 'auto' | 'prompt' | 'approve' }>;
 };
 
@@ -507,6 +510,7 @@ export function getCodexMcpConfig(): Record<string, CodexMcpServerConfig> {
 	return {
 		'clopen-mcp': {
 			url: `http://localhost:${port}/mcp`,
+			http_headers: { Authorization: `Bearer ${getMcpServiceToken()}` },
 			tools,
 		},
 	};
@@ -559,6 +563,7 @@ export function getCopilotMcpConfig(): Record<string, MCPHTTPServerConfig> {
 			url: `http://localhost:${port}/mcp`,
 			tools,
 			timeout: MCP_TOOL_CALL_TIMEOUT_MS,
+			headers: { Authorization: `Bearer ${getMcpServiceToken()}` },
 		},
 	};
 }
@@ -606,6 +611,7 @@ export function getQwenMcpConfig(): Record<string, QwenMcpServerConfig> {
 			includeTools,
 			timeout: MCP_TOOL_CALL_TIMEOUT_MS,
 			trust: true,
+			headers: { Authorization: `Bearer ${getMcpServiceToken()}` },
 		},
 	};
 }

--- a/backend/mcp/internal/remote-server.test.ts
+++ b/backend/mcp/internal/remote-server.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, test, beforeAll, afterAll, beforeEach } from 'bun:tes
 import { randomUUID } from 'node:crypto';
 
 import { handleMcpRequest } from './remote-server';
+import { getMcpServiceToken } from './service-token';
 import { authQueries, settingsQueries } from '../../database/queries';
 import { generatePAT, generateSessionToken, hashToken } from '../../auth/tokens';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database';
@@ -128,6 +129,19 @@ describe('MCP Remote Server Authentication', () => {
 	test('accepts a valid PAT token', async () => {
 		const response = await handleMcpRequest(mcpRequest(patToken));
 		expect(response.status).not.toBe(401);
+	});
+
+	test('accepts the internal service token even when auth is required', async () => {
+		// The non-Claude engines authenticate to the bridge with this loopback
+		// token, not a user session. Without it the whole clopen-mcp bridge 401s.
+		const response = await handleMcpRequest(mcpRequest(getMcpServiceToken()));
+		expect(response.status).not.toBe(401);
+	});
+
+	test('does not mint a session for the service token', async () => {
+		const before = sessionCount(testUserId);
+		await handleMcpRequest(mcpRequest(getMcpServiceToken()));
+		expect(sessionCount(testUserId)).toBe(before);
 	});
 
 	test('skips authentication in no-auth mode', async () => {

--- a/backend/mcp/internal/remote-server.ts
+++ b/backend/mcp/internal/remote-server.ts
@@ -19,6 +19,7 @@ import { debug } from '$shared/utils/logger';
 import { authQueries } from '$backend/database/queries';
 import { hashToken } from '$backend/auth/tokens';
 import { getAuthMode } from '$backend/auth/auth-service';
+import { isMcpServiceToken } from './service-token';
 
 // Lazy imports to avoid circular dependencies at module load time
 let _allServers: Parameters<typeof createRemoteMcpServer>[0] | null = null;
@@ -58,6 +59,13 @@ function validateAuthToken(request: Request): { userId: string; role: string } |
 	const token = authHeader.substring(7).trim();
 	if (!token) {
 		return null;
+	}
+
+	// Internal bridge credential: the non-Claude engines authenticate to this
+	// loopback endpoint with the process-scoped service token, not a user
+	// session. Accept it regardless of auth mode — it never leaves the host.
+	if (isMcpServiceToken(token)) {
+		return { userId: 'mcp-service', role: 'admin' };
 	}
 
 	const tokenHash = hashToken(token);

--- a/backend/mcp/internal/service-token.ts
+++ b/backend/mcp/internal/service-token.ts
@@ -1,0 +1,51 @@
+/**
+ * Internal MCP service token.
+ *
+ * The non-Claude engines (Open Code, Codex, Copilot, Qwen) reach the internal
+ * tool bridge over HTTP at `http://localhost:<port>/mcp`. That endpoint is
+ * auth-protected (`getAuthMode() === 'required'` is the DEFAULT), but the
+ * engines run as detached SDKs/subprocesses with no user identity to present —
+ * so without a credential their handshake is rejected with 401 and the whole
+ * `clopen-mcp` bridge silently disappears (the model reports "no MCP at all").
+ *
+ * To fix this we mint ONE process-scoped secret at startup. The config builders
+ * attach it as `Authorization: Bearer <token>` on every bridge URL, and
+ * `remote-server.ts` accepts it as a first-class credential regardless of auth
+ * mode. The token only ever lives in memory and is only ever sent to loopback,
+ * so it never touches disk or the network.
+ *
+ * Claude is unaffected: it runs internal servers in-process and never hits the
+ * HTTP bridge.
+ */
+
+const PREFIX = 'clp_mcp_';
+
+function randomHex(bytes: number): string {
+	const arr = new Uint8Array(bytes);
+	crypto.getRandomValues(arr);
+	return Array.from(arr).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+let token: string | null = null;
+
+/** The process-scoped MCP bridge token, generated lazily on first use. */
+export function getMcpServiceToken(): string {
+	if (token === null) {
+		token = PREFIX + randomHex(24);
+	}
+	return token;
+}
+
+/**
+ * Constant-time check whether `candidate` is the current service token.
+ * Returns false before the token has been minted.
+ */
+export function isMcpServiceToken(candidate: string): boolean {
+	if (token === null) return false;
+	if (candidate.length !== token.length) return false;
+	let diff = 0;
+	for (let i = 0; i < candidate.length; i++) {
+		diff |= candidate.charCodeAt(i) ^ token.charCodeAt(i);
+	}
+	return diff === 0;
+}


### PR DESCRIPTION
#284 locked the in-process /mcp bridge behind Bearer auth but only touched the server side — no engine config was ever updated to send a token. Claude is unaffected (it runs internal servers in-process), but Codex, Copilot, Qwen and Open Code all reach the bridge over HTTP and predate that change, so they began 401-ing the moment auth mode is 'required' (the default). The whole clopen-mcp bridge then vanished and the model reported "no MCP available", including the built-in browser-automation server.

Complete #284 by minting a process-scoped service token in memory and attaching it as `Authorization: Bearer <token>` on every engine's bridge config (Codex via `http_headers`, the rest via `headers`). The bridge validator accepts it as a first-class credential without minting a session, so #284's hardening stays intact while the official engines get a key. The token only ever lives in memory and is only sent to loopback.

Also fix an Open Code regression where an unreachable bridge dropped the entire MCP config: gate reachability per-entry so stdio/local external servers, which never touch the bridge, always survive.