### PR TITLE
feat(mcp): centralize remote OAuth and add per-server status

### DIFF
--- a/backend/auth/permissions.ts
+++ b/backend/auth/permissions.ts
@@ -108,7 +108,10 @@ export const ADMIN_ONLY_ROUTES = new Set([
 	'mcp:install',
 	'mcp:toggle',
 	'mcp:update-config',
-	'mcp:uninstall'
+	'mcp:uninstall',
+	'mcp:status',
+	'mcp:oauth-start',
+	'mcp:oauth-complete'
 ]);
 
 /**

--- a/backend/chat/stream-manager.ts
+++ b/backend/chat/stream-manager.ts
@@ -35,7 +35,7 @@ import type { DatabaseMessage } from '$shared/types/database/schema';
 import { getProjectEngine, initializeProjectEngine } from '../engine';
 import { messageQueries, sessionQueries } from '../database/queries';
 import { snapshotService } from '../snapshot/snapshot-service';
-import { projectContextService } from '../mcp';
+import { projectContextService, refreshExpiringExternalOAuth } from '../mcp';
 import { browserMcpControl } from '../preview';
 import { extractMessageText } from '../snapshot/helpers';
 import { debug } from '$shared/utils/logger';
@@ -607,6 +607,12 @@ class StreamManager extends EventEmitter {
 			// any files (see processStream top). Without this await a fast engine on a
 			// large repo could begin editing while the baseline scan is still running.
 			if (baselineInitPromise) await baselineInitPromise;
+
+			// Refresh any near-expiry managed MCP OAuth tokens so the engine's
+			// (synchronous) MCP config builders below inject a still-valid bearer.
+			await refreshExpiringExternalOAuth().catch(error =>
+				debug.warn('chat', 'MCP OAuth refresh failed:', error)
+			);
 
 			// Stream EngineOutput events through the engine adapter
 			const streamIterable = engine.streamQuery({

--- a/backend/database/migrations/042_add_mcp_oauth.ts
+++ b/backend/database/migrations/042_add_mcp_oauth.ts
@@ -1,0 +1,20 @@
+import type { DatabaseConnection } from '$shared/types/database/connection';
+import { debug } from '$shared/utils/logger';
+
+export const description = 'Add oauth column to mcp_servers (centralized OAuth client registration + tokens)';
+
+export const up = (db: DatabaseConnection): void => {
+	debug.log('migration', 'Adding oauth column to mcp_servers...');
+	// Holds the JSON OAuth state Clopen manages on the user's behalf: dynamic
+	// client registration + access/refresh tokens. NULL = no OAuth. Kept separate
+	// from the user-editable `headers` so a refreshed token never clobbers manual
+	// config, and so every engine can be handed `Authorization: Bearer <token>`.
+	db.exec(`ALTER TABLE mcp_servers ADD COLUMN oauth TEXT`);
+	debug.log('migration', 'oauth column added');
+};
+
+export const down = (db: DatabaseConnection): void => {
+	debug.log('migration', 'Dropping oauth column from mcp_servers...');
+	db.exec('ALTER TABLE mcp_servers DROP COLUMN oauth');
+	debug.log('migration', 'oauth column dropped');
+};

--- a/backend/database/migrations/index.ts
+++ b/backend/database/migrations/index.ts
@@ -40,6 +40,7 @@ import * as migration038 from './038_add_workspace_state_to_user_projects';
 import * as migration039 from './039_create_file_audit_log';
 import * as migration040 from './040_create_mcp_servers_table';
 import * as migration041 from './041_add_mcp_config_schema';
+import * as migration042 from './042_add_mcp_oauth';
 
 // Export all migrations in order
 export const migrations = [
@@ -288,6 +289,12 @@ export const migrations = [
 		description: migration041.description,
 		up: migration041.up,
 		down: migration041.down
+	},
+	{
+		id: '042',
+		description: migration042.description,
+		up: migration042.up,
+		down: migration042.down
 	}
 ];
 

--- a/backend/database/queries/mcp-server-queries.ts
+++ b/backend/database/queries/mcp-server-queries.ts
@@ -48,6 +48,8 @@ export interface McpServerRow {
 	url: string | null;
 	headers: string;
 	config_schema: string;
+	/** JSON OAuth state Clopen manages (registration + tokens), or null. */
+	oauth: string | null;
 	source: McpSource;
 	is_enabled: number;
 	created_at: string;
@@ -139,6 +141,12 @@ export const mcpServerQueries = {
 			JSON.stringify(headers),
 			id
 		);
+	},
+
+	/** Store (or clear with null) the managed OAuth state JSON for a server. */
+	setOAuth(id: number, oauth: string | null): void {
+		const db = getDatabase();
+		db.prepare(`UPDATE mcp_servers SET oauth = ? WHERE id = ?`).run(oauth, id);
 	},
 
 	remove(id: number): void {

--- a/backend/engine/docs/adding-an-engine.md
+++ b/backend/engine/docs/adding-an-engine.md
@@ -52,6 +52,14 @@ mandatory files; optional files use the canonical names from §2.6.
 - [ ] `backend/engine/index.ts`: import + add a case in
       `createEngine(type)`. If there is a shared subprocess, call
       `disposeXxxClient()` from `disposeAllProjectEngines()`.
+- [ ] MCP config (if the SDK accepts a streamable-HTTP MCP URL):
+      - [ ] Internal bridge — add `getXxxMcpConfig()` in
+            `backend/mcp/internal/config.ts` (reuse `clopen-mcp`; see §9.12).
+      - [ ] External servers — add `getXxxExternalMcpConfig()` in
+            `backend/mcp/external/config.ts` and **forward `headers`** so the
+            centralized OAuth bearer reaches the engine. Use the SDK's real
+            header field — **Codex uses `http_headers`, not `bearer_token`**.
+            See §9.18 and `backend/mcp/README.md`.
 
 ### Stage 3 — Database (if a default provider needs to be seeded)
 

--- a/backend/engine/docs/lessons-learned.md
+++ b/backend/engine/docs/lessons-learned.md
@@ -713,3 +713,63 @@ event protocol. Until then, v1 is intentional.
 
 ---
 
+### 9.18 External (registry) MCP servers — pass auth headers; OAuth is centralized
+
+§9.12 covers the **internal** `clopen-mcp` bridge. **External** servers (the
+ones users install from the registry, stored in `mcp_servers`) are different:
+the engine connects **directly** to a third-party URL or stdio command, and
+many require authentication.
+
+> **Two distinct token systems — don't conflate them.** The internal bridge
+> uses a process-scoped, in-memory **service token** sent only over loopback
+> (`backend/mcp/internal/service-token.ts`, added in #363 to complete #284) —
+> it intentionally does **not** persist. External servers use **third-party
+> credentials** (OAuth tokens / API keys) that **must** persist across
+> restarts, so they live in the DB (`mcp_servers.oauth` / `mcp_servers.headers`).
+> Both happen to ride the same header fields described below.
+
+Two ways a new adapter silently breaks here:
+
+1. **Your `getXxxExternalMcpConfig()` must forward `headers`.** Clopen is the
+   OAuth client for remote servers (`backend/mcp/external/oauth.ts`): it runs
+   discovery + dynamic registration + PKCE, stores tokens in
+   `mcp_servers.oauth`, and `resolveServerRow()` injects
+   `Authorization: Bearer <token>` into each resolved server's `headers`
+   (alongside any static API-key header). **If your builder drops `headers`,
+   the token never reaches the engine and every authenticated server fails
+   with a 401 — invisibly.** Every existing builder forwards them
+   (`getClaude/OpenCode/Copilot/QwenExternalMcpConfig`); mirror that.
+
+2. **Use the engine's real header field — verify it, don't guess.** The field
+   name is per-SDK and a wrong key can make the engine reject its whole
+   config:
+   - OpenCode / Copilot: `headers` (generic map).
+   - Qwen: `headers` alongside `httpUrl`.
+   - **Codex: `http_headers`** (a TOML table) — **not** `bearer_token`.
+     `bearer_token` is rejected for `streamable_http`
+     (`Error loading config.toml: bearer_token is not supported for
+     streamable_http`), which aborts the entire `codex exec` run. This mirrors
+     the internal bridge in `backend/mcp/internal/config.ts`
+     (`getCodexMcpConfig` → `http_headers: { Authorization: 'Bearer …' }`).
+     When in doubt, confirm against the CLI: `codex mcp add --help`.
+
+The token is refreshed at stream start — `stream-manager` calls
+`refreshExpiringExternalOAuth()` before `engine.streamQuery()`, so the
+**synchronous** config builders below it always read a fresh access token.
+Do not add per-adapter OAuth flows or per-engine token stores; the engine just
+receives a bearer header like any other authenticated remote.
+
+Connection health is surfaced engine-agnostically by `mcp:status`
+(`backend/mcp/external/probe.ts`) — it classifies `ok / needs_auth (OAuth) /
+needs_config (missing API key) / unreachable / error`, and the Settings panel
+offers **Authenticate** (OAuth) or **Configure** (API key) accordingly. A new
+adapter needs no work here; the probe talks to the server, not the engine.
+
+What you must NOT do:
+- ❌ Drop `headers` from an external remote config (silent 401s).
+- ❌ Use `bearer_token` for Codex remote MCP — use `http_headers`.
+- ❌ Add a per-engine OAuth flow or token store — Clopen centralizes it and
+  injects the bearer into every engine, Codex included.
+
+---
+

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -40,7 +40,7 @@ import { audioRoute } from './http/audio';
 import { browserPreviewServiceManager } from './preview';
 
 // MCP remote server for Open Code custom tools
-import { handleMcpRequest, closeMcpServer } from './mcp';
+import { handleMcpRequest, closeMcpServer, completeAuthorization } from './mcp';
 
 // Auth middleware
 import { checkRouteAccess } from './auth/permissions';
@@ -107,6 +107,28 @@ const app = new Elysia()
 		// long-lived endpoint only — every other route keeps the safe default.
 		server?.timeout(request, 0);
 		return handleMcpRequest(request);
+	})
+
+	// Stable OAuth redirect target for centralized MCP sign-in. The browser is
+	// redirected here after the user consents; we exchange the code for tokens
+	// (stored against the server) and show a self-closing confirmation page. The
+	// Settings panel polls `mcp:status` to pick up the new connected state.
+	.get('/api/mcp/oauth/callback', async ({ query }) => {
+		const { code, state, error } = query as { code?: string; state?: string; error?: string };
+		const page = (title: string, body: string) =>
+			new Response(
+				`<!doctype html><html><head><meta charset="utf-8"><title>${title}</title><style>body{font-family:system-ui,sans-serif;background:#0f172a;color:#e2e8f0;display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0}div{text-align:center;max-width:28rem;padding:2rem}h1{font-size:1.1rem}p{color:#94a3b8;font-size:.9rem}</style></head><body><div><h1>${title}</h1><p>${body}</p><script>setTimeout(()=>window.close(),2500)</script></div></body></html>`,
+				{ headers: { 'Content-Type': 'text/html' } }
+			);
+		if (error) return page('Sign-in failed', `The authorization server returned: ${error}. You can close this tab and try again.`);
+		if (!code || !state) return page('Sign-in failed', 'Missing authorization code. You can close this tab and try again.');
+		try {
+			await completeAuthorization(state, code);
+			return page('Connected', 'Sign-in complete. You can close this tab and return to Clopen.');
+		} catch (err) {
+			const message = err instanceof Error ? err.message : 'Unknown error';
+			return page('Sign-in failed', `${message}. You can close this tab and try again.`);
+		}
 	})
 
 	// HTTP file upload — mounted before the WS plugin so /api/files/upload

