### PR TITLE
feat(mcp): edit stdio command/args and surface real probe errors

### DIFF
--- a/backend/database/queries/mcp-server-queries.ts
+++ b/backend/database/queries/mcp-server-queries.ts
@@ -143,6 +143,20 @@ export const mcpServerQueries = {
 		);
 	},
 
+	/**
+	 * Update a stdio server's command + args. Lets users repair incomplete
+	 * registry metadata (e.g. a CLI that needs a `mcp` subcommand to start) that
+	 * would otherwise leave the server permanently unreachable.
+	 */
+	updateCommand(id: number, command: string, args: string[]): void {
+		const db = getDatabase();
+		db.prepare(`UPDATE mcp_servers SET command = ?, args = ? WHERE id = ?`).run(
+			command,
+			JSON.stringify(args),
+			id
+		);
+	},
+
 	/** Store (or clear with null) the managed OAuth state JSON for a server. */
 	setOAuth(id: number, oauth: string | null): void {
 		const db = getDatabase();

--- a/backend/mcp/external/probe.ts
+++ b/backend/mcp/external/probe.ts
@@ -87,6 +87,31 @@ function classifyUnauthorized(res: Response): McpHealth {
 	return { state: 'needs_config', message: 'A credential (API key / token) is required' };
 }
 
+/** Cap on captured stderr so a chatty subprocess can't balloon memory. */
+const STDERR_CAP = 4000;
+
+/** Drain a subprocess's stderr into a bounded string (best-effort). */
+async function drainStderr(stream: ReadableStream<Uint8Array>): Promise<string> {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let text = '';
+	try {
+		while (text.length < STDERR_CAP) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			text += decoder.decode(value, { stream: true });
+		}
+	} catch { /* stream closed/cancelled */ } finally {
+		reader.cancel().catch(() => undefined);
+	}
+	return text;
+}
+
+/** Condense captured stderr into a short, single-line diagnostic. */
+function stderrTail(text: string): string {
+	return text.replace(/\s+/g, ' ').trim().slice(0, 300);
+}
+
 /**
  * Spawn a stdio server and run the same handshake over its stdin/stdout
  * (newline-delimited JSON-RPC) so "local" servers report a real connection
@@ -100,12 +125,17 @@ async function probeStdio(s: ResolvedExternalServer): Promise<McpHealth> {
 		proc = Bun.spawn([s.command, ...s.args], {
 			stdin: 'pipe',
 			stdout: 'pipe',
-			stderr: 'ignore',
+			stderr: 'pipe',
 			env: { ...process.env, ...s.env }
 		});
 	} catch (error) {
 		return { state: 'unreachable', message: error instanceof Error ? error.message : 'Failed to start command' };
 	}
+
+	// Capture stderr concurrently so a process that prints usage/errors and then
+	// exits (e.g. a CLI that needs a `mcp` subcommand to actually start the
+	// server) yields an actionable message instead of a misleading timeout.
+	const stderrPromise = drainStderr(proc.stderr as unknown as ReadableStream<Uint8Array>);
 
 	try {
 		const stdin = proc.stdin as unknown as { write(data: Uint8Array): number; flush?(): Promise<number> | number };
@@ -117,10 +147,30 @@ async function probeStdio(s: ResolvedExternalServer): Promise<McpHealth> {
 		await stdin.flush?.();
 
 		const rpc = await readStdoutForId(stdout, 2, STDIO_PROBE_TIMEOUT_MS);
-		if (!rpc) return { state: 'unreachable', message: `No response within ${STDIO_PROBE_TIMEOUT_MS / 1000}s` };
-		if (Array.isArray(rpc.result?.tools)) return { state: 'ok', toolCount: rpc.result.tools.length };
-		const detail = rpc.error?.message ?? 'Server did not return a tool list';
-		return AUTH_HINT.test(detail) ? { state: 'needs_config', message: detail } : { state: 'error', message: detail };
+		if (rpc) {
+			if (Array.isArray(rpc.result?.tools)) return { state: 'ok', toolCount: rpc.result.tools.length };
+			const detail = rpc.error?.message ?? 'Server did not return a tool list';
+			return AUTH_HINT.test(detail) ? { state: 'needs_config', message: detail } : { state: 'error', message: detail };
+		}
+
+		// No JSON-RPC reply. Distinguish a process that already exited (a real,
+		// reportable error — wrong command, missing subcommand, crash) from one
+		// that's still alive but silent (a genuine timeout).
+		const exitCode = await Promise.race([
+			proc.exited,
+			new Promise<number | null>(resolve => setTimeout(() => resolve(null), 250))
+		]);
+		if (exitCode !== null) {
+			const tail = stderrTail(await Promise.race([
+				stderrPromise,
+				new Promise<string>(resolve => setTimeout(() => resolve(''), 200))
+			]));
+			const detail = tail
+				? `Process exited (code ${exitCode}): ${tail}`
+				: `Process exited (code ${exitCode}) before responding`;
+			return AUTH_HINT.test(detail) ? { state: 'needs_config', message: detail } : { state: 'error', message: detail };
+		}
+		return { state: 'unreachable', message: `No response within ${STDIO_PROBE_TIMEOUT_MS / 1000}s` };
 	} catch (error) {
 		return { state: 'error', message: error instanceof Error ? error.message : 'Probe failed' };
 	} finally {

--- a/backend/mcp/external/registry-client.ts
+++ b/backend/mcp/external/registry-client.ts
@@ -109,7 +109,14 @@ function resolveStdioPackage(pkg: RegistryPackage): { command: string; args: str
 	if (!command || !pkg.identifier) return null;
 
 	const args: string[] = [];
-	for (const a of pkg.runtimeArguments ?? []) args.push(...argTokens(a));
+	const runtimeArgs = pkg.runtimeArguments ?? [];
+	// `npx` prompts before fetching an uncached package; `-y` keeps the
+	// non-interactive spawn (health probe + engine) from stalling on that prompt.
+	// Skip if the registry already supplies a confirm flag.
+	if (/(^|\/)npx$/.test(command) && !runtimeArgs.some(a => a.name === '-y' || a.name === '--yes')) {
+		args.push('-y');
+	}
+	for (const a of runtimeArgs) args.push(...argTokens(a));
 
 	// Package identifier token (with version for npm-style registries).
 	const identifier = pkg.version && pkg.registryType === 'npm'

--- a/backend/ws/mcp/crud.ts
+++ b/backend/ws/mcp/crud.ts
@@ -199,7 +199,11 @@ export const mcpCrudHandler = createRouter()
 		data: t.Object({
 			id: t.Number(),
 			env: t.Optional(t.Record(t.String(), t.String())),
-			headers: t.Optional(t.Record(t.String(), t.String()))
+			headers: t.Optional(t.Record(t.String(), t.String())),
+			// stdio only: repair an incomplete registry command (e.g. a missing
+			// `mcp` subcommand). Ignored for remote servers.
+			command: t.Optional(t.String()),
+			args: t.Optional(t.Array(t.String()))
 		}),
 		response: t.Object({ server: INSTALLED_SERVER_SCHEMA })
 	}, async ({ data }) => {
@@ -216,6 +220,13 @@ export const mcpCrudHandler = createRouter()
 		try { configSchema = JSON.parse(existing.config_schema); } catch { /* ignore */ }
 		assertRequiredConfig(configSchema, env, headers);
 		mcpServerQueries.updateConfig(data.id, env, headers);
