### PR TITLE
feat(compact): enhance compact tool rows with ANSI rendering and folder icons

### DIFF
--- a/frontend/components/auth/SetupPage.svelte
+++ b/frontend/components/auth/SetupPage.svelte
@@ -677,11 +677,28 @@
 									? 'border-violet-500 bg-violet-500/5'
 									: 'border-slate-200 dark:border-slate-700 hover:border-violet-500/40'}"
 							>
-								<div class="flex flex-col gap-1 rounded bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 p-1.5 h-10 overflow-hidden">
-									<div class="w-3/4 h-0.5 rounded-full bg-slate-200 dark:bg-slate-700"></div>
-									<div class="w-full h-0.5 rounded-full bg-slate-200 dark:bg-slate-700"></div>
-									<div class="w-2/3 h-0.5 rounded-full bg-slate-200 dark:bg-slate-700"></div>
-									<div class="w-full h-0.5 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+								<div class="relative flex flex-col gap-[3px] rounded bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 p-1.5 h-10 overflow-hidden">
+									<!-- Bold summary header -->
+									<div class="w-4/5 h-0.5 rounded-full bg-slate-300 dark:bg-slate-600"></div>
+									<!-- Timeline body: vertical rail runs behind the icon nodes -->
+									<div class="relative flex flex-col gap-[3px]">
+										<div class="absolute top-[2px] bottom-[2px] left-[1px] w-[2px] rounded-full bg-slate-300 dark:bg-slate-600"></div>
+										<!-- Edited row -->
+										<div class="relative flex items-center gap-1">
+											<span class="relative z-10 w-1 h-1 rounded-[1px] bg-slate-400 dark:bg-slate-500 shrink-0"></span>
+											<div class="w-2/5 h-0.5 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+										</div>
+										<!-- Wrote row -->
+										<div class="relative flex items-center gap-1">
+											<span class="relative z-10 w-1 h-1 rounded-[1px] bg-slate-400 dark:bg-slate-500 shrink-0"></span>
+											<div class="w-1/5 h-0.5 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+										</div>
+										<!-- Read row -->
+										<div class="relative flex items-center gap-1">
+											<span class="relative z-10 w-1 h-1 rounded-[1px] bg-slate-400 dark:bg-slate-500 shrink-0"></span>
+											<div class="w-1/2 h-0.5 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+										</div>
+									</div>
 								</div>
 								<div class="flex items-center justify-between">
 									<span class="text-xs font-semibold text-slate-900 dark:text-slate-100">Compact</span>
@@ -689,7 +706,7 @@
 										<Icon name="lucide:circle-check" class="w-3.5 h-3.5 text-violet-500" />
 									{/if}
 								</div>
-								<span class="text-2xs text-slate-500 dark:text-slate-400">Dense lines, no borders or cards</span>
+								<span class="text-2xs text-slate-500 dark:text-slate-400">Dense rows linked by a timeline rail</span>
 							</button>
 						</div>
 					</div>

--- a/frontend/components/chat/message/ChatMessage.svelte
+++ b/frontend/components/chat/message/ChatMessage.svelte
@@ -30,10 +30,14 @@
 
 	const {
 		message,
-		isLastUserMessage = false
+		isLastUserMessage = false,
+		railConnectUp = false,
+		railConnectDown = false
 	}: {
 		message: FrontendMessage;
 		isLastUserMessage?: boolean;
+		railConnectUp?: boolean;
+		railConnectDown?: boolean;
 	} = $props();
 
 	// Modal states
@@ -88,6 +92,13 @@
 
 	// Get sender info
 	const senderName = $derived(message.type === 'user' ? message.sender?.name ?? null : null);