--- a/backend/mcp/README.md
+++ b/backend/mcp/README.md
@@ -1197,6 +1197,13 @@ checklist in `backend/engine/README.md` §9.12. The summary:
    in that helper rather than building a per-engine resolver.
 4. Wire the engine's auto-approval path (runtime callback or static
    per-tool config) so MCP tool calls don't get cancelled.
+5. Add a sibling `getXxxExternalMcpConfig()` in
+   `backend/mcp/external/config.ts` for user-installed registry servers,
+   and **forward `headers`** so the centrally-managed OAuth bearer (and
+   any static API key) reaches the engine. Use the SDK's real header
+   field — Codex uses `http_headers`, **not** `bearer_token`. See
+   [External Servers, OAuth & Connection Status](#external-servers-oauth--connection-status)
+   and `backend/engine/docs/lessons-learned.md` §9.18.
 
 ### File Locations
 
@@ -1211,6 +1218,80 @@ checklist in `backend/engine/README.md` §9.12. The summary:
 | External catalog | `backend/mcp/external/registry-client.ts` | Browse the official MCP registry |
 | Per-engine config (external) | `backend/mcp/external/config.ts` | `getXxxExternalMcpConfig()` (<slug>) |
 | Namespace constants | `backend/mcp/shared/constants.ts` | `clopen-mcp`, clopen-reserved prefix, slugify |
+
+---
+
+## External Servers, OAuth & Connection Status
+
+Everything above describes **internal** custom tools (the `clopen-mcp`
+bridge). **External** servers are the ones a user installs from the official
+registry (Settings → MCP → Browse), stored in the `mcp_servers` table. Unlike
+internal tools, the engine connects to these **directly** — a stdio subprocess
+or a remote third-party URL — so authentication is Clopen's responsibility.
+
+### Centralized OAuth (one sign-in, every engine)
+
+Remote servers that need OAuth (e.g. Notion) are authenticated by **Clopen
+itself**, not by each engine. The earlier per-engine approach failed: only
+OpenCode had a callable sign-in trigger, and its token lived in OpenCode's own
+store, so Codex/Claude/etc. never got it.
+
+Flow (`backend/mcp/external/oauth.ts`):
+
+1. **Discover** — RFC 9728 protected-resource metadata → RFC 8414
+   authorization-server metadata (endpoints + dynamic registration URL).
+2. **Register** — RFC 7591 dynamic client registration (public client, PKCE).
+3. **Authorize** — authorization-code + PKCE (S256). The browser is redirected
+   to Clopen's **stable** callback `GET /api/mcp/oauth/callback` (in
+   `backend/index.ts`) — not an ephemeral per-flow loopback server.
+4. **Store** — access + refresh tokens are saved in the `mcp_servers.oauth`
+   JSON column (migration 042), separate from the user-editable `headers`.
+5. **Inject** — `resolveServerRow()` adds `Authorization: Bearer <token>` to
+   every engine's config. `refreshExpiringExternalOAuth()` runs at chat-stream
+   start (in `stream-manager`) so the synchronous per-engine builders read a
+   fresh token. **A new engine adapter needs no OAuth code** — it just receives
+   a bearer header like any authenticated remote.
+
+WS routes (admin-only): `mcp:oauth-start` (returns the authorization URL; the
+UI opens it and polls status), `mcp:oauth-complete` (manual paste fallback).
+
+### Per-engine config: forward the auth headers
+
+Each engine's external builder in `backend/mcp/external/config.ts` MUST forward
+`headers`, and must use the engine's real header field. Dropping headers causes
+silent 401s; the wrong field name can make the engine reject its whole config.
+
+| Engine | Header field | Notes |
+|--------|-------------|-------|
+| Claude | `headers` | http/sse |
+| OpenCode | `headers` | `oauth` left unset = auto-detect fallback |
+| Copilot | `headers` | — |
+| Qwen | `headers` (+ `httpUrl`) | — |
+| **Codex** | **`http_headers`** | **NOT `bearer_token`** — that's rejected for `streamable_http` and aborts the run. Matches the internal bridge. |
+
+### Required-credential validation
+
+`mcp:install` / `mcp:update-config` reject a save when a registry-declared
+required field (`configSchema[].isRequired`) is left blank — so an API-key
+server can't install into a silently-broken state.
+
+### Connection status probe
+
+`mcp:status` (`backend/mcp/external/probe.ts`) runs an engine-agnostic
+handshake (`initialize` + `tools/list`; stdio servers are spawned) and
+classifies the result:
+
+| State | Meaning | Settings action |
+|-------|---------|-----------------|
+| `ok` | Connected (handshake + tool list OK) | — |
+| `needs_auth` | 401 with a `Bearer` challenge → OAuth | **Authenticate** |
+| `needs_config` | Reachable but a static API key is missing | **Configure** |
+| `unreachable` | No response / network error | Re-check |
+| `error` | Other failure | Re-check |
+| `local` | (internal rows only) | — |
+
+The Settings panel probes on open, after install, and after enabling a server,
+so status never goes stale silently.
 
 ---
 

--- a/backend/mcp/external/config.ts
+++ b/backend/mcp/external/config.ts
@@ -19,6 +19,7 @@ import type { CLIMcpServerConfig as QwenMcpServerConfig } from '@qwen-code/sdk';
 import { debug } from '$shared/utils/logger';
 import { mcpServerQueries } from '$backend/database/queries';
 import { externalNamespace } from '../shared/constants';