+		// Persist an edited command/args for stdio servers (drop blank arg tokens).
+		if (existing.transport === 'stdio' && (data.command !== undefined || data.args !== undefined)) {
+			const command = (data.command ?? existing.command ?? '').trim();
+			if (!command) throw new Error('A stdio MCP server requires a command');
+			const args = (data.args ?? []).map(a => a.trim()).filter(a => a !== '');
+			mcpServerQueries.updateCommand(data.id, command, args);
+		}
 		debug.log('mcp', `🔧 Updated config for external MCP server: ${existing.slug}`);
 		return { server: toDTO(mcpServerQueries.getById(data.id)!) };
 	})

--- a/frontend/components/settings/mcp/McpSettings.svelte
+++ b/frontend/components/settings/mcp/McpSettings.svelte
@@ -72,6 +72,8 @@
 	let cfgDraft = $state<Record<string, string>>({}); // field name → value
 	let cfgCustomEnv = $state<{ key: string; value: string }[]>([]); // user-added env vars
 	let cfgCustomHeader = $state<{ key: string; value: string }[]>([]); // user-added headers
+	let cfgCommand = $state(''); // stdio command (Configure only)
+	let cfgArgsText = $state(''); // stdio args, one per line (Configure only)
 
 	// Group by source (env vars vs headers), not by required/optional — the
 	// per-field "*" marks what's required within each group.