+
+	// Whether this message participates in the compact timeline rail.
+	// Mirrors isRailRole() in ChatMessages so per-message rendering and the
+	// neighbour connection flags stay in sync (excludes empty user+toolResult rows).
+	const isRailMessage = $derived(
+		roleCategory === 'reasoning' || (roleCategory === 'agent' && message.type === 'assistant')
+	);
 
 	// Copy message content to clipboard (content text only, not full JSON)
 	function copyToClipboard() {
@@ -377,12 +388,18 @@
 
 {#if settings.chatAppearance === 'compact'}
 	<div
-		class="group transition-opacity py-1 {shouldBeDimmed ? 'opacity-40 cursor-not-allowed pointer-events-none' : ''}"
+		class="group transition-opacity py-1 relative isolate {shouldBeDimmed ? 'opacity-40 cursor-not-allowed pointer-events-none' : ''}"
 		onclick={handleMessageClick}
 		role="button"
 		tabindex="0"
 		onkeydown={handleBubbleKeydown}
 	>
+		{#if isRailMessage}
+			<!-- Continuous timeline rail — bridges the gap to adjacent rail messages -->
+			<div
+				class="absolute -z-10 w-px bg-slate-200 dark:bg-slate-700/60 left-[7px] {railConnectUp ? 'top-0' : 'top-[14px]'} {railConnectDown ? '-bottom-2' : 'bottom-[10px]'}"
+			></div>
+		{/if}
 		<MessageBubbleCompact
 			{message}
 			{messageTimestamp}

--- a/frontend/components/chat/message/ChatMessages.svelte
+++ b/frontend/components/chat/message/ChatMessages.svelte
@@ -71,6 +71,34 @@
 		return addDateSeparators(windowedMessages, vs.isActive ? vs.windowStart : 0);
 	});
 
+	// Whether a message participates in the compact timeline rail (agent / reasoning)
+	function isRailRole(message: any): boolean {
+		if (!message) return false;
+		if (message.type === 'reasoning') return true;
+		if (message.type === 'stream_event') return Boolean(message.reasoning);
+		if (message.type === 'assistant' && Array.isArray(message.content)) {
+			return message.content.some((c: any) => c.type === 'tool_use');
+		}
+		return false;
+	}
+
+	// Per-message rail connection flags (whether to bridge the rail up/down to neighbours)
+	const railFlagsByKey = $derived.by(() => {
+		const items = messagesWithDateSeparators;
+		const map = new Map<string, { up: boolean; down: boolean }>();
+		for (let i = 0; i < items.length; i++) {
+			const it = items[i];
+			if (it.type !== 'message') continue;
+			if (!isRailRole(it.data)) continue;
+			const prev = items[i - 1];
+			const next = items[i + 1];
+			const up = prev?.type === 'message' && isRailRole(prev.data);
+			const down = next?.type === 'message' && isRailRole(next.data);
+			map.set(it.key, { up, down });
+		}
+		return map;
+	});
+
 	// Get last user message ID for undo button logic
 	const lastUserMessageId = $derived.by(() => {
 		const userMessages = filteredMessages.filter(m => m.type === 'user');
@@ -721,8 +749,9 @@
 					{:else if item.type === 'message'}
 						{@const messageId = 'messageId' in item.data ? item.data.messageId : undefined}
 						{@const isLastUser = messageId === lastUserMessageId}
+						{@const rail = railFlagsByKey.get(item.key)}
 						<div class={isCompact ? 'mb-2' : 'mb-2 lg:mb-4'} data-message-id={messageId}>
-							<ChatMessage message={item.data} isLastUserMessage={isLastUser} />
+							<ChatMessage message={item.data} isLastUserMessage={isLastUser} railConnectUp={rail?.up ?? false} railConnectDown={rail?.down ?? false} />
 						</div>
 					{/if}
 				</div>
@@ -734,8 +763,9 @@
 					{:else if item.type === 'message'}
 						{@const messageId = 'messageId' in item.data ? item.data.messageId : undefined}
 						{@const isLastUser = messageId === lastUserMessageId}
+						{@const rail = railFlagsByKey.get(item.key)}
 						<div class={isCompact ? 'mb-2' : 'mb-2 lg:mb-4'} data-message-id={messageId}>
-							<ChatMessage message={item.data} isLastUserMessage={isLastUser} />
+							<ChatMessage message={item.data} isLastUserMessage={isLastUser} railConnectUp={rail?.up ?? false} railConnectDown={rail?.down ?? false} />
 						</div>
 					{/if}
 				</div>

--- a/frontend/components/chat/message/variants/compact/MessageBubble.svelte
+++ b/frontend/components/chat/message/variants/compact/MessageBubble.svelte
@@ -203,7 +203,7 @@
 		<!-- ── Summary / header row (first text block or fallback) ──────────── -->
 		<button
 			type="button"
-			class="w-full flex items-start gap-1.5 min-w-0 text-left bg-transparent border-none cursor-pointer py-0.5 group/header {summaryFirstWord ? '' : 'hidden'}"
+			class="w-full flex items-start gap-1.5 min-w-0 pl-[22px] text-left bg-transparent border-none cursor-pointer py-0.5 group/header {summaryFirstWord ? '' : 'hidden'}"
 			onclick={() => isCollapsed = !isCollapsed}
 		>
 			<span class="flex-1 min-w-0 text-[13px] text-slate-800 dark:text-slate-200 font-normal leading-snug">
@@ -231,12 +231,10 @@
 					<div class="relative">
 						{#if item.type === 'tool_use'}
 							<!-- Tool item -->
-							<div class="py-[1px]">
-								<Tools toolInput={item as any} />
-							</div>
+							<Tools toolInput={item as any} />
 						{:else if item.type === 'text'}
-							<!-- Text / bullet block inline in timeline -->
-							<div class="py-[3px] pl-0.5">
+							<!-- Text / bullet block inline in timeline — aligned with tool content -->
+							<div class="py-[3px] pl-[22px]">
 								<div class="text-[12px] text-slate-600 dark:text-slate-300 leading-relaxed prose-compact">
 									<TextMessage content={item.text as string} />
 								</div>
@@ -257,12 +255,15 @@
 		class="text-slate-900 dark:text-slate-100 {roleCategory === 'system' ? 'max-h-48 overflow-y-auto' : ''}"
 	>
 		{#if roleCategory === 'reasoning'}
-			<div class="text-xs text-slate-400 dark:text-slate-500">
-				{#if isThinkingInProgress}
-					<span>Thinking{thinkingDots}</span>
-				{:else}
-					<span>Thought for a moment</span>
-				{/if}
+			<!-- Reasoning row — same icon, indent, color and font as the tool rows -->
+			<div class="flex items-start gap-2 py-[2px] min-w-0">
+				<span class="relative shrink-0 w-[14px] mt-[1px] flex items-center justify-center text-slate-500 dark:text-slate-400 z-10">
+					<span class="absolute inset-0 -m-[3px] rounded bg-slate-50 dark:bg-slate-900"></span>
+					<Icon name="lucide:sparkles" class="relative w-[13px] h-[13px]" />
+				</span>
+				<span class="text-[12px] text-slate-500 dark:text-slate-400">
+					{#if isThinkingInProgress}Thinking{thinkingDots}{:else}Thought for a moment{/if}
+				</span>
 			</div>
 		{:else}
 			<MessageFormatter {message} />

--- a/frontend/components/chat/message/variants/compact/MessageBubble.svelte
+++ b/frontend/components/chat/message/variants/compact/MessageBubble.svelte
@@ -1,6 +1,8 @@
 <!--
   Compact Message Bubble
-  No header for most types — user messages show a slim header row.
+  - User: slim rounded card
+  - Agent: inline timeline with bold summary header + ALL items (tools + text) connected
+  - Assistant/Reasoning: plain text
 -->
 
 <script lang="ts">
@@ -9,7 +11,11 @@
 	import type { IconName } from '$shared/types/ui/icons';
 	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import MessageFormatter from '../../../formatters/MessageFormatter.svelte';
+	import Tools from '../../../formatters/Tools.svelte';
+	import TextMessage from '../../../formatters/TextMessage.svelte';
 	import { appState } from '$frontend/stores/core/app.svelte';
+	import { HIDDEN_TOOLS } from '../../../tools/registry';
+	import type { KnownToolName } from '$shared/types/unified';
 
 	const {
 		message,
@@ -39,6 +45,7 @@
 	let scrollContainer: HTMLDivElement | undefined = $state();
 	let isCopied = $state(false);
 	let stickToBottom = $state(true);
+	let isCollapsed = $state(false);
 
 	function handleCopy() {
 		onCopy();
@@ -83,16 +90,71 @@
 		return () => clearInterval(interval);
 	});
 	const thinkingDots = $derived('.'.repeat(thinkingDotCount));
+
+	// ─── Agent message parsing ─────────────────────────────────────────────────
+	type ContentItem = { type: string; id?: string; [key: string]: any };
+
+	/** All content items in original order, skipping hidden tools */
+	const agentItems = $derived.by(() => {
+		if (roleCategory !== 'agent') return [] as ContentItem[];
+		if (message.type !== 'assistant' || !('content' in message)) return [] as ContentItem[];
+		return (message.content as ContentItem[]).filter(item => {
+			if (item.type === 'tool_use') {
+				// Skip tools that are hidden from the stream
+				return !HIDDEN_TOOLS.has(item.name as KnownToolName);
+			}
+			if (item.type === 'text') {
+				return (item.text as string || '').trim().length > 0;
+			}
+			return false;
+		});
+	});
+
+	/** First text block used as summary header */
+	const firstTextItem = $derived(agentItems.find(i => i.type === 'text'));
+	const summaryText = $derived((firstTextItem?.text as string || '').trim());
+	const summaryFirstWord = $derived(summaryText.split(/\s+/)[0] || '');
+	const summaryRest = $derived.by(() => {
+		const spaceIdx = summaryText.indexOf(' ');
+		return spaceIdx >= 0 ? summaryText.slice(spaceIdx) : '';
+	});
+
+	/** All items AFTER the first text block go into the timeline body */
+	const timelineItems = $derived.by(() => {
+		const firstTextIdx = agentItems.findIndex(i => i.type === 'text');
+		// If there's a leading text block, show rest in timeline; otherwise show all
+		return firstTextIdx >= 0 ? agentItems.slice(firstTextIdx + 1) : agentItems;
+	});
+
+	/** Aggregate diff across edit/write tools */
+	const agentDiff = $derived.by(() => {
+		let additions = 0;
+		let deletions = 0;
+		for (const item of agentItems) {
+			if (item.type !== 'tool_use') continue;
+			if (item.name === 'Edit' || item.name === 'Patch') {
+				const inp = item.input || {};
+				if (inp.newString) additions += (inp.newString as string).split('\n').length;
+				if (inp.oldString) deletions += (inp.oldString as string).split('\n').length;
+			}
+			if (item.name === 'Write') {
+				const inp = item.input || {};
+				if (inp.content) additions += (inp.content as string).split('\n').length;
+			}
+		}
+		return { additions, deletions };
+	});
+
+	const hasDiff = $derived(agentDiff.additions > 0 || agentDiff.deletions > 0);
+	const totalItems = $derived(agentItems.length);
 </script>
 
 {#if roleCategory === 'user'}
+	<!-- User message: slim rounded card -->
 	<div class="space-y-1 rounded-sm px-3 py-2 bg-slate-100 dark:bg-slate-700/30">
-		<!-- Slim user header -->
 		<div class="flex items-center gap-2 text-xs text-slate-400 dark:text-slate-500">
 			<span class="shrink-0">{formatTime(messageTimestamp)}</span>
-			<span class="font-medium text-slate-500 dark:text-slate-400 truncate">
-				{senderName || 'You'}
-			</span>
+			<span class="font-medium text-slate-500 dark:text-slate-400 truncate">{senderName || 'You'}</span>
 			<div class="flex items-center gap-1 ml-auto shrink-0">
 				<button
 					type="button"
@@ -124,16 +186,71 @@
 				</button>
 			</div>
 		</div>
-		<!-- Message content -->
 		<div class="text-slate-900 dark:text-slate-100">
 			<MessageFormatter {message} />
 		</div>
 	</div>
+
 {:else if roleCategory === 'compact'}
 	<div class="text-xs text-slate-400 dark:text-slate-500">
 		<span>Context compacted{compactTrigger ? ` (${compactTrigger})` : ''}</span>
 	</div>
+
+{:else if roleCategory === 'agent'}
+	<!-- Agent: inline timeline layout — ONE connected vertical line for everything -->
+	<div class="min-w-0">
+
+		<!-- ── Summary / header row (first text block or fallback) ──────────── -->
+		<button
+			type="button"
+			class="w-full flex items-start gap-1.5 min-w-0 text-left bg-transparent border-none cursor-pointer py-0.5 group/header {summaryFirstWord ? '' : 'hidden'}"
+			onclick={() => isCollapsed = !isCollapsed}
+		>
+			<span class="flex-1 min-w-0 text-[13px] text-slate-800 dark:text-slate-200 font-normal leading-snug">
+				<strong class="font-semibold">{summaryFirstWord}</strong>{summaryRest}
+			</span>
+			{#if hasDiff}
+				<span class="flex items-center gap-1 shrink-0 mt-0.5">
+					{#if agentDiff.additions > 0}
+						<span class="text-[11px] font-semibold text-emerald-500 dark:text-emerald-400">+{agentDiff.additions}</span>
+					{/if}
+					{#if agentDiff.deletions > 0}
+						<span class="text-[11px] font-semibold text-red-500 dark:text-red-400">-{agentDiff.deletions}</span>
+					{/if}
+				</span>
+			{/if}
+			<Icon
+				name={isCollapsed ? 'lucide:chevron-right' : 'lucide:chevron-down'}
+				class="w-3.5 h-3.5 text-slate-400 dark:text-slate-500 shrink-0 mt-0.5 opacity-50 group-hover/header:opacity-100 transition-opacity"
+			/>
+		</button>
+
+		{#if (!isCollapsed || !summaryFirstWord) && timelineItems.length > 0}
+			<div class="relative mt-0.5">
+				{#each timelineItems as item, i (item.id ?? `item-${i}`)}
+					<div class="relative">
+						{#if item.type === 'tool_use'}
+							<!-- Tool item -->
+							<div class="py-[1px]">
+								<Tools toolInput={item as any} />
+							</div>
+						{:else if item.type === 'text'}
+							<!-- Text / bullet block inline in timeline -->
+							<div class="py-[3px] pl-0.5">
+								<div class="text-[12px] text-slate-600 dark:text-slate-300 leading-relaxed prose-compact">
+									<TextMessage content={item.text as string} />
+								</div>
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+
+	</div>
+
 {:else}
+	<!-- Assistant / reasoning / system -->
 	<div
 		bind:this={scrollContainer}
 		onscroll={handleScroll}

--- a/frontend/components/chat/tools/variants/compact/AgentTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/AgentTool.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { tick } from 'svelte';
 	import type { ToolUseBlock, AgentInput, SubAgentToolActivity } from '$shared/types/unified';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as AgentInput);
@@ -41,20 +42,26 @@
 	}
 </script>
 
-<div class="space-y-0.5 text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Agent:</span>
-		<span class="text-slate-800 dark:text-slate-200">{description || subagentType}</span>
+<div class="min-w-0">
+	<!-- Header row — matches ToolRow layout -->
+	<div class="flex items-start gap-2 py-[2px] min-w-0">
+		<span class="relative shrink-0 w-[14px] mt-[1px] flex items-center justify-center text-slate-500 dark:text-slate-400 z-10">
+			<span class="absolute inset-0 -m-[3px] rounded bg-slate-50 dark:bg-slate-900"></span>
+			<Icon name="lucide:waypoints" class="relative w-[13px] h-[13px]" />
+		</span>
+		<div class="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 flex-1 min-w-0">
+			<span class="text-[12px] text-slate-500 dark:text-slate-400 whitespace-nowrap shrink-0">Agent</span>
+			<span class="text-[12px] text-slate-700 dark:text-slate-200 min-w-0 break-words">{description || subagentType}</span>
+			<span class="text-[10px] text-slate-400 dark:text-slate-500 whitespace-nowrap">{subagentType}</span>
+			{#if toolUseCount > 0}
+				<span class="text-[10px] text-slate-400 dark:text-slate-500 whitespace-nowrap">· {toolUseCount} tool{toolUseCount === 1 ? '' : 's'}</span>
+			{/if}
+		</div>
 	</div>
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-xs text-slate-400 dark:text-slate-500">{subagentType}</span>
-		{#if toolUseCount > 0}
-			<span class="text-xs text-slate-400 dark:text-slate-500">· {toolUseCount} tool{toolUseCount === 1 ? '' : 's'}</span>
-		{/if}
-	</div>
+	<!-- Sub-activity stream — aligned under the label -->
 	{#if subMessages && subMessages.length > 0}
-		<div bind:this={scrollContainer} onscroll={handleScroll} class="max-h-39 overflow-y-auto">
-			<ul class="space-y-0.5 pl-5 list-disc text-xs text-slate-500 dark:text-slate-400">
+		<div bind:this={scrollContainer} onscroll={handleScroll} class="max-h-39 overflow-y-auto pl-[22px]">
+			<ul class="space-y-0.5 pl-3 list-disc text-xs text-slate-500 dark:text-slate-400">
 				{#each subMessages as activity}
 					{#if activity.type === 'tool_use'}
 						<li>

--- a/frontend/components/chat/tools/variants/compact/AskUserQuestionTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/AskUserQuestionTool.svelte
@@ -117,6 +117,8 @@
 	}
 </script>
 
+<!-- Opaque background so the timeline rail doesn't clash with the question borders -->
+<div class="bg-slate-50 dark:bg-slate-900">
 {#if isError || isInterrupted}
 	<div class="space-y-1.5">
 		{#each input.questions as question}
@@ -231,3 +233,4 @@
 		</button>
 	</div>
 {/if}
+</div>

--- a/frontend/components/chat/tools/variants/compact/BashOutputTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/BashOutputTool.svelte
@@ -1,17 +1,11 @@
 <script lang="ts">
 	import type { ToolUseBlock, TaskOutputInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as TaskOutputInput);
 	const taskId = $derived(input.taskId);
+	const meta = $derived(input.timeout ? `${input.timeout}ms` : '');
 </script>
 
-<div class="space-y-0.5 text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">BashOutput:</span>
-		<code class="font-mono text-slate-800 dark:text-slate-200">task:{taskId}</code>
-		{#if input.timeout}
-			<span class="text-xs text-slate-400 dark:text-slate-500">· {input.timeout}ms</span>
-		{/if}
-	</div>
-</div>
+<ToolRow icon="lucide:square-terminal" label="Bash output" inlineCode={`task:${taskId}`} {meta} />

--- a/frontend/components/chat/tools/variants/compact/BashTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/BashTool.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { ToolUseBlock, BashInput } from '$shared/types/unified';
 	import { ToolRow } from './components';
+	import { processAnsiCodes } from '$frontend/utils/terminal-formatter'
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as BashInput);
@@ -33,15 +34,17 @@
 />
 
 {#if expanded && hasOutput}
-	<div class="pl-[22px] mt-1 mb-1">
-		<div class="rounded border border-slate-200 dark:border-slate-700/60 bg-slate-950 dark:bg-black/40 overflow-hidden">
-			<!-- Terminal header -->
-			<div class="flex items-center gap-1.5 px-2.5 py-1.5 border-b border-slate-700/60">
-				<div class="w-2 h-2 rounded-full bg-blue-500 shrink-0"></div>
-				<code class="text-[10px] font-mono text-slate-300 truncate">{command}</code>
-			</div>
-			<!-- Terminal output -->
-			<pre class="text-[10px] font-mono text-slate-300 dark:text-slate-400 px-2.5 py-2 overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-words leading-relaxed">{output.trim()}</pre>
+<div class="pl-[22px] mt-1 mb-1">
+	<div class="rounded border border-slate-200 dark:border-slate-700/60 bg-slate-950 dark:bg-black/40 overflow-hidden">
+		<!-- Terminal header -->
+		<div class="flex items-center gap-1.5 px-2.5 py-1.5 border-b border-slate-700/60">
+			<div class="w-2 h-2 rounded-full bg-blue-500 shrink-0"></div>
+			<code class="text-[10px] font-mono text-slate-200 truncate">{command}</code>
 		</div>
+		<!-- Terminal output -->
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+		<pre
+			class="text-[10px] font-mono text-slate-200 px-2.5 py-2 overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-words leading-relaxed">{@html processAnsiCodes(output.trim())}</pre>
 	</div>
+</div>
 {/if}

--- a/frontend/components/chat/tools/variants/compact/BashTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/BashTool.svelte
@@ -27,24 +27,19 @@
 <ToolRow
 	icon="lucide:square-terminal"
 	{label}
-	subDetail={command}
+	inlineCode={command}
 	{chips}
 	expandable={hasOutput}
 	bind:expanded
 />
 
 {#if expanded && hasOutput}
-<div class="pl-[22px] mt-1 mb-1">
-	<div class="rounded border border-slate-200 dark:border-slate-700/60 bg-slate-950 dark:bg-black/40 overflow-hidden">
-		<!-- Terminal header -->
-		<div class="flex items-center gap-1.5 px-2.5 py-1.5 border-b border-slate-700/60">
-			<div class="w-2 h-2 rounded-full bg-blue-500 shrink-0"></div>
-			<code class="text-[10px] font-mono text-slate-200 truncate">{command}</code>
+	<!-- Output attached to the command row — toggled by clicking the command above -->
+	<div class="pl-[22px] mt-0.5 mb-1">
+		<div class="rounded border border-slate-200 dark:border-slate-700/60 bg-slate-950 dark:bg-black/40 overflow-hidden">
+			<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+			<pre
+				class="text-[10px] font-mono text-slate-200 px-2.5 py-2 overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-words leading-relaxed">{@html processAnsiCodes(output.trim())}</pre>
 		</div>
-		<!-- Terminal output -->
-		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-		<pre
-			class="text-[10px] font-mono text-slate-200 px-2.5 py-2 overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-words leading-relaxed">{@html processAnsiCodes(output.trim())}</pre>
 	</div>
-</div>
 {/if}

--- a/frontend/components/chat/tools/variants/compact/BashTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/BashTool.svelte
@@ -1,23 +1,47 @@
 <script lang="ts">
 	import type { ToolUseBlock, BashInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as BashInput);
 
 	const command = $derived(input.command || '');
-	const description = $derived(input.description);
+	const description = $derived(input.description || '');
 	const isBackground = $derived(input.runInBackground);
+	const label = $derived(description || 'Ran');
+	const chips = $derived(isBackground ? ['bg'] : []);
+
+	// Extract output from tool result if available
+	const output = $derived.by(() => {
+		const result = (toolInput as any).result;
+		if (!result?.content) return '';
+		if (typeof result.content === 'string') return result.content;
+		return result.content[0]?.text ?? '';
+	});
+	const hasOutput = $derived(Boolean(output && output.trim()));
+
+	let expanded = $state(false);
 </script>
 
-<div class="space-y-0.5 text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Bash:</span>
-		<span class="font-mono text-slate-800 dark:text-slate-200">$ {command}</span>
-		{#if isBackground}
-			<span class="text-xs px-1 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 shrink-0">bg</span>
-		{/if}
+<ToolRow
+	icon="lucide:square-terminal"
+	{label}
+	subDetail={command}
+	{chips}
+	expandable={hasOutput}
+	bind:expanded
+/>
+
+{#if expanded && hasOutput}
+	<div class="pl-[22px] mt-1 mb-1">
+		<div class="rounded border border-slate-200 dark:border-slate-700/60 bg-slate-950 dark:bg-black/40 overflow-hidden">
+			<!-- Terminal header -->
+			<div class="flex items-center gap-1.5 px-2.5 py-1.5 border-b border-slate-700/60">
+				<div class="w-2 h-2 rounded-full bg-blue-500 shrink-0"></div>
+				<code class="text-[10px] font-mono text-slate-300 truncate">{command}</code>
+			</div>
+			<!-- Terminal output -->
+			<pre class="text-[10px] font-mono text-slate-300 dark:text-slate-400 px-2.5 py-2 overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-words leading-relaxed">{output.trim()}</pre>
+		</div>
 	</div>
-	{#if description}
-		<div class="text-xs text-slate-400 dark:text-slate-500">{description}</div>
-	{/if}
-</div>
+{/if}

--- a/frontend/components/chat/tools/variants/compact/ConfigTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/ConfigTool.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { ToolUseBlock, ConfigInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as ConfigInput);
@@ -7,15 +8,7 @@
 	const key = $derived(input.key || '');
 	const value = $derived(input.value);
 	const mode = $derived(value === undefined ? 'read' : 'set');
+	const meta = $derived(value !== undefined ? `= ${value}` : '');
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Config:</span>
-		<code class="font-mono font-medium text-slate-800 dark:text-slate-200">{key}</code>
-		{#if value !== undefined}
-			<span class="text-xs text-slate-400 dark:text-slate-500">= {value}</span>
-		{/if}
-		<span class="text-xs px-1 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 shrink-0">{mode}</span>
-	</div>
-</div>
+<ToolRow icon="lucide:settings-2" label="Config" inlineCode={key} {meta} chips={[mode]} />

--- a/frontend/components/chat/tools/variants/compact/CronCreateTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/CronCreateTool.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { ToolUseBlock, CronCreateInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as CronCreateInput);
@@ -8,12 +9,4 @@
 	const schedule = $derived(input.schedule || '');
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Cron:</span>
-		<span class="font-medium text-slate-800 dark:text-slate-200">{name}</span>
-		{#if schedule}
-			<code class="font-mono text-xs text-slate-400 dark:text-slate-500">{schedule}</code>
-		{/if}
-	</div>
-</div>
+<ToolRow icon="lucide:clock" label="Cron" detail={name} meta={schedule} />

--- a/frontend/components/chat/tools/variants/compact/CronDeleteTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/CronDeleteTool.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
 	import type { ToolUseBlock, CronDeleteInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as CronDeleteInput);
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Cron delete:</span>
-		<code class="font-mono font-medium text-slate-800 dark:text-slate-200">{input.id || ''}</code>
-	</div>
-</div>
+<ToolRow icon="lucide:clock" label="Cron delete" inlineCode={input.id || ''} />

--- a/frontend/components/chat/tools/variants/compact/CronListTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/CronListTool.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
 	import type { ToolUseBlock, CronListInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as CronListInput);
+	const detail = $derived(input.filter ? `filter: ${input.filter}` : 'all jobs');
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Cron list:</span>
-		<span class="text-slate-800 dark:text-slate-200">{input.filter ? `filter: ${input.filter}` : 'all jobs'}</span>
-	</div>
-</div>
+<ToolRow icon="lucide:clock" label="Cron list" {detail} />

--- a/frontend/components/chat/tools/variants/compact/CustomMcpTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/CustomMcpTool.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import type { ToolUseBlock } from '$shared/types/unified';
 	import { mcpServersStore } from '$frontend/stores/features/mcp-servers.svelte';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 
@@ -12,16 +13,12 @@
 	}
 
 	const parsed = $derived(parseMcpToolName(toolInput.name));
-	// Prefer the human title (e.g. "Browser Automation") over the raw key.
 	const server = $derived(mcpServersStore.serverTitles[parsed.server] ?? parsed.server);
 	const tool = $derived(parsed.tool);
+	const label = $derived(`${server}`);
 
 	onMount(() => { mcpServersStore.fetchInstalled(); });
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">MCP:</span>
-		<code class="font-mono font-medium text-slate-800 dark:text-slate-200">{server}/{tool}</code>
-	</div>
-</div>
+<ToolRow icon="lucide:plug" {label} subDetail={tool} />
+

--- a/frontend/components/chat/tools/variants/compact/CustomMcpTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/CustomMcpTool.svelte
@@ -20,5 +20,5 @@
 	onMount(() => { mcpServersStore.fetchInstalled(); });
 </script>
 
-<ToolRow icon="lucide:plug" {label} subDetail={tool} />
+<ToolRow icon="lucide:plug" {label} inlineCode={tool} />
 

--- a/frontend/components/chat/tools/variants/compact/EditTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/EditTool.svelte
@@ -1,24 +1,17 @@
 <script lang="ts">
 	import type { ToolUseBlock, EditInput } from '$shared/types/unified';
-	import { FileHeader } from './components';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as EditInput);
 
 	const filePath = $derived(input.filePath || '');
 	const fileName = $derived(filePath.split(/[/\\]/).pop() || filePath || 'unknown');
-	const replaceAll = $derived(input.replaceAll || false);
 
 	const additions = $derived(input.newString ? input.newString.split('\n').length : 0);
 	const deletions = $derived(input.oldString ? input.oldString.split('\n').length : 0);
-
-	const badges = $derived.by(() => {
-		const list: string[] = [];
-		if (additions > 0) list.push(`+${additions}`);
-		if (deletions > 0) list.push(`-${deletions}`);
-		if (replaceAll) list.push('replace all');
-		return list;
-	});
+	const diff = $derived({ additions, deletions });
 </script>
 
-<FileHeader {filePath} {fileName} operation="Edit" {badges} />
+<ToolRow icon="lucide:pencil" label="Edited" {filePath} {fileName} {diff} />
+

--- a/frontend/components/chat/tools/variants/compact/EnterPlanModeTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/EnterPlanModeTool.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
 	import type { ToolUseBlock } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput: _toolInput }: { toolInput: ToolUseBlock } = $props();
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Plan:</span>
-		<span class="text-slate-800 dark:text-slate-200">entering plan mode</span>
-	</div>
-</div>
+<ToolRow icon="lucide:clipboard-list" label="Plan" detail="entering plan mode" />

--- a/frontend/components/chat/tools/variants/compact/EnterWorktreeTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/EnterWorktreeTool.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
 	import type { ToolUseBlock, EnterWorktreeInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as EnterWorktreeInput);
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Worktree enter:</span>
-		<span class="text-slate-800 dark:text-slate-200">{input.name || 'default'}</span>
-	</div>
-</div>
+<ToolRow icon="lucide:git-branch" label="Worktree enter" detail={input.name || 'default'} />

--- a/frontend/components/chat/tools/variants/compact/ExitPlanModeTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/ExitPlanModeTool.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
 	import type { ToolUseBlock } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput: _toolInput }: { toolInput: ToolUseBlock } = $props();
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Plan:</span>
-		<span class="text-slate-800 dark:text-slate-200">ready</span>
-	</div>
-</div>
+<ToolRow icon="lucide:clipboard-check" label="Plan" detail="ready" />

--- a/frontend/components/chat/tools/variants/compact/ExitWorktreeTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/ExitWorktreeTool.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { ToolUseBlock, ExitWorktreeInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as ExitWorktreeInput);
@@ -7,9 +8,4 @@
 	const keep = $derived(input.keep === true);
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Worktree exit:</span>
-		<span class="text-slate-800 dark:text-slate-200">{keep ? 'keep changes' : 'discard changes'}</span>
-	</div>
-</div>
+<ToolRow icon="lucide:git-branch" label="Worktree exit" detail={keep ? 'keep changes' : 'discard changes'} />

--- a/frontend/components/chat/tools/variants/compact/GlobTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/GlobTool.svelte
@@ -1,19 +1,15 @@
 <script lang="ts">
 	import type { ToolUseBlock, GlobInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as GlobInput);
 
 	const pattern = $derived(input.pattern || '');
-	const searchPath = $derived(input.path || 'current directory');
+	const searchPath = $derived(input.path || '');
+	const pathName = $derived(searchPath ? searchPath.split(/[/\\]/).pop() || searchPath : '');
+	const chips = $derived(pathName ? [pathName] : []);
 </script>
 
-<div class="space-y-0.5 text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Glob:</span>
-		<code class="font-mono font-medium text-slate-800 dark:text-slate-200">{pattern}</code>
-	</div>
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-xs text-slate-400 dark:text-slate-500">{searchPath}</span>
-	</div>
-</div>
+<ToolRow icon="lucide:folder-search" label="Listed files" subDetail={pattern} {chips} />
+

--- a/frontend/components/chat/tools/variants/compact/GlobTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/GlobTool.svelte
@@ -1,25 +1,18 @@
 <script lang="ts">
 	import type { ToolUseBlock, GlobInput } from '$shared/types/unified';
-	import { ToolRow } from './components';
+	import { ToolRow, projectScope } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as GlobInput);
 
 	const pattern = $derived(input.pattern || '');
 	const searchPath = $derived(input.path || '');
-	const pathName = $derived(searchPath ? searchPath.split(/[/\\]/).pop() || searchPath : '');
-	const isDirectory = $derived.by(() => {
-		if (!searchPath) return true;
-		const base = searchPath.split(/[/\\]/).pop() || '';
-		return !base.includes('.');
-	});
+	const meta = $derived(projectScope(searchPath));
 </script>
 
 <ToolRow
 	icon="lucide:folder-search"
 	label="Listed files"
-	filePath={searchPath}
-	fileName={pathName}
-	{isDirectory}
-	subDetail={pattern}
+	inlineCode={pattern}
+	{meta}
 />

--- a/frontend/components/chat/tools/variants/compact/GlobTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/GlobTool.svelte
@@ -8,8 +8,18 @@
 	const pattern = $derived(input.pattern || '');
 	const searchPath = $derived(input.path || '');
 	const pathName = $derived(searchPath ? searchPath.split(/[/\\]/).pop() || searchPath : '');
-	const chips = $derived(pathName ? [pathName] : []);
+	const isDirectory = $derived.by(() => {
+		if (!searchPath) return true;
+		const base = searchPath.split(/[/\\]/).pop() || '';
+		return !base.includes('.');
+	});
 </script>
 
-<ToolRow icon="lucide:folder-search" label="Listed files" subDetail={pattern} {chips} />
-
+<ToolRow
+	icon="lucide:folder-search"
+	label="Listed files"
+	filePath={searchPath}
+	fileName={pathName}
+	{isDirectory}
+	subDetail={pattern}
+/>

--- a/frontend/components/chat/tools/variants/compact/GrepTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/GrepTool.svelte
@@ -22,14 +22,28 @@
 	});
 
 	const meta = $derived(resultCount);
-	const chips = $derived(searchPath && pathName ? [pathName] : []);
+	const isDirectory = $derived.by(() => {
+		if (!searchPath) return true;
+		const base = searchPath.split(/[/\\]/).pop() || '';
+		return !base.includes('.');
+	});
+
+	let expanded = $state(false)
 </script>
 
 <ToolRow
 	icon="lucide:search"
 	label="Searched for regex"
-	subDetail={pattern}
+	filePath={searchPath}
+	fileName={pathName}
+	{isDirectory}
 	{meta}
-	{chips}
+	expandable={Boolean(pattern)}
+	bind:expanded
 />
 
+{#if expanded && pattern}
+	<div class="pl-[22px] mt-0.5 mb-0.5">
+		<code class="text-[10px] font-mono bg-slate-100 dark:bg-slate-800/80 text-slate-600 dark:text-slate-300 px-2 pt-[3px] pb-[1px] rounded border border-slate-200 dark:border-slate-700/60 block max-w-full truncate leading-none" title={pattern}>{pattern}</code>
+	</div>
+{/if}

--- a/frontend/components/chat/tools/variants/compact/GrepTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/GrepTool.svelte
@@ -1,28 +1,35 @@
 <script lang="ts">
 	import type { ToolUseBlock, GrepInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as GrepInput);
 
 	const pattern = $derived(input.pattern || '');
-	const searchPath = $derived(input.path || 'current directory');
-	const modifiers = $derived([
-		input.glob ? `glob:${input.glob}` : '',
-		input.type ? `type:${input.type}` : '',
-		input.caseInsensitive ? '-i' : '',
-		input.multiline ? 'multiline' : '',
-	].filter(Boolean).join(' '));
+	const searchPath = $derived(input.path || '');
+	const pathName = $derived(searchPath ? searchPath.split(/[/\\]/).pop() || searchPath : '');
+
+	// Count results from tool result if available
+	const resultCount = $derived.by(() => {
+		const result = (toolInput as any).result;
+		if (!result?.content) return '';
+		const text = typeof result.content === 'string' ? result.content :
+			result.content[0]?.text ?? '';
+		const matches = text.match(/(\d+)\s+results?/i);
+		if (matches) return `${matches[1]} results`;
+		const lines = text.split('\n').filter((l: string) => l.trim());
+		return lines.length > 0 ? `${lines.length} results` : '';
+	});
+
+	const meta = $derived(resultCount);
+	const chips = $derived(searchPath && pathName ? [pathName] : []);
 </script>
 
-<div class="space-y-0.5 text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Grep:</span>
-		<code class="font-mono font-medium text-slate-800 dark:text-slate-200">{pattern}</code>
-	</div>
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-xs text-slate-400 dark:text-slate-500">{searchPath}</span>
-		{#if modifiers}
-			<span class="text-xs font-mono text-slate-400 dark:text-slate-500">{modifiers}</span>
-		{/if}
-	</div>
-</div>
+<ToolRow
+	icon="lucide:search"
+	label="Searched for regex"
+	subDetail={pattern}
+	{meta}
+	{chips}
+/>
+

--- a/frontend/components/chat/tools/variants/compact/GrepTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/GrepTool.svelte
@@ -1,49 +1,32 @@
 <script lang="ts">
 	import type { ToolUseBlock, GrepInput } from '$shared/types/unified';
-	import { ToolRow } from './components';
+	import { ToolRow, withScope } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as GrepInput);
 
 	const pattern = $derived(input.pattern || '');
 	const searchPath = $derived(input.path || '');
-	const pathName = $derived(searchPath ? searchPath.split(/[/\\]/).pop() || searchPath : '');
 
 	// Count results from tool result if available
-	const resultCount = $derived.by(() => {
+	const resultSummary = $derived.by(() => {
 		const result = (toolInput as any).result;
 		if (!result?.content) return '';
 		const text = typeof result.content === 'string' ? result.content :
 			result.content[0]?.text ?? '';
+		if (/no matches|no results/i.test(text)) return 'no results';
 		const matches = text.match(/(\d+)\s+results?/i);
 		if (matches) return `${matches[1]} results`;
 		const lines = text.split('\n').filter((l: string) => l.trim());
-		return lines.length > 0 ? `${lines.length} results` : '';
+		return lines.length > 0 ? `${lines.length} results` : 'no results';
 	});
 
-	const meta = $derived(resultCount);
-	const isDirectory = $derived.by(() => {
-		if (!searchPath) return true;
-		const base = searchPath.split(/[/\\]/).pop() || '';
-		return !base.includes('.');
-	});
-
-	let expanded = $state(false)
+	const meta = $derived(withScope(searchPath, resultSummary));
 </script>
 
 <ToolRow
 	icon="lucide:search"
 	label="Searched for regex"
-	filePath={searchPath}
-	fileName={pathName}
-	{isDirectory}
+	inlineCode={pattern}
 	{meta}
-	expandable={Boolean(pattern)}
-	bind:expanded
 />
-
-{#if expanded && pattern}
-	<div class="pl-[22px] mt-0.5 mb-0.5">
-		<code class="text-[10px] font-mono bg-slate-100 dark:bg-slate-800/80 text-slate-600 dark:text-slate-300 px-2 pt-[3px] pb-[1px] rounded border border-slate-200 dark:border-slate-700/60 block max-w-full truncate leading-none" title={pattern}>{pattern}</code>
-	</div>
-{/if}

--- a/frontend/components/chat/tools/variants/compact/ListMcpResourcesTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/ListMcpResourcesTool.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
 	import type { ToolUseBlock, ListMcpResourcesInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as ListMcpResourcesInput);
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">MCP list:</span>
-		<span class="text-slate-800 dark:text-slate-200">{input.server || 'all servers'}</span>
-	</div>
-</div>
+<ToolRow icon="lucide:plug" label="MCP list" detail={input.server || 'all servers'} />

--- a/frontend/components/chat/tools/variants/compact/ListTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/ListTool.svelte
@@ -1,19 +1,13 @@
 <script lang="ts">
 	import type { ToolUseBlock, ListInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as ListInput);
 
 	const path = $derived(input.path || '.');
-	const ignore = $derived(input.ignore);
+	const pathName = $derived(path.split(/[/\\]/).pop() || path);
 </script>
 
-<div class="space-y-0.5 text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">List:</span>
-		<span class="font-mono font-medium text-slate-800 dark:text-slate-200">{path}</span>
-	</div>
-	{#if ignore && ignore.length > 0}
-		<div class="text-xs text-slate-400 dark:text-slate-500">ignore: {ignore.join(', ')}</div>
-	{/if}
-</div>
+<ToolRow icon="lucide:folder" label="Listed directory" subDetail={path} />
+

--- a/frontend/components/chat/tools/variants/compact/ListTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/ListTool.svelte
@@ -9,5 +9,5 @@
 	const pathName = $derived(path.split(/[/\\]/).pop() || path);
 </script>
 
-<ToolRow icon="lucide:folder" label="Listed directory" subDetail={path} />
+<ToolRow icon="lucide:folder" label="Listed directory" filePath={path} fileName={pathName} isDirectory />
 

--- a/frontend/components/chat/tools/variants/compact/LspTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/LspTool.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import type { ToolUseBlock, LspInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as LspInput);
 
+	const label = $derived(`LSP ${input.operation || 'lsp'}`);
 	const location = $derived([
 		input.filePath,
 		input.line != null ? `L${input.line}` : '',
@@ -11,14 +13,4 @@
 	].filter(Boolean).join(':'));
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">LSP {input.operation || 'lsp'}:</span>
-		{#if input.symbol}
-			<code class="font-mono font-medium text-slate-800 dark:text-slate-200">{input.symbol}</code>
-		{/if}
-		{#if location}
-			<span class="font-mono text-xs text-slate-400 dark:text-slate-500">{location}</span>
-		{/if}
-	</div>
-</div>
+<ToolRow icon="lucide:code" {label} inlineCode={input.symbol || ''} meta={location} />

--- a/frontend/components/chat/tools/variants/compact/MonitorTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/MonitorTool.svelte
@@ -1,18 +1,12 @@
 <script lang="ts">
 	import type { ToolUseBlock, MonitorInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as MonitorInput);
 
 	const target = $derived(input.bashId || input.processId || input.source || 'stream');
+	const meta = $derived(input.until ? `until: ${input.until}` : '');
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Monitor:</span>
-		<code class="font-mono font-medium text-slate-800 dark:text-slate-200">{target}</code>
-		{#if input.until}
-			<span class="text-xs text-slate-400 dark:text-slate-500">until: {input.until}</span>
-		{/if}
-	</div>
-</div>
+<ToolRow icon="lucide:activity" label="Monitor" inlineCode={target} {meta} />

--- a/frontend/components/chat/tools/variants/compact/NotebookEditTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/NotebookEditTool.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { ToolUseBlock, NotebookEditInput } from '$shared/types/unified';
-	import { FileHeader } from './components';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as NotebookEditInput);
@@ -10,11 +10,8 @@
 	const cellId = $derived(input.cellId);
 	const cellType = $derived(input.cellType || 'code');
 	const editMode = $derived(input.editMode || 'replace');
-
-	const badges = $derived([
-		editMode,
-		`${cellType} cell${cellId ? ` #${cellId}` : ''}`,
-	]);
+	const meta = $derived(`${cellType} cell${cellId ? ` #${cellId}` : ''}`);
 </script>
 
-<FileHeader filePath={notebookPath} {fileName} operation="Edit" {badges} />
+<ToolRow icon="lucide:notebook-pen" label="Edited notebook" filePath={notebookPath} {fileName} {meta} />
+

--- a/frontend/components/chat/tools/variants/compact/PatchTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/PatchTool.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { ToolUseBlock, PatchInput } from '$shared/types/unified';
-	import { FileHeader } from './components';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as PatchInput);
@@ -9,4 +9,4 @@
 	const fileName = $derived(filePath.split(/[/\\]/).pop() || filePath || 'unknown');
 </script>
 
-<FileHeader {filePath} {fileName} operation="Patch" />
+<ToolRow icon="lucide:git-merge" label="Patched" {filePath} {fileName} />

--- a/frontend/components/chat/tools/variants/compact/PushNotificationTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/PushNotificationTool.svelte
@@ -1,16 +1,9 @@
 <script lang="ts">
 	import type { ToolUseBlock, PushNotificationInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as PushNotificationInput);
 </script>
 
-<div class="space-y-0.5 text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Notify:</span>
-		<span class="font-medium text-slate-800 dark:text-slate-200">{input.title || 'notification'}</span>
-	</div>
-	{#if input.message}
-		<div class="text-xs text-slate-400 dark:text-slate-500">{input.message}</div>
-	{/if}
-</div>
+<ToolRow icon="lucide:bell" label="Notify" detail={input.title || 'notification'} meta={input.message || ''} />

--- a/frontend/components/chat/tools/variants/compact/ReadMcpResourceTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/ReadMcpResourceTool.svelte
@@ -1,16 +1,9 @@
 <script lang="ts">
 	import type { ToolUseBlock, ReadMcpResourceInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as ReadMcpResourceInput);
 </script>
 
-<div class="space-y-0.5 text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">MCP read:</span>
-		<code class="font-mono font-medium text-slate-800 dark:text-slate-200">{input.uri}</code>
-	</div>
-	{#if input.server}
-		<div class="text-xs text-slate-400 dark:text-slate-500">{input.server}</div>
-	{/if}
-</div>
+<ToolRow icon="lucide:plug" label="MCP read" inlineCode={input.uri} meta={input.server || ''} />

--- a/frontend/components/chat/tools/variants/compact/ReadTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/ReadTool.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { ToolUseBlock, ReadInput } from '$shared/types/unified';
-	import { FileHeader } from './components';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as ReadInput);
@@ -12,10 +12,10 @@
 	const meta = $derived.by(() => {
 		if (!hasLimit && !hasOffset) return '';
 		const start = hasOffset ? (input.offset as number) : 0;
-		if (hasLimit) return `${start}-${start + (input.limit as number)}`;
+		if (hasLimit) return `lines ${start} to ${start + (input.limit as number)}`;
 		return `from ${start}`;
 	});
-	const badges = $derived(meta ? [meta] : []);
 </script>
 
-<FileHeader {filePath} {fileName} operation="Read" {badges} />
+<ToolRow icon="lucide:book-open" label="Read" {filePath} {fileName} {meta} />
+

--- a/frontend/components/chat/tools/variants/compact/RemoteTriggerTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/RemoteTriggerTool.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
 	import type { ToolUseBlock, RemoteTriggerInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as RemoteTriggerInput);
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Trigger:</span>
-		<span class="font-medium text-slate-800 dark:text-slate-200">{input.name || 'remote trigger'}</span>
-	</div>
-</div>
+<ToolRow icon="lucide:zap" label="Trigger" detail={input.name || 'remote trigger'} />

--- a/frontend/components/chat/tools/variants/compact/ScheduleWakeupTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/ScheduleWakeupTool.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { ToolUseBlock, ScheduleWakeupInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as ScheduleWakeupInput);
@@ -16,14 +17,8 @@
 		const remMins = mins % 60;
 		return remMins > 0 ? `${hours}h ${remMins}m` : `${hours}h`;
 	}
+
+	const detail = $derived(formatDelay(delaySeconds));
 </script>
 
-<div class="space-y-0.5 text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Wake in:</span>
-		<span class="text-slate-800 dark:text-slate-200">{formatDelay(delaySeconds)}</span>
-	</div>
-	{#if reason}
-		<div class="text-xs text-slate-400 dark:text-slate-500">{reason}</div>
-	{/if}
-</div>
+<ToolRow icon="lucide:alarm-clock" label="Wake in" {detail} meta={reason} />

--- a/frontend/components/chat/tools/variants/compact/SkillTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/SkillTool.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
 	import type { ToolUseBlock, SkillInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as SkillInput);
 
 	const skillName = $derived(input.skill || '');
 	const skillArgs = $derived(input.args || '');
+	const inlineCode = $derived(`/${skillName}${skillArgs ? ` ${skillArgs}` : ''}`);
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Skill:</span>
-		<code class="font-mono font-medium text-slate-800 dark:text-slate-200">/{skillName}{skillArgs ? ` ${skillArgs}` : ''}</code>
-	</div>
-</div>
+<ToolRow icon="lucide:wand-sparkles" label="Skill" {inlineCode} />

--- a/frontend/components/chat/tools/variants/compact/TaskCreateTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/TaskCreateTool.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
 	import type { ToolUseBlock, TaskCreateInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as TaskCreateInput);
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">TaskCreate:</span>
-		<span class="text-slate-800 dark:text-slate-200">{input.subject || 'untitled'}</span>
-	</div>
-</div>
+<ToolRow icon="lucide:list-plus" label="TaskCreate" detail={input.subject || 'untitled'} />

--- a/frontend/components/chat/tools/variants/compact/TaskGetTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/TaskGetTool.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
 	import type { ToolUseBlock, TaskGetInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as TaskGetInput);
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">TaskGet:</span>
-		<code class="font-mono font-medium text-slate-800 dark:text-slate-200">{input.taskId || 'unknown'}</code>
-	</div>
-</div>
+<ToolRow icon="lucide:list" label="TaskGet" inlineCode={input.taskId || 'unknown'} />

--- a/frontend/components/chat/tools/variants/compact/TaskListTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/TaskListTool.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
 	import type { ToolUseBlock } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput: _toolInput }: { toolInput: ToolUseBlock } = $props();
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">TaskList</span>
-	</div>
-</div>
+<ToolRow icon="lucide:list" label="TaskList" />

--- a/frontend/components/chat/tools/variants/compact/TaskStopTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/TaskStopTool.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
 	import type { ToolUseBlock, TaskStopInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as TaskStopInput);
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">TaskStop:</span>
-		<code class="font-mono font-medium text-slate-800 dark:text-slate-200">{input.taskId || 'unknown'}</code>
-	</div>
-</div>
+<ToolRow icon="lucide:circle-stop" label="TaskStop" inlineCode={input.taskId || 'unknown'} />

--- a/frontend/components/chat/tools/variants/compact/TaskUpdateTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/TaskUpdateTool.svelte
@@ -1,16 +1,10 @@
 <script lang="ts">
 	import type { ToolUseBlock, TaskUpdateInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as TaskUpdateInput);
+	const chips = $derived(input.status ? [input.status] : []);
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">TaskUpdate:</span>
-		<code class="font-mono font-medium text-slate-800 dark:text-slate-200">{input.taskId || 'unknown'}</code>
-		{#if input.status}
-			<span class="text-xs text-slate-400 dark:text-slate-500">· {input.status}</span>
-		{/if}
-	</div>
-</div>
+<ToolRow icon="lucide:list" label="TaskUpdate" inlineCode={input.taskId || 'unknown'} {chips} />

--- a/frontend/components/chat/tools/variants/compact/TodoWriteTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/TodoWriteTool.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { ToolUseBlock, TodoWriteInput } from '$shared/types/unified';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as TodoWriteInput);
@@ -10,15 +11,23 @@
 	const inProgress = $derived(todos.find(t => t.status === 'in_progress'));
 </script>
 
-<div class="space-y-0.5">
-	<div class="flex items-center gap-1.5 text-sm">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Todo:</span>
-		<span class="text-slate-800 dark:text-slate-200">{completed}/{total} done</span>
-		{#if inProgress}
-			<span class="text-xs text-slate-400 dark:text-slate-500">· {inProgress.activeForm || inProgress.content}</span>
-		{/if}
+<div class="min-w-0">
+	<!-- Header row — matches ToolRow layout -->
+	<div class="flex items-start gap-2 py-[2px] min-w-0">
+		<span class="relative shrink-0 w-[14px] mt-[1px] flex items-center justify-center text-slate-500 dark:text-slate-400 z-10">
+			<span class="absolute inset-0 -m-[3px] rounded bg-slate-50 dark:bg-slate-900"></span>
+			<Icon name="lucide:list-todo" class="relative w-[13px] h-[13px]" />
+		</span>
+		<div class="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 flex-1 min-w-0">
+			<span class="text-[12px] text-slate-500 dark:text-slate-400 whitespace-nowrap shrink-0">Todo</span>
+			<span class="text-[12px] text-slate-700 dark:text-slate-200">{completed}/{total} done</span>
+			{#if inProgress}
+				<span class="text-[10px] text-slate-400 dark:text-slate-500 min-w-0 break-words">{inProgress.activeForm || inProgress.content}</span>
+			{/if}
+		</div>
 	</div>
-	<div class="space-y-0.5 pl-4">
+	<!-- Todo list — aligned under the label -->
+	<div class="space-y-0.5 pl-[22px]">
 		{#each todos as todo}
 			<div class="flex items-center gap-1.5 text-sm text-slate-500 dark:text-slate-400">
 				<span class="shrink-0 w-3 text-center text-xs">

--- a/frontend/components/chat/tools/variants/compact/ToolSearchTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/ToolSearchTool.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
 	import type { ToolUseBlock, ToolSearchInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as ToolSearchInput);
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">ToolSearch:</span>
-		<code class="font-mono font-medium text-slate-800 dark:text-slate-200">{input.query || ''}</code>
-	</div>
-</div>
+<ToolRow icon="lucide:search-code" label="Searched tools" inlineCode={input.query || ''} />

--- a/frontend/components/chat/tools/variants/compact/UnknownTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/UnknownTool.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { ToolUseBlock } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 
@@ -8,9 +9,4 @@
 		: toolInput.name);
 </script>
 
-<div class="text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-red-500 dark:text-red-400 shrink-0">Unhandled:</span>
-		<code class="font-mono font-medium text-slate-800 dark:text-slate-200">{originalName}</code>
-	</div>
-</div>
+<ToolRow icon="lucide:circle-alert" label="Unhandled" inlineCode={originalName} />

--- a/frontend/components/chat/tools/variants/compact/WebFetchTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/WebFetchTool.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
 	import type { ToolUseBlock, WebFetchInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as WebFetchInput);
 </script>
 
-<div class="space-y-0.5 text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Fetch:</span>
-		<span class="font-mono text-slate-800 dark:text-slate-200">{input.url || ''}</span>
-	</div>
-</div>
+<ToolRow icon="lucide:globe" label="Fetched" inlineCode={input.url || ''} />

--- a/frontend/components/chat/tools/variants/compact/WebSearchTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/WebSearchTool.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { ToolUseBlock, WebSearchInput } from '$shared/types/unified';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as WebSearchInput);
@@ -8,12 +9,4 @@
 	const domains = $derived(input.allowedDomains?.join(', ') || '');
 </script>
 
-<div class="space-y-0.5 text-sm">
-	<div class="flex items-center flex-wrap gap-x-1.5 gap-y-0.5">
-		<span class="text-slate-500 dark:text-slate-400 shrink-0">Search:</span>
-		<span class="text-slate-800 dark:text-slate-200">{query}</span>
-	</div>
-	{#if domains}
-		<div class="text-xs text-slate-400 dark:text-slate-500">{domains}</div>
-	{/if}
-</div>
+<ToolRow icon="lucide:globe" label="Searched web" inlineCode={query} meta={domains} />

--- a/frontend/components/chat/tools/variants/compact/WriteTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/WriteTool.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
 	import type { ToolUseBlock, WriteInput } from '$shared/types/unified';
-	import { FileHeader } from './components';
+	import { ToolRow } from './components';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as WriteInput);
 
 	const filePath = $derived(input.filePath || '');
 	const fileName = $derived(filePath.split(/[/\\]/).pop() || filePath || 'unknown');
+	const lines = $derived(input.content ? input.content.split('\n').length : 0);
+	const diff = $derived({ additions: lines });
 </script>
 
-<FileHeader {filePath} {fileName} operation="Write" />
+<ToolRow icon="lucide:file-plus" label="Wrote" {filePath} {fileName} {diff} />
+

--- a/frontend/components/chat/tools/variants/compact/components/ToolRow.svelte
+++ b/frontend/components/chat/tools/variants/compact/components/ToolRow.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import { getFileIcon } from '$frontend/utils/file-icon-mappings';
+	import { getFolderIcon } from '$frontend/utils/folder-icon-mappings';
 	import { requestRevealFile } from '$frontend/stores/core/files.svelte';
 	import { getVisiblePanels, workspaceState } from '$frontend/stores/ui/workspace.svelte';
 	import type { IconName } from '$shared/types/ui/icons';
@@ -19,6 +20,8 @@
 		filePath?: string;
 		/** Override displayed filename */
 		fileName?: string;
+		/** Whether the path points to a directory/folder */
+		isDirectory?: boolean;
 		/** Right-side meta text e.g. "lines 100 to 140" */
 		meta?: string;
 		/** Diff stats shown inline after file pill */
@@ -40,6 +43,7 @@
 		label,
 		filePath = '',
 		fileName,
+		isDirectory = false,
 		meta = '',
 		diff,
 		subDetail = '',
@@ -50,7 +54,11 @@
 	}: Props = $props();
 
 	const displayName = $derived(fileName || (filePath ? filePath.split(/[/\\]/).pop() || filePath : ''));
-	const fileIconName = $derived(displayName ? (getFileIcon(displayName) as IconName) : 'lucide:file');
+	const fileIconName = $derived.by(() => {
+		if (!displayName) return 'lucide:file';
+		if (isDirectory) return getFolderIcon(displayName, false) as IconName;
+		return getFileIcon(displayName) as IconName;
+	});
 	const hasFile = $derived(Boolean(displayName));
 	const hasDiff = $derived(Boolean(diff && (diff.additions || diff.deletions)));
 
@@ -71,14 +79,14 @@
 
 <!-- Main tool row -->
 <div
-	class="flex items-start gap-2 py-[3px] min-w-0 {expandable ? 'cursor-pointer' : ''}"
+	class="flex items-center gap-2 py-[3px] min-w-0 {expandable ? 'cursor-pointer' : ''}"
 	role={expandable ? 'button' : undefined}
 	tabindex={expandable ? 0 : undefined}
 	onclick={handleRowClick}
 	onkeydown={(e) => e.key === 'Enter' && handleRowClick()}
 >
 	<!-- Operation icon — same size as timeline dot area -->
-	<span class="shrink-0 mt-0.5 w-[14px] flex items-center justify-center text-slate-500 dark:text-slate-400">
+	<span class="shrink-0 w-[14px] flex items-center justify-center text-slate-500 dark:text-slate-400">
 		<Icon name={icon} class="w-[13px] h-[13px]" />
 	</span>
 
@@ -91,12 +99,12 @@
 		{#if hasFile}
 			<button
 				type="button"
-				class="inline-flex items-center gap-[5px] px-[4px] py-[2px] rounded border border-transparent hover:border-slate-200 dark:hover:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-700/60 transition-colors shrink-0 cursor-pointer"
+				class="inline-flex items-center gap-[5px] px-[3px] rounded border border-transparent hover:border-slate-200 dark:hover:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-700/60 transition-colors shrink-0 cursor-pointer"
 				onclick={handleFileClick}
 				title={filePath}
 			>
-				<Icon name={fileIconName} class="w-[11px] h-[11px] shrink-0 text-red-500 dark:text-red-400" />
-				<span class="font-mono text-[11px] font-medium text-slate-700 dark:text-slate-200 max-w-[180px] truncate leading-none">{displayName}</span>
+				<Icon name={fileIconName} class="w-[11px] h-[11px] shrink-0 {isDirectory ? 'text-amber-500 dark:text-amber-400' : 'text-red-500 dark:text-red-400'}" />
+				<span class="font-mono text-[11px] font-medium text-slate-700 dark:text-slate-200 max-w-[180px] truncate">{displayName}</span>
 			</button>
 		{/if}
 
@@ -117,7 +125,7 @@
 
 		<!-- Right meta -->
 		{#if meta}
-			<span class="text-[10px] text-slate-400 dark:text-slate-500 whitespace-nowrap shrink-0 ml-auto">{meta}</span>
+			<span class="text-[10px] text-slate-400 dark:text-slate-500 whitespace-nowrap shrink-0">{meta}</span>
 		{/if}
 
 		<!-- Expandable chevron -->
@@ -133,6 +141,8 @@
 <!-- Sub-detail code pill (command, pattern, etc.) -->
 {#if subDetail}
 	<div class="pl-[22px] mt-0.5 mb-0.5">
-		<code class="text-[10px] font-mono bg-slate-100 dark:bg-slate-800/80 text-slate-600 dark:text-slate-300 px-2 py-0.5 rounded border border-slate-200 dark:border-slate-700/60 block max-w-full truncate leading-tight" title={subDetail}>{subDetail}</code>
+		<code class="text-[10px] font-mono bg-slate-100 dark:bg-slate-800/80 text-slate-600 dark:text-slate-300 px-2 py-0.5 rounded border border-slate-200 dark:border-slate-700/60 flex items-center max-w-full min-w-0" title={subDetail}>
+			<span class="truncate">{subDetail}</span>
+		</code>
 	</div>
 {/if}

--- a/frontend/components/chat/tools/variants/compact/components/ToolRow.svelte
+++ b/frontend/components/chat/tools/variants/compact/components/ToolRow.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { getFileIcon } from '$frontend/utils/file-icon-mappings';
+	import { requestRevealFile } from '$frontend/stores/core/files.svelte';
+	import { getVisiblePanels, workspaceState } from '$frontend/stores/ui/workspace.svelte';
+	import type { IconName } from '$shared/types/ui/icons';
+
+	interface DiffStat {
+		additions?: number;
+		deletions?: number;
+	}
+
+	interface Props {
+		/** Icon for the operation (lucide icon name) */
+		icon: IconName;
+		/** Action label e.g. "Edited", "Read", "Ran command" */
+		label: string;
+		/** Full file path — triggers file pill */
+		filePath?: string;
+		/** Override displayed filename */
+		fileName?: string;
+		/** Right-side meta text e.g. "lines 100 to 140" */
+		meta?: string;
+		/** Diff stats shown inline after file pill */
+		diff?: DiffStat;
+		/** Sub-detail shown as a code pill below (for search patterns, commands) */
+		subDetail?: string;
+		/** Extra tag chips shown after label */
+		chips?: string[];
+		/** Whether this row has expandable content (adds chevron) */
+		expandable?: boolean;
+		/** Whether the expandable content is shown */
+		expanded?: boolean;
+		/** Called when header row is clicked (for expandable rows) */
+		onclick?: () => void;
+	}
+
+	let {
+		icon,
+		label,
+		filePath = '',
+		fileName,
+		meta = '',
+		diff,
+		subDetail = '',
+		chips = [],
+		expandable = false,
+		expanded = $bindable(false),
+		onclick,
+	}: Props = $props();
+
+	const displayName = $derived(fileName || (filePath ? filePath.split(/[/\\]/).pop() || filePath : ''));
+	const fileIconName = $derived(displayName ? (getFileIcon(displayName) as IconName) : 'lucide:file');
+	const hasFile = $derived(Boolean(displayName));
+	const hasDiff = $derived(Boolean(diff && (diff.additions || diff.deletions)));
+
+	function handleFileClick(e: MouseEvent) {
+		e.stopPropagation();
+		if (!filePath) return;
+		const panels = getVisiblePanels(workspaceState.layout);
+		if (panels.includes('files')) requestRevealFile(filePath);
+	}
+
+	function handleRowClick() {
+		if (expandable) {
+			expanded = !expanded;
+			onclick?.();
+		}
+	}
+</script>
+
+<!-- Main tool row -->
+<div
+	class="flex items-start gap-2 py-[3px] min-w-0 {expandable ? 'cursor-pointer' : ''}"
+	role={expandable ? 'button' : undefined}
+	tabindex={expandable ? 0 : undefined}
+	onclick={handleRowClick}
+	onkeydown={(e) => e.key === 'Enter' && handleRowClick()}
+>
+	<!-- Operation icon — same size as timeline dot area -->
+	<span class="shrink-0 mt-0.5 w-[14px] flex items-center justify-center text-slate-500 dark:text-slate-400">
+		<Icon name={icon} class="w-[13px] h-[13px]" />
+	</span>
+
+	<!-- Row content: label + file pill + diff + meta -->
+	<div class="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 flex-1 min-w-0">
+		<!-- Action label -->
+		<span class="text-[12px] text-slate-500 dark:text-slate-400 whitespace-nowrap shrink-0">{label}</span>
+
+		<!-- File pill -->
+		{#if hasFile}
+			<button
+				type="button"
+				class="inline-flex items-center gap-[5px] px-[4px] py-[2px] rounded border border-transparent hover:border-slate-200 dark:hover:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-700/60 transition-colors shrink-0 cursor-pointer"
+				onclick={handleFileClick}
+				title={filePath}
+			>
+				<Icon name={fileIconName} class="w-[11px] h-[11px] shrink-0 text-red-500 dark:text-red-400" />
+				<span class="font-mono text-[11px] font-medium text-slate-700 dark:text-slate-200 max-w-[180px] truncate leading-none">{displayName}</span>
+			</button>
+		{/if}
+
+		<!-- Diff stats (inline after file pill) -->
+		{#if hasDiff}
+			{#if diff?.additions}
+				<span class="text-[11px] font-semibold text-emerald-500 dark:text-emerald-400 shrink-0">+{diff.additions}</span>
+			{/if}
+			{#if diff?.deletions}
+				<span class="text-[11px] font-semibold text-red-500 dark:text-red-400 shrink-0">-{diff.deletions}</span>
+			{/if}
+		{/if}
+
+		<!-- Chips -->
+		{#each chips as chip}
+			<span class="text-[10px] text-slate-400 dark:text-slate-500 whitespace-nowrap shrink-0 font-mono">{chip}</span>
+		{/each}
+
+		<!-- Right meta -->
+		{#if meta}
+			<span class="text-[10px] text-slate-400 dark:text-slate-500 whitespace-nowrap shrink-0 ml-auto">{meta}</span>
+		{/if}
+
+		<!-- Expandable chevron -->
+		{#if expandable}
+			<Icon
+				name={expanded ? 'lucide:chevron-down' : 'lucide:chevron-right'}
+				class="w-3 h-3 text-slate-400 dark:text-slate-500 shrink-0 ml-auto"
+			/>
+		{/if}
+	</div>
+</div>
+
+<!-- Sub-detail code pill (command, pattern, etc.) -->
+{#if subDetail}
+	<div class="pl-[22px] mt-0.5 mb-0.5">
+		<code class="text-[10px] font-mono bg-slate-100 dark:bg-slate-800/80 text-slate-600 dark:text-slate-300 px-2 py-0.5 rounded border border-slate-200 dark:border-slate-700/60 block max-w-full truncate leading-tight" title={subDetail}>{subDetail}</code>
+	</div>
+{/if}

--- a/frontend/components/chat/tools/variants/compact/components/ToolRow.svelte
+++ b/frontend/components/chat/tools/variants/compact/components/ToolRow.svelte
@@ -26,8 +26,10 @@
 		meta?: string;
 		/** Diff stats shown inline after file pill */
 		diff?: DiffStat;
-		/** Sub-detail shown as a code pill below (for search patterns, commands) */
-		subDetail?: string;
+		/** Inline highlighted code shown within the row (patterns, commands, queries) */
+		inlineCode?: string;
+		/** Plain primary text shown within the row (titles, names, prose values) */
+		detail?: string;
 		/** Extra tag chips shown after label */
 		chips?: string[];
 		/** Whether this row has expandable content (adds chevron) */
@@ -46,7 +48,8 @@
 		isDirectory = false,
 		meta = '',
 		diff,
-		subDetail = '',
+		inlineCode = '',
+		detail = '',
 		chips = [],
 		expandable = false,
 		expanded = $bindable(false),
@@ -79,21 +82,35 @@
 
 <!-- Main tool row -->
 <div
-	class="flex items-center gap-2 py-[3px] min-w-0 {expandable ? 'cursor-pointer' : ''}"
+	class="flex items-start gap-2 py-[2px] min-w-0 {expandable ? 'cursor-pointer' : ''}"
 	role={expandable ? 'button' : undefined}
 	tabindex={expandable ? 0 : undefined}
 	onclick={handleRowClick}
 	onkeydown={(e) => e.key === 'Enter' && handleRowClick()}
 >
-	<!-- Operation icon — same size as timeline dot area -->
-	<span class="shrink-0 w-[14px] flex items-center justify-center text-slate-500 dark:text-slate-400">
-		<Icon name={icon} class="w-[13px] h-[13px]" />
+	<!-- Operation icon — sits on the timeline rail (node masks it), top-aligned with the first line -->
+	<span class="relative shrink-0 w-[14px] mt-[1px] flex items-center justify-center text-slate-500 dark:text-slate-400 z-10">
+		<span class="absolute inset-0 -m-[3px] rounded bg-slate-50 dark:bg-slate-900"></span>
+		<Icon name={icon} class="relative w-[13px] h-[13px]" />
 	</span>
 
 	<!-- Row content: label + file pill + diff + meta -->
 	<div class="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 flex-1 min-w-0">
 		<!-- Action label -->
 		<span class="text-[12px] text-slate-500 dark:text-slate-400 whitespace-nowrap shrink-0">{label}</span>
+
+		<!-- Inline highlighted code (pattern, command, query) -->
+		{#if inlineCode}
+			<code
+				class="font-mono text-[11px] text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-800/70 rounded px-1.5 py-[1px] min-w-0 break-all whitespace-pre-wrap leading-snug"
+				title={inlineCode}
+			>{inlineCode}</code>
+		{/if}
+
+		<!-- Plain primary detail (title, name, prose value) -->
+		{#if detail}
+			<span class="text-[12px] text-slate-700 dark:text-slate-200 min-w-0 break-words">{detail}</span>
+		{/if}
 
 		<!-- File pill -->
 		{#if hasFile}
@@ -125,24 +142,7 @@
 
 		<!-- Right meta -->
 		{#if meta}
-			<span class="text-[10px] text-slate-400 dark:text-slate-500 whitespace-nowrap shrink-0">{meta}</span>
-		{/if}
-
-		<!-- Expandable chevron -->
-		{#if expandable}
-			<Icon
-				name={expanded ? 'lucide:chevron-down' : 'lucide:chevron-right'}
-				class="w-3 h-3 text-slate-400 dark:text-slate-500 shrink-0 ml-auto"
-			/>
+			<span class="text-[10px] text-slate-400 dark:text-slate-500 min-w-0 break-all">{meta}</span>
 		{/if}
 	</div>
 </div>
-
-<!-- Sub-detail code pill (command, pattern, etc.) -->
-{#if subDetail}
-	<div class="pl-[22px] mt-0.5 mb-0.5">
-		<code class="text-[10px] font-mono bg-slate-100 dark:bg-slate-800/80 text-slate-600 dark:text-slate-300 px-2 py-0.5 rounded border border-slate-200 dark:border-slate-700/60 flex items-center max-w-full min-w-0" title={subDetail}>
-			<span class="truncate">{subDetail}</span>
-		</code>
-	</div>
-{/if}

--- a/frontend/components/chat/tools/variants/compact/components/index.ts
+++ b/frontend/components/chat/tools/variants/compact/components/index.ts
@@ -4,3 +4,4 @@ export { default as DiffBlock } from './DiffBlock.svelte';
 export { default as StatsBadges } from './StatsBadges.svelte';
 export { default as InfoLine } from './InfoLine.svelte';
 export { default as TerminalCommand } from './TerminalCommand.svelte';
+export { default as ToolRow } from './ToolRow.svelte';

--- a/frontend/components/chat/tools/variants/compact/components/index.ts
+++ b/frontend/components/chat/tools/variants/compact/components/index.ts
@@ -5,3 +5,4 @@ export { default as StatsBadges } from './StatsBadges.svelte';
 export { default as InfoLine } from './InfoLine.svelte';
 export { default as TerminalCommand } from './TerminalCommand.svelte';
 export { default as ToolRow } from './ToolRow.svelte';
+export { projectScope, relativeToProject, withScope } from './scope';

--- a/frontend/components/chat/tools/variants/compact/components/scope.ts
+++ b/frontend/components/chat/tools/variants/compact/components/scope.ts
@@ -1,0 +1,26 @@
+import { currentProjectName, currentProjectPath } from '$frontend/stores/core/projects.svelte';
+
+/** Path of `target` relative to the current project root, or the original path. */
+export function relativeToProject(target: string): string {
+	if (!target) return '';
+	const root = currentProjectPath();
+	if (root && target === root) return '';
+	if (root && target.startsWith(root)) {
+		return target.slice(root.length).replace(/^[/\\]+/, '');
+	}
+	return target;
+}
+
+/** `(project · relpath)` scope label, mirroring Claude Code's search rows. */
+export function projectScope(target: string): string {
+	const name = currentProjectName();
+	const rel = relativeToProject(target);
+	const parts = [name, rel].filter(Boolean);
+	return parts.length ? `(${parts.join(' · ')})` : '';
+}
+
+/** Combine a `(project · path)` scope with a trailing summary, e.g. `(clopen · src), 3 results`. */
+export function withScope(target: string, summary: string): string {
+	const scope = projectScope(target);
+	return [scope, summary].filter(Boolean).join(', ');
+}

--- a/frontend/components/settings/appearance/AppearanceSettings.svelte
+++ b/frontend/components/settings/appearance/AppearanceSettings.svelte
@@ -173,11 +173,28 @@
 						: 'border-slate-200 dark:border-slate-700 hover:border-violet-500/40'}"
 					aria-pressed={settings.chatAppearance === 'compact'}
 				>
-					<div class="flex flex-col gap-1.5 rounded-md bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 p-2 h-15 overflow-hidden">
-						<div class="w-3/4 h-1 rounded-full bg-slate-200 dark:bg-slate-700"></div>
-						<div class="w-full h-1 rounded-full bg-slate-200 dark:bg-slate-700"></div>
-						<div class="w-2/3 h-1 rounded-full bg-slate-200 dark:bg-slate-700"></div>
-						<div class="w-full h-1 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+					<div class="flex flex-col gap-[5px] rounded-md bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 p-2 h-15 overflow-hidden">
+						<!-- Bold summary header -->
+						<div class="w-4/5 h-1 rounded-full bg-slate-300 dark:bg-slate-600"></div>
+						<!-- Timeline body: vertical rail runs behind the icon nodes -->
+						<div class="relative flex flex-col gap-[5px]">
+							<div class="absolute top-[3px] bottom-[3px] left-[2px] w-[3px] rounded-full bg-slate-300 dark:bg-slate-600"></div>
+							<!-- Edited row -->
+							<div class="relative flex items-center gap-1.5">
+								<span class="relative z-10 w-[7px] h-[7px] rounded-[2px] bg-slate-400 dark:bg-slate-500 shrink-0"></span>
+								<div class="w-2/5 h-1 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+							</div>
+							<!-- Wrote row -->
+							<div class="relative flex items-center gap-1.5">
+								<span class="relative z-10 w-[7px] h-[7px] rounded-[2px] bg-slate-400 dark:bg-slate-500 shrink-0"></span>
+								<div class="w-1/5 h-1 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+							</div>
+							<!-- Read row -->
+							<div class="relative flex items-center gap-1.5">
+								<span class="relative z-10 w-[7px] h-[7px] rounded-[2px] bg-slate-400 dark:bg-slate-500 shrink-0"></span>
+								<div class="w-1/2 h-1 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+							</div>
+						</div>
 					</div>
 					<div class="flex items-center justify-between">
 						<span class="text-sm font-semibold text-slate-900 dark:text-slate-100">Compact</span>
@@ -185,7 +202,7 @@
 							<Icon name="lucide:circle-check" class="w-4 h-4 text-violet-500" />
 						{/if}
 					</div>
-					<span class="text-xs text-slate-600 dark:text-slate-500">Dense lines, no borders or cards</span>
+					<span class="text-xs text-slate-600 dark:text-slate-500">Dense rows linked by a timeline rail</span>
 				</button>
 			</div>
 		</div>


### PR DESCRIPTION
# Enhance compact tool rows with ANSI rendering and folder icons

## Summary

This PR enhances the compact variants of tool rows in chat messages by adding ANSI color rendering for terminal output, folder icons for file tools, and restructuring agent message layouts for clarity.

## Changes

- Refactor compact tool components to use a shared `ToolRow` with icons and compact layout
- Add ANSI rendering to Bash tool terminal output
- Extract and show folder icons in file-related tool rows (Edit, Write, Patch)
- Improve agent message rendering: timeline layout, bold summary headers, and collapsible details
- Consolidate and clean up per-tool compact variants for consistency and code reuse

## Preview

<img width="387" height="665" alt="image" src="https://github.com/user-attachments/assets/8f8d3687-65d9-4659-9b0e-7ffd8681e9bc" />