+import type { McpServerRow } from '$backend/database/queries';
 import type { ResolvedExternalServer } from './types';
 
 /** Codex flattens `mcp_servers.<name>.<key>` config to `--config` flags. */
@@ -27,6 +28,13 @@ type CodexMcpServerConfig = {
 	args?: string[];
 	env?: Record<string, string>;
 	url?: string;
+	/**
+	 * Streamable-HTTP auth headers. Codex rejects an inline `bearer_token` for
+	 * streamable_http but accepts an `http_headers` table (the same field the
+	 * internal `clopen-mcp` bridge uses), so the centrally-managed
+	 * `Authorization: Bearer …` and any static API-key headers reach Codex.
+	 */
+	http_headers?: Record<string, string>;
 };
 
 function parseJson<T>(raw: string, fallback: T): T {
@@ -37,15 +45,18 @@ function parseJson<T>(raw: string, fallback: T): T {
 	}
 }
 
-/**
- * Load every enabled external server from the DB, parsing JSON columns and
- * computing its `<slug>` namespace key.
- */
-export function getEnabledExternalServers(): ResolvedExternalServer[] {
-	// `mcp_servers` also holds INTERNAL (code-defined) rows used only for the
-	// Settings listing + toggle — exclude them here so they're never emitted as
-	// real external servers the engine would try to connect to.
-	return mcpServerQueries.getEnabled().filter(row => row.source !== 'internal').map(row => ({
+/** Parse a raw DB row into a connection-ready resolved server. */
+export function resolveServerRow(row: McpServerRow): ResolvedExternalServer {
+	const headers = parseJson<Record<string, string>>(row.headers, {});
+	// Inject the Clopen-managed OAuth access token as a bearer header so EVERY
+	// engine (Codex included) authenticates with the same token. A user-set
+	// `Authorization` header always wins. `refreshExpiringExternalOAuth()` runs
+	// at stream start, so the token read here is fresh.
+	const oauth = row.oauth ? parseJson<{ accessToken?: string } | null>(row.oauth, null) : null;
+	if (oauth?.accessToken && !headers.Authorization && !headers.authorization) {
+		headers.Authorization = `Bearer ${oauth.accessToken}`;
+	}
+	return {
 		id: row.id,
 		slug: row.slug,
 		namespace: externalNamespace(row.slug),
@@ -55,8 +66,40 @@ export function getEnabledExternalServers(): ResolvedExternalServer[] {
 		args: parseJson<string[]>(row.args, []),
 		env: parseJson<Record<string, string>>(row.env, {}),
 		url: row.url,
-		headers: parseJson<Record<string, string>>(row.headers, {})
-	}));
+		headers
+	};
+}
+
+/**
+ * Load every enabled external server from the DB, parsing JSON columns and
+ * computing its `<slug>` namespace key.
+ */
+export function getEnabledExternalServers(): ResolvedExternalServer[] {
+	// `mcp_servers` also holds INTERNAL (code-defined) rows used only for the
+	// Settings listing + toggle — exclude them here so they're never emitted as
+	// real external servers the engine would try to connect to.
+	return mcpServerQueries.getEnabled().filter(row => row.source !== 'internal').map(resolveServerRow);
+}
+
+/**
+ * A remote server with no configured static credential (API key / bearer
+ * header) relies on OAuth. We turn on each engine's native OAuth
+ * auto-detection for these so the engine runs the MCP authorization handshake
+ * (dynamic client registration, RFC 7591) instead of hitting an
+ * unauthenticated 401 and silently exposing zero tools — the failure that hid
+ * `com-notion-mcp` on every non-Claude engine. Servers carrying a static
+ * header are left as plain authenticated remotes.
+ */
+export function remoteNeedsOAuth(s: ResolvedExternalServer): boolean {
+	return (s.transport === 'http' || s.transport === 'sse')
+		&& !!s.url
+		&& Object.keys(s.headers).length === 0;
+}
+
+/** Qwen OAuth fields for a credential-less remote (dynamic discovery). */
+function remoteAuthQwen(s: ResolvedExternalServer): Partial<QwenMcpServerConfig> {
+	if (!remoteNeedsOAuth(s)) return {};
+	return { oauth: { enabled: true }, authProviderType: 'dynamic_discovery' };
 }
 
 // ---------------------------------------------------------------------------
@@ -93,6 +136,10 @@ export function getOpenCodeExternalMcpConfig(): Record<string, McpLocalConfig | 
 				enabled: true
 			};
 		} else if ((s.transport === 'http' || s.transport === 'sse') && s.url) {
+			// `oauth` is intentionally left unset: Open Code's default is OAuth
+			// auto-detection (set it to `false` only to opt out). Credential-less
+			// remotes therefore get the authorization handshake for free; the
+			// interactive sign-in is driven separately via the MCP auth flow.
 			out[s.namespace] = {
 				type: 'remote',
 				url: s.url,
@@ -122,7 +169,12 @@ export function getCodexExternalMcpConfig(): Record<string, CodexMcpServerConfig
 				...(Object.keys(s.env).length > 0 ? { env: s.env } : {})
 			};
 		} else if ((s.transport === 'http' || s.transport === 'sse') && s.url) {
-			out[s.namespace] = { url: s.url };
+			// `http_headers` carries the injected OAuth bearer (and any static API
+			// key), matching the internal bridge — so Codex authenticates too.
+			out[s.namespace] = {
+				url: s.url,
+				...(Object.keys(s.headers).length > 0 ? { http_headers: s.headers } : {})
+			};
 		}
 	}
 	logBuilt('Codex', out);