@@ -233,6 +235,8 @@
 		cfgDraft = {};
 		cfgCustomEnv = [];
 		cfgCustomHeader = [];
+		cfgCommand = '';
+		cfgArgsText = '';
 	}
 
 	// --- Install flow (modal + confirmation) ---
@@ -250,6 +254,10 @@
 		]);
 		cfgCustomEnv = [];
 		cfgCustomHeader = [];
+		// Pre-fill the stdio launch command so users can repair incomplete registry
+		// metadata (e.g. a missing `mcp` subcommand) before the server is installed.
+		cfgCommand = server.command ?? '';
+		cfgArgsText = (server.args ?? []).join('\n');
 	}
 
 	function closeInstall() {
@@ -265,6 +273,11 @@
 			installError = `Required: ${cfgMissingRequired.map(m => m.name).join(', ')}`;
 			return;
 		}
+		const isStdio = server.transport === 'stdio';
+		if (isStdio && !cfgCommand.trim()) {
+			installError = 'A local (stdio) server requires a command';
+			return;
+		}
 		installing = true;
 		installError = null;
 		try {
@@ -276,8 +289,8 @@
 				registryName: server.registryName,
 				version: server.version,
 				transport: server.transport,
-				command: server.command,
-				args: server.args,
+				command: isStdio ? cfgCommand.trim() : server.command,
+				args: isStdio ? cfgArgsText.split('\n').map(a => a.trim()).filter(Boolean) : server.args,
 				url: server.url,
 				env,
 				headers,
@@ -304,6 +317,10 @@
 		cfgDraft = Object.fromEntries(
 			schema.map(f => [f.name, (f.kind === 'header' ? server.headers[f.name] : server.env[f.name]) ?? ''])
 		);
+		// stdio command/args are editable here so users can repair incomplete
+		// registry metadata (e.g. a missing `mcp` subcommand).
+		cfgCommand = server.command ?? '';
+		cfgArgsText = (server.args ?? []).join('\n');
 		// Stored keys NOT declared by the registry are user-added — show them,
 		// pre-filled, in the Custom sections so they're clearly distinct.
 		const knownEnv = new Set(schema.filter(f => f.kind === 'env').map(f => f.name));
@@ -324,9 +341,16 @@
 		savingConfig = true;
 		try {
 			const { env, headers } = collectConfig();
-			await mcpServersStore.updateConfig(server.id, env, headers);
+			const isStdio = server.transport === 'stdio';
+			const command = isStdio ? cfgCommand.trim() : undefined;
+			const args = isStdio ? cfgArgsText.split('\n').map(a => a.trim()).filter(Boolean) : undefined;
+			await mcpServersStore.updateConfig(server.id, env, headers, command, args);
 			mcpServersStore.hasPendingChanges = true;
+			const id = server.id;
 			closeConfig();
+			// Auto re-probe so the new status reflects whatever was edited, without
+			// a manual Re-check.
+			void mcpServersStore.checkStatus(id);
 		} catch (error) {
 			debug.error('settings', 'update MCP config failed', error);
 		} finally {
@@ -647,8 +671,26 @@
 	<Button variant="ghost" size="sm" onclick={onAdd}>{addLabel}</Button>
 {/snippet}
 
-{#snippet configForm()}
+{#snippet configForm(allowCommandEdit: boolean)}
 	<div class="space-y-5">
+		{#if allowCommandEdit && cfgTransport === 'stdio'}
+			<div class="space-y-3">
+				<div class="space-y-1">
+					<Input label="Command" type="text" placeholder="npx" bind:value={cfgCommand} />
+				</div>
+				<div class="space-y-1">
+					<p class="text-xs font-semibold text-slate-400 dark:text-slate-500">Arguments</p>
+					<textarea
+						bind:value={cfgArgsText}
+						rows="3"
+						placeholder={'-y\nxcodebuildmcp\nmcp'}
+						class="w-full px-3 py-2 text-sm font-mono bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg outline-none focus:ring-2 focus:ring-violet-500/20 focus:border-violet-600 transition-colors text-slate-900 dark:text-slate-100 placeholder-slate-400 resize-y"
+					></textarea>
+					<p class="text-[11px] text-slate-400">One argument per line, in order.</p>
+				</div>
+				<div class="border-t border-slate-300 dark:border-slate-600"></div>
+			</div>
+		{/if}
 		{#if showEnvSection}
 			<div class="space-y-5">
 				{#if cfgEnvFields.length > 0}
@@ -701,7 +743,7 @@
 					</div>
 				{/if}
 
-				{@render configForm()}
+				{@render configForm(true)}
 
 				{#if installError}
 					<p class="text-xs text-red-500">{installError}</p>
@@ -711,7 +753,7 @@
 	{/snippet}
 	{#snippet footer()}
 		<Button variant="ghost" onclick={closeInstall}>Cancel</Button>
-		<Button variant="primary" loading={installing} disabled={cfgMissingRequired.length > 0} onclick={confirmInstall}>Install</Button>
+		<Button variant="primary" loading={installing} disabled={cfgMissingRequired.length > 0 || (installTarget?.transport === 'stdio' && !cfgCommand.trim())} onclick={confirmInstall}>Install</Button>
 	{/snippet}
 </Modal>
 
@@ -720,7 +762,7 @@
 	{#snippet children()}
 		{#if configTarget}
 			<div class="space-y-4 text-sm">
-				{@render configForm()}
+				{@render configForm(true)}
 
 				{#if cfgMissingRequired.length > 0}
 					<p class="text-xs text-red-500">Required: {cfgMissingRequired.map(m => m.name).join(', ')}</p>
@@ -734,7 +776,7 @@
 	{/snippet}
 	{#snippet footer()}
 		<Button variant="ghost" onclick={closeConfig}>Cancel</Button>
-		<Button variant="primary" loading={savingConfig} disabled={cfgMissingRequired.length > 0} onclick={saveConfig}>Save</Button>
+		<Button variant="primary" loading={savingConfig} disabled={cfgMissingRequired.length > 0 || (configTarget?.transport === 'stdio' && !cfgCommand.trim())} onclick={saveConfig}>Save</Button>
 	{/snippet}
 </Modal>
 

--- a/frontend/stores/features/mcp-servers.svelte.ts
+++ b/frontend/stores/features/mcp-servers.svelte.ts
@@ -185,8 +185,20 @@ export const mcpServersStore = {
 		if (enabled) this.checkStatus(id);
 	},
 
-	async updateConfig(id: number, env: Record<string, string>, headers: Record<string, string>): Promise<void> {
-		await ws.http('mcp:update-config', { id, env, headers });
+	async updateConfig(
+		id: number,
+		env: Record<string, string>,
+		headers: Record<string, string>,
+		command?: string,
+		args?: string[]
+	): Promise<void> {
+		await ws.http('mcp:update-config', {
+			id,
+			env,
+			headers,
+			...(command !== undefined ? { command } : {}),
+			...(args !== undefined ? { args } : {})
+		});
 		await this.refreshInstalled();
 	},
 


### PR DESCRIPTION
External MCP servers from the registry sometimes ship incomplete launch metadata. com.xcodebuildmcp/XcodeBuildMCP v2.6.2, for example, declares no package arguments, so Clopen ran `npx xcodebuildmcp@2.6.2` — which only prints usage and exits, since the server needs the `mcp` subcommand. The probe reported a misleading "Unreachable / no response" and there was no way to fix the command from the UI.

- Configure and Install modals can now edit a stdio server's command and args (one argument per line), so users can repair incomplete registry metadata. Saving in Configure auto re-probes the server.
- Probe captures the subprocess stderr and distinguishes a process that exited early (reported as an actionable error with the stderr tail) from one that is still running but silent (a genuine timeout).
- Inject `-y` for npx-based packages so the non-interactive spawn never stalls on a confirmation prompt.