@@ -136,6 +188,10 @@ export function getCopilotExternalMcpConfig(): Record<string, CopilotMcpServerCo
 		if (s.transport === 'stdio' && s.command) {
 			out[s.namespace] = { type: 'local', command: s.command, args: s.args, env: s.env };
 		} else if ((s.transport === 'http' || s.transport === 'sse') && s.url) {
+			// Leaving `oauthClientId` unset makes the Copilot runtime perform
+			// dynamic client registration when the server demands OAuth. The
+			// interactive consent is delegated to us via the `mcp.oauth_required`
+			// event (see the Copilot adapter's MCP auth wiring).
 			out[s.namespace] = {
 				type: s.transport,
 				url: s.url,
@@ -154,9 +210,9 @@ export function getQwenExternalMcpConfig(): Record<string, QwenMcpServerConfig> 
 		if (s.transport === 'stdio' && s.command) {
 			out[s.namespace] = { command: s.command, args: s.args, env: s.env, trust: true };
 		} else if (s.transport === 'http' && s.url) {
-			out[s.namespace] = { httpUrl: s.url, headers: s.headers, trust: true };
+			out[s.namespace] = { httpUrl: s.url, headers: s.headers, trust: true, ...remoteAuthQwen(s) };
 		} else if (s.transport === 'sse' && s.url) {
-			out[s.namespace] = { url: s.url, headers: s.headers, trust: true };
+			out[s.namespace] = { url: s.url, headers: s.headers, trust: true, ...remoteAuthQwen(s) };
 		}
 	}
 	logBuilt('Qwen', out);

--- a/backend/mcp/external/oauth.ts
+++ b/backend/mcp/external/oauth.ts
@@ -1,0 +1,329 @@
+/**
+ * Centralized MCP OAuth client.
+ *
+ * Clopen performs the OAuth 2.1 authorization-code + PKCE flow ITSELF (with
+ * RFC 8414/9728 discovery and RFC 7591 dynamic client registration), stores the
+ * resulting access/refresh tokens in the `mcp_servers.oauth` column, and injects
+ * `Authorization: Bearer <token>` into EVERY engine's config. This replaces the
+ * old per-engine delegation, where each engine kept its own token store so only
+ * OpenCode could sign in and the result never reached Codex/Claude/etc.
+ *
+ * The redirect lands on Clopen's own stable callback route
+ * (`/api/mcp/oauth/callback`), so there is no ephemeral per-flow loopback server
+ * to race against — the earlier "localhost:NNNNN refused to connect" failure.
+ */
+
+import { debug } from '$shared/utils/logger';
+import { SERVER_ENV } from '$backend/utils/env';
+import { mcpServerQueries } from '$backend/database/queries';
+
+/** Persisted per-server OAuth state (JSON in `mcp_servers.oauth`). */
+export interface OAuthRecord {
+	clientId: string;
+	clientSecret?: string;
+	authorizationEndpoint: string;
+	tokenEndpoint: string;
+	registrationEndpoint?: string;
+	redirectUri: string;
+	scope?: string;
+	resource?: string;
+	accessToken?: string;
+	refreshToken?: string;
+	/** Epoch ms when the access token expires. */
+	expiresAt?: number;
+}
+
+/** Refresh tokens whose access token expires within this window. */
+const REFRESH_SKEW_MS = 60_000;
+
+// In-memory authorization flows awaiting their callback, keyed by `state`.
+interface PendingFlow {
+	serverId: number;
+	codeVerifier: string;
+	record: OAuthRecord;
+}
+const pendingFlows = new Map<string, PendingFlow>();
+
+// ---------------------------------------------------------------------------
+// Storage helpers
+// ---------------------------------------------------------------------------
+
+export function loadOAuth(serverId: number): OAuthRecord | null {
+	const row = mcpServerQueries.getById(serverId);
+	if (!row?.oauth) return null;
+	try { return JSON.parse(row.oauth) as OAuthRecord; } catch { return null; }
+}
+
+function saveOAuth(serverId: number, record: OAuthRecord): void {
+	mcpServerQueries.setOAuth(serverId, JSON.stringify(record));
+}
+
+export function clearOAuth(serverId: number): void {
+	mcpServerQueries.setOAuth(serverId, null);
+}
+
+/** The fixed redirect URI served by Clopen's HTTP layer. */
+export function oauthRedirectUri(): string {
+	return `http://localhost:${SERVER_ENV.PORT}/api/mcp/oauth/callback`;
+}
+
+// ---------------------------------------------------------------------------
+// PKCE + crypto
+// ---------------------------------------------------------------------------
+
+function base64url(bytes: Uint8Array): string {
+	let str = '';
+	for (const b of bytes) str += String.fromCharCode(b);
+	return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function randomToken(byteLength = 32): string {
+	return base64url(crypto.getRandomValues(new Uint8Array(byteLength)));
+}
+
+async function pkceChallenge(verifier: string): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+	return base64url(new Uint8Array(digest));
+}
+
+// ---------------------------------------------------------------------------
+// Discovery (RFC 9728 protected-resource → RFC 8414 authorization-server)
+// ---------------------------------------------------------------------------
+
+interface DiscoveredAuthServer {
+	authorizationEndpoint: string;
+	tokenEndpoint: string;
+	registrationEndpoint?: string;
+	scope?: string;
+	resource?: string;
+}
+
+/** Pull the `resource_metadata` URL out of a `WWW-Authenticate: Bearer …` header. */
+function resourceMetadataFromHeader(wwwAuthenticate?: string): string | null {
+	if (!wwwAuthenticate) return null;
+	const match = wwwAuthenticate.match(/resource_metadata="([^"]+)"/i);
+	return match?.[1] ?? null;
+}
+
+async function fetchJson(url: string): Promise<Record<string, unknown> | null> {
+	try {
+		const res = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(10_000) });
+		if (!res.ok) return null;
+		return await res.json() as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Resolve the authorization server metadata for a remote MCP `resourceUrl`,
+ * preferring the `resource_metadata` hint from its 401 challenge.
+ */
+export async function discover(resourceUrl: string, wwwAuthenticate?: string): Promise<DiscoveredAuthServer> {
+	const origin = new URL(resourceUrl).origin;
+
+	// 1. Protected-resource metadata → authorization server + resource id.
+	const prmUrl = resourceMetadataFromHeader(wwwAuthenticate) ?? `${origin}/.well-known/oauth-protected-resource`;
+	const prm = await fetchJson(prmUrl);
+	const authServers = Array.isArray(prm?.authorization_servers) ? prm.authorization_servers as string[] : [];
+	const asBase = (authServers[0] ?? origin).replace(/\/$/, '');
+	const resource = typeof prm?.resource === 'string' ? prm.resource : undefined;
+
+	// 2. Authorization-server metadata (try OAuth, then OpenID locations).
+	const asMeta = await fetchJson(`${asBase}/.well-known/oauth-authorization-server`)
+		?? await fetchJson(`${asBase}/.well-known/openid-configuration`);
+	if (!asMeta?.authorization_endpoint || !asMeta?.token_endpoint) {
+		throw new Error('Server does not advertise an OAuth authorization server');
+	}
+
+	const scopesSupported = Array.isArray(asMeta.scopes_supported) ? (asMeta.scopes_supported as string[]).join(' ') : undefined;
+	return {
+		authorizationEndpoint: asMeta.authorization_endpoint as string,
+		tokenEndpoint: asMeta.token_endpoint as string,
+		registrationEndpoint: typeof asMeta.registration_endpoint === 'string' ? asMeta.registration_endpoint : undefined,
+		scope: scopesSupported,
+		resource
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic client registration (RFC 7591)
+// ---------------------------------------------------------------------------
+
+async function registerClient(registrationEndpoint: string, redirectUri: string, scope?: string): Promise<{ clientId: string; clientSecret?: string }> {
+	const res = await fetch(registrationEndpoint, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+		signal: AbortSignal.timeout(10_000),
+		body: JSON.stringify({
+			client_name: 'Clopen',
+			redirect_uris: [redirectUri],
+			grant_types: ['authorization_code', 'refresh_token'],
+			response_types: ['code'],
+			token_endpoint_auth_method: 'none',
+			...(scope ? { scope } : {})
+		})
+	});
+	if (!res.ok) {
+		throw new Error(`Dynamic client registration failed (${res.status})`);
+	}
+	const data = await res.json() as { client_id?: string; client_secret?: string };
+	if (!data.client_id) throw new Error('Registration response missing client_id');
+	return { clientId: data.client_id, clientSecret: data.client_secret };
+}
+
+// ---------------------------------------------------------------------------
+// Token endpoint
+// ---------------------------------------------------------------------------
+
+interface TokenResponse {
+	access_token: string;
+	refresh_token?: string;
+	expires_in?: number;
+}
+
+async function postToken(tokenEndpoint: string, params: Record<string, string>, clientSecret?: string): Promise<TokenResponse> {
+	const headers: Record<string, string> = { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' };
+	if (clientSecret) {
+		headers.Authorization = `Basic ${btoa(`${params.client_id}:${clientSecret}`)}`;
+	}
+	const res = await fetch(tokenEndpoint, {
+		method: 'POST',
+		headers,
+		signal: AbortSignal.timeout(10_000),
+		body: new URLSearchParams(params).toString()
+	});
+	if (!res.ok) {
+		const text = await res.text().catch(() => '');
+		throw new Error(`Token request failed (${res.status})${text ? `: ${text.slice(0, 200)}` : ''}`);
+	}
+	return await res.json() as TokenResponse;
+}
+
+function withExpiry(record: OAuthRecord, token: TokenResponse): OAuthRecord {
+	return {
+		...record,
+		accessToken: token.access_token,
+		refreshToken: token.refresh_token ?? record.refreshToken,
+		expiresAt: token.expires_in ? Date.now() + token.expires_in * 1000 : undefined
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Public flow API
+// ---------------------------------------------------------------------------
+
+/**
+ * Begin an authorization flow for a server. Discovers + (re)registers a client,
+ * remembers the PKCE verifier keyed by `state`, and returns the URL the user
+ * must open. Completion arrives at the callback route (or the manual paste).
+ */
+export async function startAuthorization(serverId: number, resourceUrl: string, wwwAuthenticate?: string): Promise<{ authorizationUrl: string }> {
+	const disc = await discover(resourceUrl, wwwAuthenticate);
+	const redirectUri = oauthRedirectUri();
+
+	// Reuse a prior registration when present; otherwise register dynamically.
+	const existing = loadOAuth(serverId);
+	let clientId = existing?.clientId;
+	let clientSecret = existing?.clientSecret;
+	if (!clientId) {
+		if (!disc.registrationEndpoint) throw new Error('Server requires a pre-registered OAuth client (no dynamic registration)');
+		({ clientId, clientSecret } = await registerClient(disc.registrationEndpoint, redirectUri, disc.scope));
+	}
+
+	const codeVerifier = randomToken(32);
+	const codeChallenge = await pkceChallenge(codeVerifier);
+	const state = randomToken(16);
+
+	const record: OAuthRecord = {
+		clientId,
+		clientSecret,
+		authorizationEndpoint: disc.authorizationEndpoint,
+		tokenEndpoint: disc.tokenEndpoint,
+		registrationEndpoint: disc.registrationEndpoint,
+		redirectUri,
+		scope: disc.scope,
+		resource: disc.resource
+	};
+	pendingFlows.set(state, { serverId, codeVerifier, record });
+
+	const url = new URL(disc.authorizationEndpoint);
+	url.searchParams.set('response_type', 'code');
+	url.searchParams.set('client_id', clientId);
+	url.searchParams.set('redirect_uri', redirectUri);
+	url.searchParams.set('code_challenge', codeChallenge);
+	url.searchParams.set('code_challenge_method', 'S256');
+	url.searchParams.set('state', state);
+	if (disc.scope) url.searchParams.set('scope', disc.scope);
+	if (disc.resource) url.searchParams.set('resource', disc.resource);
+
+	debug.log('mcp', `🔐 OAuth flow started for server ${serverId} (state ${state.slice(0, 6)}…)`);
+	return { authorizationUrl: url.toString() };
+}
+
+/** Whether a `state` belongs to a known pending flow (callback validation). */
+export function hasPendingFlow(state: string): boolean {
+	return pendingFlows.has(state);
+}
+
+/**
+ * Exchange the authorization `code` for tokens and persist them. Returns the
+ * server id the flow belonged to so callers can refresh the UI.
+ */
+export async function completeAuthorization(state: string, code: string): Promise<number> {
+	const flow = pendingFlows.get(state);
+	if (!flow) throw new Error('Unknown or expired authorization state');
+	pendingFlows.delete(state);
+
+	const token = await postToken(flow.record.tokenEndpoint, {
+		grant_type: 'authorization_code',
+		code,
+		redirect_uri: flow.record.redirectUri,
+		client_id: flow.record.clientId,
+		code_verifier: flow.codeVerifier,
+		...(flow.record.resource ? { resource: flow.record.resource } : {})
+	}, flow.record.clientSecret);
+
+	saveOAuth(flow.serverId, withExpiry(flow.record, token));
+	debug.log('mcp', `🔓 OAuth tokens stored for server ${flow.serverId}`);
+	return flow.serverId;
+}
+
+/**
+ * Return a usable access token for a server, refreshing it first if it is about
+ * to expire. Returns null when the server has no OAuth or the refresh fails.
+ */
+export async function getValidAccessToken(serverId: number): Promise<string | null> {
+	const record = loadOAuth(serverId);
+	if (!record?.accessToken) return null;
+
+	const expiringSoon = record.expiresAt != null && record.expiresAt - Date.now() < REFRESH_SKEW_MS;
+	if (expiringSoon && record.refreshToken) {
+		try {
+			const token = await postToken(record.tokenEndpoint, {
+				grant_type: 'refresh_token',
+				refresh_token: record.refreshToken,
+				client_id: record.clientId,
+				...(record.resource ? { resource: record.resource } : {})
+			}, record.clientSecret);
+			const next = withExpiry(record, token);
+			saveOAuth(serverId, next);
+			return next.accessToken ?? null;
+		} catch (error) {
+			debug.warn('mcp', `OAuth refresh failed for server ${serverId}:`, error);
+			return record.accessToken; // try the (possibly stale) token rather than nothing
+		}
+	}
+	return record.accessToken;
+}
+
+/**
+ * Refresh every enabled server's token that is close to expiry. Called at chat
+ * stream start so the sync per-engine config builders read fresh tokens.
+ */
+export async function refreshExpiringExternalOAuth(): Promise<void> {
+	for (const row of mcpServerQueries.getEnabled()) {
+		if (row.source === 'internal' || !row.oauth) continue;
+		await getValidAccessToken(row.id).catch(() => undefined);
+	}
+}

--- a/backend/mcp/external/probe.ts
+++ b/backend/mcp/external/probe.ts
@@ -1,0 +1,258 @@
+/**
+ * External MCP — connection health probe.
+ *
+ * Performs the MCP handshake (`initialize` → `tools/list`) against a stored
+ * server using its own config, and classifies the outcome. This is what makes
+ * a broken external server VISIBLE in Settings instead of silently exposing
+ * zero tools to an engine — the failure mode that hid `com-notion-mcp`
+ * (OAuth 401) and `ai-trendsmcp-google-trends` (missing API key).
+ *
+ * The probe is engine-agnostic: it talks to the remote URL directly with the
+ * stored headers. It therefore reflects whether the server is reachable and
+ * whether the *stored* credential is sufficient. For OAuth servers (no static
+ * credential) it reports `needs_auth` — the engine still authenticates via its
+ * own per-engine token store, but the user gets a clear, actionable signal.
+ */
+
+import { debug } from '$shared/utils/logger';
+import type { ResolvedExternalServer } from './types';
+
+/**
+ * Classified outcome of a connection probe.
+ *  - `needs_auth`   : OAuth sign-in required (offer Authenticate)
+ *  - `needs_config` : a static credential / API key is missing (offer Configure)
+ */
+export type McpHealthState = 'ok' | 'needs_auth' | 'needs_config' | 'unreachable' | 'error' | 'local';
+
+export interface McpHealth {
+	state: McpHealthState;
+	/** Tool count when `ok`. */
+	toolCount?: number;
+	/** Human-readable detail for non-ok states. */
+	message?: string;
+}
+
+const PROBE_TIMEOUT_MS = 12_000;
+const STDIO_PROBE_TIMEOUT_MS = 15_000;
+const PROTOCOL_VERSION = '2025-03-26';
+
+/** Patterns in an error payload that indicate a missing/invalid credential. */
+const AUTH_HINT = /\b(api[\s-]?key|unauthor|forbidden|token|auth|sign[\s-]?in|login|credential)\b/i;
+
+interface JsonRpcResponse {
+	result?: {
+		tools?: unknown[];
+		isError?: boolean;
+		content?: Array<{ type?: string; text?: string }>;
+	};
+	error?: { message?: string };
+}
+
+/**
+ * Read a streamable-HTTP MCP response body, which may be either plain JSON or
+ * an SSE stream (`text/event-stream`). Returns the first JSON-RPC object found.
+ */
+async function readRpc(res: Response): Promise<JsonRpcResponse | null> {
+	const text = await res.text();
+	const trimmed = text.trim();
+	if (!trimmed) return null;
+	// Plain JSON.
+	if (trimmed.startsWith('{')) {
+		try { return JSON.parse(trimmed) as JsonRpcResponse; } catch { /* fall through */ }
+	}
+	// SSE: pick the last `data:` line carrying a JSON-RPC object.
+	for (const line of trimmed.split('\n').reverse()) {
+		const t = line.trim();
+		if (t.startsWith('data:')) {
+			const payload = t.slice(5).trim();
+			try { return JSON.parse(payload) as JsonRpcResponse; } catch { /* keep scanning */ }
+		}
+	}
+	return null;
+}
+
+function rpcBody(method: string, id?: number, params?: unknown): string {
+	return JSON.stringify({ jsonrpc: '2.0', ...(id != null ? { id } : {}), method, ...(params != null ? { params } : {}) });
+}
+
+/**
+ * A 401/403 with a `Bearer` challenge is an OAuth server → offer sign-in.
+ * Otherwise the server wants a static credential we don't have → offer Configure.
+ */
+function classifyUnauthorized(res: Response): McpHealth {
+	const challenge = res.headers.get('www-authenticate') ?? '';
+	if (/bearer/i.test(challenge)) {
+		return { state: 'needs_auth', message: 'OAuth sign-in required' };
+	}
+	return { state: 'needs_config', message: 'A credential (API key / token) is required' };
+}
+
+/**
+ * Spawn a stdio server and run the same handshake over its stdin/stdout
+ * (newline-delimited JSON-RPC) so "local" servers report a real connection
+ * status, consistent with remote ones. The subprocess is always killed.
+ */
+async function probeStdio(s: ResolvedExternalServer): Promise<McpHealth> {
+	if (!s.command) return { state: 'error', message: 'No command configured' };
+
+	let proc: ReturnType<typeof Bun.spawn>;
+	try {
+		proc = Bun.spawn([s.command, ...s.args], {
+			stdin: 'pipe',
+			stdout: 'pipe',
+			stderr: 'ignore',
+			env: { ...process.env, ...s.env }
+		});
+	} catch (error) {
+		return { state: 'unreachable', message: error instanceof Error ? error.message : 'Failed to start command' };
+	}
+
+	try {
+		const stdin = proc.stdin as unknown as { write(data: Uint8Array): number; flush?(): Promise<number> | number };
+		const stdout = proc.stdout as unknown as ReadableStream<Uint8Array>;
+		const write = (obj: unknown) => stdin.write(new TextEncoder().encode(`${JSON.stringify(obj)}\n`));
+		write({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'clopen-probe', version: '1.0.0' } } });
+		write({ jsonrpc: '2.0', method: 'notifications/initialized' });
+		write({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+		await stdin.flush?.();
+
+		const rpc = await readStdoutForId(stdout, 2, STDIO_PROBE_TIMEOUT_MS);
+		if (!rpc) return { state: 'unreachable', message: `No response within ${STDIO_PROBE_TIMEOUT_MS / 1000}s` };
+		if (Array.isArray(rpc.result?.tools)) return { state: 'ok', toolCount: rpc.result.tools.length };
+		const detail = rpc.error?.message ?? 'Server did not return a tool list';
+		return AUTH_HINT.test(detail) ? { state: 'needs_config', message: detail } : { state: 'error', message: detail };
+	} catch (error) {
+		return { state: 'error', message: error instanceof Error ? error.message : 'Probe failed' };
+	} finally {
+		proc.kill();
+	}
+}
+
+/** Read newline-delimited JSON-RPC from a stream until the response `id` arrives. */
+async function readStdoutForId(stream: ReadableStream<Uint8Array>, id: number, timeoutMs: number): Promise<JsonRpcResponse | null> {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let buffer = '';
+	const deadline = Date.now() + timeoutMs;
+	try {
+		while (Date.now() < deadline) {
+			const remaining = deadline - Date.now();
+			const chunk = await Promise.race([
+				reader.read(),
+				new Promise<{ done: true; value: undefined }>(resolve => setTimeout(() => resolve({ done: true, value: undefined }), remaining))
+			]);
+			if (chunk.done) break;
+			buffer += decoder.decode(chunk.value, { stream: true });
+			let nl: number;
+			while ((nl = buffer.indexOf('\n')) >= 0) {
+				const line = buffer.slice(0, nl).trim();
+				buffer = buffer.slice(nl + 1);
+				if (!line) continue;
+				try {
+					const msg = JSON.parse(line) as JsonRpcResponse & { id?: number };
+					if (msg.id === id) return msg;
+				} catch { /* ignore non-JSON log lines */ }
+			}
+		}
+		return null;
+	} finally {
+		// cancel() (not releaseLock) settles any still-pending read() so this
+		// never throws on an outstanding request.
+		reader.cancel().catch(() => undefined);
+	}
+}
+
+/**
+ * Probe a single resolved server. Remote servers do a network handshake; stdio
+ * servers are spawned and handshaken over stdio so every server reports a real
+ * connection status.
+ */
+export async function probeServer(s: ResolvedExternalServer): Promise<McpHealth> {
+	if (s.transport === 'stdio') return probeStdio(s);
+	if (!s.url) return { state: 'error', message: 'No URL configured' };
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+	const baseHeaders: Record<string, string> = {
+		'Content-Type': 'application/json',
+		Accept: 'application/json, text/event-stream',
+		...s.headers
+	};
+
+	try {
+		// 1. initialize
+		const initRes = await fetch(s.url, {
+			method: 'POST',
+			headers: baseHeaders,
+			signal: controller.signal,
+			body: rpcBody('initialize', 1, {
+				protocolVersion: PROTOCOL_VERSION,
+				capabilities: {},
+				clientInfo: { name: 'clopen-probe', version: '1.0.0' }
+			})
+		});
+
+		if (initRes.status === 401 || initRes.status === 403) {
+			return classifyUnauthorized(initRes);
+		}
+		if (!initRes.ok) {
+			return { state: 'error', message: `Server responded ${initRes.status} ${initRes.statusText}` };
+		}
+
+		const sessionId = initRes.headers.get('mcp-session-id') ?? undefined;
+		await readRpc(initRes); // drain
+		const sessionHeaders = sessionId ? { ...baseHeaders, 'mcp-session-id': sessionId } : baseHeaders;
+
+		// 2. initialized notification (best-effort; some servers require it)
+		await fetch(s.url, {
+			method: 'POST',
+			headers: sessionHeaders,
+			signal: controller.signal,
+			body: rpcBody('notifications/initialized')
+		}).catch(() => undefined);
+
+		// 3. tools/list
+		const listRes = await fetch(s.url, {
+			method: 'POST',
+			headers: sessionHeaders,
+			signal: controller.signal,
+			body: rpcBody('tools/list', 2)
+		});
+
+		if (listRes.status === 401 || listRes.status === 403) {
+			return classifyUnauthorized(listRes);
+		}
+		if (!listRes.ok) {
+			return { state: 'error', message: `Server responded ${listRes.status} ${listRes.statusText}` };
+		}
+
+		const rpc = await readRpc(listRes);
+		if (!rpc) return { state: 'error', message: 'Server returned an unreadable response' };
+
+		// A proper tools/list returns `result.tools`. Servers that gate listing
+		// behind a credential (e.g. trendsmcp) instead return an error result
+		// such as "No API key …" — surface that as needs_auth so the user knows
+		// to add the credential rather than seeing a generic failure.
+		if (Array.isArray(rpc.result?.tools)) {
+			return { state: 'ok', toolCount: rpc.result.tools.length };
+		}
+
+		const detail = rpc.error?.message
+			?? rpc.result?.content?.map(c => c.text).filter(Boolean).join(' ')
+			?? 'Server did not return a tool list';
+		// Listing gated behind a credential (e.g. trendsmcp "No API key …") — the
+		// server is reachable, so this is a missing static credential, not OAuth.
+		if (AUTH_HINT.test(detail)) {
+			return { state: 'needs_config', message: detail };
+		}
+		return { state: 'error', message: detail };
+	} catch (error) {
+		if (error instanceof Error && error.name === 'AbortError') {
+			return { state: 'unreachable', message: `No response within ${PROBE_TIMEOUT_MS / 1000}s` };
+		}
+		debug.warn('mcp', `Probe failed for ${s.slug}:`, error);
+		return { state: 'unreachable', message: error instanceof Error ? error.message : 'Could not reach server' };
+	} finally {
+		clearTimeout(timeout);
+	}
+}

--- a/backend/mcp/index.ts
+++ b/backend/mcp/index.ts
@@ -74,7 +74,18 @@ export {
 
 // External catalog + types (used by the WS layer and Settings → MCP)
 export { listRegistryServers, mapRegistryServer } from './external/registry-client';
-export { getEnabledExternalServers } from './external/config';
+export { getEnabledExternalServers, resolveServerRow, remoteNeedsOAuth } from './external/config';
+export { probeServer } from './external/probe';
+export type { McpHealth, McpHealthState } from './external/probe';
+export {
+	startAuthorization,
+	completeAuthorization,
+	getValidAccessToken,
+	refreshExpiringExternalOAuth,
+	hasPendingFlow,
+	clearOAuth,
+	loadOAuth
+} from './external/oauth';
 export type { CatalogServer, CatalogEnvVar, CatalogPage, ResolvedExternalServer } from './external/types';
 
 // ---------------------------------------------------------------------------

--- a/backend/ws/mcp/crud.ts
+++ b/backend/ws/mcp/crud.ts
@@ -15,7 +15,16 @@ import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { debug } from '$shared/utils/logger';
 import { mcpServerQueries, type McpConfigField, type McpServerRow, type McpTransport } from '$backend/database/queries';
-import { slugifyRegistryName, externalNamespace, refreshInternalEnabledCache } from '$backend/mcp';
+import {
+	slugifyRegistryName,
+	externalNamespace,
+	refreshInternalEnabledCache,
+	probeServer,
+	resolveServerRow,
+	startAuthorization,
+	completeAuthorization,
+	getValidAccessToken
+} from '$backend/mcp';
 
 const TRANSPORT_SCHEMA = t.Union([t.Literal('stdio'), t.Literal('http'), t.Literal('sse')]);
 
@@ -82,6 +91,31 @@ function toDTO(row: McpServerRow) {
 	};
 }
 
+/**
+ * Reject an install/configure that omits a credential the catalog marked
+ * `isRequired`. Without this, a remote server whose auth header (e.g. an API
+ * key or `Authorization` bearer) is left blank installs "successfully" and then
+ * silently fails at connect time on every engine — the exact failure mode that
+ * left `ai-trendsmcp-google-trends` undetectable. OAuth-only servers declare no
+ * required field, so they pass here and are handled by the engine auth flow.
+ */
+function assertRequiredConfig(
+	configSchema: McpConfigField[],
+	env: Record<string, string>,
+	headers: Record<string, string>
+): void {
+	const missing = configSchema
+		.filter(field => field.isRequired)
+		.filter(field => {
+			const source = field.kind === 'header' ? headers : env;
+			return (source[field.name] ?? '').trim() === '';
+		})
+		.map(field => field.name);
+	if (missing.length > 0) {
+		throw new Error(`Missing required configuration: ${missing.join(', ')}`);
+	}
+}
+
 /** Derive a slug that doesn't collide with an already-installed server. */
 function uniqueSlug(base: string): string {
 	const root = slugifyRegistryName(base);
@@ -127,6 +161,7 @@ export const mcpCrudHandler = createRouter()
 		if ((data.transport === 'http' || data.transport === 'sse') && !data.url) {
 			throw new Error('A remote MCP server requires a URL');
 		}
+		assertRequiredConfig(data.configSchema ?? [], data.env ?? {}, data.headers ?? {});
 
 		const slug = uniqueSlug(data.slug || data.name);
 		const row = mcpServerQueries.insert({
@@ -175,9 +210,63 @@ export const mcpCrudHandler = createRouter()
 		// Drop blank values so we never store empty env/header entries.
 		const clean = (obj?: Record<string, string>) =>
 			Object.fromEntries(Object.entries(obj ?? {}).filter(([, v]) => v.trim() !== ''));
-		mcpServerQueries.updateConfig(data.id, clean(data.env), clean(data.headers));
+		const env = clean(data.env);
+		const headers = clean(data.headers);
+		let configSchema: McpConfigField[] = [];
+		try { configSchema = JSON.parse(existing.config_schema); } catch { /* ignore */ }
+		assertRequiredConfig(configSchema, env, headers);
+		mcpServerQueries.updateConfig(data.id, env, headers);
 		debug.log('mcp', `🔧 Updated config for external MCP server: ${existing.slug}`);
 		return { server: toDTO(mcpServerQueries.getById(data.id)!) };
+	})
+	.http('mcp:status', {
+		data: t.Object({ id: t.Number() }),
+		response: t.Object({
+			status: t.Object({
+				state: t.Union([
+					t.Literal('ok'),
+					t.Literal('needs_auth'),
+					t.Literal('needs_config'),
+					t.Literal('unreachable'),
+					t.Literal('error'),
+					t.Literal('local')
+				]),
+				toolCount: t.Optional(t.Number()),
+				message: t.Optional(t.String())
+			})
+		})
+	}, async ({ data }) => {
+		debug.log('path', `mcp:status ${data.id}`);
+		const existing = mcpServerQueries.getById(data.id);
+		if (!existing) throw new Error('MCP server not found');
+		if (existing.source === 'internal') return { status: { state: 'local' as const } };
+		// Refresh a near-expiry OAuth token first so the probe (which reads the
+		// stored bearer) reflects the truly-authenticated state.
+		if (existing.oauth) await getValidAccessToken(existing.id);
+		const status = await probeServer(resolveServerRow(mcpServerQueries.getById(data.id)!));
+		return { status };
+	})
+	.http('mcp:oauth-start', {
+		data: t.Object({ id: t.Number() }),
+		response: t.Object({ authorizationUrl: t.String() })
+	}, async ({ data }) => {
+		debug.log('path', `mcp:oauth-start ${data.id}`);
+		const existing = mcpServerQueries.getById(data.id);
+		if (!existing) throw new Error('MCP server not found');
+		if (existing.transport === 'stdio' || !existing.url) throw new Error('Only remote MCP servers use OAuth sign-in');
+		// Clopen drives the whole OAuth flow; the resulting token is injected into
+		// every engine, so this single sign-in works for Codex/Claude/all engines.
+		return startAuthorization(existing.id, existing.url);
+	})
+	.http('mcp:oauth-complete', {
+		// Manual fallback: the user pastes the full redirected URL (or its
+		// code+state) when the loopback callback could not be reached.
+		data: t.Object({ state: t.String(), code: t.String() }),
+		response: t.Object({ success: t.Boolean() })
+	}, async ({ data }) => {
+		debug.log('path', 'mcp:oauth-complete');
+		await completeAuthorization(data.state, data.code);
+		return { success: true };
 	})
 	.http('mcp:uninstall', {
 		data: t.Object({ id: t.Number() }),

--- a/frontend/components/settings/mcp/McpSettings.svelte
+++ b/frontend/components/settings/mcp/McpSettings.svelte
@@ -9,9 +9,11 @@
 		type CatalogServer,
 		type InstalledMcpServer,
 		type McpConfigField,
+		type McpHealthState,
 		type McpTransport
 	} from '$frontend/stores/features/mcp-servers.svelte';
 	import { debug } from '$shared/utils/logger';
+	import type { IconName } from '$shared/types/ui/icons';
 
 	interface Props {
 		showHeader?: boolean;
@@ -50,6 +52,14 @@
 	let installTarget = $state<CatalogServer | null>(null);
 	let installing = $state(false);
 	let installError = $state<string | null>(null);
+
+	// A remote catalog entry that declares no credential fields almost always
+	// authenticates via OAuth — surface that so the user knows to finish sign-in
+	// from the Installed list after installing.
+	const installNeedsOAuth = $derived(
+		!!installTarget && installTarget.transport !== 'stdio'
+			&& installTarget.envVars.length === 0 && installTarget.headerVars.length === 0
+	);
 
 	// Configure modal (edit env / headers on an installed server)
 	let configTarget = $state<InstalledMcpServer | null>(null);
@@ -100,8 +110,26 @@
 	});
 
 	onMount(() => {
-		mcpServersStore.refreshInstalled();
+		void (async () => {
+			await mcpServersStore.refreshInstalled();
+			mcpServersStore.checkAllStatuses();
+		})();
 	});
+
+	const statuses = $derived(mcpServersStore.statuses);
+	const checking = $derived(mcpServersStore.checking);
+
+	// Visual mapping for a probed connection state.
+	function statusMeta(state: McpHealthState): { label: string; icon: IconName; class: string } {
+		switch (state) {
+			case 'ok': return { label: 'Connected', icon: 'lucide:circle-check', class: 'text-emerald-600 dark:text-emerald-400' };
+			case 'needs_auth': return { label: 'Needs sign-in', icon: 'lucide:lock', class: 'text-amber-600 dark:text-amber-400' };
+			case 'needs_config': return { label: 'Needs setup', icon: 'lucide:key', class: 'text-amber-600 dark:text-amber-400' };
+			case 'unreachable': return { label: 'Unreachable', icon: 'lucide:wifi-off', class: 'text-red-500 dark:text-red-400' };
+			case 'error': return { label: 'Error', icon: 'lucide:triangle-alert', class: 'text-red-500 dark:text-red-400' };
+			case 'local': return { label: 'Connected', icon: 'lucide:circle-check', class: 'text-emerald-600 dark:text-emerald-400' };
+		}
+	}
 
 	function transportLabel(t: string): string {
 		if (t === 'stdio') return 'local (stdio)';
@@ -112,6 +140,17 @@
 	function commandLine(s: { transport: string; command?: string | null; args?: string[]; url?: string | null }): string {
 		if (s.transport === 'stdio') return `${s.command ?? ''} ${(s.args ?? []).join(' ')}`.trim();
 		return s.url ?? '';
+	}
+
+	async function onAuthenticate(server: InstalledMcpServer) {
+		busyId = server.id;
+		try {
+			await mcpServersStore.authenticate(server.id);
+		} catch (error) {
+			debug.error('settings', 'authenticate MCP failed', error);
+		} finally {
+			busyId = null;
+		}
 	}
 
 	async function onToggle(server: InstalledMcpServer) {
@@ -379,6 +418,53 @@
 								{#if server.source !== 'internal'}
 									<p class="text-[11px] text-slate-400 mt-1 truncate">{commandLine(server)}</p>
 								{/if}
+								{#if server.source !== 'internal'}
+									<div class="flex items-center gap-2 mt-2">
+										{#if !server.enabled}
+											<span class="inline-flex items-center gap-1 text-[11px] font-semibold text-slate-400">
+												<Icon name="lucide:ban" class="w-3.5 h-3.5" />
+												Disabled
+											</span>
+										{:else if checking[server.id]}
+											<span class="inline-flex items-center gap-1.5 text-[11px] text-slate-400">
+												<span class="w-3 h-3 border-2 border-slate-300 border-t-transparent rounded-full animate-spin"></span>
+												Checking…
+											</span>
+										{:else if statuses[server.id]}
+											{@const health = statuses[server.id]}
+											{@const meta = statusMeta(health.state)}
+											<span class="inline-flex items-center gap-1 text-[11px] font-semibold {meta.class}" title={health.message ?? ''}>
+												<Icon name={meta.icon} class="w-3.5 h-3.5" />
+												{meta.label}
+											</span>
+											{#if health.state === 'needs_auth'}
+												<button
+													type="button"
+													disabled={busyId === server.id}
+													onclick={() => onAuthenticate(server)}
+													class="text-[11px] font-semibold text-violet-600 hover:text-violet-700 dark:text-violet-400 disabled:opacity-50"
+												>
+													Authenticate
+												</button>
+											{:else if health.state === 'needs_config'}
+												<button
+													type="button"
+													onclick={() => openConfig(server)}
+													class="text-[11px] font-semibold text-violet-600 hover:text-violet-700 dark:text-violet-400"
+												>
+													Configure
+												</button>
+											{/if}
+											<button
+												type="button"
+												onclick={() => mcpServersStore.checkStatus(server.id)}
+												class="text-[11px] text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+											>
+												Re-check
+											</button>
+										{/if}
+									</div>
+								{/if}
 							</div>
 							<div class="flex items-center gap-2 shrink-0">
 								<button
@@ -478,9 +564,6 @@
 								<span class="text-[10px] px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-500">{transportLabel(server.transport)}</span>
 								{#if server.version}
 									<span class="text-[10px] px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-500">v{server.version}</span>
-								{/if}
-								{#if server.envVars.length > 0}
-									<span class="text-[10px] px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-500">{server.envVars.length} config var{server.envVars.length === 1 ? '' : 's'}</span>
 								{/if}
 							</div>
 							{#if server.description}
@@ -607,6 +690,17 @@
 	{#snippet children()}
 		{#if installTarget}
 			<div class="space-y-4 text-sm">
+				{#if installNeedsOAuth}
+					<div class="flex items-start gap-2 p-3 bg-violet-500/5 border border-violet-500/20 rounded-lg text-violet-700 dark:text-violet-300">
+						<Icon name="lucide:lock" class="w-4 h-4 mt-0.5 shrink-0" />
+						<span class="text-xs">
+							This server uses OAuth sign-in. After installing, open it under
+							<span class="font-semibold">Installed</span> and click
+							<span class="font-semibold">Authenticate</span> to connect.
+						</span>
+					</div>
+				{/if}
+
 				{@render configForm()}
 
 				{#if installError}
@@ -633,7 +727,7 @@
 				{/if}
 
 				{#if configTarget.transport !== 'stdio'}
-					<p class="text-[11px] text-slate-400">Uses OAuth (browser sign-in)? Header auth won't apply — leave these blank.</p>
+					<p class="text-[11px] text-slate-400">For OAuth servers, leave these blank and use Authenticate instead — sign-in is managed for you and applied to every engine.</p>
 				{/if}
 			</div>
 		{/if}

--- a/frontend/stores/features/mcp-servers.svelte.ts
+++ b/frontend/stores/features/mcp-servers.svelte.ts
@@ -67,6 +67,15 @@ export interface CatalogServer {
 	packageHint?: string;
 }
 
+/** Connection health classified by the backend probe. */
+export type McpHealthState = 'ok' | 'needs_auth' | 'needs_config' | 'unreachable' | 'error' | 'local';
+
+export interface McpHealth {
+	state: McpHealthState;
+	toolCount?: number;
+	message?: string;
+}
+
 export interface InstallPayload {
 	slug: string;
 	name: string;
@@ -86,6 +95,10 @@ export interface InstallPayload {
 let installed = $state<InstalledMcpServer[]>([]);
 let installedLoaded = $state(false);
 
+// Per-server connection health (keyed by id). `checking` drives the spinner.
+let statuses = $state<Record<number, McpHealth>>({});
+let checking = $state<Record<number, boolean>>({});
+
 let catalog = $state<CatalogServer[]>([]);
 let catalogCursor = $state<string | null>(null);
 let catalogSearch = $state('');
@@ -103,6 +116,8 @@ let catalogReqId = 0;
 export const mcpServersStore = {
 	get installed() { return installed; },
 	get installedLoaded() { return installedLoaded; },
+	get statuses() { return statuses; },
+	get checking() { return checking; },
 	get catalog() { return catalog; },
 	get catalogCursor() { return catalogCursor; },
 	get catalogSearch() { return catalogSearch; },
@@ -157,12 +172,17 @@ export const mcpServersStore = {
 	async install(payload: InstallPayload): Promise<InstalledMcpServer> {
 		const result = await ws.http('mcp:install', payload);
 		await this.refreshInstalled();
+		// Probe the just-installed server so its status shows immediately.
+		this.checkStatus(result.server.id);
 		return result.server;
 	},
 
 	async toggle(id: number, enabled: boolean): Promise<void> {
 		await ws.http('mcp:toggle', { id, enabled });
 		await this.refreshInstalled();
+		// Probe a freshly-enabled server so its connection status appears without a
+		// manual re-check (disabled servers render a static "Disabled" instead).
+		if (enabled) this.checkStatus(id);
 	},
 
 	async updateConfig(id: number, env: Record<string, string>, headers: Record<string, string>): Promise<void> {
@@ -173,6 +193,57 @@ export const mcpServersStore = {
 	async uninstall(id: number): Promise<void> {
 		await ws.http('mcp:uninstall', { id });
 		await this.refreshInstalled();
+	},
+
+	/** Probe one server's connection health and cache the result. */
+	async checkStatus(id: number): Promise<void> {
+		checking = { ...checking, [id]: true };
+		try {
+			const result = await ws.http('mcp:status', { id });
+			statuses = { ...statuses, [id]: result.status };
+		} catch (error) {
+			debug.error('settings', `Failed to probe MCP server ${id}:`, error);
+			statuses = { ...statuses, [id]: { state: 'error', message: 'Status check failed' } };
+		} finally {
+			checking = { ...checking, [id]: false };
+		}
+	},
+
+	/**
+	 * Start the centralized OAuth sign-in: open the authorization URL in a new
+	 * tab (Clopen runs the whole flow and its stable callback stores the token),
+	 * then poll status until the server reports connected. The resulting token is
+	 * injected into every engine, so one sign-in covers all of them.
+	 */
+	async authenticate(id: number): Promise<void> {
+		checking = { ...checking, [id]: true };
+		try {
+			const { authorizationUrl } = await ws.http('mcp:oauth-start', { id });
+			window.open(authorizationUrl, '_blank', 'noopener');
+		} catch (error) {
+			debug.error('settings', `MCP OAuth start failed for ${id}:`, error);
+			statuses = { ...statuses, [id]: { state: 'error', message: error instanceof Error ? error.message : 'Sign-in failed' } };
+			checking = { ...checking, [id]: false };
+			return;
+		}
+		// Poll for completion (the callback stores the token out-of-band).
+		for (let i = 0; i < 60; i++) {
+			await new Promise(resolve => setTimeout(resolve, 2000));
+			try {
+				const result = await ws.http('mcp:status', { id });
+				if (result.status.state !== 'needs_auth') {
+					statuses = { ...statuses, [id]: result.status };
+					break;
+				}
+			} catch { /* keep polling */ }
+		}
+		checking = { ...checking, [id]: false };
+	},
+
+	/** Probe every enabled, non-internal server (used when the panel opens). */
+	async checkAllStatuses(): Promise<void> {
+		const targets = installed.filter(s => s.enabled && s.source !== 'internal');
+		await Promise.all(targets.map(s => this.checkStatus(s.id)));
 	},
 
 	// ========================================================================
@@ -228,6 +299,8 @@ export const mcpServersStore = {
 	reset() {
 		installed = [];
 		installedLoaded = false;
+		statuses = {};
+		checking = {};
 		catalog = [];
 		catalogCursor = null;
 		catalogSearch = '';


### PR DESCRIPTION
Remote MCP servers needing auth failed silently on non-Claude engines: OAuth was delegated per-engine (only OpenCode could sign in, and its token never reached Codex/Claude/others), missing API keys were never caught at install, and nothing surfaced the failure in Settings.

Clopen now acts as the OAuth client itself and shows real connection status for every installed server.

Centralized OAuth
- Discovery (RFC 9728/8414) + dynamic client registration (RFC 7591) + authorization-code with PKCE, driven by Clopen.
- Stable callback at GET /api/mcp/oauth/callback (no ephemeral loopback); tokens stored in mcp_servers.oauth (migration 042).
- Access token injected as Authorization: Bearer into every engine and refreshed at stream start. Codex receives it via http_headers (its streamable_http rejects inline bearer_token), matching the internal bridge; OpenCode/Copilot/Qwen use their existing headers field.

Validation
- Reject install/configure when a registry-required credential is blank.

Connection status
- Engine-agnostic probe (initialize + tools/list; stdio servers spawned) classifies ok / needs_auth (OAuth) / needs_config (API key) / unreachable / error.
- Settings shows a consistent status line per server with Authenticate (OAuth) or Configure (API key) and Re-check, probed on open, after install, and after enabling. Install modal flags OAuth servers upfront.

Docs
- backend/mcp/README.md: external servers, centralized OAuth, per-engine header field table, probe states.
- engine docs: lessons-learned §9.18 and adding-an-engine checklist so new adapters forward auth headers and avoid the bearer_token mistake.