### PR TITLE
feat(task-client): add Trello task client with kanban board, card detail

### DIFF
--- a/backend/ws/git/branch-name.ts
+++ b/backend/ws/git/branch-name.ts
@@ -148,7 +148,7 @@ export const branchNameHandler = createRouter()
 		const diffResult = await execGit(['diff', '--cached'], cwd);
 		const rawDiff = diffResult.stdout;
 
-		if (!rawDiff.trim()) {
+		if (!rawDiff.trim() && !data.customPrompt) {
 			throw new Error('No staged changes to generate a branch name for');
 		}
 

--- a/frontend/app.css
+++ b/frontend/app.css
@@ -311,3 +311,42 @@
 	}
 }
 
+@utility colorblind-pattern-green {
+	background-image: repeating-linear-gradient(45deg, transparent, transparent 4px, rgba(255,255,255,0.3) 4px, rgba(255,255,255,0.3) 8px) !important;
+}
+@utility colorblind-pattern-yellow {
+	background-image: radial-gradient(rgba(0,0,0,0.15) 20%, transparent 20%), radial-gradient(rgba(0,0,0,0.15) 20%, transparent 20%) !important;
+	background-size: 8px 8px !important;
+	background-position: 0 0, 4px 4px !important;
+}
+@utility colorblind-pattern-orange {
+	background-image: repeating-linear-gradient(90deg, transparent, transparent 4px, rgba(255,255,255,0.3) 4px, rgba(255,255,255,0.3) 8px) !important;
+}
+@utility colorblind-pattern-red {
+	background-image: repeating-linear-gradient(45deg, transparent, transparent 4px, rgba(255,255,255,0.25) 4px, rgba(255,255,255,0.25) 8px), repeating-linear-gradient(-45deg, transparent, transparent 4px, rgba(255,255,255,0.25) 4px, rgba(255,255,255,0.25) 8px) !important;
+}
+@utility colorblind-pattern-purple {
+	background-image: repeating-linear-gradient(0deg, transparent, transparent 4px, rgba(255,255,255,0.3) 4px, rgba(255,255,255,0.3) 8px) !important;
+}
+@utility colorblind-pattern-blue {
+	background-image: radial-gradient(circle, rgba(255,255,255,0.3) 30%, transparent 30%) !important;
+	background-size: 8px 8px !important;
+}
+@utility colorblind-pattern-sky {
+	background-image: repeating-linear-gradient(60deg, transparent, transparent 3px, rgba(255,255,255,0.3) 3px, rgba(255,255,255,0.3) 6px) !important;
+}
+@utility colorblind-pattern-lime {
+	background-image: linear-gradient(45deg, rgba(0,0,0,0.15) 25%, transparent 25%), linear-gradient(-45deg, rgba(0,0,0,0.15) 25%, transparent 25%), linear-gradient(45deg, transparent 75%, rgba(0,0,0,0.15) 75%), linear-gradient(-45deg, transparent 75%, rgba(0,0,0,0.15) 75%) !important;
+	background-size: 8px 8px !important;
+	background-position: 0 0, 0 4px, 4px -4px, -4px 0px !important;
+}
+@utility colorblind-pattern-pink {
+	background-image: repeating-linear-gradient(135deg, transparent, transparent 4px, rgba(255,255,255,0.3) 4px, rgba(255,255,255,0.3) 8px) !important;
+}
+@utility colorblind-pattern-black {
+	background-image: linear-gradient(135deg, rgba(255,255,255,0.2) 25%, transparent 25%), linear-gradient(225deg, rgba(255,255,255,0.2) 25%, transparent 25%), linear-gradient(45deg, rgba(255,255,255,0.2) 25%, transparent 25%), linear-gradient(315deg, rgba(255,255,255,0.2) 25%, transparent 25%) !important;
+	background-size: 10px 10px !important;
+	background-position: 5px 0, 5px 5px, 0 5px, 0 0 !important;
+}
+
+

--- a/frontend/components/git/CommitForm.svelte
+++ b/frontend/components/git/CommitForm.svelte
@@ -5,6 +5,7 @@
 	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import { clickOutside } from '$frontend/utils/click-outside';
 	import { settings } from '$frontend/stores/features/settings.svelte';
+	import { taskClientStore } from '$frontend/stores/features/task-client.svelte';
 	import { projectState } from '$frontend/stores/core/projects.svelte';
 	import { showError } from '$frontend/stores/ui/notification.svelte';
 	import {
@@ -87,6 +88,7 @@
 	let branchNameDraft = $state('');
 	let showBranchDraft = $state(false);
 	let showGenerateDropdown = $state(false);
+	let showBranchSubmenu = $state(false);
 	let generateBtnEl = $state<HTMLButtonElement | null>(null);
 	let generateMenuStyle = $state('');
 
@@ -98,11 +100,17 @@
 			? `right: ${window.innerWidth - rect.right}px; bottom: ${window.innerHeight - rect.top + 6}px;`
 			: `right: ${window.innerWidth - rect.right}px; top: ${rect.bottom + 6}px;`;
 		showGenerateDropdown = true;
+		showBranchSubmenu = settings.commitGenerator.ticketSource === 'trello' && !!taskClientStore.selectedBoardId;
 	}
 
 	function handleGenerateClick() {
 		if (!onCreateBranch) { generateCommitMessage(); return; }
-		showGenerateDropdown ? (showGenerateDropdown = false) : openGenerateMenu();
+		if (showGenerateDropdown) {
+			showGenerateDropdown = false;
+			showBranchSubmenu = false;
+		} else {
+			openGenerateMenu();
+		}
 	}
 
 	function generateBoth() {
@@ -181,11 +189,29 @@
 		return parts.join('\n');
 	}
 
-	function buildBranchExtra(): string {
+	function buildBranchExtra(source?: 'card' | 'diff'): string {
 		const config = settings.commitGenerator.branchConfig;
-		if (!config) return '';
-		const { maxWords, allowedPrefixes, context } = config;
 		const parts: string[] = [];
+
+		const useCard = source === 'card' || (source === undefined && settings.commitGenerator.ticketSource === 'trello' && taskClientStore.activeCardId);
+
+		if (useCard) {
+			const activeCardId = taskClientStore.activeCardId;
+			if (activeCardId) {
+				const activeCard = taskClientStore.cards.find(c => c.id === activeCardId);
+				if (activeCard) {
+					parts.push(`CRITICAL: The branch description MUST be generated directly from this task card title: "${activeCard.name}".`);
+					
+					const ticketLanguage = settings.commitGenerator.ticketLanguage;
+					if (ticketLanguage === 'en') {
+						parts.push('Write/translate the branch description in English.');
+					}
+				}
+			}
+		}
+
+		if (!config) return parts.join('\n');
+		const { maxWords, allowedPrefixes, context } = config;
 		if (maxWords !== 3) parts.push(`Description must be at most ${maxWords} word${maxWords === 1 ? '' : 's'}.`);
 		const prefixes = (allowedPrefixes ?? '').split(',').map(s => s.trim()).filter(Boolean);
 		if (prefixes.length) parts.push(`Prefix must be one of: ${prefixes.join(', ')}.`);
@@ -230,17 +256,43 @@
 		}
 	}
 
-	async function generateBranchName() {
+	async function generateBranchName(source?: 'card' | 'diff') {
 		const projectId = projectState.currentProject?.id;
 		if (!projectId || stagedCount === 0 || isGeneratingBranch || repoBusy) return;
 
 		setGitOp(projectId, 'isGeneratingBranch', true, repoPath);
 		try {
-			const { useCustomModel, engine, provider, modelId, branchSeparator, branchConfig } = settings.commitGenerator;
+			const { useCustomModel, engine, provider, modelId, branchSeparator, branchConfig, ticketSource, ticketPrefix } = settings.commitGenerator;
+			const msgSep = branchConfig?.branchMessageSeparator !== undefined ? branchConfig.branchMessageSeparator : '-';
+
+			// 1. Get the ticket ID/prefix if enabled and active
+			let ticketId = '';
+			if (ticketSource === 'trello') {
+				const activeCardId = taskClientStore.activeCardId;
+				if (activeCardId) {
+					const activeCard = taskClientStore.cards.find(c => c.id === activeCardId);
+					if (activeCard) {
+						if (ticketPrefix === 'id-short' && activeCard.idShort) {
+							ticketId = String(activeCard.idShort);
+						} else if (activeCard.shortLink) {
+							ticketId = activeCard.shortLink;
+						} else {
+							// fallback to parsing shortLink from Trello card URL
+							const match = activeCard.url?.match(/\/c\/([a-zA-Z0-9]+)/);
+							if (match) {
+								ticketId = match[1];
+							}
+						}
+					}
+				}
+			}
+
+			// Fallback to AI generation
 			const resolvedEngine = useCustomModel ? engine : settings.selectedEngine;
 			const resolvedProvider = useCustomModel ? provider : settings.selectedProvider;
 			const resolvedModel = useCustomModel ? modelId : settings.selectedModelId;
-			const extra = buildBranchExtra();
+			const extra = buildBranchExtra(source);
+
 			const result = await ws.http('git:generate-branch-name', {
 				projectId,
 				engine: resolvedEngine,
@@ -251,7 +303,33 @@
 				...(repoPath && { repoPath }),
 				...(extra && { customPrompt: extra })
 			});
-			branchNameDraft = result.branchName;
+
+			let branchName = result.branchName;
+			
+			// Find the separator index that divides the prefix and the description
+			const sepIdx = branchSeparator ? branchName.indexOf(branchSeparator) : -1;
+			let prefix = '';
+			let description = branchName;
+			if (sepIdx !== -1) {
+				prefix = branchName.slice(0, sepIdx + branchSeparator.length);
+				description = branchName.slice(sepIdx + branchSeparator.length);
+			}
+
+			// Format the description with the custom branch message separator (defaulting to '-')
+			let formattedDesc = description.split('-').join(msgSep);
+
+			// 2. Prepends the ticket ID if found
+			if (ticketId) {
+				if (formattedDesc) {
+					formattedDesc = `${ticketId}${msgSep}${formattedDesc}`;
+				} else {
+					formattedDesc = ticketId;
+				}
+			}
+
+			branchName = `${prefix}${formattedDesc}`;
+
+			branchNameDraft = branchName;
 			showBranchDraft = true;
 		} catch (err) {
 			showError('Generate Branch Failed', err instanceof Error ? err.message : 'Failed to generate branch name');
@@ -275,9 +353,320 @@
 			setGitOp(projectId, 'isCreatingBranch', false, repoPath);
 		}
 	}
+
+	let showCardSelector = $state(false);
+	let cardSearchQuery = $state('');
+	let selectedListId = $state<string | null>(null);
+	let listContainerEl = $state<HTMLDivElement | null>(null);
+
+	$effect(() => {
+		if (listContainerEl) {
+			// Trigger on dropdown open, board change, or list change
+			const _open = showCardSelector;
+			const _board = taskClientStore.selectedBoardId;
+			const _list = selectedListId;
+			listContainerEl.scrollTop = 0;
+		}
+	});
+
+	const filteredCards = $derived(
+		taskClientStore.cards.filter(c =>
+			c.idList === selectedListId && (
+				!cardSearchQuery.trim() ||
+				c.name.toLowerCase().includes(cardSearchQuery.toLowerCase()) ||
+				String(c.idShort || '').includes(cardSearchQuery) ||
+				(c.shortLink || '').toLowerCase().includes(cardSearchQuery.toLowerCase())
+			)
+		)
+	);
+
+	const filteredLists = $derived(
+		taskClientStore.lists.filter(l =>
+			!cardSearchQuery.trim() ||
+			l.name.toLowerCase().includes(cardSearchQuery.toLowerCase())
+		)
+	);
+
+	function openCardSelector() {
+		showCardSelector = true;
+		cardSearchQuery = '';
+		if (taskClientStore.activeCardId) {
+			const activeCard = taskClientStore.cards.find(c => c.id === taskClientStore.activeCardId);
+			if (activeCard) {
+				selectedListId = activeCard.idList;
+				return;
+			}
+		}
+		selectedListId = null;
+	}
+
+	const sortedBoards = $derived(
+		taskClientStore.boards.map(board => ({
+			...board,
+			isStarred: taskClientStore.boardStars.some(s => s.idBoard === board.id)
+		})).sort((a, b) => {
+			if (a.isStarred && !b.isStarred) return -1;
+			if (!a.isStarred && b.isStarred) return 1;
+			return a.name.localeCompare(b.name);
+		})
+	);
+
+	const filteredBoards = $derived(
+		sortedBoards.filter(b =>
+			!cardSearchQuery.trim() ||
+			b.name.toLowerCase().includes(cardSearchQuery.toLowerCase())
+		)
+	);
+
+	function selectTrelloCard(cardId: string) {
+		taskClientStore.activeCardId = cardId;
+		showCardSelector = false;
+	}
+
+	function clearActiveCard() {
+		taskClientStore.activeCardId = null;
+	}
 </script>
 
 <div class="px-2 py-2">
+	{#if settings.commitGenerator.ticketSource === 'trello'}
+		{@const activeCard = taskClientStore.cards.find(c => c.id === taskClientStore.activeCardId)}
+		<div class="relative flex items-center mb-2">
+			{#if activeCard}
+				{@const activeTicketLabel = settings.commitGenerator.ticketPrefix === 'id-short' && activeCard.idShort ? `#${activeCard.idShort}` : (activeCard.shortLink || '')}
+				<!-- Linked Card Card -->
+				<div class="flex items-center justify-between w-full gap-3 p-2 rounded-md border border-slate-200 dark:border-slate-800/80 bg-slate-50 dark:bg-slate-900/30 text-xs shadow-sm">
+					<div class="flex items-center gap-2.5 min-w-0">
+						<div class="flex items-center justify-center w-5 h-5 rounded-md bg-violet-500/10 text-violet-500 dark:text-violet-400 shrink-0">
+							<Icon name="lucide:trello" class="w-3.5 h-3.5" />
+						</div>
+						{#if activeTicketLabel}
+							<span class="font-mono text-[10px] font-bold bg-violet-500/10 text-violet-600 dark:text-violet-400 px-1.5 py-0.5 rounded border border-violet-500/20 shrink-0">
+								{activeTicketLabel}
+							</span>
+						{/if}
+						{#if activeCard.url}
+							<a
+								href={activeCard.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="truncate font-medium text-slate-700 dark:text-slate-200 hover:text-violet-600 dark:hover:text-violet-400 hover:underline min-w-0"
+							>
+								{activeCard.name}
+							</a>
+						{:else}
+							<span class="truncate font-medium text-slate-700 dark:text-slate-200">{activeCard.name}</span>
+						{/if}
+					</div>
+					<div class="flex items-center gap-2 shrink-0">
+						<button
+							type="button"
+							onclick={openCardSelector}
+							class="text-[10px] font-semibold text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 hover:underline cursor-pointer border-none bg-transparent"
+						>
+							Change
+						</button>
+						<div class="w-[1px] h-3 bg-slate-200 dark:bg-slate-800"></div>
+						<button
+							type="button"
+							onclick={clearActiveCard}
+							class="p-1 rounded-md text-slate-400 hover:text-slate-600 dark:hover:text-slate-350 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors cursor-pointer border-none bg-transparent flex items-center justify-center"
+							aria-label="Clear active card"
+						>
+							<Icon name="lucide:x" class="w-3.5 h-3.5" />
+						</button>
+					</div>
+				</div>
+			{:else}
+				<!-- Unlinked Placeholder Card -->
+				<button
+					type="button"
+					onclick={openCardSelector}
+					class="flex items-center gap-2 p-2 w-full rounded-md border border-dashed border-slate-200 dark:border-slate-800 hover:border-violet-500/40 bg-slate-50/50 dark:bg-slate-900/10 hover:bg-violet-500/5 dark:hover:bg-violet-500/5 text-xs text-slate-500 hover:text-violet-600 dark:text-slate-400 dark:hover:text-violet-400 cursor-pointer transition-all duration-200 text-left"
+				>
+					<Icon name="lucide:trello" class="w-3.5 h-3.5 text-slate-400 dark:text-slate-500 shrink-0" />
+					<span class="font-medium">Link Trello card...</span>
+				</button>
+			{/if}
+			
+			<!-- Card Selector Dropdown -->
+			{#if showCardSelector}
+				<!-- Click outside backdrop to close -->
+				<button type="button" class="fixed inset-0 z-40 bg-transparent cursor-default border-none w-full h-full" onclick={() => showCardSelector = false}></button>
+				
+				<div class="absolute top-full mt-1 left-0 z-50 w-72 p-2 rounded-md border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 shadow-2xl flex flex-col gap-1.5 animate-in fade-in slide-in-from-top-2 duration-150">
+					<!-- Search input -->
+					<div class="relative flex items-center px-2.5 py-1.5 bg-slate-50 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-slate-800 focus-within:border-slate-350 dark:focus-within:border-slate-700">
+						<Icon name="lucide:search" class="w-3.5 h-3.5 text-slate-400 mr-2 shrink-0" />
+						<input
+							type="text"
+							bind:value={cardSearchQuery}
+							placeholder={!taskClientStore.selectedBoardId ? "Search boards..." : !selectedListId ? "Search lists..." : "Search cards..."}
+							class="w-full bg-transparent border-none text-xs text-slate-800 dark:text-slate-200 placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:outline-none focus:ring-0 p-0"
+						/>
+					</div>
+					
+					<!-- Cards List -->
+					<div bind:this={listContainerEl} class="flex-grow overflow-y-auto max-h-48 pr-0.5 flex flex-col gap-0.5">
+						{#if !taskClientStore.selectedBoardId}
+							{#if taskClientStore.accounts.length === 0}
+								<div class="text-xs text-slate-500 text-center py-4">
+									No Trello account connected.
+									<div class="text-[10px] text-slate-400 mt-1">Please connect your account in the Task Client.</div>
+								</div>
+							{:else}
+								{#if taskClientStore.loadingBoards}
+									<div class="text-xs text-slate-500 text-center py-4 flex items-center justify-center gap-1.5">
+										<Icon name="lucide:loader" class="w-3.5 h-3.5 animate-spin text-violet-500" />
+										<span>Loading boards...</span>
+									</div>
+								{:else if taskClientStore.boards.length === 0}
+									<div class="text-xs text-slate-500 text-center py-4 px-2">
+										No boards found.
+										<button
+											type="button"
+											onclick={() => taskClientStore.loadBoards()}
+											class="mt-2 w-full px-2 py-1 bg-slate-100 dark:bg-slate-900 hover:bg-slate-200 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-800 rounded text-slate-700 dark:text-slate-300 font-medium text-[11px] cursor-pointer transition-colors"
+										>
+											Reload Boards
+										</button>
+									</div>
+								{:else if filteredBoards.length === 0}
+									<div class="text-xs text-slate-500 text-center py-4 px-2">No boards match your search.</div>
+								{:else}
+									{@const starred = filteredBoards.filter(b => b.isStarred)}
+									{@const unstarred = filteredBoards.filter(b => !b.isStarred)}
+
+									{#if starred.length > 0}
+										<div class="px-2.5 py-1 text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider shrink-0">Starred Boards</div>
+										{#each starred as board}
+											<button
+												type="button"
+												class="w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-left border-none cursor-pointer text-xs transition-colors hover:bg-slate-50 dark:hover:bg-slate-900 bg-transparent text-slate-700 dark:text-slate-350 hover:text-slate-900 dark:hover:text-slate-100 font-medium"
+												onclick={() => { taskClientStore.selectBoard(board.id); selectedListId = null; cardSearchQuery = ''; }}
+											>
+												<Icon name="lucide:star" class="w-3.5 h-3.5 text-amber-500 fill-amber-500 shrink-0" />
+												<span class="truncate">{board.name}</span>
+											</button>
+										{/each}
+										
+										{#if unstarred.length > 0}
+											<div class="h-[1px] bg-slate-100 dark:bg-slate-900 my-1 shrink-0"></div>
+										{/if}
+									{/if}
+
+									{#if unstarred.length > 0}
+										{#if starred.length > 0}
+											<div class="px-2.5 py-1 text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider shrink-0">All Boards</div>
+										{/if}
+										{#each unstarred as board}
+											<button
+												type="button"
+												class="w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-left border-none cursor-pointer text-xs transition-colors hover:bg-slate-50 dark:hover:bg-slate-900 bg-transparent text-slate-650 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100"
+												onclick={() => { taskClientStore.selectBoard(board.id); selectedListId = null; cardSearchQuery = ''; }}
+											>
+												<Icon name="lucide:trello" class="w-3.5 h-3.5 text-slate-400 dark:text-slate-500 shrink-0" />
+												<span class="truncate font-medium">{board.name}</span>
+											</button>
+										{/each}
+									{/if}
+								{/if}
+							{/if}
+						{:else}
+							<!-- Header with active board name and a Switch Board button -->
+							<div class="flex flex-col border-b border-slate-100 dark:border-slate-900/60 pb-1.5 mb-1.5 shrink-0 gap-1 px-2.5">
+								<div class="flex items-center justify-between">
+									<div class="flex items-center gap-1.5 min-w-0">
+										<Icon name="lucide:trello" class="w-3.5 h-3.5 text-slate-400 dark:text-slate-500 shrink-0" />
+										<div class="flex items-center gap-1 text-[10px] text-slate-400 dark:text-slate-500 font-semibold truncate">
+											<span class="uppercase tracking-wider">Board:</span>
+											<span class="text-slate-700 dark:text-slate-300 font-bold truncate max-w-[130px]">{taskClientStore.selectedBoard?.name ?? 'Loading...'}</span>
+										</div>
+									</div>
+									<button
+										type="button"
+										onclick={() => { taskClientStore.selectBoard(null); selectedListId = null; cardSearchQuery = ''; }}
+										class="text-[10px] text-violet-650 dark:text-violet-400 hover:underline cursor-pointer border-none bg-transparent font-medium shrink-0"
+									>
+										Switch
+									</button>
+								</div>
+
+								{#if selectedListId}
+									{@const activeList = taskClientStore.lists.find(l => l.id === selectedListId)}
+									<div class="flex items-center justify-between border-t border-slate-50 dark:border-slate-900/40 pt-1 mt-0.5">
+										<div class="flex items-center gap-1.5 min-w-0">
+											<Icon name="lucide:list" class="w-3.5 h-3.5 text-slate-400 dark:text-slate-500 shrink-0" />
+											<div class="flex items-center gap-1 text-[10px] text-slate-400 dark:text-slate-500 font-semibold truncate font-semibold truncate">
+												<span class="uppercase tracking-wider">List:</span>
+												<span class="text-slate-700 dark:text-slate-300 font-bold truncate max-w-[140px]">{activeList?.name ?? 'Loading...'}</span>
+											</div>
+										</div>
+										<button
+											type="button"
+											onclick={() => { selectedListId = null; cardSearchQuery = ''; }}
+											class="text-[10px] text-violet-650 dark:text-violet-400 hover:underline cursor-pointer border-none bg-transparent font-medium shrink-0"
+										>
+											Back
+										</button>
+									</div>
+								{/if}
+							</div>
+
+							{#if !selectedListId}
+								{#if taskClientStore.loadingCards}
+									<div class="text-xs text-slate-500 text-center py-4 flex items-center justify-center gap-1.5">
+										<Icon name="lucide:loader" class="w-3.5 h-3.5 animate-spin text-violet-500" />
+										<span>Loading lists...</span>
+									</div>
+								{:else if filteredLists.length === 0}
+									<div class="text-xs text-slate-500 text-center py-4 px-2">No lists match your search.</div>
+								{:else}
+									<div class="px-2.5 py-1 text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider shrink-0">Select a List:</div>
+									{#each filteredLists as list}
+										<button
+											type="button"
+											class="w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-left border-none cursor-pointer text-xs transition-colors hover:bg-slate-50 dark:hover:bg-slate-900 bg-transparent text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100"
+											onclick={() => { selectedListId = list.id; cardSearchQuery = ''; }}
+										>
+											<Icon name="lucide:list" class="w-3.5 h-3.5 text-slate-400 dark:text-slate-500 shrink-0" />
+											<span class="truncate font-medium">{list.name}</span>
+										</button>
+									{/each}
+								{/if}
+							{:else}
+								{#if taskClientStore.loadingCards}
+									<div class="text-xs text-slate-500 text-center py-4 flex items-center justify-center gap-1.5">
+										<Icon name="lucide:loader" class="w-3.5 h-3.5 animate-spin text-violet-500" />
+										<span>Loading cards...</span>
+									</div>
+								{:else if filteredCards.length === 0}
+									<div class="text-xs text-slate-500 text-center py-4">No cards found.</div>
+								{:else}
+									{#each filteredCards as card}
+										{@const isActive = card.id === taskClientStore.activeCardId}
+										{@const ticketLabel = settings.commitGenerator.ticketPrefix === 'id-short' && card.idShort ? `#${card.idShort}` : (card.shortLink || '')}
+										<button
+											type="button"
+											class="w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-left border-none cursor-pointer text-xs transition-colors bg-transparent text-slate-700 dark:text-slate-350 hover:bg-slate-50 dark:hover:bg-slate-900 hover:text-slate-900 dark:hover:text-slate-100 {isActive ? 'bg-violet-500/5 dark:bg-violet-500/10 text-violet-600 dark:text-violet-400 font-medium' : ''}"
+											onclick={() => selectTrelloCard(card.id)}
+										>
+											{#if ticketLabel}
+												<span class="font-mono text-[9px] font-semibold px-1.5 py-0.5 rounded border shrink-0 text-center {isActive ? 'bg-violet-500/10 dark:bg-violet-500/15 text-violet-600 dark:text-violet-400 border-violet-500/20 dark:border-violet-500/30' : 'bg-slate-50 dark:bg-slate-900 text-slate-500 dark:text-slate-400 border-slate-200/60 dark:border-slate-850'}">
+													{ticketLabel}
+												</span>
+											{/if}
+											<span class="line-clamp-2 leading-tight">{card.name}</span>
+										</button>
+									{/each}
+								{/if}
+							{/if}
+						{/if}
+					</div>
+				</div>
+			{/if}
+		</div>
+	{/if}
 	<div class="flex flex-col gap-1.5">
 			<textarea
 			bind:this={textareaEl}
@@ -355,14 +744,14 @@
 					<span>Commit{stagedCount > 0 ? ` (${stagedCount})` : ''}</span>
 				{/if}
 			</button>
-			<div class="relative h-7 flex-shrink-0" use:clickOutside={() => showGenerateDropdown = false}>
+			<div class="relative h-7 flex-shrink-0" use:clickOutside={() => { showGenerateDropdown = false; showBranchSubmenu = false; }}>
 				<button
 					bind:this={generateBtnEl}
 					type="button"
 					class="flex items-center justify-center w-8 h-7 rounded-md bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-700 text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-violet-600 dark:hover:text-violet-400 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-white dark:disabled:hover:bg-slate-800/80 disabled:hover:text-slate-500 flex-shrink-0
 						{showGenerateDropdown ? 'bg-violet-500/10 text-violet-600 dark:text-violet-400' : ''}"
 					onclick={handleGenerateClick}
-					disabled={stagedCount === 0 || isGenerating || isGeneratingBranch || isCommitting}
+					disabled={(stagedCount === 0 && !(settings.commitGenerator.ticketSource === 'trello' && taskClientStore.selectedBoardId)) || isGenerating || isGeneratingBranch || isCommitting}
 					title={onCreateBranch ? 'AI generation options' : stagedCount > 0 ? 'Generate commit message' : 'Stage changes first'}
 					aria-haspopup="menu"
 					aria-expanded={showGenerateDropdown}
@@ -391,17 +780,63 @@
 							<Icon name="lucide:message-square" class="w-3.5 h-3.5 flex-shrink-0" />
 							<span class="flex-1 text-xs font-medium truncate">Generate commit message</span>
 						</button>
-						<button
-							type="button"
-							role="menuitem"
-							class="flex w-full items-center gap-2.5 px-3 py-1.5 text-left bg-transparent border-none transition-colors
-								{stagedCount === 0 || repoBusy ? 'text-slate-300 dark:text-slate-600 cursor-not-allowed' : 'text-slate-700 dark:text-slate-200 hover:bg-violet-500/10 cursor-pointer'}"
-							onclick={() => { showGenerateDropdown = false; generateBranchName(); }}
-							disabled={stagedCount === 0 || repoBusy}
-						>
-							<Icon name="lucide:git-branch-plus" class="w-3.5 h-3.5 flex-shrink-0" />
-							<span class="flex-1 text-xs font-medium truncate">Generate branch name</span>
-						</button>
+						{#if settings.commitGenerator.ticketSource === 'trello' && taskClientStore.selectedBoardId}
+							<div>
+								<button
+									type="button"
+									role="menuitem"
+									class="flex w-full items-center gap-2.5 px-3 py-1.5 text-left bg-transparent border-none transition-colors
+										{(stagedCount === 0 && !taskClientStore.activeCardId) || repoBusy ? 'text-slate-300 dark:text-slate-600 cursor-not-allowed' : 'text-slate-700 dark:text-slate-200 hover:bg-violet-500/10 cursor-pointer'}"
+									onclick={(e) => {
+										e.preventDefault();
+										e.stopPropagation();
+										showBranchSubmenu = !showBranchSubmenu;
+									}}
+									disabled={(stagedCount === 0 && !taskClientStore.activeCardId) || repoBusy}
+								>
+									<Icon name="lucide:git-branch-plus" class="w-3.5 h-3.5 flex-shrink-0" />
+									<span class="flex-1 text-xs font-medium truncate">Generate branch name</span>
+									<Icon name={showBranchSubmenu ? "lucide:chevron-down" : "lucide:chevron-right"} class="w-3 h-3 text-slate-400 flex-shrink-0 ml-auto" />
+								</button>
+								{#if showBranchSubmenu}
+									<div class="pl-4 py-1 bg-slate-50/50 dark:bg-slate-900/20 border-l border-slate-200 dark:border-slate-700 ml-4 mr-2 my-1 flex flex-col gap-0.5 rounded-r">
+										<button
+											type="button"
+											class="flex w-full items-center gap-2 px-2 py-1 text-left bg-transparent border-none rounded text-[11px] font-medium transition-colors
+												{!taskClientStore.activeCardId || repoBusy ? 'text-slate-300 dark:text-slate-600 cursor-not-allowed' : 'text-slate-600 dark:text-slate-300 hover:bg-violet-500/10 hover:text-violet-600 dark:hover:text-violet-400 cursor-pointer'}"
+											onclick={() => { showGenerateDropdown = false; showBranchSubmenu = false; generateBranchName('card'); }}
+											disabled={!taskClientStore.activeCardId || repoBusy}
+											title={!taskClientStore.activeCardId ? 'Select a card first' : ''}
+										>
+											<Icon name="lucide:file-text" class="w-3 h-3 flex-shrink-0" />
+											<span class="truncate">From card title</span>
+										</button>
+										<button
+											type="button"
+											class="flex w-full items-center gap-2 px-2 py-1 text-left bg-transparent border-none rounded text-[11px] font-medium transition-colors
+												{stagedCount === 0 || repoBusy ? 'text-slate-300 dark:text-slate-600 cursor-not-allowed' : 'text-slate-600 dark:text-slate-300 hover:bg-violet-500/10 hover:text-violet-600 dark:hover:text-violet-400 cursor-pointer'}"
+											onclick={() => { showGenerateDropdown = false; showBranchSubmenu = false; generateBranchName('diff'); }}
+											disabled={stagedCount === 0 || repoBusy}
+										>
+											<Icon name="lucide:file-diff" class="w-3 h-3 flex-shrink-0" />
+											<span class="truncate">From diff</span>
+										</button>
+									</div>
+								{/if}
+							</div>
+						{:else}
+							<button
+								type="button"
+								role="menuitem"
+								class="flex w-full items-center gap-2.5 px-3 py-1.5 text-left bg-transparent border-none transition-colors
+									{stagedCount === 0 || repoBusy ? 'text-slate-300 dark:text-slate-600 cursor-not-allowed' : 'text-slate-700 dark:text-slate-200 hover:bg-violet-500/10 cursor-pointer'}"
+								onclick={() => { showGenerateDropdown = false; generateBranchName(); }}
+								disabled={stagedCount === 0 || repoBusy}
+							>
+								<Icon name="lucide:git-branch-plus" class="w-3.5 h-3.5 flex-shrink-0" />
+								<span class="flex-1 text-xs font-medium truncate">Generate branch name</span>
+							</button>
+						{/if}
 						<div class="my-1 mx-2 border-t border-slate-200 dark:border-slate-700/70"></div>
 						<button
 							type="button"

--- a/frontend/components/settings/model/ModelSettings.svelte
+++ b/frontend/components/settings/model/ModelSettings.svelte
@@ -2,6 +2,7 @@
 	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import Modal from '$frontend/components/common/overlay/Modal.svelte';
 	import { settings, updateSettings } from '$frontend/stores/features/settings.svelte';
+	import { taskClientStore } from '$frontend/stores/features/task-client.svelte';
 	import { modelStore } from '$frontend/stores/features/models.svelte';
 	import { ENGINES } from '$shared/constants/engines';
 	import type { EngineType } from '$shared/types/unified';
@@ -21,15 +22,25 @@
 	let showModelConfig = $state(false);
 	let showCommitConfig = $state(false);
 	let showBranchConfig = $state(false);
+	let showTicketConfig = $state(false);
+	const isTrelloConnected = $derived(taskClientStore.accounts.length > 0);
 
 	let commitConfigDraft = $state<CommitMessageConfig>({ style: 'technical', subjectLength: 72, allowedTypes: '', context: '' });
-	let branchConfigDraft = $state<BranchNameConfig>({ maxWords: 3, allowedPrefixes: '', context: '' });
+	let branchConfigDraft = $state<BranchNameConfig>({ maxWords: 3, allowedPrefixes: '', context: '', branchMessageSeparator: '-' });
+	let ticketPrefixDraft = $state<'short-link' | 'id-short'>('short-link');
+	let ticketLanguageDraft = $state<'auto' | 'en'>('auto');
 
 	$effect(() => {
 		if (showCommitConfig) commitConfigDraft = { ...commitGen.commitConfig };
 	});
 	$effect(() => {
 		if (showBranchConfig) branchConfigDraft = { ...commitGen.branchConfig };
+	});
+	$effect(() => {
+		if (showTicketConfig) {
+			ticketPrefixDraft = commitGen.ticketPrefix || 'short-link';
+			ticketLanguageDraft = commitGen.ticketLanguage || 'auto';
+		}
 	});
 
 	function saveCommitConfig() {
@@ -40,6 +51,17 @@
 	function saveBranchConfig() {
 		updateSettings({ commitGenerator: { ...commitGen, branchConfig: { ...branchConfigDraft } } });
 		showBranchConfig = false;
+	}
+
+	function saveTicketConfig() {
+		updateSettings({
+			commitGenerator: {
+				...commitGen,
+				ticketPrefix: ticketPrefixDraft,
+				ticketLanguage: ticketLanguageDraft
+			}
+		});
+		showTicketConfig = false;
 	}
 
 	const STYLE_OPTIONS = [
@@ -151,6 +173,10 @@
 	function selectBranchSeparator(value: string) {
 		updateSettings({ commitGenerator: { ...commitGen, branchSeparator: value } });
 	}
+
+	function updateTicketSource(value: 'none' | 'trello') {
+		updateSettings({ commitGenerator: { ...commitGen, ticketSource: value } });
+	}
 </script>
 
 <div class="py-1">
@@ -249,6 +275,58 @@
 						</div>
 					</button>
 				{/each}
+			</div>
+		</div>
+
+		<!-- Ticket ID Integration -->
+		<div class="mb-5">
+			<div class="flex items-center justify-between mb-2">
+				<label class="block text-sm font-semibold text-slate-700 dark:text-slate-300">Branch Ticket</label>
+				{#if commitGen.ticketSource && commitGen.ticketSource !== 'none'}
+					<button type="button" onclick={() => showTicketConfig = true} class="flex items-center gap-1 text-xs text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 transition-colors cursor-pointer">
+						<Icon name="lucide:settings-2" class="w-3 h-3" />
+						Configure
+					</button>
+				{/if}
+			</div>
+			<div class="flex gap-2">
+				<button
+					type="button"
+					class="flex-1 flex items-center gap-2.5 p-3 border-2 rounded-xl text-left cursor-pointer transition-all duration-200
+						{commitGen.ticketSource === 'none' || !commitGen.ticketSource
+						? 'border-violet-600 bg-gradient-to-br from-violet-500/10 to-purple-500/5 dark:from-violet-500/12 dark:to-purple-500/8'
+						: 'border-slate-200 dark:border-slate-800 bg-slate-100/80 dark:bg-slate-800/80 hover:border-violet-500/20 dark:hover:border-violet-500/35'}"
+					onclick={() => updateTicketSource('none')}
+				>
+					<Icon name="lucide:ban" class="w-4 h-4 {commitGen.ticketSource === 'none' || !commitGen.ticketSource ? 'text-violet-600' : 'text-slate-400'}" />
+					<div>
+						<div class="text-sm font-medium text-slate-900 dark:text-slate-100">None</div>
+						<div class="text-xs text-slate-500 dark:text-slate-400">Do not prepend ticket ID</div>
+					</div>
+				</button>
+				
+				<button
+					type="button"
+					disabled={!isTrelloConnected}
+					class="flex-1 flex items-center gap-2.5 p-3 border-2 rounded-xl text-left transition-all duration-200
+						{commitGen.ticketSource === 'trello'
+						? 'border-violet-600 bg-gradient-to-br from-violet-500/10 to-purple-500/5 dark:from-violet-500/12 dark:to-purple-500/8'
+						: 'border-slate-200 dark:border-slate-800 bg-slate-100/80 dark:bg-slate-800/80 hover:border-violet-500/20 dark:hover:border-violet-500/35'}
+						{!isTrelloConnected ? 'opacity-40 cursor-not-allowed hover:border-slate-200 dark:hover:border-slate-800' : 'cursor-pointer'}"
+					onclick={() => updateTicketSource('trello')}
+				>
+					<Icon name="lucide:trello" class="w-4 h-4 {commitGen.ticketSource === 'trello' ? 'text-violet-600' : 'text-slate-400'}" />
+					<div>
+						<div class="text-sm font-medium text-slate-900 dark:text-slate-100">Trello</div>
+						<div class="text-xs text-slate-500 dark:text-slate-400">
+							{#if isTrelloConnected}
+								Use active Trello card ID
+							{:else}
+								Account not connected
+							{/if}
+						</div>
+					</div>
+				</button>
 			</div>
 		</div>
 
@@ -377,6 +455,24 @@
 					{/each}
 				</div>
 			</div>
+
+			<div>
+				<label class="block text-sm font-semibold text-slate-700 dark:text-slate-300 mb-2">Branch message separator</label>
+				<div class="flex gap-2">
+					{#each [
+						{ value: '-', label: 'Dash', desc: '-' },
+						{ value: '_', label: 'Underscore', desc: '_' }
+					] as sepOption}
+						{@const isActive = (branchConfigDraft.branchMessageSeparator ?? '-') === sepOption.value}
+						<button type="button" onclick={() => branchConfigDraft.branchMessageSeparator = sepOption.value}
+							class="flex-1 flex flex-col gap-0.5 p-3 border-2 rounded-xl text-center cursor-pointer transition-all duration-200
+								{isActive ? 'border-violet-600 bg-gradient-to-br from-violet-500/10 to-purple-500/5 dark:from-violet-500/12 dark:to-purple-500/8' : 'border-slate-200 dark:border-slate-800 bg-slate-100/80 dark:bg-slate-800/80 hover:border-violet-500/20'}">
+							<span class="text-sm font-medium text-slate-900 dark:text-slate-100">{sepOption.label}</span>
+							<span class="text-xs text-slate-500 dark:text-slate-400 font-mono">{sepOption.desc}</span>
+						</button>
+					{/each}
+				</div>
+			</div>
 			<div>
 				<label class="block text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1.5">Allowed prefixes <span class="text-slate-400 font-normal">(optional)</span></label>
 				<input type="text" bind:value={branchConfigDraft.allowedPrefixes}
@@ -398,6 +494,64 @@
 			Cancel
 		</button>
 		<button type="button" onclick={saveBranchConfig} class="inline-flex items-center gap-2 px-3 py-2 text-sm font-semibold rounded-lg bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer">
+			Save
+		</button>
+	{/snippet}
+</Modal>
+
+<Modal isOpen={showTicketConfig} onClose={() => showTicketConfig = false} size="md">
+	{#snippet header()}
+		<div class="flex items-center justify-between px-4 py-3 md:px-6 md:py-4">
+			<h2 class="text-base font-bold text-slate-900 dark:text-slate-100">Configure Branch Ticket</h2>
+			<button type="button" class="p-1.5 rounded-lg text-slate-500 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-violet-500/10 transition-colors cursor-pointer" onclick={() => showTicketConfig = false}>
+				<Icon name="lucide:x" class="w-4 h-4" />
+			</button>
+		</div>
+	{/snippet}
+	{#snippet children()}
+		<div class="space-y-5">
+			<div>
+				<label class="block text-sm font-semibold text-slate-700 dark:text-slate-300 mb-2">ID Format</label>
+				<div class="flex gap-2">
+					{#each [
+						{ value: 'short-link', label: 'Short Link', desc: '7Hk9Xm1' },
+						{ value: 'id-short', label: 'Short ID', desc: '123' }
+					] as opt}
+						{@const isActive = ticketPrefixDraft === opt.value}
+						<button type="button" onclick={() => ticketPrefixDraft = opt.value as any}
+							class="flex-1 flex flex-col gap-0.5 p-3 border-2 rounded-xl text-left cursor-pointer transition-all duration-200
+								{isActive ? 'border-violet-600 bg-gradient-to-br from-violet-500/10 to-purple-500/5 dark:from-violet-500/12 dark:to-purple-500/8' : 'border-slate-200 dark:border-slate-800 bg-slate-100/80 dark:bg-slate-800/80 hover:border-violet-500/20'}">
+							<span class="text-sm font-medium text-slate-900 dark:text-slate-100">{opt.label}</span>
+							<span class="text-xs text-slate-500 dark:text-slate-400 font-mono">({opt.desc})</span>
+						</button>
+					{/each}
+				</div>
+			</div>
+
+			<div>
+				<label class="block text-sm font-semibold text-slate-700 dark:text-slate-300 mb-2">Language</label>
+				<div class="flex gap-2">
+					{#each [
+						{ value: 'auto', label: 'Auto', desc: 'Default' },
+						{ value: 'en', label: 'English', desc: 'English' }
+					] as langOption}
+						{@const isActive = ticketLanguageDraft === langOption.value}
+						<button type="button" onclick={() => ticketLanguageDraft = langOption.value as any}
+							class="flex-1 flex flex-col gap-0.5 p-3 border-2 rounded-xl text-left cursor-pointer transition-all duration-200
+								{isActive ? 'border-violet-600 bg-gradient-to-br from-violet-500/10 to-purple-500/5 dark:from-violet-500/12 dark:to-purple-500/8' : 'border-slate-200 dark:border-slate-800 bg-slate-100/80 dark:bg-slate-800/80 hover:border-violet-500/20'}">
+							<span class="text-sm font-medium text-slate-900 dark:text-slate-100">{langOption.label}</span>
+							<span class="text-xs text-slate-500 dark:text-slate-400">{langOption.desc}</span>
+						</button>
+					{/each}
+				</div>
+			</div>
+		</div>
+	{/snippet}
+	{#snippet footer()}
+		<button type="button" onclick={() => showTicketConfig = false} class="px-3 py-2 text-sm font-medium bg-transparent border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors cursor-pointer">
+			Cancel
+		</button>
+		<button type="button" onclick={saveTicketConfig} class="inline-flex items-center gap-2 px-3 py-2 text-sm font-semibold rounded-lg bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer">
 			Save
 		</button>
 	{/snippet}

--- a/frontend/components/task-client/CardDetailModal.svelte
+++ b/frontend/components/task-client/CardDetailModal.svelte
@@ -11,9 +11,39 @@
 		cardId: string | null;
 		isOpen: boolean;
 		onClose: () => void;
+		initialSection?: 'labels' | 'members' | 'dates' | null;
 	}
 
-	let { cardId, isOpen, onClose }: Props = $props();
+	let { cardId, isOpen, onClose, initialSection = null }: Props = $props();
+
+	let datesBtnEl = $state<HTMLButtonElement | null>(null);
+	let datesBadgeBtnEl = $state<HTMLButtonElement | null>(null);
+
+	$effect(() => {
+		if (isOpen && cardId) {
+			if (initialSection === 'labels') {
+				showLabelsPopover = true;
+			} else if (initialSection === 'members') {
+				showMembersPopover = true;
+			} else if (initialSection === 'dates') {
+				setTimeout(() => {
+					const triggerEl = datesBadgeBtnEl || datesBtnEl;
+					if (triggerEl) {
+						datesPopoverSource = datesBadgeBtnEl ? 'badge' : 'button';
+						updatePopoverPosition(triggerEl, 520);
+					} else {
+						popoverLeft = window.innerWidth / 2 - 144;
+						popoverTop = window.innerHeight / 2 - 260;
+					}
+					showDatesPopover = true;
+				}, 50);
+			}
+		} else {
+			showLabelsPopover = false;
+			showMembersPopover = false;
+			showDatesPopover = false;
+		}
+	});
 
 	// Component States
 	let isEditingDesc = $state(false);
@@ -1330,6 +1360,7 @@
 						{#if !(card.start || card.due)}
 						<div>
 							<button
+								bind:this={datesBtnEl}
 								type="button"
 								onclick={(e) => {
 									if (showDatesPopover && datesPopoverSource === 'button') {
@@ -1880,6 +1911,7 @@
 								<div class="flex items-center">
 									<!-- Clickable date badge button to open popover -->
 									<button
+										bind:this={datesBadgeBtnEl}
 										type="button"
 										onclick={(e) => {
 											if (showDatesPopover && datesPopoverSource === 'badge') {
@@ -2861,7 +2893,7 @@
 			<button
 				type="button"
 				onclick={handleRemoveDates}
-				class="flex-1 py-1.5 bg-slate-800 hover:bg-slate-700 border border-slate-750 text-slate-300 font-semibold rounded transition cursor-pointer"
+				class="flex-1 py-1.5 bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-300 font-semibold rounded transition cursor-pointer"
 			>
 				Remove
 			</button>

--- a/frontend/components/task-client/CardDetailModal.svelte
+++ b/frontend/components/task-client/CardDetailModal.svelte
@@ -1,0 +1,3200 @@
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { taskClientStore, type TrelloChecklist } from '$frontend/stores/features/task-client.svelte';
+	import { debug } from '$shared/utils/logger';
+	import { marked } from 'marked';
+	import RichTextEditor from './RichTextEditor.svelte';
+	import { untrack } from 'svelte';
+	import { formatFileSize } from '$frontend/utils/format';
+
+	interface Props {
+		cardId: string | null;
+		isOpen: boolean;
+		onClose: () => void;
+	}
+
+	let { cardId, isOpen, onClose }: Props = $props();
+
+	// Component States
+	let isEditingDesc = $state(false);
+	let editDescVal = $state('');
+	let newCheckItemVals = $state<Record<string, string>>({});
+	let activeAddCheckItemId = $state<string | null>(null);
+	let commentVal = $state('');
+	let isWritingComment = $state(false);
+	let editCommentHTML = $state('');
+	let showActivityDetails = $state(false);
+
+	const isCommentEmpty = $derived.by(() => {
+		if (!editCommentHTML) return true;
+		const text = editCommentHTML.replace(/<[^>]*>/g, '').trim();
+		return text.length === 0 && !editCommentHTML.includes('<img');
+	});
+
+	// Get current active card from store list
+	const card = $derived(
+		cardId ? taskClientStore.cards.find((c) => c.id === cardId) : null
+	);
+
+	// Get list details
+	const list = $derived(
+		card ? taskClientStore.lists.find((l) => l.id === card.idList) : null
+	);
+
+	$effect(() => {
+		console.log('CardDetailModal state changed - isOpen:', isOpen, 'cardId:', cardId, 'resolved card:', card);
+	});
+
+	// Load card details when card changes
+	$effect(() => {
+		if (isOpen && cardId) {
+			untrack(() => {
+				taskClientStore.fetchCardDetails(cardId);
+				if (card) {
+					editDescVal = card.desc || '';
+				}
+			});
+			isEditingDesc = false;
+			isWritingComment = false;
+			editCommentHTML = '';
+			activeAddCheckItemId = null;
+			newCheckItemVals = {};
+			commentVal = '';
+		}
+	});
+
+	// Actions handlers
+	async function handleToggleDueComplete() {
+		if (!card) return;
+		try {
+			await taskClientStore.toggleDueComplete(card.id, !card.dueComplete);
+		} catch (e) {
+			debug.error('task-client', 'Failed to toggle completion:', e);
+		}
+	}
+
+	let editDescHTML = $state('');
+
+	const mentionOptions = $derived.by(() => {
+		const list: { id: string; fullName: string; username: string; avatarUrl: string | null; isSpecial: boolean }[] = [
+			{
+				id: 'card',
+				fullName: 'All members on the card',
+				username: 'card',
+				avatarUrl: null,
+				isSpecial: true
+			},
+			{
+				id: 'board',
+				fullName: 'All members on the board',
+				username: 'board',
+				avatarUrl: null,
+				isSpecial: true
+			}
+		];
+		
+		if (card && card.members) {
+			for (const m of card.members) {
+				list.unshift({
+					id: m.id,
+					fullName: m.fullName,
+					username: m.username || m.fullName.toLowerCase().replace(/\s+/g, ''),
+					avatarUrl: m.avatarUrl,
+					isSpecial: false
+				});
+			}
+		}
+		return list;
+	});
+
+	function highlightCode(line: string, lang: string): string {
+		if (!line) return '<br>';
+		
+		const l = lang ? lang.toLowerCase() : '';
+		
+		// Default patterns anchored to start of string
+		let keywords = /^\b(const|let|var|function|return|if|else|for|while|do|switch|case|break|continue|import|export|from|class|extends|new|this|typeof|instanceof|in|of|as|async|await|try|catch|finally|throw|default|null|undefined|true|false)\b/;
+		let builtins = /^\b(console|window|document|process|global|Math|JSON|Object|Array|String|Number|Boolean|Map|Set|Promise|Error)\b/;
+		let comments = /^\/\/.*|^\/\*.*?\*\//;
+		let strings = /^"(\\.|[^"\\])*"|^'(\\.|[^'\\])*'|^`(\\.|[^`\\])*`/;
+		let numbers = /^\b\d+(\.\d+)?\b/;
+		let functions = /^\b[a-zA-Z_]\w*(?=\s*\()/;
+		
+		if (l === 'python' || l === 'py') {
+			keywords = /^\b(def|class|return|if|elif|else|for|while|break|continue|import|from|as|in|is|and|or|not|lambda|try|except|finally|raise|assert|pass|global|nonlocal|with|yield|None|True|False)\b/;
+			builtins = /^\b(print|len|range|str|int|float|list|dict|set|tuple|type|abs|max|min|sum|open|enumerate|zip)\b/;
+			comments = /^#.*/;
+			strings = /^f?"(\\.|[^"\\])*"|^f?'(\\.|[^'\\])*'/;
+		} else if (l === 'rust' || l === 'rs') {
+			keywords = /^\b(fn|let|mut|const|static|impl|struct|enum|trait|use|mod|pub|return|if|else|loop|while|for|in|match|break|continue|async|await|type|as|ref|self|Self|true|false)\b/;
+			builtins = /^\b(println|format|vec|panic|Option|Some|None|Result|Ok|Err|String|Box|Rc|Arc)\b/;
+			comments = /^\/\/.*|^\/\*.*?\*\//;
+			strings = /^"(\\.|[^"\\])*"|^'(\\.|[^'\\])*'/;
+		} else if (l === 'go') {
+			keywords = /^\b(func|var|const|type|struct|interface|package|import|return|if|else|switch|case|default|select|for|range|break|continue|go|chan|defer|fallthrough|map|nil|true|false)\b/;
+			builtins = /^\b(fmt|Println|Printf|Print|make|new|len|cap|append|panic|recover|string|int|float64|bool|error)\b/;
+			comments = /^\/\/.*|^\/\*.*?\*\//;
+			strings = /^"(\\.|[^"\\])*"|^`[^`]*`/;
+		} else if (l === 'sql') {
+			keywords = /^\b(SELECT|FROM|WHERE|INSERT|INTO|UPDATE|SET|DELETE|CREATE|TABLE|ALTER|DROP|INDEX|JOIN|INNER|LEFT|RIGHT|OUTER|ON|AND|OR|NOT|IN|LIKE|IS|NULL|TRUE|FALSE|ORDER|BY|GROUP|HAVING|LIMIT|OFFSET|UNION|ALL|AS)\b/i;
+			builtins = /^\b(COUNT|SUM|AVG|MIN|MAX|COALESCE|CONCAT|NOW|DATE|TIME)\b/i;
+			comments = /^--.*/;
+			strings = /^'(\\.|[^'\\])*'/;
+		} else if (l === 'css' || l === 'scss') {
+			keywords = /^\b(important|media|keyframes|import|include|mixin|extend)\b/;
+			comments = /^\/\*[\s\S]*?\*\/|^\/\/.*/;
+			strings = /^"(\\.|[^"\\])*"|^'(\\.|[^'\\])*'/;
+		}
+		
+		const isHtml = l === 'html' || l === 'xml';
+		const htmlTagPattern = /^<\/?[a-zA-Z0-9_:-]+(?:\s+[a-zA-Z0-9_:-]+(?:\s*=\s*(?:"[^"]*"|'[^']*'))?)*\s*\/?>/;
+		const htmlCommentPattern = /^<!--[\s\S]*?-->/;
+		
+		let html = '';
+		let index = 0;
+		
+		const escapeHtml = (text: string) => {
+			return text
+				.replace(/&/g, '&amp;')
+				.replace(/</g, '&lt;')
+				.replace(/>/g, '&gt;')
+				.replace(/"/g, '&quot;')
+				.replace(/'/g, '&#039;');
+		};
+		
+		const highlightHtmlTag = (tag: string): string => {
+			let res = '';
+			let idx = 0;
+			const tagHeadMatch = tag.match(/^<\/?([a-zA-Z0-9_:-]+)/);
+			if (tagHeadMatch) {
+				const tagText = tag.startsWith('</') ? '</' : '<';
+				res += `<span class="token-operator">${escapeHtml(tagText)}</span>`;
+				res += `<span class="token-keyword">${tagHeadMatch[1]}</span>`;
+				idx = tagHeadMatch[0].length;
+			}
+			
+			while (idx < tag.length) {
+				const sub = tag.slice(idx);
+				
+				if (sub.startsWith('/>')) {
+					res += `<span class="token-operator">/&gt;</span>`;
+					break;
+				}
+				if (sub.startsWith('>')) {
+					res += `<span class="token-operator">&gt;</span>`;
+					break;
+				}
+				
+				const attrMatch = sub.match(/^\s+([a-zA-Z0-9_:-]+)/);
+				if (attrMatch) {
+					res += ` <span class="token-builtin">${attrMatch[1]}</span>`;
+					idx += attrMatch[0].length;
+					continue;
+				}
+				
+				const eqValMatch = sub.match(/^\s*=\s*("[^"]*"|'[^']*')/);
+				if (eqValMatch) {
+					const eqIdx = eqValMatch[0].indexOf('=');
+					res += escapeHtml(eqValMatch[0].slice(0, eqIdx + 1));
+					res += `<span class="token-string">${escapeHtml(eqValMatch[1])}</span>`;
+					idx += eqValMatch[0].length;
+					continue;
+				}
+				
+				res += escapeHtml(tag[idx]);
+				idx++;
+			}
+			return res;
+		};
+		
+		while (index < line.length) {
+			const substring = line.slice(index);
+			
+			if (isHtml) {
+				const commentMatch = substring.match(htmlCommentPattern);
+				if (commentMatch) {
+					html += `<span class="token-comment">${escapeHtml(commentMatch[0])}</span>`;
+					index += commentMatch[0].length;
+					continue;
+				}
+				const tagMatch = substring.match(htmlTagPattern);
+				if (tagMatch) {
+					html += highlightHtmlTag(tagMatch[0]);
+					index += tagMatch[0].length;
+					continue;
+				}
+			}
+			
+			if (l === 'css' || l === 'scss') {
+				const propMatch = substring.match(/^\b([a-zA-Z-]+)(?=\s*:)/);
+				if (propMatch) {
+					html += `<span class="token-builtin">${escapeHtml(propMatch[0])}</span>`;
+					index += propMatch[0].length;
+					continue;
+				}
+			}
+			
+			let stringMatch = substring.match(strings);
+			if (stringMatch) {
+				html += `<span class="token-string">${escapeHtml(stringMatch[0])}</span>`;
+				index += stringMatch[0].length;
+				continue;
+			}
+			
+			let commentMatch = substring.match(comments);
+			if (commentMatch) {
+				html += `<span class="token-comment">${escapeHtml(commentMatch[0])}</span>`;
+				index += commentMatch[0].length;
+				continue;
+			}
+			
+			let kwMatch = substring.match(keywords);
+			if (kwMatch) {
+				html += `<span class="token-keyword">${escapeHtml(kwMatch[0])}</span>`;
+				index += kwMatch[0].length;
+				continue;
+			}
+			
+			let biMatch = substring.match(builtins);
+			if (biMatch) {
+				html += `<span class="token-builtin">${escapeHtml(biMatch[0])}</span>`;
+				index += biMatch[0].length;
+				continue;
+			}
+			
+			let fnMatch = substring.match(functions);
+			if (fnMatch) {
+				html += `<span class="token-function">${escapeHtml(fnMatch[0])}</span>`;
+				index += fnMatch[0].length;
+				continue;
+			}
+			
+			let numMatch = substring.match(numbers);
+			if (numMatch) {
+				html += `<span class="token-number">${escapeHtml(numMatch[0])}</span>`;
+				index += numMatch[0].length;
+				continue;
+			}
+			
+			html += escapeHtml(line[index]);
+			index++;
+		}
+		
+		return html;
+	}
+
+	function renderMarkdownWithMentions(markdown: string, isEditor = false): string {
+		if (!markdown) return '';
+		if (typeof document === 'undefined') return marked.parse(markdown) as string;
+		
+		const html = marked.parse(markdown) as string;
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(html, 'text/html');
+
+		// Wrap lines inside pre code blocks with div elements for line numbering support
+		const preElements = doc.querySelectorAll('pre');
+		for (const pre of preElements) {
+			const code = pre.querySelector('code');
+			if (code) {
+				const langClass = Array.from(code.classList).find(c => c.startsWith('language-'));
+				const lang = langClass ? langClass.replace('language-', '') : '';
+				const text = code.textContent || '';
+				const lines = text.split(/\r?\n/);
+				if (lines.length > 1 && lines[lines.length - 1] === '') {
+					lines.pop();
+				}
+				code.innerHTML = lines.map(line => `<div>${highlightCode(line, lang)}</div>`).join('');
+			}
+		}
+
+		function processNode(node: Node) {
+			if (node.nodeType === Node.ELEMENT_NODE) {
+				const tag = (node as HTMLElement).tagName.toUpperCase();
+				if (tag === 'PRE' || tag === 'CODE' || tag === 'A') {
+					return;
+				}
+				const children = Array.from(node.childNodes);
+				for (const child of children) {
+					processNode(child);
+				}
+			} else if (node.nodeType === Node.TEXT_NODE) {
+				const text = node.textContent || '';
+				const mentionRegex = /(?:\b|^)@(card|board|\w+)/g;
+				if (mentionRegex.test(text)) {
+					const fragment = document.createDocumentFragment();
+					let lastIndex = 0;
+					mentionRegex.lastIndex = 0;
+					
+					let match;
+					while ((match = mentionRegex.exec(text)) !== null) {
+						if (match.index > lastIndex) {
+							fragment.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
+						}
+						
+						const span = document.createElement('span');
+						span.className = 'bg-violet-600/20 text-violet-400 font-semibold px-1.5 py-0.5 rounded mx-0.5 inline-block';
+						if (isEditor) {
+							span.contentEditable = 'false';
+							span.className += ' select-all';
+						}
+						span.textContent = match[0].trim();
+						fragment.appendChild(span);
+						
+						lastIndex = mentionRegex.lastIndex;
+					}
+					
+					if (lastIndex < text.length) {
+						fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+					}
+					
+					node.parentNode?.replaceChild(fragment, node);
+				}
+			}
+		}
+
+		processNode(doc.body);
+		return doc.body.innerHTML;
+	}
+
+	function htmlToMarkdown(html: string): string {
+		if (typeof document === 'undefined') return html;
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(html, 'text/html');
+
+		function nodeToMarkdown(node: Node): string {
+			if (node.nodeType === Node.TEXT_NODE) {
+				return node.textContent || '';
+			}
+			if (node.nodeType !== Node.ELEMENT_NODE) {
+				return '';
+			}
+
+			const el = node as HTMLElement;
+			const tagName = el.tagName.toUpperCase();
+
+			// Process children first, except for PRE
+			let childrenMd = '';
+			if (tagName !== 'PRE') {
+				for (let i = 0; i < el.childNodes.length; i++) {
+					childrenMd += nodeToMarkdown(el.childNodes[i]);
+				}
+			}
+
+			switch (tagName) {
+				case 'H1': return `# ${childrenMd}\n\n`;
+				case 'H2': return `## ${childrenMd}\n\n`;
+				case 'H3': return `### ${childrenMd}\n\n`;
+				case 'STRONG':
+				case 'B': return `**${childrenMd}**`;
+				case 'EM':
+				case 'I': return `*${childrenMd}*`;
+				case 'STRIKE':
+				case 'S':
+				case 'DEL': return `~~${childrenMd}~~`;
+				case 'CODE': return `\`${childrenMd}\``;
+				case 'PRE': {
+					const codeEl = el.querySelector('code');
+					let lang = '';
+					if (codeEl) {
+						const classList = Array.from(codeEl.classList);
+						const langClass = classList.find(cls => cls.startsWith('language-'));
+						if (langClass) {
+							lang = langClass.replace('language-', '');
+						}
+					}
+					let textContent = '';
+					const divs = el.querySelectorAll('code > div, pre > div');
+					if (divs.length > 0) {
+						textContent = Array.from(divs).map(d => d.textContent).join('\n');
+					} else {
+						textContent = el.textContent || '';
+					}
+					return `\n\`\`\`${lang}\n${textContent.trim()}\n\`\`\`\n\n`;
+				}
+				case 'A': return `[${childrenMd}](${el.getAttribute('href') || ''})`;
+				case 'IMG': return `![image](${el.getAttribute('src') || ''})`;
+				case 'P': return `${childrenMd}\n\n`;
+				case 'BR': return '\n';
+				case 'LI': {
+					const parent = el.parentElement;
+					if (parent && parent.tagName.toUpperCase() === 'OL') {
+						const siblings = Array.from(parent.children);
+						const index = siblings.indexOf(el) + 1;
+						return `${index}. ${childrenMd}\n`;
+					}
+					return `- ${childrenMd}\n`;
+				}
+				case 'UL':
+				case 'OL': return `${childrenMd}\n`;
+				case 'DIV': return `${childrenMd}\n`;
+				default: return childrenMd;
+			}
+		}
+
+		let md = '';
+		for (let i = 0; i < doc.body.childNodes.length; i++) {
+			md += nodeToMarkdown(doc.body.childNodes[i]);
+		}
+
+		return md.trim();
+	}
+
+	async function handleSaveDesc() {
+		if (!card) return;
+		try {
+			const markdown = htmlToMarkdown(editDescHTML);
+			await taskClientStore.updateCardDescription(card.id, markdown);
+			isEditingDesc = false;
+			editDescHTML = '';
+		} catch (e) {
+			debug.error('task-client', 'Failed to update description:', e);
+		}
+	}
+
+	function handleCancelDesc() {
+		isEditingDesc = false;
+		editDescHTML = '';
+	}
+
+	async function handleToggleCheckItem(checklistId: string, itemId: string, currentState: 'complete' | 'incomplete') {
+		if (!card) return;
+		const newState = currentState === 'complete' ? 'incomplete' : 'complete';
+		try {
+			await taskClientStore.updateCheckItemState(card.id, checklistId, itemId, newState);
+		} catch (e) {
+			debug.error('task-client', 'Failed to toggle check item:', e);
+		}
+	}
+
+	async function handleAddCheckItem(checklistId: string) {
+		const val = newCheckItemVals[checklistId];
+		if (!val || !val.trim()) return;
+		try {
+			await taskClientStore.addCheckItem(checklistId, val.trim());
+			newCheckItemVals[checklistId] = '';
+			activeAddCheckItemId = null;
+		} catch (e) {
+			debug.error('task-client', 'Failed to add check item:', e);
+		}
+	}
+
+	async function handleAddComment() {
+		if (!card || isCommentEmpty) return;
+		try {
+			const markdown = htmlToMarkdown(editCommentHTML);
+			if (!markdown.trim()) return;
+			await taskClientStore.addComment(card.id, markdown);
+			editCommentHTML = '';
+			commentVal = '';
+			isWritingComment = false;
+		} catch (e) {
+			debug.error('task-client', 'Failed to submit comment:', e);
+		}
+	}
+
+	async function handleUploadImageForEditor(file: File): Promise<string> {
+		if (!card) throw new Error('No active card');
+		const created = await taskClientStore.addAttachmentFile(card.id, file);
+		if (!created || !created.url) {
+			throw new Error('Failed to upload image to Trello');
+		}
+		return created.url;
+	}
+
+	// Checklist actions
+	let editingChecklistId = $state<string | null>(null);
+	let editChecklistNameVal = $state('');
+
+	function startEditChecklist(checklistId: string, currentName: string) {
+		editingChecklistId = checklistId;
+		editChecklistNameVal = currentName;
+	}
+
+	function cancelEditChecklist() {
+		editingChecklistId = null;
+		editChecklistNameVal = '';
+	}
+
+	async function handleSaveChecklistName(checklistId: string) {
+		if (!editChecklistNameVal.trim() || editingChecklistId !== checklistId) return;
+		try {
+			await taskClientStore.updateChecklistName(checklistId, editChecklistNameVal.trim());
+			editingChecklistId = null;
+			editChecklistNameVal = '';
+		} catch (e) {
+			debug.error('task-client', 'Failed to update checklist name:', e);
+		}
+	}
+
+	let editingCheckItemId = $state<string | null>(null);
+	let editCheckItemNameVal = $state('');
+
+	function startEditCheckItem(itemId: string, currentName: string) {
+		editingCheckItemId = itemId;
+		editCheckItemNameVal = currentName;
+	}
+
+	function cancelEditCheckItem() {
+		editingCheckItemId = null;
+		editCheckItemNameVal = '';
+	}
+
+	async function handleSaveCheckItemName(checklistId: string, itemId: string) {
+		if (!card || !editCheckItemNameVal.trim() || editingCheckItemId !== itemId) return;
+		try {
+			await taskClientStore.updateCheckItemName(card.id, checklistId, itemId, editCheckItemNameVal.trim());
+			editingCheckItemId = null;
+			editCheckItemNameVal = '';
+		} catch (e) {
+			debug.error('task-client', 'Failed to update check item name:', e);
+		}
+	}
+
+	async function handleDeleteChecklist(checklistId: string) {
+		try {
+			await taskClientStore.deleteChecklist(checklistId);
+		} catch (e) {
+			debug.error('task-client', 'Failed to delete checklist:', e);
+		}
+	}
+
+	async function handleDeleteCheckItem(checklistId: string, itemId: string) {
+		if (!card) return;
+		try {
+			await taskClientStore.deleteCheckItem(card.id, checklistId, itemId);
+		} catch (e) {
+			debug.error('task-client', 'Failed to delete check item:', e);
+		}
+	}
+
+	let hideCheckedMap = $state<Record<string, boolean>>({});
+	function toggleHideCheckedItems(checklistId: string) {
+		hideCheckedMap[checklistId] = !hideCheckedMap[checklistId];
+	}
+
+	// Comment actions
+	let editingCommentId = $state<string | null>(null);
+	let editExistingCommentHTML = $state('');
+
+	function startEditComment(actionId: string, currentText: string) {
+		editingCommentId = actionId;
+		editExistingCommentHTML = currentText ? renderMarkdownWithMentions(currentText, true) : '';
+	}
+
+	function cancelEditComment() {
+		editingCommentId = null;
+		editExistingCommentHTML = '';
+	}
+
+	async function handleSaveComment(actionId: string) {
+		const markdown = htmlToMarkdown(editExistingCommentHTML);
+		if (!markdown.trim()) return;
+		try {
+			await taskClientStore.updateComment(actionId, markdown.trim());
+			editingCommentId = null;
+			editExistingCommentHTML = '';
+		} catch (e) {
+			debug.error('task-client', 'Failed to update comment:', e);
+		}
+	}
+
+	async function handleDeleteComment(actionId: string) {
+		if (!card) return;
+		if (confirm('Are you sure you want to delete this comment?')) {
+			try {
+				await taskClientStore.deleteComment(card.id, actionId);
+			} catch (e) {
+				debug.error('task-client', 'Failed to delete comment:', e);
+			}
+		}
+	}
+
+	// Create Checklist popover
+	let showAddChecklistPopover = $state(false);
+	let newChecklistName = $state('');
+	let boardChecklists = $state<TrelloChecklist[]>([]);
+	let loadingChecklists = $state(false);
+	let selectedCopyChecklistId = $state('');
+	let showCopyDropdown = $state(false);
+	let isCreatingChecklist = $state(false);
+
+	// Labels popover state
+	let showLabelsPopover = $state(false);
+	let labelsPopoverMode = $state<'list' | 'create' | 'edit'>('list');
+	let searchLabelQuery = $state('');
+	let editingLabelId = $state<string | null>(null);
+	let labelFormName = $state('');
+	let labelFormColor = $state('green');
+
+	const filteredLabels = $derived(
+		taskClientStore.boardLabels.filter(
+			(label) =>
+				!searchLabelQuery ||
+				label.name.toLowerCase().includes(searchLabelQuery.toLowerCase())
+		)
+	);
+
+	// Members popover state
+	let showMembersPopover = $state(false);
+	let searchMemberQuery = $state('');
+
+	const filteredMembers = $derived(
+		taskClientStore.boardMembers.filter(
+			(m) =>
+				!searchMemberQuery ||
+				m.fullName.toLowerCase().includes(searchMemberQuery.toLowerCase()) ||
+				(m.username ?? '').toLowerCase().includes(searchMemberQuery.toLowerCase())
+		)
+	);
+
+	// Attachment popover state
+	let showAttachmentPopover = $state(false);
+	let attachLinkUrl = $state('');
+	let attachLinkName = $state('');
+	let isAttaching = $state(false);
+	let attachFileInput: HTMLInputElement | undefined = $state();
+	let openAttachmentMenuId = $state<string | null>(null);
+	let editingAttachmentId = $state<string | null>(null);
+	let editingAttachmentName = $state('');
+	let commentSectionEl: HTMLDivElement | undefined = $state();
+	let previewAttachment = $state<{ id: string; name: string; url: string; date: string; mimeType: string; bytes?: number; previews: { url: string; width: number; height: number }[] } | null>(null);
+	const formattedPreviewDate = $derived(
+		previewAttachment ? new Date(previewAttachment.date).toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true }) : ''
+	);
+
+	function handleWindowKeyDown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			if (previewAttachment) {
+				e.preventDefault();
+				e.stopPropagation();
+				previewAttachment = null;
+			}
+		}
+	}
+
+	const filteredActions = $derived.by(() => {
+		const allActions = taskClientStore.activeCardActions;
+		if (showActivityDetails) {
+			return allActions;
+		}
+		// Hide details: show all comments, and only the oldest non-comment action (creation/addition)
+		const nonComments = allActions.filter(a => a.type !== 'commentCard');
+		const oldestNonComment = nonComments.length > 0 ? nonComments[nonComments.length - 1] : null;
+
+		return allActions.filter((action) => {
+			if (action.type === 'commentCard') return true;
+			if (oldestNonComment && action.id === oldestNonComment.id) return true;
+			return false;
+		});
+	});
+
+	const labelColorMap: Record<string, string> = {
+		green: '#61bd4f',
+		yellow: '#f2d600',
+		orange: '#ff9f1a',
+		red: '#eb5a46',
+		purple: '#c377e0',
+		blue: '#0079bf',
+		sky: '#00c2e0',
+		lime: '#51e898',
+		pink: '#ff78cb',
+		black: '#344563'
+	};
+
+	const labelColors = ['green', 'yellow', 'orange', 'red', 'purple', 'blue', 'sky', 'lime', 'pink', 'black'];
+
+	async function handleToggleLabelOnCard(labelId: string) {
+		if (!card) return;
+		const hasLabel = card.labels.some((l) => l.id === labelId);
+		try {
+			if (hasLabel) {
+				await taskClientStore.removeLabelFromCard(card.id, labelId);
+			} else {
+				await taskClientStore.addLabelToCard(card.id, labelId);
+			}
+		} catch (err) {
+			debug.error('task-client', 'Failed to toggle label:', err);
+		}
+	}
+
+	async function handleSaveLabel() {
+		if (!labelFormColor) return;
+		try {
+			if (labelsPopoverMode === 'create') {
+				await taskClientStore.createLabel(labelFormName, labelFormColor);
+			} else if (labelsPopoverMode === 'edit' && editingLabelId) {
+				await taskClientStore.updateLabel(editingLabelId, labelFormName, labelFormColor);
+			}
+			labelsPopoverMode = 'list';
+			editingLabelId = null;
+			labelFormName = '';
+		} catch (err) {
+			debug.error('task-client', 'Failed to save label:', err);
+		}
+	}
+
+	async function handleDeleteLabel(labelId: string) {
+		try {
+			await taskClientStore.deleteLabel(labelId);
+			labelsPopoverMode = 'list';
+			editingLabelId = null;
+			labelFormName = '';
+		} catch (err) {
+			debug.error('task-client', 'Failed to delete label:', err);
+		}
+	}
+
+	function startCreateLabel() {
+		labelsPopoverMode = 'create';
+		editingLabelId = null;
+		labelFormName = '';
+		labelFormColor = 'green';
+	}
+
+	function startEditLabel(labelId: string, name: string, color: string) {
+		labelsPopoverMode = 'edit';
+		editingLabelId = labelId;
+		labelFormName = name;
+		labelFormColor = color;
+	}
+
+	const selectedCopyChecklistLabel = $derived.by(() => {
+		if (!selectedCopyChecklistId) return '(none)';
+		const cl = boardChecklists.find((c) => c.id === selectedCopyChecklistId);
+		if (!cl) return '(none)';
+		const cardOfCl = taskClientStore.cards.find((c) => c.id === cl.idCard);
+		const cardName = cardOfCl ? cardOfCl.name : 'Unknown Card';
+		return `${cardName}: ${cl.name}`;
+	});
+
+	interface GroupedChecklist {
+		cardId: string;
+		cardName: string;
+		checklists: TrelloChecklist[];
+	}
+
+	const groupedChecklists = $derived.by(() => {
+		const groups: GroupedChecklist[] = [];
+		for (const cl of boardChecklists) {
+			const cardOfCl = taskClientStore.cards.find((c) => c.id === cl.idCard);
+			const cardName = cardOfCl ? cardOfCl.name : 'Unknown Card';
+			let group = groups.find((g) => g.cardId === cl.idCard);
+			if (!group) {
+				group = { cardId: cl.idCard, cardName, checklists: [] };
+				groups.push(group);
+			}
+			group.checklists.push(cl);
+		}
+		return groups;
+	});
+
+	$effect(() => {
+		if (showAddChecklistPopover) {
+			loadingChecklists = true;
+			selectedCopyChecklistId = '';
+			showCopyDropdown = false;
+			taskClientStore.fetchBoardChecklists().then((data) => {
+				boardChecklists = data;
+				loadingChecklists = false;
+			}).catch((err) => {
+				debug.error('task-client', 'Failed to fetch board checklists:', err);
+				loadingChecklists = false;
+			});
+		}
+	});
+
+	async function handleCreateChecklist() {
+		if (!card || !newChecklistName.trim() || isCreatingChecklist) return;
+		isCreatingChecklist = true;
+		try {
+			const copyFromId = selectedCopyChecklistId;
+			await taskClientStore.addChecklist(card.id, newChecklistName.trim());
+			
+			if (copyFromId) {
+				const source = boardChecklists.find((cl) => cl.id === copyFromId);
+				if (source && source.checkItems && source.checkItems.length > 0) {
+					const lastCl = taskClientStore.activeCardChecklists[taskClientStore.activeCardChecklists.length - 1];
+					if (lastCl) {
+						const sortedItems = [...source.checkItems].sort((a, b) => a.pos - b.pos);
+						for (const item of sortedItems) {
+							await taskClientStore.addCheckItem(lastCl.id, item.name);
+						}
+					}
+				}
+			}
+			
+			newChecklistName = '';
+			selectedCopyChecklistId = '';
+			showAddChecklistPopover = false;
+		} catch (e) {
+			debug.error('task-client', 'Failed to create checklist:', e);
+		} finally {
+			isCreatingChecklist = false;
+		}
+	}
+
+	// Due Date popover
+	let showDatesPopover = $state(false);
+	let datesPopoverSource = $state<'button' | 'badge'>('button');
+	let hasStartDate = $state(false);
+	let newStartDateVal = $state('');
+	let hasDueDate = $state(false);
+	let newDueDateVal = $state('');
+	let dueReminderVal = $state<number>(-1);
+	let recurringVal = $state<string>('Never');
+
+	let calendarYear = $state(new Date().getFullYear());
+	let calendarMonth = $state(new Date().getMonth());
+	let activeDateField = $state<'start' | 'due'>('due');
+
+	let popoverTop = $state(0);
+	let popoverLeft = $state(0);
+
+	function updatePopoverPosition(triggerElement: HTMLElement, popoverHeight = 520) {
+		if (!triggerElement) return;
+		const triggerRect = triggerElement.getBoundingClientRect();
+		const viewportWidth = window.innerWidth;
+		const viewportHeight = window.innerHeight;
+
+		// Calculate viewport-relative left
+		let left = triggerRect.left;
+		const popoverWidth = 288;
+		if (left + popoverWidth > viewportWidth) {
+			left = viewportWidth - popoverWidth - 16;
+		}
+		popoverLeft = Math.max(16, left);
+
+		// Calculate viewport-relative top (flip up if it goes past the bottom boundary)
+		if (triggerRect.bottom + popoverHeight > viewportHeight) {
+			popoverTop = Math.max(16, triggerRect.top - popoverHeight - 8);
+		} else {
+			popoverTop = triggerRect.bottom + 8;
+		}
+	}
+
+	const monthNames = [
+		'January', 'February', 'March', 'April', 'May', 'June',
+		'July', 'August', 'September', 'October', 'November', 'December'
+	];
+
+	function prevMonth() {
+		if (calendarMonth === 0) {
+			calendarMonth = 11;
+			calendarYear -= 1;
+		} else {
+			calendarMonth -= 1;
+		}
+	}
+
+	function nextMonth() {
+		if (calendarMonth === 11) {
+			calendarMonth = 0;
+			calendarYear += 1;
+		} else {
+			calendarMonth += 1;
+		}
+	}
+
+	function prevYear() {
+		calendarYear -= 1;
+	}
+
+	function nextYear() {
+		calendarYear += 1;
+	}
+
+	function selectCalendarDay(day: number, month: number, year: number) {
+		const pad = (n: number) => String(n).padStart(2, '0');
+		const dateStr = `${year}-${pad(month + 1)}-${pad(day)}`;
+		
+		if (activeDateField === 'start') {
+			hasStartDate = true;
+			const existingTime = newStartDateVal ? newStartDateVal.split('T')[1] : '09:00';
+			newStartDateVal = `${dateStr}T${existingTime}`;
+		} else {
+			hasDueDate = true;
+			const existingTime = newDueDateVal ? newDueDateVal.split('T')[1] : '12:00';
+			newDueDateVal = `${dateStr}T${existingTime}`;
+		}
+	}
+
+	function isCellSelected(day: number, month: number, year: number) {
+		const val = activeDateField === 'start' ? newStartDateVal : newDueDateVal;
+		if (!val) return false;
+		const d = new Date(val);
+		return d.getDate() === day && d.getMonth() === month && d.getFullYear() === year;
+	}
+
+	const calendarDays = $derived.by(() => {
+		const firstDayIndex = new Date(calendarYear, calendarMonth, 1).getDay();
+		const totalDays = new Date(calendarYear, calendarMonth + 1, 0).getDate();
+		const prevMonthTotalDays = new Date(calendarYear, calendarMonth, 0).getDate();
+
+		const cells = [];
+
+		for (let i = firstDayIndex - 1; i >= 0; i--) {
+			const d = prevMonthTotalDays - i;
+			const m = calendarMonth === 0 ? 11 : calendarMonth - 1;
+			const y = calendarMonth === 0 ? calendarYear - 1 : calendarYear;
+			cells.push({ day: d, month: m, year: y, current: false });
+		}
+
+		for (let d = 1; d <= totalDays; d++) {
+			cells.push({ day: d, month: calendarMonth, year: calendarYear, current: true });
+		}
+
+		const remaining = 42 - cells.length;
+		for (let d = 1; d <= remaining; d++) {
+			const m = calendarMonth === 11 ? 0 : calendarMonth + 1;
+			const y = calendarMonth === 11 ? calendarYear + 1 : calendarYear;
+			cells.push({ day: d, month: m, year: y, current: false });
+		}
+
+		return cells;
+	});
+
+	const recurringDayNumber = $derived.by(() => {
+		const d = newDueDateVal ? new Date(newDueDateVal) : new Date();
+		const dateNum = d.getDate();
+		const suffix = (n: number) => {
+			if (n > 3 && n < 21) return 'th';
+			switch (n % 10) {
+				case 1:  return "st";
+				case 2:  return "nd";
+				case 3:  return "rd";
+				default: return "th";
+			}
+		};
+		return `${dateNum}${suffix(dateNum)}`;
+	});
+
+	const recurringDayOfWeekDesc = $derived.by(() => {
+		const d = newDueDateVal ? new Date(newDueDateVal) : new Date();
+		const daysOfWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+		const dayName = daysOfWeek[d.getDay()];
+		
+		const dateNum = d.getDate();
+		const occurrence = Math.ceil(dateNum / 7);
+		
+		const temp = new Date(d.getTime());
+		temp.setDate(temp.getDate() + 7);
+		const isLast = temp.getMonth() !== d.getMonth();
+		
+		const ordinals = ['first', 'second', 'third', 'fourth', 'fifth'];
+		const occurrenceWord = ordinals[occurrence - 1] ?? 'first';
+		
+		if (isLast) {
+			return `Monthly on the last ${dayName}`;
+		}
+		return `Monthly on the ${occurrenceWord} ${dayName}`;
+	});
+
+	const recurringYearlyDesc = $derived.by(() => {
+		const d = newDueDateVal ? new Date(newDueDateVal) : new Date();
+		const monthName = monthNames[d.getMonth()];
+		const dateNum = d.getDate();
+		const suffix = (n: number) => {
+			if (n > 3 && n < 21) return 'th';
+			switch (n % 10) {
+				case 1:  return "st";
+				case 2:  return "nd";
+				case 3:  return "rd";
+				default: return "th";
+			}
+		};
+		return `Yearly on ${monthName} ${dateNum}${suffix(dateNum)}`;
+	});
+
+	$effect(() => {
+		if (showDatesPopover && card) {
+			if (card.start) {
+				hasStartDate = true;
+				const d = new Date(card.start);
+				const tzoffset = d.getTimezoneOffset() * 60000;
+				newStartDateVal = (new Date(d.getTime() - tzoffset)).toISOString().slice(0, 16);
+			} else {
+				hasStartDate = false;
+				newStartDateVal = '';
+			}
+
+			if (card.due) {
+				hasDueDate = true;
+				const d = new Date(card.due);
+				const tzoffset = d.getTimezoneOffset() * 60000;
+				newDueDateVal = (new Date(d.getTime() - tzoffset)).toISOString().slice(0, 16);
+			} else {
+				hasDueDate = false;
+				newDueDateVal = '';
+			}
+
+			if (card.dueReminder !== undefined) {
+				dueReminderVal = card.dueReminder ?? -1;
+			} else {
+				dueReminderVal = -1;
+			}
+
+			const savedRecurring = localStorage.getItem(`clopen_trello_card_recurring_${card.id}`);
+			recurringVal = savedRecurring || 'Never';
+
+			const initialDate = card.due ? new Date(card.due) : (card.start ? new Date(card.start) : new Date());
+			calendarYear = initialDate.getFullYear();
+			calendarMonth = initialDate.getMonth();
+			activeDateField = card.due ? 'due' : (card.start ? 'start' : 'due');
+		}
+	});
+
+	async function handleSaveDates() {
+		if (!card) return;
+		try {
+			const startStr = hasStartDate && newStartDateVal ? new Date(newStartDateVal).toISOString() : null;
+			const dueStr = hasDueDate && newDueDateVal ? new Date(newDueDateVal).toISOString() : null;
+			await taskClientStore.updateCardDates(card.id, startStr, dueStr, dueReminderVal);
+			localStorage.setItem(`clopen_trello_card_recurring_${card.id}`, recurringVal);
+			showDatesPopover = false;
+		} catch (e) {
+			debug.error('task-client', 'Failed to save dates:', e);
+		}
+	}
+
+	async function handleRemoveDates() {
+		if (!card) return;
+		try {
+			await taskClientStore.updateCardDates(card.id, null, null, -1);
+			localStorage.removeItem(`clopen_trello_card_recurring_${card.id}`);
+			showDatesPopover = false;
+		} catch (e) {
+			debug.error('task-client', 'Failed to remove dates:', e);
+		}
+	}
+
+
+
+	// Card Actions
+	async function handleArchiveCard() {
+		if (!card) return;
+		if (confirm('Are you sure you want to archive this card?')) {
+			try {
+				await taskClientStore.archiveCard(card.id);
+				onClose();
+			} catch (e) {
+				debug.error('task-client', 'Failed to archive card:', e);
+			}
+		}
+	}
+
+	async function handleDeleteCard() {
+		if (!card) return;
+		if (confirm('Are you sure you want to permanently delete this card? This action cannot be undone.')) {
+			try {
+				await taskClientStore.deleteCard(card.id);
+				onClose();
+			} catch (e) {
+				debug.error('task-client', 'Failed to delete card:', e);
+			}
+		}
+	}
+
+	// Calculate checklist metrics helper
+	function getChecklistProgress(checkItems: any[] = []) {
+		if (!checkItems || checkItems.length === 0) return { percent: 0, checked: 0, total: 0 };
+		const checked = checkItems.filter((i) => i.state === 'complete').length;
+		const total = checkItems.length;
+		return {
+			percent: Math.round((checked / total) * 100),
+			checked,
+			total
+		};
+	}
+
+	// Format action content text based on its type
+	function formatActionText(action: any) {
+		const creator = action.memberCreator?.fullName || 'Someone';
+		switch (action.type) {
+			case 'createCard':
+				return `${creator} created this card`;
+			case 'updateCard':
+				if (action.data?.listBefore && action.data?.listAfter) {
+					return `${creator} moved this card from ${action.data.listBefore.name} to ${action.data.listAfter.name}`;
+				}
+				if (action.data?.listAfter) {
+					return `${creator} added this card to ${action.data.listAfter.name}`;
+				}
+				if (action.data?.card?.closed !== undefined) {
+					return `${creator} ${action.data.card.closed ? 'archived' : 'sent'} this card to the board`;
+				}
+				if (action.data?.card?.dueComplete !== undefined) {
+					return `${creator} marked this card as ${action.data.card.dueComplete ? 'complete' : 'incomplete'}`;
+				}
+				if (action.data?.old?.due !== undefined || action.data?.card?.due !== undefined) {
+					if (action.data.card.due) {
+						const d = new Date(action.data.card.due).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true });
+						if (action.data.old?.due) {
+							return `${creator} changed the due date of this card to ${d}`;
+						} else {
+							return `${creator} set this card to be due ${d}`;
+						}
+					} else {
+						return `${creator} removed the due date from this card`;
+					}
+				}
+				return `${creator} updated this card`;
+			case 'commentCard':
+				return `${creator} commented`;
+			case 'addChecklistToCard':
+				return `${creator} added Checklist to this card`;
+			case 'updateCheckItemStateOnCard':
+				const state = action.data?.checkItem?.state;
+				const itemName = action.data?.checkItem?.name || 'an item';
+				if (state === 'complete') {
+					return `${creator} completed ${itemName} on this card`;
+				} else {
+					return `${creator} marked ${itemName} as incomplete`;
+				}
+			default:
+				return `${creator} performed an action`;
+		}
+	}
+
+	// Due Date helpers
+	function getDateBadgeInfo(startStr: string | null, dueStr: string | null, dueComplete: boolean) {
+		const now = new Date();
+		let formattedText = '';
+		let badge = '';
+		let badgeClass = '';
+
+		const formatOptions: Intl.DateTimeFormatOptions = {
+			month: 'short',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: '2-digit',
+			hour12: true
+		};
+
+		if (startStr && dueStr) {
+			const start = new Date(startStr);
+			const due = new Date(dueStr);
+			
+			const formattedStart = start.toLocaleString('en-US', { month: 'short', day: 'numeric' });
+			const formattedDue = due.toLocaleString('en-US', formatOptions);
+			formattedText = `${formattedStart} - ${formattedDue}`;
+		} else if (startStr) {
+			const start = new Date(startStr);
+			formattedText = `Starts ${start.toLocaleString('en-US', formatOptions)}`;
+		} else if (dueStr) {
+			const due = new Date(dueStr);
+			formattedText = due.toLocaleString('en-US', formatOptions);
+		}
+
+		if (dueStr) {
+			const due = new Date(dueStr);
+			if (dueComplete) {
+				badge = 'Complete';
+				badgeClass = 'bg-green-600 text-white';
+			} else if (due < now) {
+				badge = 'Overdue';
+				badgeClass = 'bg-red-500 text-white';
+			} else {
+				const diffMs = due.getTime() - now.getTime();
+				const diffHrs = diffMs / (1000 * 60 * 60);
+				if (diffHrs >= 0 && diffHrs <= 24) {
+					badge = 'Due soon';
+					badgeClass = 'bg-amber-500 text-slate-950';
+				}
+			}
+		}
+
+		return { formattedText, badge, badgeClass };
+	}
+</script>
+
+<svelte:window onkeydown={handleWindowKeyDown} />
+
+{#if isOpen && card}
+	<!-- Backdrop overlay -->
+	<div
+		class="fixed inset-0 z-[200] flex items-center justify-center bg-slate-950/80 p-4 backdrop-blur-sm"
+		role="dialog"
+		aria-modal="true"
+	>
+		<!-- Click outside helper -->
+		<button
+			type="button"
+			class="absolute inset-0 bg-transparent border-none w-full h-full cursor-default"
+			onclick={onClose}
+			aria-label="Close modal"
+		></button>
+
+		<!-- Modal Container -->
+		<div class="relative w-full max-w-6xl h-[90dvh] max-h-[850px] bg-slate-900 border border-slate-800 rounded-2xl shadow-2xl flex flex-col z-10 overflow-hidden text-slate-100 modal-container-el">
+			<!-- Header -->
+			<header class="flex items-center justify-between px-6 py-4 border-b border-slate-800 shrink-0">
+				<!-- List Name Dropdown Muted Indicator -->
+				<div class="flex items-center gap-2">
+					<div class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-slate-800 text-xs font-semibold text-slate-300">
+						<span>{list?.name || 'List'}</span>
+						<Icon name="lucide:chevron-down" class="w-3.5 h-3.5 opacity-60" />
+					</div>
+				</div>
+
+				<!-- Right Controls -->
+				<div class="flex items-center gap-2">
+					<button
+						type="button"
+						class="flex items-center justify-center w-8 h-8 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors border-none bg-transparent cursor-pointer"
+						aria-label="Watch card"
+						title="Watch"
+					>
+						<Icon name="lucide:eye" class="w-4 h-4" />
+					</button>
+					<a
+						href={card.url}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="flex items-center justify-center w-8 h-8 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors"
+						title="Open in Trello"
+					>
+						<Icon name="lucide:arrow-up-right" class="w-4 h-4" />
+					</a>
+					<button
+						type="button"
+						onclick={onClose}
+						class="flex items-center justify-center w-8 h-8 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors border-none bg-transparent cursor-pointer"
+						aria-label="Close details"
+					>
+						<Icon name="lucide:x" class="w-4 h-4" />
+					</button>
+				</div>
+			</header>
+
+			<!-- Loading details loader overlay -->
+			{#if taskClientStore.loadingDetails}
+				<div class="absolute inset-0 top-16 bg-slate-900/60 z-30 flex items-center justify-center gap-2.5 text-slate-400">
+					<Icon name="lucide:loader" class="w-5 h-5 animate-spin text-violet-500" />
+					<span class="text-sm">Loading details…</span>
+				</div>
+			{/if}
+
+			<!-- Scrollable content area -->
+			<div class="flex-1 overflow-y-auto md:overflow-hidden p-6 md:pr-0 flex flex-col md:flex-row gap-6 md:gap-0">
+				<!-- Left main column -->
+				<div class="flex-1 flex flex-col gap-6 md:overflow-y-auto md:h-full md:pr-6">
+					<!-- Title with complete checkmark toggle -->
+					<div class="flex items-start gap-3">
+						<button
+							type="button"
+							onclick={handleToggleDueComplete}
+							class="flex items-center justify-center w-6 h-6 rounded-full border hover:border-green-500 transition cursor-pointer shrink-0 mt-1
+								{card.dueComplete ? 'bg-green-500 border-green-500' : 'bg-transparent border-slate-700'}"
+							title={card.dueComplete ? 'Mark incomplete' : 'Mark complete'}
+						>
+							{#if card.dueComplete}
+								<Icon name="lucide:check" class="w-3.5 h-3.5 text-white stroke-[3]" />
+							{/if}
+						</button>
+						<div class="flex-1 min-w-0">
+							<h2 class="text-xl font-bold text-slate-100 leading-tight m-0">{card.name}</h2>
+						</div>
+					</div>
+
+					<!-- Quick buttons row with Popovers -->
+					<div class="flex flex-wrap gap-2 text-xs relative">
+						<!-- Labels Button (hidden if labels already shown below) -->
+						{#if !(card.labels && card.labels.length > 0)}
+						<div class="relative">
+							<button
+								type="button"
+								onclick={() => { showLabelsPopover = !showLabelsPopover; showAddChecklistPopover = false; showDatesPopover = false; }}
+								class="flex items-center gap-1 px-3 py-1.5 rounded-lg border text-slate-300 hover:bg-slate-700 transition cursor-pointer
+									{showLabelsPopover ? 'bg-slate-700 border-violet-500' : 'bg-slate-800 border-slate-700'}"
+							>
+								<Icon name="lucide:tag" class="w-3.5 h-3.5" />
+								<span>Labels</span>
+							</button>
+
+							{#if showLabelsPopover}
+								<button
+									type="button"
+									class="fixed inset-0 z-30 bg-transparent cursor-default border-none w-full h-full"
+									onclick={() => showLabelsPopover = false}
+									aria-label="Close labels popover"
+								></button>
+
+								<div class="absolute left-0 mt-2 z-40 w-72 p-4 rounded-xl border border-slate-700 bg-slate-950 shadow-2xl flex flex-col gap-3">
+									{@render labelsPopoverContent()}
+								</div>
+							{/if}
+						</div>
+						{/if}
+
+						<!-- Dates Button (hidden if dates already shown below) -->
+						{#if !(card.start || card.due)}
+						<div>
+							<button
+								type="button"
+								onclick={(e) => {
+									if (showDatesPopover && datesPopoverSource === 'button') {
+										showDatesPopover = false;
+									} else {
+										datesPopoverSource = 'button';
+										updatePopoverPosition(e.currentTarget as HTMLElement, 520);
+										showDatesPopover = true;
+									}
+									showAddChecklistPopover = false;
+								}}
+								class="flex items-center gap-1 px-3 py-1.5 rounded-lg border text-slate-300 hover:bg-slate-700 transition cursor-pointer
+									{showDatesPopover && datesPopoverSource === 'button' ? 'bg-slate-700 border-violet-500' : 'bg-slate-800 border-slate-700'}"
+							>
+								<Icon name="lucide:clock" class="w-3.5 h-3.5" />
+								<span>Dates</span>
+							</button>
+						</div>
+						{/if}
+
+						<!-- Checklist Button -->
+						<div class="relative">
+							<button
+								type="button"
+								onclick={() => { showAddChecklistPopover = !showAddChecklistPopover; showDatesPopover = false; }}
+								class="flex items-center gap-1 px-3 py-1.5 rounded-lg border text-slate-300 hover:bg-slate-700 transition cursor-pointer
+									{showAddChecklistPopover ? 'bg-slate-700 border-violet-500' : 'bg-slate-800 border-slate-700'}"
+							>
+								<Icon name="lucide:square-check" class="w-3.5 h-3.5" />
+								<span>Checklist</span>
+							</button>
+
+							{#if showAddChecklistPopover}
+								<button
+									type="button"
+									class="fixed inset-0 z-30 bg-transparent cursor-default border-none w-full h-full"
+									onclick={() => showAddChecklistPopover = false}
+									aria-label="Close add checklist popover"
+								></button>
+
+								<div class="absolute left-0 mt-2 z-40 w-64 p-4 rounded-xl border border-slate-700 bg-slate-950 shadow-2xl flex flex-col gap-3">
+									<h4 class="text-xs font-bold text-slate-200 m-0">Add checklist</h4>
+									<div class="flex flex-col gap-1">
+										<label for="checklist-name-input" class="text-[10px] text-slate-400 font-semibold">Title</label>
+										<input
+											id="checklist-name-input"
+											type="text"
+											placeholder="Checklist"
+											bind:value={newChecklistName}
+											disabled={isCreatingChecklist}
+											onkeydown={(e) => {
+												if (e.key === 'Enter') handleCreateChecklist();
+												if (e.key === 'Escape') showAddChecklistPopover = false;
+											}}
+											class="w-full px-2.5 py-1.5 rounded bg-slate-900 border border-slate-700 text-slate-200 text-xs focus:outline-none focus:ring-1 focus:ring-violet-500 disabled:opacity-50"
+										/>
+									</div>
+
+									<div class="flex flex-col gap-1 relative">
+										<span class="text-[10px] text-slate-400 font-semibold select-none">Copy items from...</span>
+										<button
+											type="button"
+											disabled={isCreatingChecklist}
+											onclick={() => showCopyDropdown = !showCopyDropdown}
+											class="w-full px-2.5 py-1.5 rounded bg-slate-900 border border-slate-700 text-slate-200 text-xs text-left flex items-center justify-between cursor-pointer focus:outline-none focus:ring-1 focus:ring-violet-500 animate-none disabled:opacity-50 disabled:cursor-not-allowed"
+										>
+											<span class="truncate">{selectedCopyChecklistLabel}</span>
+											<Icon name="lucide:chevron-down" class="w-3.5 h-3.5 text-slate-400 shrink-0" />
+										</button>
+
+										{#if showCopyDropdown}
+											<button
+												type="button"
+												class="fixed inset-0 z-40 bg-transparent cursor-default border-none w-full h-full"
+												onclick={() => showCopyDropdown = false}
+											></button>
+
+											<div class="absolute left-0 right-0 top-full mt-1 z-50 max-h-48 overflow-y-auto rounded-lg border border-slate-700 bg-slate-900 shadow-xl py-1">
+												<button
+													type="button"
+													onclick={() => {
+														selectedCopyChecklistId = '';
+														showCopyDropdown = false;
+													}}
+													class="w-full px-3 py-1.5 text-left text-xs hover:bg-slate-800 transition-colors border-none bg-transparent cursor-pointer flex items-center justify-between"
+												>
+													<span class={!selectedCopyChecklistId ? 'text-violet-400 font-medium' : 'text-slate-300'}>(none)</span>
+												</button>
+
+												{#if loadingChecklists}
+													<div class="px-3 py-2 text-xs text-slate-500 text-center">Loading checklists...</div>
+												{:else if groupedChecklists.length === 0}
+													<div class="px-3 py-2 text-xs text-slate-500 text-center">No checklists on board</div>
+												{:else}
+													{#each groupedChecklists as group}
+														<div class="first:mt-1">
+															<span class="text-[10px] text-slate-400 font-semibold px-3 py-1 select-none block truncate">
+																{group.cardName}
+															</span>
+															{#each group.checklists as cl}
+																{@const isSelected = selectedCopyChecklistId === cl.id}
+																<button
+																	type="button"
+																	onclick={() => {
+																		selectedCopyChecklistId = cl.id;
+																		showCopyDropdown = false;
+																	}}
+																	class="w-full pl-6 pr-3 py-1.5 text-left text-xs hover:bg-slate-800 {isSelected ? 'text-violet-400 font-medium' : 'text-slate-300'} transition-colors border-none bg-transparent cursor-pointer flex items-center justify-between"
+																>
+																	<span class="truncate">
+																		{cl.name}
+																	</span>
+																</button>
+															{/each}
+														</div>
+													{/each}
+												{/if}
+											</div>
+										{/if}
+									</div>
+
+									<div class="text-[10px]">
+										<button
+											type="button"
+											disabled={isCreatingChecklist || !newChecklistName.trim()}
+											onclick={handleCreateChecklist}
+											class="w-full py-1.5 bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded transition cursor-pointer border-none flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+										>
+											{#if isCreatingChecklist}
+												<Icon name="lucide:loader" class="w-3.5 h-3.5 animate-spin" />
+												<span>Adding...</span>
+											{:else}
+												<span>Add</span>
+											{/if}
+										</button>
+									</div>
+								</div>
+							{/if}
+						</div>
+
+				<!-- Members Button (hidden if members already shown below) -->
+				{#if !(card.members && card.members.length > 0)}
+				<div class="relative">
+					<button
+						type="button"
+						onclick={() => { showMembersPopover = !showMembersPopover; showLabelsPopover = false; showAddChecklistPopover = false; showDatesPopover = false; }}
+						class="flex items-center gap-1 px-3 py-1.5 rounded-lg border text-slate-300 hover:bg-slate-700 transition cursor-pointer
+							{showMembersPopover ? 'bg-slate-700 border-violet-500' : 'bg-slate-800 border-slate-700'}"
+					>
+						<Icon name="lucide:user-plus" class="w-3.5 h-3.5" />
+						<span>Members</span>
+					</button>
+
+					{#if showMembersPopover}
+						<button
+							type="button"
+							class="fixed inset-0 z-30 bg-transparent cursor-default border-none w-full h-full"
+							onclick={() => showMembersPopover = false}
+							aria-label="Close members popover"
+						></button>
+
+						<div class="absolute left-0 mt-2 z-40 w-72 p-4 rounded-xl border border-slate-700 bg-slate-950 shadow-2xl flex flex-col gap-3">
+							<!-- Header -->
+							<div class="flex items-center justify-between">
+								<h4 class="text-xs font-bold text-slate-200 m-0">Members</h4>
+								<button
+									type="button"
+									onclick={() => showMembersPopover = false}
+									class="flex items-center justify-center w-6 h-6 rounded text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition border-none bg-transparent cursor-pointer"
+									aria-label="Close members popover"
+								>
+									<Icon name="lucide:x" class="w-3.5 h-3.5" />
+								</button>
+							</div>
+
+							<!-- Search -->
+							<input
+								type="text"
+								placeholder="Search members"
+								bind:value={searchMemberQuery}
+								class="w-full px-3 py-2 rounded-lg bg-slate-900 border border-slate-700 text-slate-200 text-xs focus:outline-none focus:ring-2 focus:ring-violet-500 placeholder-slate-500"
+							/>
+
+							<!-- Board Members List -->
+							<div class="flex flex-col gap-1">
+								<span class="text-[10px] font-bold text-slate-500 uppercase tracking-wider mb-1">Board members</span>
+								{#if filteredMembers.length === 0}
+									<div class="text-slate-500 text-xs py-2 text-center">No members found</div>
+								{:else}
+									{#each filteredMembers as member}
+										{@const isAssigned = card?.members.some(m => m.id === member.id)}
+										<button
+											type="button"
+											onclick={async () => {
+												if (isAssigned) {
+													await taskClientStore.removeMemberFromCard(card.id, member.id);
+												} else {
+													await taskClientStore.addMemberToCard(card.id, member.id);
+												}
+											}}
+											class="flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-slate-800 transition cursor-pointer border-none bg-transparent w-full text-left
+												{isAssigned ? 'bg-slate-800/60' : ''}"
+										>
+											<!-- Avatar -->
+											{#if member.avatarUrl}
+												<img
+													src="{member.avatarUrl}/30.png"
+													alt={member.fullName}
+													class="w-7 h-7 rounded-full object-cover border border-slate-700 shrink-0"
+												/>
+											{:else}
+												<div class="w-7 h-7 rounded-full bg-violet-600 flex items-center justify-center text-[11px] font-bold text-white border border-slate-700 shrink-0">
+													{member.fullName.charAt(0).toUpperCase()}
+												</div>
+											{/if}
+											<!-- Name -->
+											<span class="flex-1 text-xs text-slate-200 truncate">{member.fullName}</span>
+											<!-- Check if assigned -->
+											{#if isAssigned}
+												<div class="w-4 h-4 rounded-full bg-violet-600 flex items-center justify-center shrink-0">
+													<Icon name="lucide:check" class="w-2.5 h-2.5 text-white stroke-[3]" />
+												</div>
+											{/if}
+										</button>
+									{/each}
+								{/if}
+							</div>
+						</div>
+					{/if}
+				</div>
+				{/if}
+
+				<!-- Attachment Button -->
+				<div class="relative">
+					<!-- Hidden file input -->
+					<input
+						bind:this={attachFileInput}
+						type="file"
+						class="hidden"
+						onchange={async (e) => {
+							const file = (e.currentTarget as HTMLInputElement).files?.[0];
+							if (!file) return;
+							isAttaching = true;
+							try {
+								await taskClientStore.addAttachmentFile(card.id, file);
+								showAttachmentPopover = false;
+							} catch { /* error logged in store */ } finally {
+								isAttaching = false;
+								if (attachFileInput) attachFileInput.value = '';
+							}
+						}}
+					/>
+
+					<button
+						type="button"
+						onclick={() => { showAttachmentPopover = !showAttachmentPopover; showLabelsPopover = false; showAddChecklistPopover = false; showDatesPopover = false; showMembersPopover = false; }}
+						class="flex items-center gap-1 px-3 py-1.5 rounded-lg border text-slate-300 hover:bg-slate-700 transition cursor-pointer
+							{showAttachmentPopover ? 'bg-slate-700 border-violet-500' : 'bg-slate-800 border-slate-700'}"
+					>
+						<Icon name="lucide:paperclip" class="w-3.5 h-3.5" />
+						<span>Attachment</span>
+					</button>
+
+					{#if showAttachmentPopover}
+						<button
+							type="button"
+							class="fixed inset-0 z-30 bg-transparent cursor-default border-none w-full h-full"
+							onclick={() => showAttachmentPopover = false}
+							aria-label="Close attachment popover"
+						></button>
+
+						<div class="absolute left-0 mt-2 z-40 w-80 rounded-xl border border-slate-700 bg-slate-950 shadow-2xl flex flex-col overflow-hidden">
+							<!-- Header -->
+							<div class="flex items-center justify-between px-4 py-3 border-b border-slate-800">
+								<h4 class="text-xs font-bold text-slate-200 m-0">Attach</h4>
+								<button
+									type="button"
+									onclick={() => showAttachmentPopover = false}
+									class="flex items-center justify-center w-6 h-6 rounded text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition border-none bg-transparent cursor-pointer"
+									aria-label="Close attachment popover"
+								>
+									<Icon name="lucide:x" class="w-3.5 h-3.5" />
+								</button>
+							</div>
+
+							<div class="flex flex-col gap-4 p-4">
+								<!-- File upload section -->
+								<div class="flex flex-col gap-1.5">
+									<span class="text-xs font-bold text-slate-200">Attach a file from your computer</span>
+									<span class="text-[11px] text-slate-500">You can also drag and drop files to upload them.</span>
+									<button
+										type="button"
+										disabled={isAttaching}
+										onclick={() => attachFileInput?.click()}
+										class="w-full py-2 rounded-lg border border-slate-700 bg-slate-900 hover:bg-slate-800 text-slate-300 text-xs font-semibold transition cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+									>
+										{#if isAttaching}
+											<Icon name="lucide:loader" class="w-3.5 h-3.5 animate-spin" />
+											<span>Uploading...</span>
+										{:else}
+											<span>Choose a file</span>
+										{/if}
+									</button>
+								</div>
+
+								<!-- Divider -->
+								<div class="border-t border-slate-800"></div>
+
+								<!-- Link section -->
+								<div class="flex flex-col gap-3">
+									<div class="flex flex-col gap-1">
+										<label for="attach-url-input" class="text-xs font-bold text-slate-200">
+											Search or paste a link <span class="text-red-400">*</span>
+										</label>
+										<input
+											id="attach-url-input"
+											type="url"
+											placeholder="Find recent links or paste a new link"
+											bind:value={attachLinkUrl}
+											class="w-full px-3 py-2 rounded-lg bg-slate-900 border border-slate-700 text-slate-200 text-xs focus:outline-none focus:ring-2 focus:ring-violet-500 placeholder-slate-500"
+										/>
+									</div>
+
+									<div class="flex flex-col gap-1">
+										<label for="attach-name-input" class="text-xs font-bold text-slate-200">Display text (optional)</label>
+										<input
+											id="attach-name-input"
+											type="text"
+											placeholder="Text to display"
+											bind:value={attachLinkName}
+											class="w-full px-3 py-2 rounded-lg bg-slate-900 border border-slate-700 text-slate-200 text-xs focus:outline-none focus:ring-2 focus:ring-violet-500 placeholder-slate-500"
+										/>
+										<span class="text-[10px] text-slate-500">Give this link a title or description</span>
+									</div>
+								</div>
+
+								<!-- Recently viewed boards -->
+								{#if taskClientStore.recentBoards.length > 0}
+									<div class="flex flex-col gap-1.5">
+										<span class="text-xs font-bold text-slate-200">Recently viewed</span>
+										<div class="flex flex-col gap-0.5 max-h-36 overflow-y-auto">
+											{#each taskClientStore.recentBoards.slice(0, 5) as board}
+												<button
+													type="button"
+													onclick={() => {
+														attachLinkUrl = `https://trello.com/b/${board.id}`;
+														attachLinkName = attachLinkName || board.name;
+													}}
+													class="flex items-center gap-2.5 px-2 py-2 rounded-lg hover:bg-slate-800 transition cursor-pointer border-none bg-transparent text-left w-full"
+												>
+													<div class="w-7 h-5 rounded shrink-0 flex items-center justify-center" style="background-color: {board.prefs?.backgroundColor ?? '#0079bf'}">
+														<Icon name="lucide:layout-dashboard" class="w-3 h-3 text-white/80" />
+													</div>
+													<div class="flex flex-col min-w-0">
+														<span class="text-xs font-semibold text-slate-200 truncate">{board.name}</span>
+														<span class="text-[10px] text-slate-500">{board.accountName}</span>
+													</div>
+												</button>
+											{/each}
+										</div>
+									</div>
+								{/if}
+							</div>
+
+							<!-- Footer -->
+							<div class="flex items-center justify-end gap-2 px-4 py-3 border-t border-slate-800">
+								<button
+									type="button"
+									onclick={() => { showAttachmentPopover = false; attachLinkUrl = ''; attachLinkName = ''; }}
+									class="px-4 py-1.5 text-xs font-semibold text-slate-300 hover:text-slate-100 bg-transparent hover:bg-slate-800 rounded-lg transition cursor-pointer border-none"
+								>
+									Cancel
+								</button>
+								<button
+									type="button"
+									disabled={!attachLinkUrl.trim() || isAttaching}
+									onclick={async () => {
+										if (!attachLinkUrl.trim()) return;
+										isAttaching = true;
+										try {
+											await taskClientStore.addAttachmentUrl(card.id, attachLinkUrl.trim(), attachLinkName.trim() || undefined);
+											showAttachmentPopover = false;
+											attachLinkUrl = '';
+											attachLinkName = '';
+										} catch { /* error logged in store */ } finally {
+											isAttaching = false;
+										}
+									}}
+									class="px-4 py-1.5 text-xs font-semibold text-white bg-violet-600 hover:bg-violet-700 rounded-lg transition cursor-pointer border-none disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5"
+								>
+									{#if isAttaching}
+										<Icon name="lucide:loader" class="w-3 h-3 animate-spin" />
+									{/if}
+									Insert
+								</button>
+							</div>
+						</div>
+					{/if}
+				</div>
+					</div>
+
+					<!-- Members and Labels row -->
+					<div class="flex flex-wrap gap-6 border-b border-slate-800 pb-5">
+						<!-- Members -->
+						{#if card.members && card.members.length > 0}
+							<div class="flex flex-col gap-1.5 relative">
+								<span class="text-[10px] font-bold text-slate-500 uppercase tracking-wider">Members</span>
+								<div class="flex items-center gap-1.5">
+									{#each card.members as member}
+										{#if member.avatarUrl}
+											<img src="{member.avatarUrl}/30.png" alt={member.fullName} title={member.fullName} class="w-7 h-7 rounded-full object-cover border border-slate-700" />
+										{:else}
+											<div class="w-7 h-7 rounded-full bg-violet-600 flex items-center justify-center text-xs font-bold text-white border border-slate-700" title={member.fullName}>
+												{member.fullName.charAt(0).toUpperCase()}
+											</div>
+										{/if}
+									{/each}
+									<button
+										type="button"
+										onclick={() => { showMembersPopover = !showMembersPopover; showLabelsPopover = false; showDatesPopover = false; }}
+										class="flex items-center justify-center w-7 h-7 rounded-full border border-dashed hover:border-slate-500 text-slate-400 hover:text-slate-200 transition cursor-pointer bg-transparent
+											{showMembersPopover ? 'border-violet-500' : 'border-slate-700'}"
+									>
+										<Icon name="lucide:plus" class="w-3.5 h-3.5" />
+									</button>
+								</div>
+
+								{#if showMembersPopover}
+									<button
+										type="button"
+										class="fixed inset-0 z-30 bg-transparent cursor-default border-none w-full h-full"
+										onclick={() => showMembersPopover = false}
+										aria-label="Close members popover"
+									></button>
+									<div class="absolute left-0 top-full mt-2 z-40 w-72 p-4 rounded-xl border border-slate-700 bg-slate-950 shadow-2xl flex flex-col gap-3">
+										<!-- Header -->
+										<div class="flex items-center justify-between">
+											<h4 class="text-xs font-bold text-slate-200 m-0">Members</h4>
+											<button
+												type="button"
+												onclick={() => showMembersPopover = false}
+												class="flex items-center justify-center w-6 h-6 rounded text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition border-none bg-transparent cursor-pointer"
+												aria-label="Close members popover"
+											>
+												<Icon name="lucide:x" class="w-3.5 h-3.5" />
+											</button>
+										</div>
+										<!-- Search -->
+										<input
+											type="text"
+											placeholder="Search members"
+											bind:value={searchMemberQuery}
+											class="w-full px-3 py-2 rounded-lg bg-slate-900 border border-slate-700 text-slate-200 text-xs focus:outline-none focus:ring-2 focus:ring-violet-500 placeholder-slate-500"
+										/>
+										<!-- Board Members List -->
+										<div class="flex flex-col gap-1">
+											<span class="text-[10px] font-bold text-slate-500 uppercase tracking-wider mb-1">Board members</span>
+											{#if filteredMembers.length === 0}
+												<div class="text-slate-500 text-xs py-2 text-center">No members found</div>
+											{:else}
+												{#each filteredMembers as member}
+													{@const isAssigned = card?.members.some(m => m.id === member.id)}
+													<button
+														type="button"
+														onclick={async () => {
+															if (isAssigned) {
+																await taskClientStore.removeMemberFromCard(card.id, member.id);
+															} else {
+																await taskClientStore.addMemberToCard(card.id, member.id);
+															}
+														}}
+														class="flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-slate-800 transition cursor-pointer border-none bg-transparent w-full text-left
+															{isAssigned ? 'bg-slate-800/60' : ''}"
+													>
+														{#if member.avatarUrl}
+															<img src="{member.avatarUrl}/30.png" alt={member.fullName} class="w-7 h-7 rounded-full object-cover border border-slate-700 shrink-0" />
+														{:else}
+															<div class="w-7 h-7 rounded-full bg-violet-600 flex items-center justify-center text-[11px] font-bold text-white border border-slate-700 shrink-0">
+																{member.fullName.charAt(0).toUpperCase()}
+															</div>
+														{/if}
+														<span class="flex-1 text-xs text-slate-200 truncate">{member.fullName}</span>
+														{#if isAssigned}
+															<div class="w-4 h-4 rounded-full bg-violet-600 flex items-center justify-center shrink-0">
+																<Icon name="lucide:check" class="w-2.5 h-2.5 text-white stroke-[3]" />
+															</div>
+														{/if}
+													</button>
+												{/each}
+											{/if}
+										</div>
+									</div>
+								{/if}
+							</div>
+						{/if}
+
+						<!-- Labels -->
+						{#if card.labels && card.labels.length > 0}
+							<div class="flex flex-col gap-1.5 relative">
+								<span class="text-[10px] font-bold text-slate-500 uppercase tracking-wider">Labels</span>
+								<div class="flex items-center gap-1.5 flex-wrap">
+									{#each card.labels as label}
+										{@const labelColorMap: Record<string, string> = {
+											'green': '#61bd4f', 'yellow': '#f2d600', 'orange': '#ff9f1a',
+											'red': '#eb5a46', 'purple': '#c377e0', 'blue': '#0079bf',
+											'sky': '#00c2e0', 'lime': '#51e898', 'pink': '#ff78cb', 'black': '#344563'
+										}}
+										{@const bg = labelColorMap[label.color] ?? label.color ?? '#6b7280'}
+										<span
+											class="text-sm font-bold h-8 min-w-[48px] px-3 rounded flex items-center justify-center text-white shadow-sm
+												{taskClientStore.colorblindMode ? `colorblind-pattern-${label.color}` : ''}"
+											style="background-color: {bg}"
+										>
+											<span>{label.name || ''}</span>
+										</span>
+									{/each}
+									<button
+										type="button"
+										onclick={() => { showLabelsPopover = !showLabelsPopover; showAddChecklistPopover = false; showDatesPopover = false; showMembersPopover = false; }}
+										class="flex items-center justify-center w-8 h-8 rounded hover:bg-slate-700/80 border hover:border-slate-600 text-slate-400 hover:text-slate-200 transition cursor-pointer
+											{showLabelsPopover ? 'bg-slate-700/80 border-violet-500' : 'bg-slate-800/80 border-slate-700/60'}"
+									>
+										<Icon name="lucide:plus" class="w-4 h-4" />
+									</button>
+								</div>
+
+								{#if showLabelsPopover}
+									<button
+										type="button"
+										class="fixed inset-0 z-30 bg-transparent cursor-default border-none w-full h-full"
+										onclick={() => showLabelsPopover = false}
+										aria-label="Close labels popover"
+									></button>
+									<div class="absolute left-0 top-full mt-2 z-40 w-72 p-4 rounded-xl border border-slate-700 bg-slate-950 shadow-2xl flex flex-col gap-3">
+										{@render labelsPopoverContent()}
+									</div>
+								{/if}
+							</div>
+						{/if}
+
+						<!-- Dates Section (if either start or due is set) -->
+						{#if card.start || card.due}
+							{@const dateInfo = getDateBadgeInfo(card.start, card.due, card.dueComplete)}
+							<div class="flex flex-col gap-1.5">
+								<span class="text-[10px] font-bold text-slate-500 uppercase tracking-wider">
+									{card.start && card.due ? 'Dates' : (card.start ? 'Start date' : 'Due date')}
+								</span>
+								<div class="flex items-center">
+									<!-- Clickable date badge button to open popover -->
+									<button
+										type="button"
+										onclick={(e) => {
+											if (showDatesPopover && datesPopoverSource === 'badge') {
+												showDatesPopover = false;
+											} else {
+												datesPopoverSource = 'badge';
+												updatePopoverPosition(e.currentTarget as HTMLElement, 520);
+												showDatesPopover = true;
+											}
+											showAddChecklistPopover = false;
+										}}
+										class="flex items-center bg-slate-800/80 hover:bg-slate-700/80 border border-slate-700/60 hover:border-slate-600 rounded-lg px-2.5 py-1.5 gap-2 text-xs text-slate-200 transition-colors cursor-pointer font-medium select-none"
+									>
+										<span>{dateInfo.formattedText}</span>
+										{#if dateInfo.badge}
+											<span class="px-1.5 py-0.5 rounded text-[9px] font-bold text-white uppercase tracking-wide {dateInfo.badgeClass}">
+												{dateInfo.badge}
+											</span>
+										{/if}
+										<Icon name="lucide:chevron-down" class="w-3.5 h-3.5 text-slate-400" />
+									</button>
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<!-- Description Section -->
+					<div class="flex flex-col gap-2">
+						<div class="flex items-center justify-between">
+							<div class="flex items-center gap-2 text-slate-200 font-bold text-sm">
+								<Icon name="lucide:align-left" class="w-4 h-4 text-slate-400" />
+								<span>Description</span>
+							</div>
+							{#if !isEditingDesc && card.desc}
+								<button
+									type="button"
+									onclick={() => { isEditingDesc = true; editDescHTML = card.desc ? renderMarkdownWithMentions(card.desc, true) : ''; }}
+									class="px-2.5 py-1 text-xs bg-slate-800 hover:bg-slate-700 text-slate-300 font-semibold rounded transition cursor-pointer border-none"
+								>
+									Edit
+								</button>
+							{/if}
+						</div>
+
+						{#if isEditingDesc}
+							<div class="flex flex-col gap-2 mt-1 pl-6 relative">
+								<RichTextEditor
+									bind:html={editDescHTML}
+									placeholder="Need formatting help? Type /help."
+									showDirectLinkImage={true}
+									showMarkdownIcon={true}
+									enableCodeToolbar={true}
+									mentionOptions={mentionOptions}
+									onImageUpload={handleUploadImageForEditor}
+								/>
+
+								<div class="flex items-center gap-1.5 mt-2">
+									<button
+										type="button"
+										onclick={handleSaveDesc}
+										class="px-4 py-1.5 text-sm bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded-lg transition-colors cursor-pointer border-none"
+									>
+										Save
+									</button>
+									<button
+										type="button"
+										onclick={handleCancelDesc}
+										class="px-3 py-1.5 text-sm bg-transparent hover:bg-slate-800 hover:text-slate-200 text-slate-400 font-semibold rounded-lg transition-colors cursor-pointer border-none"
+									>
+										Cancel
+									</button>
+								</div>
+							</div>
+						{:else}
+							{#if card.desc}
+								<div class="pl-6">
+									<button
+										type="button"
+										onclick={() => { isEditingDesc = true; editDescHTML = card.desc ? renderMarkdownWithMentions(card.desc, true) : ''; }}
+										class="w-full text-left bg-transparent hover:bg-slate-800/30 rounded-lg p-2 -ml-2 text-sm leading-relaxed text-slate-300 cursor-pointer transition-colors border-none markdown-preview-container"
+									>
+										{@html renderMarkdownWithMentions(card.desc, false)}
+									</button>
+								</div>
+							{:else}
+								<div class="pl-6">
+									<button
+										type="button"
+										onclick={() => { isEditingDesc = true; editDescHTML = ''; }}
+										class="w-full text-left bg-slate-800/20 hover:bg-slate-800/40 border border-slate-800/80 hover:border-slate-700 rounded-lg px-4 py-3 text-sm text-slate-400 hover:text-slate-300 cursor-pointer transition-colors select-none leading-relaxed min-h-[56px] border-solid"
+									>
+										Add a more detailed description...
+									</button>
+								</div>
+							{/if}
+						{/if}
+					</div>
+
+				<!-- Attachments Section -->
+				{#if taskClientStore.activeCardAttachments.length > 0}
+					<div class="flex flex-col gap-3">
+						<!-- Header -->
+						<div class="flex items-center justify-between">
+							<div class="flex items-center gap-2 text-slate-200 font-bold text-sm">
+								<Icon name="lucide:paperclip" class="w-4 h-4 text-slate-400" />
+								<span>Attachments</span>
+							</div>
+							<!-- Add button opens attachment popover -->
+							<button
+								type="button"
+								onclick={() => { showAttachmentPopover = !showAttachmentPopover; showLabelsPopover = false; showAddChecklistPopover = false; showDatesPopover = false; showMembersPopover = false; }}
+								class="px-3 py-1 text-xs font-semibold text-slate-300 bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-lg transition cursor-pointer"
+							>
+								Add
+							</button>
+						</div>
+
+						<!-- Attachment list -->
+						<div class="flex flex-col gap-2 pl-6">
+							{#each taskClientStore.activeCardAttachments as attachment}
+								{@const isImage = attachment.mimeType?.startsWith('image/') || attachment.previews?.length > 0}
+								{@const thumbUrl = attachment.previews?.find(p => p.width >= 150)?.url ?? attachment.previews?.[0]?.url}
+								{@const addedDate = new Date(attachment.date)}
+								{@const minutesAgo = Math.round((Date.now() - addedDate.getTime()) / 60000)}
+								{@const timeLabel = minutesAgo < 1 ? 'Added just now' : minutesAgo < 60 ? `Added ${minutesAgo}m ago` : minutesAgo < 1440 ? `Added ${Math.round(minutesAgo/60)}h ago` : `Added ${addedDate.toLocaleDateString()}`}
+
+								<div class="flex items-center gap-3 group py-1">
+									<!-- Thumbnail -->
+									<button
+										type="button"
+										onclick={() => { previewAttachment = attachment; }}
+										class="w-16 h-12 rounded-lg border border-slate-700 bg-slate-800 flex items-center justify-center shrink-0 overflow-hidden hover:border-slate-600 transition cursor-pointer p-0"
+									>
+										{#if isImage && thumbUrl}
+											<img src={thumbUrl} alt={attachment.name} class="w-full h-full object-cover" />
+										{:else}
+											<div class="flex flex-col items-center gap-0.5">
+												<Icon name="lucide:file" class="w-5 h-5 text-slate-400" />
+												<span class="text-[9px] text-slate-500 uppercase font-bold truncate max-w-[56px] px-1">
+													{attachment.name.split('.').pop() ?? 'file'}
+												</span>
+											</div>
+										{/if}
+									</button>
+
+									<!-- Info -->
+									<div class="flex flex-col gap-0.5 flex-1 min-w-0">
+										<button
+											type="button"
+											onclick={() => { previewAttachment = attachment; }}
+											class="text-xs font-semibold text-slate-200 truncate hover:underline text-left cursor-pointer border-none bg-transparent p-0 m-0 w-fit max-w-full"
+										>
+											{attachment.name}
+										</button>
+										<span class="text-[11px] text-slate-500">{timeLabel}</span>
+									</div>
+
+									<!-- Actions -->
+									<div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition shrink-0 relative">
+										<!-- External link -->
+										<a
+											href={attachment.url}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="flex items-center justify-center w-7 h-7 rounded-lg bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-400 hover:text-slate-200 transition"
+											title="Open in browser"
+										>
+											<Icon name="lucide:external-link" class="w-3.5 h-3.5" />
+										</a>
+
+										<!-- "..." menu button -->
+										<button
+											type="button"
+											onclick={(e) => { e.stopPropagation(); openAttachmentMenuId = openAttachmentMenuId === attachment.id ? null : attachment.id; }}
+											class="flex items-center justify-center w-7 h-7 rounded-lg bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-400 hover:text-slate-200 transition cursor-pointer
+												{openAttachmentMenuId === attachment.id ? 'bg-slate-700 border-slate-600 text-slate-200' : ''}"
+											title="More options"
+										>
+											<Icon name="lucide:ellipsis" class="w-3.5 h-3.5" />
+										</button>
+
+										<!-- Dropdown menu -->
+										{#if openAttachmentMenuId === attachment.id}
+											<button
+												type="button"
+												class="fixed inset-0 z-30 bg-transparent cursor-default border-none w-full h-full"
+												onclick={() => { openAttachmentMenuId = null; editingAttachmentId = null; }}
+												aria-label="Close attachment menu"
+											></button>
+
+											{#if editingAttachmentId === attachment.id}
+												<!-- Edit attachment panel -->
+												<div class="absolute right-0 top-full mt-1 z-40 w-72 rounded-xl border border-slate-700 bg-slate-900 shadow-2xl p-4 flex flex-col gap-3">
+													<div class="flex items-center gap-2">
+														<button
+															type="button"
+															onclick={() => { editingAttachmentId = null; }}
+															class="flex items-center justify-center w-6 h-6 rounded text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition border-none bg-transparent cursor-pointer shrink-0"
+															aria-label="Back"
+														>
+															<Icon name="lucide:chevron-left" class="w-4 h-4" />
+														</button>
+														<span class="flex-1 text-center text-sm font-bold text-slate-200">Edit attachment</span>
+														<button
+															type="button"
+															onclick={() => { openAttachmentMenuId = null; editingAttachmentId = null; }}
+															class="flex items-center justify-center w-6 h-6 rounded text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition border-none bg-transparent cursor-pointer shrink-0"
+															aria-label="Close"
+														>
+															<Icon name="lucide:x" class="w-4 h-4" />
+														</button>
+													</div>
+													<div class="flex flex-col gap-1.5">
+														<label class="text-xs font-bold text-slate-300">File name</label>
+														<input
+															type="text"
+															bind:value={editingAttachmentName}
+															class="w-full px-3 py-2.5 rounded-lg bg-slate-800 border-2 border-blue-500 text-slate-200 text-sm focus:outline-none"
+														/>
+													</div>
+													<button
+														type="button"
+														onclick={async () => {
+															if (!editingAttachmentName.trim()) return;
+															await taskClientStore.renameAttachment(card.id, attachment.id, editingAttachmentName.trim());
+															openAttachmentMenuId = null;
+															editingAttachmentId = null;
+														}}
+														class="w-full py-2.5 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold transition cursor-pointer border-none"
+													>
+														Update
+													</button>
+												</div>
+											{:else}
+												<!-- Menu list -->
+												<div class="absolute right-0 top-full mt-1 z-40 w-44 rounded-xl border border-slate-700 bg-slate-900 shadow-2xl overflow-hidden py-1">
+													<button
+														type="button"
+														onclick={() => { editingAttachmentId = attachment.id; editingAttachmentName = attachment.name; }}
+														class="w-full text-left px-4 py-2.5 text-sm text-slate-200 hover:bg-slate-800 transition cursor-pointer border-none bg-transparent"
+													>
+														Edit
+													</button>
+													<button
+														type="button"
+														onclick={() => {
+															openAttachmentMenuId = null;
+															editCommentHTML = `<a href="${attachment.url}">${attachment.name || attachment.url}</a>`;
+															isWritingComment = true;
+															setTimeout(() => commentSectionEl?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 50);
+														}}
+														class="w-full text-left px-4 py-2.5 text-sm text-slate-200 hover:bg-slate-800 transition cursor-pointer border-none bg-transparent"
+													>
+														Comment
+													</button>
+													<a
+														href={attachment.url}
+														download={attachment.name}
+														onclick={() => openAttachmentMenuId = null}
+														class="block w-full text-left px-4 py-2.5 text-sm text-slate-200 hover:bg-slate-800 transition cursor-pointer no-underline"
+													>
+														Download
+													</a>
+													<button
+														type="button"
+														onclick={async () => { openAttachmentMenuId = null; await taskClientStore.deleteAttachment(card.id, attachment.id); }}
+														class="w-full text-left px-4 py-2.5 text-sm text-red-400 hover:bg-slate-800 transition cursor-pointer border-none bg-transparent"
+													>
+														Remove
+													</button>
+												</div>
+											{/if}
+										{/if}
+									</div>
+								</div>
+							{/each}
+						</div>
+					</div>
+				{/if}
+
+					<!-- Checklists Section -->
+					{#if taskClientStore.activeCardChecklists && taskClientStore.activeCardChecklists.length > 0}
+						<div class="flex flex-col gap-6 mt-2">
+							{#each taskClientStore.activeCardChecklists as checklist}
+								{@const progress = getChecklistProgress(checklist.checkItems)}
+								<div class="flex flex-col gap-3">
+									<!-- Checklist Header -->
+									<div class="flex items-center justify-between">
+										<div class="flex items-center gap-2 text-slate-200 font-bold text-sm flex-1 min-w-0 mr-4">
+											<Icon name="lucide:square-check" class="w-4 h-4 text-slate-400 shrink-0" />
+											{#if editingChecklistId === checklist.id}
+												<div class="flex-1">
+													<input
+														type="text"
+														bind:value={editChecklistNameVal}
+														onkeydown={(e) => {
+															if (e.key === 'Enter') handleSaveChecklistName(checklist.id);
+															if (e.key === 'Escape') cancelEditChecklist();
+														}}
+														onblur={() => handleSaveChecklistName(checklist.id)}
+														autofocus
+														class="w-full px-2 py-1 rounded bg-slate-950 border border-slate-700 text-sm font-semibold text-slate-100 focus:outline-none focus:ring-1 focus:ring-violet-500"
+													/>
+												</div>
+											{:else}
+												<button
+													type="button"
+													onclick={() => startEditChecklist(checklist.id, checklist.name)}
+													class="text-left font-bold text-slate-200 hover:text-slate-100 hover:bg-slate-800/50 px-1 rounded transition-colors cursor-pointer border-none bg-transparent m-0 truncate flex-1 leading-normal"
+													title="Click to edit checklist title"
+												>
+													{checklist.name}
+												</button>
+											{/if}
+										</div>
+										<div class="flex items-center gap-2 shrink-0">
+											{#if checklist.checkItems && checklist.checkItems.some((i) => i.state === 'complete')}
+												<button
+													type="button"
+													onclick={() => toggleHideCheckedItems(checklist.id)}
+													class="px-2.5 py-1 text-xs bg-slate-800/80 hover:bg-slate-700 text-slate-300 font-semibold rounded transition border border-slate-700/50 cursor-pointer"
+												>
+													{hideCheckedMap[checklist.id] ? 'Show checked items' : 'Hide checked items'}
+												</button>
+											{/if}
+											<button
+												type="button"
+												onclick={() => handleDeleteChecklist(checklist.id)}
+												class="px-2.5 py-1 text-xs bg-slate-800/80 hover:bg-red-950/20 border border-slate-700/50 hover:border-red-900/30 text-slate-300 hover:text-red-400 rounded transition cursor-pointer"
+											>
+												Delete
+											</button>
+										</div>
+									</div>
+
+									<!-- Checklist Progress Bar -->
+									<div class="flex items-center gap-3">
+										<span
+											class="text-xs font-bold text-slate-500 w-8"
+											class:text-green-500={progress.percent === 100}
+										>
+											{progress.percent}%
+										</span>
+										<div class="flex-1 h-1.5 bg-slate-800 rounded-full overflow-hidden">
+											<div
+												class="h-full bg-violet-500 transition-all duration-300"
+												class:bg-green-500={progress.percent === 100}
+												style="width: {progress.percent}%"
+											></div>
+										</div>
+									</div>
+
+									<!-- Check Items list -->
+									{#if checklist.checkItems && checklist.checkItems.length > 0}
+										{@const displayedItems = hideCheckedMap[checklist.id]
+											? checklist.checkItems.filter((i) => i.state !== 'complete')
+											: checklist.checkItems}
+										{#if displayedItems.length > 0}
+											<div class="flex flex-col gap-1 pl-6">
+												{#each displayedItems as item}
+													<div class="group flex items-center justify-between gap-2.5 py-1.5 text-sm text-slate-300 hover:bg-slate-800/30 px-1.5 rounded transition-colors">
+														{#if editingCheckItemId === item.id}
+															<div class="flex-grow flex flex-col gap-2 bg-slate-950/40 p-2.5 rounded-lg border border-slate-800 max-w-lg">
+																<textarea
+																	bind:value={editCheckItemNameVal}
+																	onkeydown={(e) => {
+																		if (e.key === 'Enter' && !e.shiftKey) {
+																			e.preventDefault();
+																			handleSaveCheckItemName(checklist.id, item.id);
+																		}
+																		if (e.key === 'Escape') cancelEditCheckItem();
+																	}}
+																	autofocus
+																	class="w-full min-h-14 p-2 rounded-lg border border-slate-700 bg-slate-950 text-xs text-slate-100 focus:outline-none focus:ring-1 focus:ring-violet-500 focus:border-violet-500 resize-y leading-relaxed font-sans"
+																></textarea>
+																<div class="flex items-center justify-between gap-3 mt-0.5">
+																	<div class="flex items-center gap-2">
+																		<button
+																			type="button"
+																			onclick={() => handleSaveCheckItemName(checklist.id, item.id)}
+																			class="px-3 py-1.5 text-xs bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded-lg transition cursor-pointer border-none"
+																		>
+																			Save
+																		</button>
+																		<button
+																			type="button"
+																			onclick={cancelEditCheckItem}
+																			class="px-2.5 py-1.5 text-xs text-slate-400 hover:text-slate-200 font-semibold rounded-lg transition cursor-pointer bg-transparent border-none"
+																		>
+																			Cancel
+																		</button>
+																	</div>
+																	<div class="flex items-center gap-2.5 text-[10px] text-slate-400">
+																		<button type="button" class="flex items-center gap-1 bg-transparent hover:bg-slate-800 border-none text-slate-400 hover:text-slate-200 cursor-pointer py-1 px-1.5 rounded">
+																			<Icon name="lucide:user-plus" class="w-3.5 h-3.5" />
+																			<span>Assign</span>
+																		</button>
+																		<button type="button" class="flex items-center gap-1 bg-transparent hover:bg-slate-800 border-none text-slate-400 hover:text-slate-200 cursor-pointer py-1 px-1.5 rounded">
+																			<Icon name="lucide:clock" class="w-3.5 h-3.5" />
+																			<span>Due date</span>
+																		</button>
+																		<button type="button" class="bg-transparent hover:bg-slate-800 border-none text-slate-400 hover:text-slate-200 cursor-pointer p-1 rounded">
+																			<Icon name="lucide:ellipsis" class="w-3.5 h-3.5" />
+																		</button>
+																	</div>
+																</div>
+															</div>
+														{:else}
+															<div class="flex items-center gap-2.5 flex-1 min-w-0">
+																<input
+																	type="checkbox"
+																	checked={item.state === 'complete'}
+																	onclick={() => handleToggleCheckItem(checklist.id, item.id, item.state)}
+																	class="w-3.5 h-3.5 accent-green-500 rounded bg-slate-950 border border-slate-700 cursor-pointer shrink-0"
+																/>
+																<button
+																	type="button"
+																	onclick={() => startEditCheckItem(item.id, item.name)}
+																	class="text-left leading-normal flex-1 break-words font-sans text-sm text-slate-300 hover:text-slate-100 hover:bg-slate-800/50 px-1 rounded transition-colors cursor-pointer border-none bg-transparent m-0"
+																	class:line-through={item.state === 'complete'}
+																	class:text-slate-500={item.state === 'complete'}
+																	title="Click to edit item name"
+																>
+																	{item.name}
+																</button>
+															</div>
+															<button
+																type="button"
+																onclick={() => handleDeleteCheckItem(checklist.id, item.id)}
+																class="text-slate-500 hover:text-red-400 p-0.5 rounded hover:bg-slate-850 cursor-pointer border-none bg-transparent opacity-0 group-hover:opacity-100 transition-opacity"
+																title="Delete check item"
+															>
+																<Icon name="lucide:trash-2" class="w-3.5 h-3.5" />
+															</button>
+														{/if}
+													</div>
+												{/each}
+											</div>
+										{/if}
+									{/if}
+
+									<!-- Add Checklist item input form -->
+									<div class="pl-6">
+										{#if activeAddCheckItemId === checklist.id}
+											<div class="flex flex-col gap-2 max-w-md">
+												<input
+													type="text"
+													placeholder="Add an item"
+													bind:value={newCheckItemVals[checklist.id]}
+													onkeydown={(e) => {
+														if (e.key === 'Enter') handleAddCheckItem(checklist.id);
+														if (e.key === 'Escape') activeAddCheckItemId = null;
+													}}
+													class="w-full px-3 py-1.5 rounded-lg border border-slate-700 bg-slate-950 text-xs text-slate-100 focus:outline-none focus:ring-1 focus:ring-violet-500"
+												/>
+												<div class="flex gap-2">
+													<button
+														type="button"
+														onclick={() => handleAddCheckItem(checklist.id)}
+														class="px-2.5 py-1 text-xs bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded transition cursor-pointer border-none"
+													>
+														Add
+													</button>
+													<button
+														type="button"
+														onclick={() => activeAddCheckItemId = null}
+														class="px-2.5 py-1 text-xs bg-transparent hover:bg-slate-800 text-slate-400 hover:text-slate-200 font-semibold rounded transition cursor-pointer border border-slate-700"
+													>
+														Cancel
+													</button>
+												</div>
+											</div>
+										{:else}
+											<button
+												type="button"
+												onclick={() => {
+													activeAddCheckItemId = checklist.id;
+													newCheckItemVals[checklist.id] = '';
+												}}
+												class="px-3 py-1.5 text-xs bg-slate-800/80 hover:bg-slate-800 text-slate-300 font-semibold rounded transition cursor-pointer border-none"
+											>
+												Add an item
+											</button>
+										{/if}
+									</div>
+								</div>
+							{/each}
+						</div>
+					{/if}
+				</div>
+
+				<!-- Right activities / comments column -->
+				<div bind:this={commentSectionEl} class="w-full md:w-[360px] md:shrink-0 border-t md:border-t-0 md:border-l border-slate-800 pt-6 md:pt-0 md:pl-6 flex flex-col md:h-full md:pr-0">
+					<!-- Comments header -->
+					<div class="flex items-center justify-between md:pr-6">
+						<div class="flex items-center gap-2 text-slate-200 font-bold text-sm">
+							<Icon name="lucide:message-square" class="w-4 h-4 text-slate-400" />
+							<span>Comments and activity</span>
+						</div>
+						<button
+							type="button"
+							onclick={() => showActivityDetails = !showActivityDetails}
+							class="px-2.5 py-1 text-xs bg-slate-800 hover:bg-slate-700 text-slate-400 hover:text-slate-200 font-semibold rounded transition cursor-pointer border-none"
+						>
+							{showActivityDetails ? 'Hide details' : 'Show details'}
+						</button>
+					</div>
+
+					<!-- Activity feed list (scrollable) -->
+					<div class="flex-1 overflow-y-auto flex flex-col gap-5 pt-1 md:pr-6">
+
+					<!-- Write a comment input -->
+					{#if isWritingComment}
+						<div class="flex flex-col gap-2 animate-in fade-in duration-150 relative">
+							<RichTextEditor
+								bind:html={editCommentHTML}
+								placeholder="Write a comment..."
+								showDirectLinkImage={false}
+								showMarkdownIcon={false}
+								enableCodeToolbar={false}
+								dropdownAlign="right"
+								mentionOptions={mentionOptions}
+								onImageUpload={handleUploadImageForEditor}
+							/>
+							<div class="flex items-center gap-1.5 select-none">
+								<button
+									type="button"
+									onclick={handleAddComment}
+									disabled={isCommentEmpty}
+									class="px-4 py-1.5 text-sm bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded-lg transition-colors cursor-pointer border-none disabled:opacity-50 disabled:cursor-not-allowed"
+								>
+									Save
+								</button>
+								<button
+									type="button"
+									onclick={() => {
+										isWritingComment = false;
+										editCommentHTML = '';
+									}}
+									class="px-3 py-1.5 text-sm bg-transparent hover:bg-slate-800 hover:text-slate-200 text-slate-400 font-semibold rounded-lg transition-colors cursor-pointer border-none"
+								>
+									Cancel
+								</button>
+								
+								<label class="flex items-center gap-1.5 text-xs text-slate-400 hover:text-slate-200 cursor-pointer ml-1 select-none">
+									<input
+										type="checkbox"
+										checked={card.badges?.subscribed ?? false}
+										disabled
+										class="w-3.5 h-3.5 accent-violet-600 rounded bg-slate-900 border border-slate-700 cursor-not-allowed shrink-0"
+									/>
+									<span>Watch</span>
+								</label>
+							</div>
+						</div>
+					{:else}
+						<button
+							type="button"
+							onclick={() => {
+								isWritingComment = true;
+								editCommentHTML = '';
+							}}
+							class="w-full text-left bg-slate-800/20 hover:bg-slate-800/40 border border-slate-800/80 hover:border-slate-700 rounded-lg px-4 py-3 text-xs text-slate-400 hover:text-slate-300 cursor-pointer transition-colors select-none leading-relaxed min-h-[44px] border-solid"
+						>
+							Write a comment...
+						</button>
+					{/if}
+
+					<!-- Activity feed -->
+					<div class="flex flex-col gap-4">
+						{#each filteredActions as action}
+							<div class="flex gap-2.5 items-start text-xs">
+								<!-- Creator avatar -->
+								{#if action.memberCreator?.avatarUrl}
+									<img src="{action.memberCreator.avatarUrl}/30.png" alt="" class="w-6 h-6 rounded-full object-cover border border-slate-700 shrink-0 mt-0.5" />
+								{:else}
+									<div class="w-6 h-6 rounded-full bg-violet-600 flex items-center justify-center text-[10px] font-bold text-white border border-slate-700 shrink-0 mt-0.5">
+										{action.memberCreator?.fullName.charAt(0).toUpperCase()}
+									</div>
+								{/if}
+
+								<!-- Activity details -->
+								<div class="flex-1 flex flex-col gap-1 min-w-0">
+									<div class="text-slate-300">
+										<span class="font-bold text-slate-200">{action.memberCreator?.fullName}</span>
+										{#if action.type === 'commentCard'}
+											<span>commented:</span>
+										{:else}
+											<span>{formatActionText(action).replace(action.memberCreator?.fullName || '', '').trim()}</span>
+										{/if}
+									</div>
+									<div class="text-[10px] text-slate-500">
+										{new Date(action.date).toLocaleString('id-ID', { day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' })}
+									</div>
+									{#if action.type === 'commentCard' && action.data?.text}
+										{#if editingCommentId === action.id}
+											<div class="flex flex-col gap-2 mt-1">
+												<RichTextEditor
+													bind:html={editExistingCommentHTML}
+													placeholder="Edit your comment..."
+													showDirectLinkImage={false}
+													showMarkdownIcon={false}
+													enableCodeToolbar={false}
+													dropdownAlign="right"
+													mentionOptions={mentionOptions}
+													onImageUpload={handleUploadImageForEditor}
+												/>
+												<div class="flex gap-2 text-[10px] mt-1.5 select-none">
+													<button
+														type="button"
+														onclick={() => handleSaveComment(action.id)}
+														class="px-2.5 py-1 bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded transition cursor-pointer border-none"
+													>
+														Save
+													</button>
+													<button
+														type="button"
+														onclick={cancelEditComment}
+														class="px-2.5 py-1 bg-transparent hover:bg-slate-800 text-slate-400 hover:text-slate-200 font-semibold rounded transition cursor-pointer border border-slate-700"
+													>
+														Cancel
+													</button>
+												</div>
+											</div>
+										{:else}
+											<div class="mt-1 p-2 rounded-lg bg-slate-950 border border-slate-800 text-slate-300 leading-relaxed font-sans max-w-full break-words markdown-preview-container">
+												{@html renderMarkdownWithMentions(action.data.text || '', false)}
+											</div>
+											<div class="flex gap-2 text-[10px] text-slate-500 mt-0.5">
+												<button
+													type="button"
+													onclick={() => startEditComment(action.id, action.data.text || '')}
+													class="hover:text-slate-300 underline cursor-pointer border-none bg-transparent p-0"
+												>
+													Edit
+												</button>
+												<span>•</span>
+												<button
+													type="button"
+													onclick={() => handleDeleteComment(action.id)}
+													class="hover:text-red-400 underline cursor-pointer border-none bg-transparent p-0"
+												>
+													Delete
+												</button>
+											</div>
+										{/if}
+									{/if}
+								</div>
+							</div>
+						{/each}
+
+						{#if filteredActions.length === 0}
+							<p class="text-xs text-slate-500 italic text-center py-4">No recent activity</p>
+						{/if}
+					</div>
+
+					</div>
+
+					<!-- Card Actions (Archive/Delete) -->
+					<div class="flex flex-col gap-2 shrink-0 border-t border-slate-800 pt-4 md:pr-6">
+						<span class="text-[10px] font-bold text-slate-500 uppercase tracking-wider">Card Actions</span>
+						<div class="flex gap-2 text-xs">
+							<button
+								type="button"
+								onclick={handleArchiveCard}
+								class="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-300 rounded-lg transition cursor-pointer"
+								title="Archive this card"
+							>
+								<Icon name="lucide:archive" class="w-3.5 h-3.5" />
+								<span>Archive</span>
+							</button>
+							<button
+								type="button"
+								onclick={handleDeleteCard}
+								class="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 bg-red-950/20 hover:bg-red-950/40 border border-red-900/30 hover:border-red-900/50 text-red-400 rounded-lg transition cursor-pointer"
+								title="Permanently delete card"
+							>
+								<Icon name="lucide:trash-2" class="w-3.5 h-3.5" />
+								<span>Delete</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+
+		</div>
+	</div>
+	<!-- Popover rendered outside backdrop to avoid containing block offsets from filter/transform -->
+	{#if showDatesPopover}
+		<!-- Click outside handler overlay -->
+		<button
+			type="button"
+			class="fixed inset-0 z-[205] bg-transparent cursor-default border-none w-full h-full"
+			onclick={() => showDatesPopover = false}
+			aria-label="Close dates picker"
+		></button>
+
+		<div 
+			style="top: {popoverTop}px; left: {popoverLeft}px;"
+			class="fixed z-[210]"
+		>
+			{@render datesPopoverContent()}
+		</div>
+	{/if}
+
+	{#if previewAttachment}
+		<!-- Backdrop block -->
+		<button
+			type="button"
+			class="fixed inset-0 z-[250] bg-black/90 backdrop-blur-sm cursor-default border-none w-full h-full animate-in fade-in duration-200"
+			onclick={() => previewAttachment = null}
+			aria-label="Close attachment preview"
+		></button>
+
+		<!-- Close button in top-right of screen -->
+		<button
+			type="button"
+			onclick={() => previewAttachment = null}
+			class="fixed top-6 right-6 z-[260] p-2.5 rounded-full bg-slate-900/60 hover:bg-slate-800/80 transition text-slate-400 hover:text-slate-200 cursor-pointer border border-slate-700/50 animate-in fade-in zoom-in-95 duration-200"
+			aria-label="Close"
+		>
+			<Icon name="lucide:x" class="w-5 h-5" />
+		</button>
+
+		<!-- Main Preview Content Area (Centered) -->
+		<div class="fixed inset-0 z-[255] pointer-events-none flex items-center justify-center p-4">
+			<div class="pointer-events-auto flex flex-col items-center justify-center max-w-full max-h-full">
+				{#if previewAttachment.mimeType?.startsWith('image/') || previewAttachment.previews?.length > 0}
+					<img
+						src={previewAttachment.url}
+						alt={previewAttachment.name}
+						class="max-w-[90vw] max-h-[70vh] object-contain rounded-lg shadow-2xl border border-slate-800/50 animate-in fade-in zoom-in-95 duration-200"
+					/>
+				{:else}
+					<div class="flex flex-col items-center gap-4 text-center animate-in fade-in zoom-in-95 duration-200">
+						<span class="text-lg font-bold text-slate-100 max-w-md">There is no preview available for this attachment.</span>
+						<a
+							href={previewAttachment.url}
+							download={previewAttachment.name}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="px-6 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-semibold text-sm transition cursor-pointer shadow-md no-underline flex items-center gap-2"
+						>
+							<Icon name="lucide:download" class="w-4 h-4" />
+							Download
+						</a>
+					</div>
+				{/if}
+			</div>
+		</div>
+
+		<!-- Bottom Details Panel -->
+		<div class="fixed bottom-0 left-0 right-0 z-[255] pointer-events-none flex flex-col items-center pb-8 px-4">
+			<div class="pointer-events-auto flex flex-col items-center text-center max-w-2xl bg-slate-950/80 backdrop-blur-md px-6 py-4 rounded-2xl border border-slate-800/60 shadow-2xl animate-in slide-in-from-bottom duration-250">
+				<h3 class="text-base font-bold text-slate-100 truncate max-w-md m-0 mb-1">{previewAttachment.name}</h3>
+				<div class="text-xs text-slate-400 mb-4 flex items-center gap-1.5 justify-center">
+					<span>Added {formattedPreviewDate}</span>
+					{#if previewAttachment.bytes}
+						<span>•</span>
+						<span>{formatFileSize(previewAttachment.bytes)}</span>
+					{/if}
+				</div>
+
+				<div class="flex items-center gap-6 text-sm">
+					<a
+						href={previewAttachment.url}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="flex items-center gap-2 text-slate-300 hover:text-slate-100 font-semibold no-underline transition"
+					>
+						<Icon name="lucide:external-link" class="w-4 h-4" />
+						Open in new tab
+					</a>
+					<a
+						href={previewAttachment.url}
+						download={previewAttachment.name}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="flex items-center gap-2 text-slate-300 hover:text-slate-100 font-semibold no-underline transition"
+					>
+						<Icon name="lucide:download" class="w-4 h-4" />
+						Download
+					</a>
+					<button
+						type="button"
+						onclick={async () => {
+							if (previewAttachment) {
+								const id = previewAttachment.id;
+								previewAttachment = null;
+								await taskClientStore.deleteAttachment(card.id, id);
+							}
+						}}
+						class="flex items-center gap-2 text-slate-300 hover:text-red-400 font-semibold bg-transparent border-none cursor-pointer transition p-0"
+					>
+						<Icon name="lucide:x" class="w-4 h-4" />
+						Delete
+					</button>
+				</div>
+			</div>
+		</div>
+	{/if}
+{/if}
+
+{#snippet datesPopoverContent()}
+	<div class="w-72 p-4 rounded-xl border border-slate-700 bg-slate-950 shadow-2xl flex flex-col gap-3">
+		<!-- Header -->
+		<div class="flex items-center justify-between">
+			<h4 class="text-xs font-bold text-slate-200 m-0">Dates</h4>
+			<button
+				type="button"
+				onclick={() => showDatesPopover = false}
+				class="text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer p-0.5 rounded hover:bg-slate-900 transition-colors"
+			>
+				<Icon name="lucide:x" class="w-3.5 h-3.5" />
+			</button>
+		</div>
+
+		<!-- Calendar month/year navigation -->
+		<div class="flex items-center justify-between text-xs text-slate-200 font-semibold bg-slate-900/50 py-1 px-1.5 rounded border border-slate-800">
+			<div class="flex items-center gap-0.5">
+				<button
+					type="button"
+					onclick={prevYear}
+					class="p-1 hover:bg-slate-800 rounded text-slate-400 hover:text-slate-200 cursor-pointer border-none bg-transparent"
+					title="Previous year"
+				>
+					<Icon name="lucide:chevrons-left" class="w-3.5 h-3.5" />
+				</button>
+				<button
+					type="button"
+					onclick={prevMonth}
+					class="p-1 hover:bg-slate-800 rounded text-slate-400 hover:text-slate-200 cursor-pointer border-none bg-transparent"
+					title="Previous month"
+				>
+					<Icon name="lucide:chevron-left" class="w-3.5 h-3.5" />
+				</button>
+			</div>
+			
+			<span class="select-none">{monthNames[calendarMonth]} {calendarYear}</span>
+
+			<div class="flex items-center gap-0.5">
+				<button
+					type="button"
+					onclick={nextMonth}
+					class="p-1 hover:bg-slate-800 rounded text-slate-400 hover:text-slate-200 cursor-pointer border-none bg-transparent"
+					title="Next month"
+				>
+					<Icon name="lucide:chevron-right" class="w-3.5 h-3.5" />
+				</button>
+				<button
+					type="button"
+					onclick={nextYear}
+					class="p-1 hover:bg-slate-800 rounded text-slate-400 hover:text-slate-200 cursor-pointer border-none bg-transparent"
+					title="Next year"
+				>
+					<Icon name="lucide:chevrons-right" class="w-3.5 h-3.5" />
+				</button>
+			</div>
+		</div>
+
+		<!-- Weekday Headers -->
+		<div class="grid grid-cols-7 text-center text-[10px] font-bold text-slate-500 select-none">
+			<span>Su</span>
+			<span>Mo</span>
+			<span>Tu</span>
+			<span>We</span>
+			<span>Th</span>
+			<span>Fr</span>
+			<span>Sa</span>
+		</div>
+
+		<!-- Day cells grid -->
+		<div class="grid grid-cols-7 gap-1 text-center text-xs">
+			{#each calendarDays as cell}
+				{@const isSelected = isCellSelected(cell.day, cell.month, cell.year)}
+				<button
+					type="button"
+					onclick={() => selectCalendarDay(cell.day, cell.month, cell.year)}
+					class="aspect-square flex items-center justify-center rounded-full text-xs cursor-pointer border-none transition-colors
+						{cell.current ? 'text-slate-200' : 'text-slate-600'}
+						{isSelected 
+							? 'bg-violet-600 text-white font-bold' 
+							: cell.current 
+								? 'bg-transparent hover:bg-slate-800' 
+								: 'bg-transparent hover:bg-slate-900/50'}"
+				>
+					{cell.day}
+				</button>
+			{/each}
+		</div>
+
+		<!-- Start date row -->
+		<div class="flex flex-col gap-1">
+			<span class="text-[10px] text-slate-400 font-semibold select-none">Start date</span>
+			<div class="flex items-center gap-2">
+				<input
+					type="checkbox"
+					bind:checked={hasStartDate}
+					class="w-4 h-4 accent-violet-600 rounded bg-slate-900 border border-slate-700 cursor-pointer shrink-0"
+				/>
+				<input
+					type="datetime-local"
+					bind:value={newStartDateVal}
+					disabled={!hasStartDate}
+					onfocus={() => activeDateField = 'start'}
+					class="flex-1 px-2.5 py-1.5 rounded bg-slate-900 text-slate-200 text-xs focus:outline-none focus:ring-1 focus:ring-violet-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all
+						{activeDateField === 'start' ? 'border border-violet-500 ring-1 ring-violet-500' : 'border border-slate-700'}"
+				/>
+			</div>
+		</div>
+
+		<!-- Due date row -->
+		<div class="flex flex-col gap-1">
+			<span class="text-[10px] text-slate-400 font-semibold select-none">Due date</span>
+			<div class="flex items-center gap-2">
+				<input
+					type="checkbox"
+					bind:checked={hasDueDate}
+					class="w-4 h-4 accent-violet-600 rounded bg-slate-900 border border-slate-700 cursor-pointer shrink-0"
+				/>
+				<input
+					type="datetime-local"
+					bind:value={newDueDateVal}
+					disabled={!hasDueDate}
+					onfocus={() => activeDateField = 'due'}
+					class="flex-1 px-2.5 py-1.5 rounded bg-slate-900 text-slate-200 text-xs focus:outline-none focus:ring-1 focus:ring-violet-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all
+						{activeDateField === 'due' ? 'border border-violet-500 ring-1 ring-violet-500' : 'border border-slate-700'}"
+				/>
+			</div>
+		</div>
+
+		<!-- Recurring -->
+		<div class="flex flex-col gap-1">
+			<span class="text-[10px] text-slate-400 font-semibold select-none">Recurring</span>
+			<select
+				bind:value={recurringVal}
+				class="w-full px-2.5 py-1.5 rounded bg-slate-900 border border-slate-700 text-slate-200 text-xs focus:outline-none focus:ring-1 focus:ring-violet-500 cursor-pointer"
+			>
+				<option>Never</option>
+				<option>Daily</option>
+				<option>Monday to Friday</option>
+				<option>Weekly</option>
+				<option>Monthly on the {recurringDayNumber}</option>
+				<option>{recurringDayOfWeekDesc}</option>
+				<option>{recurringYearlyDesc}</option>
+			</select>
+		</div>
+
+		<!-- Set due date reminder -->
+		<div class="flex flex-col gap-1">
+			<span class="text-[10px] text-slate-400 font-semibold select-none">Set due date reminder</span>
+			<select
+				bind:value={dueReminderVal}
+				class="w-full px-2.5 py-1.5 rounded bg-slate-900 border border-slate-700 text-slate-200 text-xs focus:outline-none focus:ring-1 focus:ring-violet-500 cursor-pointer"
+			>
+				<option value={-1}>None</option>
+				<option value={0}>At time of due date</option>
+				<option value={5}>5 Minutes before</option>
+				<option value={10}>10 Minutes before</option>
+				<option value={15}>15 Minutes before</option>
+				<option value={60}>1 Hour before</option>
+				<option value={120}>2 Hours before</option>
+				<option value={1440}>1 Day before</option>
+				<option value={2880}>2 Days before</option>
+				<option value={10080}>1 Week before</option>
+				<option value={20160}>2 Weeks before</option>
+			</select>
+		</div>
+
+		<!-- Actions -->
+		<div class="flex gap-2 text-[10px] mt-1">
+			<button
+				type="button"
+				onclick={handleSaveDates}
+				class="flex-1 py-1.5 bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded transition cursor-pointer border-none"
+			>
+				Save
+			</button>
+			<button
+				type="button"
+				onclick={handleRemoveDates}
+				class="flex-1 py-1.5 bg-slate-800 hover:bg-slate-700 border border-slate-750 text-slate-300 font-semibold rounded transition cursor-pointer"
+			>
+				Remove
+			</button>
+		</div>
+	</div>
+{/snippet}
+
+{#snippet labelsPopoverContent()}
+	<!-- Header -->
+	<div class="flex items-center justify-between border-b border-slate-800 pb-2 mb-1">
+		{#if labelsPopoverMode === 'list'}
+			<h4 class="text-xs font-bold text-slate-200 m-0">Labels</h4>
+		{:else if labelsPopoverMode === 'create'}
+			<div class="flex items-center gap-1">
+				<button
+					type="button"
+					onclick={() => { labelsPopoverMode = 'list'; }}
+					class="text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer p-0.5 rounded hover:bg-slate-900 transition-colors"
+					title="Back"
+				>
+					<Icon name="lucide:chevron-left" class="w-3.5 h-3.5" />
+				</button>
+				<h4 class="text-xs font-bold text-slate-200 m-0">Create label</h4>
+			</div>
+		{:else if labelsPopoverMode === 'edit'}
+			<div class="flex items-center gap-1">
+				<button
+					type="button"
+					onclick={() => { labelsPopoverMode = 'list'; }}
+					class="text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer p-0.5 rounded hover:bg-slate-900 transition-colors"
+					title="Back"
+				>
+					<Icon name="lucide:chevron-left" class="w-3.5 h-3.5" />
+				</button>
+				<h4 class="text-xs font-bold text-slate-200 m-0">Change label</h4>
+			</div>
+		{/if}
+		<button
+			type="button"
+			onclick={() => { showLabelsPopover = false; }}
+			class="text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer p-0.5 rounded hover:bg-slate-900 transition-colors"
+			aria-label="Close labels popover"
+		>
+			<Icon name="lucide:x" class="w-3.5 h-3.5" />
+		</button>
+	</div>
+
+	{#if labelsPopoverMode === 'list'}
+		<!-- Search box -->
+		<div class="relative">
+			<input
+				type="text"
+				placeholder="Search labels..."
+				bind:value={searchLabelQuery}
+				class="w-full bg-slate-900 border border-slate-800 focus:border-slate-700 text-slate-200 rounded px-2.5 py-1.5 text-xs placeholder-slate-500"
+			/>
+		</div>
+
+		<!-- Labels List -->
+		<div class="flex flex-col gap-1 max-h-56 overflow-y-auto pr-1">
+			<span class="text-[10px] font-bold text-slate-500 uppercase tracking-wider mb-1">Labels</span>
+			{#if filteredLabels.length === 0}
+				<div class="text-slate-500 text-xs py-2 text-center">No labels found</div>
+			{:else}
+				{#each filteredLabels as label}
+					{@const isAssigned = card?.labels.some(l => l.id === label.id)}
+					{@const bg = labelColorMap[label.color] ?? label.color ?? '#6b7280'}
+					<div class="flex items-center gap-2 group/row">
+						<!-- Toggle checkbox -->
+						<button
+							type="button"
+							onclick={() => handleToggleLabelOnCard(label.id)}
+							class="flex items-center justify-center w-5 h-5 rounded border border-slate-700 bg-slate-900 hover:border-slate-500 transition cursor-pointer shrink-0"
+						>
+							{#if isAssigned}
+								<Icon name="lucide:check" class="w-3.5 h-3.5 text-violet-500 font-bold" />
+							{/if}
+						</button>
+
+						<!-- Colored label bar -->
+						<button
+							type="button"
+							onclick={() => handleToggleLabelOnCard(label.id)}
+							style="background-color: {bg};"
+							class="flex-1 flex items-center text-left px-3 h-8 rounded text-white font-semibold text-xs transition cursor-pointer min-w-0 select-none shadow-sm hover:brightness-110 active:brightness-95
+								{taskClientStore.colorblindMode ? `colorblind-pattern-${label.color}` : ''}"
+						>
+							<span class="truncate pr-1">{label.name || ''}</span>
+						</button>
+
+						<!-- Edit pencil button -->
+						<button
+							type="button"
+							onclick={() => startEditLabel(label.id, label.name, label.color)}
+							class="w-8 h-8 flex items-center justify-center text-slate-400 hover:text-slate-200 hover:bg-slate-900 rounded transition cursor-pointer shrink-0"
+							title="Edit label"
+						>
+							<Icon name="lucide:pencil" class="w-4 h-4" />
+						</button>
+					</div>
+				{/each}
+			{/if}
+		</div>
+
+		<!-- Action buttons -->
+		<div class="flex flex-col gap-2 pt-1 border-t border-slate-900">
+			<button
+				type="button"
+				onclick={startCreateLabel}
+				class="w-full py-1.5 bg-slate-900 hover:bg-slate-800 border border-slate-800 text-slate-300 font-semibold rounded text-xs transition cursor-pointer text-center"
+			>
+				Create a new label
+			</button>
+			<button
+				type="button"
+				onclick={() => taskClientStore.toggleColorblindMode()}
+				class="w-full py-1.5 bg-slate-900 hover:bg-slate-800 border border-slate-800 text-slate-300 font-semibold rounded text-xs transition cursor-pointer text-center"
+			>
+				{taskClientStore.colorblindMode ? 'Disable' : 'Enable'} colorblind friendly mode
+			</button>
+		</div>
+
+	{:else if labelsPopoverMode === 'create' || labelsPopoverMode === 'edit'}
+		<!-- Title / Name Input -->
+		<div class="flex flex-col gap-1.5">
+			<label for="label-name-input" class="text-[10px] font-bold text-slate-500 uppercase tracking-wider">Title</label>
+			<input
+				id="label-name-input"
+				type="text"
+				placeholder="Label title..."
+				bind:value={labelFormName}
+				class="w-full bg-slate-900 border border-slate-800 focus:border-slate-700 text-slate-200 rounded px-2.5 py-1.5 text-xs"
+			/>
+		</div>
+
+		<!-- Color Selector Grid -->
+		<div class="flex flex-col gap-1.5">
+			<span class="text-[10px] font-bold text-slate-500 uppercase tracking-wider">Select a color</span>
+			<div class="grid grid-cols-5 gap-2">
+				{#each labelColors as color}
+					{@const bg = labelColorMap[color] ?? color}
+					{@const isSelected = labelFormColor === color}
+					<button
+						type="button"
+						onclick={() => { labelFormColor = color; }}
+						style="background-color: {bg};"
+						class="w-10 h-8 rounded relative transition-transform cursor-pointer shadow-sm hover:scale-105 active:scale-95 flex items-center justify-center
+							{isSelected ? 'ring-2 ring-violet-500 ring-offset-2 ring-offset-slate-950' : ''}
+							{taskClientStore.colorblindMode ? `colorblind-pattern-${color}` : ''}"
+						title={color}
+					>
+						{#if isSelected}
+							<Icon name="lucide:check" class="w-4 h-4 text-white drop-shadow" />
+						{/if}
+					</button>
+				{/each}
+			</div>
+		</div>
+
+		<!-- Form Actions -->
+		<div class="flex items-center gap-2 pt-2 border-t border-slate-900">
+			{#if labelsPopoverMode === 'create'}
+				<button
+					type="button"
+					onclick={handleSaveLabel}
+					class="flex-1 py-1.5 bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded text-xs transition cursor-pointer border-none"
+				>
+					Create
+				</button>
+			{:else}
+				<button
+					type="button"
+					onclick={handleSaveLabel}
+					class="flex-1 py-1.5 bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded text-xs transition cursor-pointer border-none"
+				>
+					Save
+				</button>
+				<button
+					type="button"
+					onclick={() => handleDeleteLabel(editingLabelId!)}
+					class="flex-1 py-1.5 bg-red-600 hover:bg-red-700 text-white font-semibold rounded text-xs transition cursor-pointer border-none"
+				>
+					Delete
+				</button>
+			{/if}
+		</div>
+	{/if}
+{/snippet}
+
+
+<style>
+	.markdown-preview-container :global(a) {
+		color: #579dff !important;
+		text-decoration: underline !important;
+	}
+	.markdown-preview-container :global(a:hover) {
+		color: #85b8ff !important;
+	}
+	.markdown-preview-container :global(ul) {
+		list-style-type: disc !important;
+		padding-left: 1.25rem !important;
+		margin-top: 0.5rem !important;
+		margin-bottom: 0.5rem !important;
+	}
+	.markdown-preview-container :global(ol) {
+		list-style-type: decimal !important;
+		padding-left: 1.25rem !important;
+		margin-top: 0.5rem !important;
+		margin-bottom: 0.5rem !important;
+	}
+	.markdown-preview-container :global(li) {
+		display: list-item !important;
+		margin-top: 0.25rem !important;
+		margin-bottom: 0.25rem !important;
+	}
+	.markdown-preview-container :global(strong) {
+		font-weight: 700 !important;
+		color: rgb(241 245 249) !important;
+	}
+	.markdown-preview-container :global(em) {
+		font-style: italic !important;
+	}
+	.markdown-preview-container :global(h1) {
+		font-size: 1.5rem !important;
+		font-weight: 700 !important;
+		margin-top: 1rem !important;
+		margin-bottom: 0.5rem !important;
+	}
+	.markdown-preview-container :global(h2) {
+		font-size: 1.25rem !important;
+		font-weight: 700 !important;
+		margin-top: 1rem !important;
+		margin-bottom: 0.5rem !important;
+	}
+	.markdown-preview-container :global(h3) {
+		font-size: 1.125rem !important;
+		font-weight: 700 !important;
+		margin-top: 1rem !important;
+		margin-bottom: 0.5rem !important;
+	}
+	.markdown-preview-container :global(code) {
+		background-color: rgb(15 23 42) !important;
+		color: rgb(241 245 249) !important;
+		padding: 0.125rem 0.25rem !important;
+		border-radius: 0.25rem !important;
+		font-family: monospace !important;
+		font-size: 0.85em !important;
+	}
+	.markdown-preview-container :global(p) {
+		margin-top: 0.5rem !important;
+		margin-bottom: 0.5rem !important;
+	}
+	.markdown-preview-container :global(pre) {
+		background-color: rgb(15 23 42) !important;
+		color: rgb(241 245 249) !important;
+		padding: 0.75rem 0.75rem 0.75rem 1.75rem !important;
+		border-radius: 0.5rem !important;
+		border: 1px solid rgb(51 65 85) !important;
+		font-family: monospace !important;
+		font-size: 0.875rem !important;
+		margin: 1rem 0 !important;
+		overflow-x: auto !important;
+		position: relative !important;
+	}
+	.markdown-preview-container :global(pre)::before {
+		content: "" !important;
+		position: absolute !important;
+		left: 0 !important;
+		top: 0 !important;
+		bottom: 0 !important;
+		width: 1.75rem !important;
+		background-color: rgba(30, 41, 59, 0.4) !important;
+		border-right: 1px solid rgba(71, 85, 105, 0.4) !important;
+		border-radius: 0.5rem 0 0 0.5rem !important;
+		pointer-events: none !important;
+	}
+	.markdown-preview-container :global(pre code) {
+		background-color: transparent !important;
+		padding: 0 !important;
+		border-radius: 0 !important;
+		font-size: 1em !important;
+		display: block !important;
+		counter-reset: line !important;
+	}
+	.markdown-preview-container :global(pre code div) {
+		position: relative !important;
+		padding-left: 0.6rem !important;
+	}
+	.markdown-preview-container :global(pre code div)::before {
+		counter-increment: line !important;
+		content: counter(line) !important;
+		position: absolute !important;
+		top: 0 !important;
+		bottom: 0 !important;
+		left: -1.75rem !important;
+		width: 1.75rem !important;
+		display: inline-flex !important;
+		align-items: center !important;
+		justify-content: center !important;
+		color: rgb(100 116 139) !important;
+		font-size: 0.75rem !important;
+		font-family: monospace !important;
+		pointer-events: none !important;
+		user-select: none !important;
+	}
+	.markdown-preview-container :global(blockquote) {
+		border-left: 0.25rem solid rgb(139 92 246) !important;
+		padding-left: 1rem !important;
+		color: rgb(148 163 184) !important;
+		margin: 0.5rem 0 !important;
+		font-style: italic !important;
+	}
+	.markdown-preview-container :global(pre code .token-keyword) {
+		color: #569cd6 !important;
+		font-weight: 500;
+	}
+	.markdown-preview-container :global(pre code .token-string) {
+		color: #80c990 !important;
+	}
+	.markdown-preview-container :global(pre code .token-comment) {
+		color: #6a9955 !important;
+		font-style: italic;
+	}
+	.markdown-preview-container :global(pre code .token-number) {
+		color: #b5cea8 !important;
+	}
+	.markdown-preview-container :global(pre code .token-function) {
+		color: #dcdcaa !important;
+	}
+	.markdown-preview-container :global(pre code .token-builtin) {
+		color: #4fc1ff !important;
+	}
+	.markdown-preview-container :global(pre code .token-operator) {
+		color: #d4d4d4 !important;
+	}
+</style>

--- a/frontend/components/task-client/RichTextEditor.svelte
+++ b/frontend/components/task-client/RichTextEditor.svelte
@@ -1,0 +1,2241 @@
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { debug } from '$shared/utils/logger';
+
+	interface Props {
+		html: string;
+		placeholder?: string;
+		showDirectLinkImage?: boolean;
+		showAttachmentButton?: boolean;
+		showMarkdownIcon?: boolean;
+		enableCodeToolbar?: boolean;
+		dropdownAlign?: 'left' | 'right';
+		mentionOptions?: { id: string; fullName: string; username: string; avatarUrl: string | null; isSpecial: boolean }[];
+		onImageUpload?: (file: File) => Promise<string>;
+	}
+
+	let {
+		html = $bindable(''),
+		placeholder = '',
+		showDirectLinkImage = false,
+		showAttachmentButton = false,
+		showMarkdownIcon = false,
+		enableCodeToolbar = false,
+		dropdownAlign = 'left',
+		mentionOptions = [],
+		onImageUpload = undefined
+	}: Props = $props();
+
+	let editorRef = $state<HTMLElement | null>(null);
+	let autocompleteRef = $state<HTMLElement | null>(null);
+	let codeToolbarRef = $state<HTMLElement | null>(null);
+	let fileInputRef = $state<HTMLInputElement | null>(null);
+
+	let showFormattingHelp = $state(false);
+	let showMoreMenu = $state(false);
+	let showListMenu = $state(false);
+	let showInsertMenu = $state(false);
+
+	function closeAllEditorMenus() {
+		showMoreMenu = false;
+		showListMenu = false;
+		showInsertMenu = false;
+	}
+
+	let insertSearchQuery = $state('');
+	let insertSelectedIndex = $state(0);
+	let insertSubMenu = $state<'main' | 'mention' | 'emoji'>('main');
+	let selectedEmojiCategory = $state('people');
+	let hoveredEmoji = $state<{ char: string; name: string; code: string } | null>(null);
+
+	const emojiCategories = [
+		{ id: 'people', icon: 'lucide:smile', label: 'People' },
+		{ id: 'nature', icon: 'lucide:trees', label: 'Nature' },
+		{ id: 'food', icon: 'lucide:utensils', label: 'Food & Drink' },
+		{ id: 'activity', icon: 'lucide:trophy', label: 'Activity' },
+		{ id: 'travel', icon: 'lucide:car', label: 'Travel & Places' },
+		{ id: 'objects', icon: 'lucide:lightbulb', label: 'Objects' },
+		{ id: 'symbols', icon: 'lucide:heart', label: 'Symbols' },
+		{ id: 'flags', icon: 'lucide:flag', label: 'Flags' }
+	];
+
+	const emojisData: Record<string, { char: string; name: string; code: string }[]> = {
+		people: [
+			{ char: '😀', name: 'Grinning Face', code: ':grinning:' },
+			{ char: '😃', name: 'Grinning Face with Big Eyes', code: ':smiley:' },
+			{ char: '😄', name: 'Grinning Face with Smiling Eyes', code: ':smile:' },
+			{ char: '😁', name: 'Beaming Face with Smiling Eyes', code: ':grin:' },
+			{ char: '😆', name: 'Grinning Squinting Face', code: ':laughing:' },
+			{ char: '😅', name: 'Grinning Face with Sweat', code: ':sweat_smile:' },
+			{ char: '😂', name: 'Face with Tears of Joy', code: ':joy:' },
+			{ char: '🤣', name: 'Rolling on the Floor Laughing', code: ':rofl:' },
+			{ char: '😇', name: 'Smiling Face with Halo', code: ':innocent:' },
+			{ char: '😉', name: 'Winking Face', code: ':wink:' },
+			{ char: '😊', name: 'Smiling Face with Smiling Eyes', code: ':blush:' },
+			{ char: '😋', name: 'Face Savoring Food', code: ':yum:' },
+			{ char: '😎', name: 'Smiling Face with Sunglasses', code: ':sunglasses:' },
+			{ char: '😍', name: 'Smiling Face with Heart-Eyes', code: ':heart_eyes:' },
+			{ char: '😘', name: 'Face Blowing a Kiss', code: ':kissing_heart:' },
+			{ char: '😗', name: 'Kissing Face', code: ':kissing:' },
+			{ char: '😙', name: 'Kissing Face with Smiling Eyes', code: ':kissing_smiling_eyes:' },
+			{ char: '😚', name: 'Kissing Face with Closed Eyes', code: ':kissing_closed_eyes:' },
+			{ char: '🙂', name: 'Slightly Smiling Face', code: ':slightly_smiling_face:' },
+			{ char: '🤗', name: 'Hugging Face', code: ':hugs:' },
+			{ char: '🤩', name: 'Star-Struck', code: ':star_struck:' },
+			{ char: '🤔', name: 'Thinking Face', code: ':thinking:' },
+			{ char: '🤨', name: 'Face with Raised Eyebrow', code: ':raised_eyebrow:' },
+			{ char: '😐', name: 'Neutral Face', code: ':neutral_face:' },
+			{ char: '😑', name: 'Expressionless Face', code: ':expressionless:' },
+			{ char: '😶', name: 'Face Without Mouth', code: ':no_mouth:' },
+			{ char: '🙄', name: 'Face with Rolling Eyes', code: ':roll_eyes:' },
+			{ char: '😏', name: 'Smirking Face', code: ':smirk:' },
+			{ char: '😣', name: 'Persevering Face', code: ':persevere:' },
+			{ char: '😥', name: 'Sad but Relieved Face', code: ':disappointed_relieved:' },
+			{ char: '😮', name: 'Face with Open Mouth', code: ':open_mouth:' },
+			{ char: '🤐', name: 'Zipper-Mouth Face', code: ':zipper_mouth_face:' },
+			{ char: '😯', name: 'Hushed Face', code: ':hushed:' },
+			{ char: '😪', name: 'Sleepy Face', code: ':sleepy:' },
+			{ char: '😫', name: 'Tired Face', code: ':tired_face:' },
+			{ char: '😴', name: 'Sleeping Face', code: ':sleeping:' }
+		],
+		nature: [
+			{ char: '🐶', name: 'Dog Face', code: ':dog:' },
+			{ char: '🐱', name: 'Cat Face', code: ':cat:' },
+			{ char: '🐭', name: 'Mouse Face', code: ':mouse:' },
+			{ char: '🐹', name: 'Hamster Face', code: ':hamster:' },
+			{ char: '🐰', name: 'Rabbit Face', code: ':rabbit:' },
+			{ char: '🦊', name: 'Fox Face', code: ':fox:' },
+			{ char: '🐻', name: 'Bear Face', code: ':bear:' },
+			{ char: '🐼', name: 'Panda Face', code: ':panda_face:' },
+			{ char: '🐨', name: 'Koala', code: ':koala:' },
+			{ char: '🐯', name: 'Tiger Face', code: ':tiger:' },
+			{ char: '🦁', name: 'Lion Face', code: ':lion:' },
+			{ char: '🐮', name: 'Cow Face', code: ':cow:' },
+			{ char: '🐷', name: 'Pig Face', code: ':pig:' },
+			{ char: '🐸', name: 'Frog Face', code: ':frog:' },
+			{ char: '🐵', name: 'Monkey Face', code: ':monkey_face:' },
+			{ char: '🐔', name: 'Chicken', code: ':chicken:' },
+			{ char: '🐧', name: 'Penguin', code: ':penguin:' },
+			{ char: '🐦', name: 'Bird', code: ':bird:' },
+			{ char: '🐤', name: 'Baby Chick', code: ':baby_chick:' },
+			{ char: '🦆', name: 'Duck', code: ':duck:' },
+			{ char: '🦅', name: 'Eagle', code: ':eagle:' },
+			{ char: '🦉', name: 'Owl', code: ':owl:' },
+			{ char: '🦇', name: 'Bat', code: ':bat:' },
+			{ char: '🐺', name: 'Wolf Face', code: ':wolf:' },
+			{ char: '🐗', name: 'Boar', code: ':boar:' },
+			{ char: '🐴', name: 'Horse Face', code: ':horse:' },
+			{ char: '🦄', name: 'Unicorn Face', code: ':unicorn:' },
+			{ char: '🐝', name: 'Honeybee', code: ':bee:' },
+			{ char: '🐛', name: 'Bug', code: ':bug:' },
+			{ char: '🦋', name: 'Butterfly', code: ':butterfly:' },
+			{ char: '🐌', name: 'Snail', code: ':snail:' },
+			{ char: '🐞', name: 'Lady Beetle', code: ':lady_beetle:' },
+			{ char: '🐜', name: 'Ant', code: ':ant:' },
+			{ char: '🕷️', name: 'Spider', code: ':spider:' },
+			{ char: '🐢', name: 'Turtle', code: ':turtle:' },
+			{ char: '🐍', name: 'Snake', code: ':snake:' }
+		],
+		food: [
+			{ char: '🍏', name: 'Green Apple', code: ':green_apple:' },
+			{ char: '🍎', name: 'Red Apple', code: ':apple:' },
+			{ char: '🍐', name: 'Pear', code: ':pear:' },
+			{ char: '🍊', name: 'Tangerine', code: ':tangerine:' },
+			{ char: '🍋', name: 'Lemon', code: ':lemon:' },
+			{ char: '🍌', name: 'Banana', code: ':banana:' },
+			{ char: '🍉', name: 'Watermelon', code: ':watermelon:' },
+			{ char: '🍇', name: 'Grapes', code: ':grapes:' },
+			{ char: '🍓', name: 'Strawberry', code: ':strawberry:' },
+			{ char: '🍒', name: 'Cherries', code: ':cherries:' },
+			{ char: '🍑', name: 'Peach', code: ':peach:' },
+			{ char: '🍍', name: 'Pineapple', code: ':pineapple:' },
+			{ char: '🥥', name: 'Coconut', code: ':coconut:' },
+			{ char: '🥝', name: 'Kiwi Fruit', code: ':kiwi_fruit:' },
+			{ char: '🍅', name: 'Tomato', code: ':tomato:' },
+			{ char: '🥑', name: 'Avocado', code: ':avocado:' },
+			{ char: '🍆', name: 'Eggplant', code: ':eggplant:' },
+			{ char: '🥔', name: 'Potato', code: ':potato:' },
+			{ char: '🥕', name: 'Carrot', code: ':carrot:' },
+			{ char: '🌽', name: 'Ear of Maize', code: ':corn:' },
+			{ char: '🌶️', name: 'Hot Pepper', code: ':hot_pepper:' },
+			{ char: '🍄', name: 'Mushroom', code: ':mushroom:' },
+			{ char: '🥜', name: 'Peanuts', code: ':peanuts:' },
+			{ char: '🌰', name: 'Chestnut', code: ':chestnut:' },
+			{ char: '🍞', name: 'Bread', code: ':bread:' },
+			{ char: '🥐', name: 'Croissant', code: ':croissant:' },
+			{ char: '🥖', name: 'Baguette Bread', code: ':baguette_bread:' },
+			{ char: '🥨', name: 'Pretzel', code: ':pretzel:' },
+			{ char: '🥞', name: 'Pancakes', code: ':pancakes:' },
+			{ char: '🧀', name: 'Cheese Wedge', code: ':cheese:' },
+			{ char: '🍖', name: 'Meat on Bone', code: ':meat_on_bone:' },
+			{ char: '🍗', name: 'Poultry Leg', code: ':poultry_leg:' },
+			{ char: '🥩', name: 'Cut of Meat', code: ':cut_of_meat:' },
+			{ char: '🥓', name: 'Bacon', code: ':bacon:' },
+			{ char: '🍔', name: 'Hamburger', code: ':hamburger:' },
+			{ char: '🍟', name: 'French Fries', code: ':fries:' }
+		],
+		activity: [
+			{ char: '⚽', name: 'Soccer Ball', code: ':soccer:' },
+			{ char: '🏀', name: 'Basketball', code: ':basketball:' },
+			{ char: '🏈', name: 'American Football', code: ':football:' },
+			{ char: '⚾', name: 'Baseball', code: ':baseball:' },
+			{ char: '🥎', name: 'Softball', code: ':softball:' },
+			{ char: '🎾', name: 'Tennis', code: ':tennis:' },
+			{ char: '🏐', name: 'Volleyball', code: ':volleyball:' },
+			{ char: '🏉', name: 'Rugby Football', code: ':rugby_football:' },
+			{ char: '🎱', name: 'Pool 8 Ball', code: ':8_ball:' },
+			{ char: '🏓', name: 'Ping Pong', code: ':ping_pong:' },
+			{ char: '🏸', name: 'Badminton', code: ':badminton:' },
+			{ char: '🥅', name: 'Goal Net', code: ':goal_net:' },
+			{ char: '⛳', name: 'Flag in Hole', code: ':golf:' },
+			{ char: '⛸️', name: 'Ice Skate', code: ':ice_skate:' },
+			{ char: '🎣', name: 'Fishing Pole', code: ':fishing_pole_and_fish:' },
+			{ char: '🎽', name: 'Running Shirt with Sash', code: ':running_shirt_with_sash:' },
+			{ char: '🎿', name: 'Skis', code: ':skis:' },
+			{ char: '🛷', name: 'Sled', code: ':sled:' },
+			{ char: '🥌', name: 'Curling Stone', code: ':curling_stone:' },
+			{ char: '🎯', name: 'Direct Hit', code: ':dart:' },
+			{ char: '🎮', name: 'Video Game', code: ':video_game:' },
+			{ char: '🎰', name: 'Slot Machine', code: ':slot_machine:' },
+			{ char: '🎲', name: 'Game Die', code: ':game_die:' },
+			{ char: '🧩', name: 'Puzzle Piece', code: ':jigsaw:' },
+			{ char: '🎳', name: 'Bowling', code: ':bowling:' }
+		],
+		travel: [
+			{ char: '🚗', name: 'Automobile', code: ':car:' },
+			{ char: '🚕', name: 'Taxi', code: ':taxi:' },
+			{ char: '🚙', name: 'Recreational Vehicle', code: ':blue_car:' },
+			{ char: '🚌', name: 'Bus', code: ':bus:' },
+			{ char: '🚎', name: 'Trolleybus', code: ':trolleybus:' },
+			{ char: '🏎️', name: 'Racing Car', code: ':racing_car:' },
+			{ char: '🚓', name: 'Police Car', code: ':police_car:' },
+			{ char: '🚑', name: 'Ambulance', code: ':ambulance:' },
+			{ char: '🚒', name: 'Fire Engine', code: ':fire_engine:' },
+			{ char: '🚐', name: 'Minibus', code: ':minibus:' },
+			{ char: '🚚', name: 'Delivery Truck', code: ':truck:' },
+			{ char: '🚛', name: 'Articulated Lorry', code: ':articulated_lorry:' },
+			{ char: '🚜', name: 'Tractor', code: ':tractor:' },
+			{ char: '🚲', name: 'Bicycle', code: ':bicycle:' },
+			{ char: '🛵', name: 'Motor Scooter', code: ':motor_scooter:' },
+			{ char: '🏍️', name: 'Motorcycle', code: ':motorcycle:' },
+			{ char: '🚨', name: 'Police Car Light', code: ':rotating_light:' },
+			{ char: '✈️', name: 'Airplane', code: ':airplane:' },
+			{ char: '🛫', name: 'Airplane Departure', code: ':flight_departure:' },
+			{ char: '🛬', name: 'Airplane Arrival', code: ':flight_arrival:' },
+			{ char: '⛵', name: 'Sailboat', code: ':sailboat:' },
+			{ char: '🛥️', name: 'Motor Boat', code: ':motorboat:' },
+			{ char: '🛳️', name: 'Passenger Ship', code: ':passenger_ship:' },
+			{ char: '🚢', name: 'Ship', code: ':ship:' }
+		],
+		objects: [
+			{ char: '💡', name: 'Electric Light Bulb', code: ':lightbulb:' },
+			{ char: '💻', name: 'Laptop Computer', code: ':computer:' },
+			{ char: '📱', name: 'Mobile Phone', code: ':iphone:' },
+			{ char: '☎️', name: 'Telephone', code: ':telephone:' },
+			{ char: '📺', name: 'Television', code: ':tv:' },
+			{ char: '📷', name: 'Camera', code: ':camera:' },
+			{ char: '🔍', name: 'Magnifying Glass Left', code: ':search:' },
+			{ char: '🕯️', name: 'Candle', code: ':candle:' },
+			{ char: '🗑️', name: 'Wastebasket', code: ':wastebasket:' },
+			{ char: '🔑', name: 'Key', code: ':key:' },
+			{ char: '🔒', name: 'Locked', code: ':lock:' },
+			{ char: '🔓', name: 'Unlocked', code: ':unlock:' },
+			{ char: '🔨', name: 'Hammer', code: ':hammer:' },
+			{ char: '🔧', name: 'Wrench', code: ':wrench:' },
+			{ char: '📦', name: 'Package', code: ':package:' },
+			{ char: '✉️', name: 'Envelope', code: ':envelope:' }
+		],
+		symbols: [
+			{ char: '❤️', name: 'Red Heart', code: ':heart:' },
+			{ char: '💛', name: 'Yellow Heart', code: ':yellow_heart:' },
+			{ char: '💚', name: 'Green Heart', code: ':green_heart:' },
+			{ char: '💙', name: 'Blue Heart', code: ':blue_heart:' },
+			{ char: '💜', name: 'Purple Heart', code: ':purple_heart:' },
+			{ char: '🖤', name: 'Black Heart', code: ':black_heart:' },
+			{ char: '💔', name: 'Broken Heart', code: ':broken_heart:' },
+			{ char: '❣️', name: 'Heart Exclamation', code: ':heavy_heart_exclamation:' },
+			{ char: '💕', name: 'Two Hearts', code: ':two_hearts:' },
+			{ char: '💞', name: 'Revolving Hearts', code: ':revolving_hearts:' },
+			{ char: '💓', name: 'Beating Heart', code: ':heartbeat:' },
+			{ char: '💗', name: 'Growing Heart', code: ':heartpulse:' },
+			{ char: '💖', name: 'Sparkling Heart', code: ':sparkles:' },
+			{ char: '💘', name: 'Heart with Arrow', code: ':cupid:' },
+			{ char: '💝', name: 'Heart with Ribbon', code: ':gift_heart:' },
+			{ char: '💟', name: 'Heart Decoration', code: ':heart_decoration:' },
+			{ char: '🌟', name: 'Glowing Star', code: ':star2:' },
+			{ char: '⭐', name: 'Star', code: ':star:' }
+		],
+		flags: [
+			{ char: '🏁', name: 'Chequered Flag', code: ':checkered_flag:' },
+			{ char: '🚩', name: 'Triangular Flag', code: ':triangular_flag_on_post:' },
+			{ char: '🎌', name: 'Crossed Flags', code: ':crossed_flags:' },
+			{ char: '🏴‍☠️', name: 'Pirate Flag', code: ':pirate_flag:' }
+		]
+	};
+
+	const insertItems = [
+		{
+			id: 'mention',
+			title: 'Mention',
+			desc: 'Mention someone to send them a notification',
+			icon: 'lucide:at-sign',
+			shortcut: '@',
+			action: () => {
+				closeAllEditorMenus();
+				if (editorRef) {
+					editorRef.focus();
+				}
+				insertTextAtCursor('@');
+				setTimeout(() => {
+					checkAutocomplete();
+				}, 0);
+			}
+		},
+		{
+			id: 'emoji',
+			title: 'Emoji',
+			desc: 'Use emojis to express ideas 🎉 and emotions 😄',
+			icon: 'lucide:smile',
+			shortcut: ':',
+			action: () => {
+				insertSubMenu = 'emoji';
+				insertSearchQuery = '';
+				insertSelectedIndex = 0;
+				selectedEmojiCategory = 'people';
+				hoveredEmoji = null;
+			}
+		},
+		{
+			id: 'link',
+			title: 'Link',
+			desc: 'Insert a hyperlink',
+			icon: 'lucide:link',
+			shortcut: '⌘K',
+			action: () => {
+				closeAllEditorMenus();
+				insertLinkCommand();
+			}
+		},
+		{
+			id: 'image',
+			title: 'Image',
+			desc: 'Insert an image via URL',
+			icon: 'lucide:image',
+			shortcut: '⌘⇧I',
+			action: () => {
+				closeAllEditorMenus();
+				insertImageCommand();
+			}
+		},
+		{
+			id: 'code',
+			title: 'Code snippet',
+			desc: 'Display code with syntax highlighting',
+			icon: 'lucide:braces',
+			shortcut: '```',
+			action: () => {
+				insertCodeBlock();
+				closeAllEditorMenus();
+			}
+		},
+		{
+			id: 'quote',
+			title: 'Quote',
+			desc: 'Insert a block quote',
+			icon: 'lucide:quote',
+			shortcut: '>',
+			action: () => {
+				execEditorCommand('formatBlock', '<blockquote>');
+				closeAllEditorMenus();
+			}
+		},
+		{
+			id: 'divider',
+			title: 'Divider',
+			desc: 'Insert a horizontal line divider',
+			icon: 'lucide:minus',
+			shortcut: '---',
+			action: () => {
+				execEditorCommand('insertHorizontalRule');
+				closeAllEditorMenus();
+			}
+		}
+	];
+
+	const filteredInsertItems = $derived(
+		insertItems
+			.filter(item => !showDirectLinkImage || (item.id !== 'link' && item.id !== 'image'))
+			.filter(item =>
+				item.title.toLowerCase().includes(insertSearchQuery.toLowerCase()) ||
+				item.desc.toLowerCase().includes(insertSearchQuery.toLowerCase())
+			)
+	);
+
+	const filteredMentionOptions = $derived(
+		mentionOptions.filter(m =>
+			m.fullName.toLowerCase().includes(insertSearchQuery.toLowerCase()) ||
+			m.username.toLowerCase().includes(insertSearchQuery.toLowerCase())
+		)
+	);
+
+	const filteredEmojis = $derived.by(() => {
+		if (!insertSearchQuery) {
+			return emojisData[selectedEmojiCategory] || [];
+		}
+		const list: { char: string; name: string; code: string }[] = [];
+		for (const cat in emojisData) {
+			for (const emoji of emojisData[cat]) {
+				if (
+					emoji.name.toLowerCase().includes(insertSearchQuery.toLowerCase()) ||
+					emoji.code.toLowerCase().includes(insertSearchQuery.toLowerCase())
+				) {
+					list.push(emoji);
+				}
+			}
+		}
+		return list;
+	});
+
+	const activeEmojiPreview = $derived.by(() => {
+		if (hoveredEmoji) return hoveredEmoji;
+		const list = filteredEmojis;
+		if (list.length > 0 && insertSelectedIndex < list.length) {
+			return list[insertSelectedIndex];
+		}
+		return null;
+	});
+
+	// Formatting active states
+	let isBoldActive = $state(false);
+	let isItalicActive = $state(false);
+	let isHeadingActive = $state(false);
+	let isBulletListActive = $state(false);
+	let isNumberedListActive = $state(false);
+	const isListActive = $derived(isBulletListActive || isNumberedListActive);
+	let isStrikethroughActive = $state(false);
+	let isCodeActive = $state(false);
+
+	let activeCodeNode = $state<HTMLPreElement | null>(null);
+	let activeCodeLanguage = $state('');
+	let activeCodeIsWrapped = $state(false);
+	let codeToolbarCoords = $state({ top: 0, left: 0 });
+
+	const codeLanguages = [
+		{ id: '', name: '(None)' },
+		{ id: 'abap', name: 'ABAP' },
+		{ id: 'actionscript', name: 'ActionScript' },
+		{ id: 'ada', name: 'Ada' },
+		{ id: 'applescript', name: 'AppleScript' },
+		{ id: 'arduino', name: 'Arduino' },
+		{ id: 'autoit', name: 'Autoit' },
+		{ id: 'c', name: 'C' },
+		{ id: 'cpp', name: 'C++' },
+		{ id: 'csharp', name: 'C#' },
+		{ id: 'css', name: 'CSS' },
+		{ id: 'dart', name: 'Dart' },
+		{ id: 'dockerfile', name: 'Dockerfile' },
+		{ id: 'elixir', name: 'Elixir' },
+		{ id: 'elm', name: 'Elm' },
+		{ id: 'erlang', name: 'Erlang' },
+		{ id: 'go', name: 'Go' },
+		{ id: 'graphql', name: 'GraphQL' },
+		{ id: 'groovy', name: 'Groovy' },
+		{ id: 'haskell', name: 'Haskell' },
+		{ id: 'html', name: 'HTML' },
+		{ id: 'java', name: 'Java' },
+		{ id: 'javascript', name: 'JavaScript' },
+		{ id: 'json', name: 'JSON' },
+		{ id: 'kotlin', name: 'Kotlin' },
+		{ id: 'latex', name: 'LaTeX' },
+		{ id: 'less', name: 'Less' },
+		{ id: 'lisp', name: 'Lisp' },
+		{ id: 'lua', name: 'Lua' },
+		{ id: 'makefile', name: 'Makefile' },
+		{ id: 'markdown', name: 'Markdown' },
+		{ id: 'matlab', name: 'MATLAB' },
+		{ id: 'objectivec', name: 'Objective-C' },
+		{ id: 'pascal', name: 'Pascal' },
+		{ id: 'perl', name: 'Perl' },
+		{ id: 'php', name: 'PHP' },
+		{ id: 'powershell', name: 'PowerShell' },
+		{ id: 'python', name: 'Python' },
+		{ id: 'r', name: 'R' },
+		{ id: 'ruby', name: 'Ruby' },
+		{ id: 'rust', name: 'Rust' },
+		{ id: 'scala', name: 'Scala' },
+		{ id: 'scheme', name: 'Scheme' },
+		{ id: 'scss', name: 'SCSS' },
+		{ id: 'shell', name: 'Shell' },
+		{ id: 'sql', name: 'SQL' },
+		{ id: 'swift', name: 'Swift' },
+		{ id: 'toml', name: 'TOML' },
+		{ id: 'typescript', name: 'TypeScript' },
+		{ id: 'vbnet', name: 'VB.NET' },
+		{ id: 'xml', name: 'XML' },
+		{ id: 'yaml', name: 'YAML' }
+	];
+
+	function updateActiveFormats() {
+		if (typeof document === 'undefined' || !editorRef) return;
+
+		// Focus retention guard: if focus is currently inside the code block toolbar,
+		// don't hide it or update formatting active states based on selection outside editor.
+		const activeEl = document.activeElement;
+		if (codeToolbarRef && activeEl && codeToolbarRef.contains(activeEl)) {
+			return;
+		}
+
+		const selection = window.getSelection();
+		const isSelectionInEditor = !!(selection && selection.rangeCount > 0 && selection.anchorNode && editorRef.contains(selection.anchorNode));
+
+		isBoldActive = isSelectionInEditor ? document.queryCommandState('bold') : false;
+		isItalicActive = isSelectionInEditor ? document.queryCommandState('italic') : false;
+		isBulletListActive = isSelectionInEditor ? document.queryCommandState('insertUnorderedList') : false;
+		isNumberedListActive = isSelectionInEditor ? document.queryCommandState('insertOrderedList') : false;
+		isStrikethroughActive = isSelectionInEditor ? document.queryCommandState('strikeThrough') : false;
+		
+		// Check if cursor is in heading or code block
+		if (isSelectionInEditor && selection) {
+			const range = selection.getRangeAt(0);
+			let parent: HTMLElement | null = range.commonAncestorContainer as HTMLElement;
+			if (parent.nodeType === Node.TEXT_NODE) {
+				parent = parent.parentElement;
+			}
+			
+			// Heading check
+			let heading = false;
+			let headingParent: HTMLElement | null = parent;
+			while (headingParent && headingParent !== editorRef) {
+				if (headingParent.tagName === 'H3' || headingParent.tagName === 'H1' || headingParent.tagName === 'H2') {
+					heading = true;
+					break;
+				}
+				headingParent = headingParent.parentElement;
+			}
+			isHeadingActive = heading;
+
+			// Code check
+			let code = false;
+			let codePre: HTMLPreElement | null = null;
+			let codeParent: HTMLElement | null = parent;
+			while (codeParent && codeParent !== editorRef) {
+				if (codeParent.tagName === 'PRE') {
+					code = true;
+					codePre = codeParent as HTMLPreElement;
+					break;
+				}
+				codeParent = codeParent.parentElement;
+			}
+			isCodeActive = code;
+			activeCodeNode = codePre;
+
+			if (codePre && enableCodeToolbar) {
+				const codeEl = codePre.querySelector('code');
+				const langClass = codeEl ? Array.from(codeEl.classList).find(c => c.startsWith('language-')) : null;
+				activeCodeLanguage = langClass ? langClass.replace('language-', '') : '';
+				activeCodeIsWrapped = codePre.classList.contains('whitespace-pre-wrap');
+				
+				const rect = codePre.getBoundingClientRect();
+				const wrapperRect = editorRef.parentElement?.getBoundingClientRect();
+				if (wrapperRect) {
+					codeToolbarCoords = {
+						top: rect.bottom - wrapperRect.top + 6,
+						left: rect.left - wrapperRect.left + rect.width / 2
+					};
+				}
+			} else {
+				activeCodeLanguage = '';
+				activeCodeIsWrapped = false;
+			}
+		} else {
+			isHeadingActive = false;
+			isCodeActive = false;
+			activeCodeNode = null;
+			activeCodeLanguage = '';
+			activeCodeIsWrapped = false;
+		}
+	}
+
+	$effect(() => {
+		const handleSelectionChange = () => {
+			updateActiveFormats();
+		};
+		document.addEventListener('selectionchange', handleSelectionChange);
+		updateActiveFormats();
+		return () => {
+			document.removeEventListener('selectionchange', handleSelectionChange);
+		};
+	});
+
+	function handleEditorSelectionOrInput() {
+		updateActiveFormats();
+		if (activeCodeNode && isCodeActive && enableCodeToolbar) {
+			enforceCodeBlockStructure(activeCodeNode);
+		}
+		checkAutocomplete();
+		if (editorRef) {
+			html = editorRef.innerHTML;
+		}
+		checkActiveLink();
+	}
+
+	function execEditorCommand(command: string, value: string = '') {
+		document.execCommand(command, false, value);
+		if (editorRef) {
+			html = editorRef.innerHTML;
+		}
+		updateActiveFormats();
+	}
+
+	function insertLinkCommand() {
+		insertLinkUrl = '';
+		insertLinkText = '';
+		if (typeof window !== 'undefined') {
+			const selection = window.getSelection();
+			if (selection && selection.rangeCount > 0) {
+				const range = selection.getRangeAt(0);
+				if (editorRef && editorRef.contains(range.commonAncestorContainer)) {
+					savedRange = range.cloneRange();
+					insertLinkText = selection.toString();
+				} else {
+					savedRange = null;
+				}
+			} else {
+				savedRange = null;
+			}
+		}
+		showInsertLinkPopover = true;
+	}
+
+	function insertImageCommand() {
+		insertImageUrl = '';
+		if (typeof window !== 'undefined') {
+			const selection = window.getSelection();
+			if (selection && selection.rangeCount > 0) {
+				const range = selection.getRangeAt(0);
+				if (editorRef && editorRef.contains(range.commonAncestorContainer)) {
+					savedRange = range.cloneRange();
+				} else {
+					savedRange = null;
+				}
+			} else {
+				savedRange = null;
+			}
+		}
+		showInsertImagePopover = true;
+	}
+
+	function handleInsertImageUrl() {
+		if (typeof document === 'undefined' || !editorRef || !insertImageUrl.trim()) return;
+
+		const url = insertImageUrl.trim();
+		editorRef.focus();
+
+		const selection = window.getSelection();
+		if (selection) {
+			selection.removeAllRanges();
+			if (savedRange) {
+				selection.addRange(savedRange);
+			}
+
+			const range = selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+			if (range) {
+				range.deleteContents();
+
+				const imgNode = document.createElement('img');
+				imgNode.setAttribute('src', url);
+				imgNode.setAttribute('alt', 'image');
+				imgNode.className = 'max-w-full h-auto rounded-lg my-2 inline-block';
+
+				range.insertNode(imgNode);
+
+				range.setStartAfter(imgNode);
+				range.setEndAfter(imgNode);
+				selection.removeAllRanges();
+				selection.addRange(range);
+			} else {
+				const imgNode = document.createElement('img');
+				imgNode.setAttribute('src', url);
+				imgNode.setAttribute('alt', 'image');
+				imgNode.className = 'max-w-full h-auto rounded-lg my-2 inline-block';
+				editorRef.appendChild(imgNode);
+			}
+		}
+
+		html = editorRef.innerHTML;
+		showInsertImagePopover = false;
+		savedRange = null;
+		updateActiveFormats();
+	}
+
+	async function handleUploadImageFile(file: File) {
+		isUploadingImage = true;
+		try {
+			if (onImageUpload) {
+				const url = await onImageUpload(file);
+				if (url) {
+					insertImageUrl = url;
+					handleInsertImageUrl();
+				}
+			} else {
+				const reader = new FileReader();
+				reader.onload = () => {
+					const dataUrl = reader.result as string;
+					if (dataUrl) {
+						insertImageUrl = dataUrl;
+						handleInsertImageUrl();
+					}
+				};
+				reader.readAsDataURL(file);
+			}
+		} catch (e) {
+			debug.error('task-client', 'Image upload failed:', e);
+		} finally {
+			isUploadingImage = false;
+		}
+	}
+
+	async function handlePaste(e: ClipboardEvent) {
+		const items = e.clipboardData?.items;
+		if (!items) return;
+		for (let i = 0; i < items.length; i++) {
+			const item = items[i];
+			if (item.type.startsWith('image/')) {
+				e.preventDefault();
+				const file = item.getAsFile();
+				if (file) {
+					if (typeof window !== 'undefined') {
+						const selection = window.getSelection();
+						if (selection && selection.rangeCount > 0) {
+							savedRange = selection.getRangeAt(0).cloneRange();
+						}
+					}
+					await handleUploadImageFile(file);
+				}
+				break;
+			}
+		}
+	}
+
+	async function handleDrop(e: DragEvent) {
+		const files = e.dataTransfer?.files;
+		if (!files) return;
+		for (let i = 0; i < files.length; i++) {
+			const file = files[i];
+			if (file.type.startsWith('image/')) {
+				e.preventDefault();
+				if (typeof window !== 'undefined' && (document as any).caretRangeFromPoint) {
+					const range = (document as any).caretRangeFromPoint(e.clientX, e.clientY);
+					if (range) {
+						savedRange = range;
+					}
+				}
+				await handleUploadImageFile(file);
+				break;
+			}
+		}
+	}
+
+	function insertTextAtCursor(text: string) {
+		if (typeof document === 'undefined') return;
+		const selection = window.getSelection();
+		if (!selection || selection.rangeCount === 0) return;
+		const range = selection.getRangeAt(0);
+		range.deleteContents();
+		const textNode = document.createTextNode(text);
+		range.insertNode(textNode);
+		
+		// Move cursor inside the text node to keep focus active on text level
+		range.setStart(textNode, text.length);
+		range.setEnd(textNode, text.length);
+		selection.removeAllRanges();
+		selection.addRange(range);
+		
+		if (editorRef) {
+			html = editorRef.innerHTML;
+		}
+		updateActiveFormats();
+	}
+
+	function insertCodeBlock() {
+		if (typeof document === 'undefined') return;
+		const selection = window.getSelection();
+		if (!selection || selection.rangeCount === 0) return;
+		const range = selection.getRangeAt(0);
+		
+		const preNode = document.createElement('pre');
+		preNode.className = 'bg-slate-900 text-slate-200 p-3 rounded-lg font-mono text-xs my-2 overflow-x-auto border border-slate-800';
+		const codeNode = document.createElement('code');
+		
+		const text = range.toString().trim() || '// Write your code here';
+		const lines = text.split(/\r?\n/);
+		codeNode.innerHTML = lines.map(line => `<div>${line || '<br>'}</div>`).join('');
+		preNode.appendChild(codeNode);
+		
+		range.deleteContents();
+		range.insertNode(preNode);
+		
+		// Set focus inside the code block
+		const newRange = document.createRange();
+		newRange.selectNodeContents(codeNode);
+		selection.removeAllRanges();
+		selection.addRange(newRange);
+		
+		if (editorRef) {
+			html = editorRef.innerHTML;
+		}
+		updateActiveFormats();
+	}
+
+	function wrapSelectionInCode() {
+		const selection = window.getSelection();
+		if (!selection || selection.rangeCount === 0) return;
+		const range = selection.getRangeAt(0);
+		
+		// If selection is empty, insert a placeholder code tag
+		if (range.collapsed) {
+			const codeNode = document.createElement('code');
+			codeNode.className = 'bg-slate-900 text-slate-200 px-1 py-0.5 rounded font-mono text-xs';
+			codeNode.innerHTML = 'code';
+			range.insertNode(codeNode);
+			
+			// Move selection inside the code node
+			const newRange = document.createRange();
+			newRange.selectNodeContents(codeNode);
+			selection.removeAllRanges();
+			selection.addRange(newRange);
+		} else {
+			// Wrap selection in <code>
+			const codeNode = document.createElement('code');
+			codeNode.className = 'bg-slate-900 text-slate-200 px-1 py-0.5 rounded font-mono text-xs';
+			codeNode.appendChild(range.extractContents());
+			range.insertNode(codeNode);
+			
+			// Reselect the wrapped contents
+			const newRange = document.createRange();
+			newRange.selectNode(codeNode);
+			selection.removeAllRanges();
+			selection.addRange(newRange);
+		}
+		
+		if (editorRef) {
+			html = editorRef.innerHTML;
+		}
+		updateActiveFormats();
+	}
+
+	function enforceCodeBlockStructure(preEl: HTMLPreElement) {
+		const codeEl = preEl.querySelector('code');
+		if (!codeEl) return;
+		
+		let hasTextOutsideDiv = false;
+		for (const node of Array.from(codeEl.childNodes)) {
+			if (node.nodeType === Node.TEXT_NODE && node.textContent?.trim() !== '') {
+				hasTextOutsideDiv = true;
+				break;
+			}
+		}
+		
+		if (hasTextOutsideDiv) {
+			const selection = window.getSelection();
+			let caretOffset = 0;
+			let activeDivIdx = 0;
+			
+			if (selection && selection.rangeCount > 0) {
+				const range = selection.getRangeAt(0);
+				const tempRange = range.cloneRange();
+				tempRange.selectNodeContents(codeEl);
+				tempRange.setEnd(range.startContainer, range.startOffset);
+				
+				const preCaretText = tempRange.toString();
+				const caretLines = preCaretText.split('\n');
+				activeDivIdx = caretLines.length - 1;
+				caretOffset = caretLines[caretLines.length - 1].length;
+			}
+			
+			const rawText = codeEl.textContent || '';
+			const lines = rawText.split('\n');
+			if (lines.length > 1 && lines[lines.length - 1] === '') {
+				lines.pop();
+			}
+			
+			const langClass = Array.from(codeEl.classList).find(c => c.startsWith('language-'));
+			const lang = langClass ? langClass.replace('language-', '') : '';
+			
+			codeEl.innerHTML = lines.map(line => `<div>${highlightCode(line, lang)}</div>`).join('');
+			
+			const divs = codeEl.querySelectorAll('div');
+			if (divs.length > 0) {
+				const targetDiv = divs[Math.min(activeDivIdx, divs.length - 1)];
+				const newRange = document.createRange();
+				
+				let currentOffset = 0;
+				let foundNode: Node | null = null;
+				let nodeOffset = 0;
+				
+				function traverse(n: Node) {
+					if (n.nodeType === Node.TEXT_NODE) {
+						const len = n.textContent?.length || 0;
+						if (currentOffset + len >= caretOffset) {
+							foundNode = n;
+							nodeOffset = caretOffset - currentOffset;
+							return true;
+						}
+						currentOffset += len;
+					} else {
+						for (const child of Array.from(n.childNodes)) {
+							if (traverse(child)) return true;
+						}
+					}
+					return false;
+				}
+				
+				traverse(targetDiv);
+				
+				if (foundNode) {
+					try {
+						newRange.setStart(foundNode, nodeOffset);
+						newRange.setEnd(foundNode, nodeOffset);
+						if (selection) {
+							selection.removeAllRanges();
+							selection.addRange(newRange);
+						}
+					} catch (err) {
+						debug.error('task-client', 'Error restoring code block caret offset:', err);
+					}
+				}
+			}
+		}
+	}
+
+	function handleDeleteCodeBlock() {
+		if (!activeCodeNode) return;
+		activeCodeNode.remove();
+		if (editorRef) {
+			html = editorRef.innerHTML;
+		}
+		activeCodeNode = null;
+		updateActiveFormats();
+	}
+
+	function handleSelectCodeLanguage(lang: string) {
+		if (!activeCodeNode) return;
+		const codeEl = activeCodeNode.querySelector('code');
+		if (codeEl) {
+			const langClass = Array.from(codeEl.classList).find(c => c.startsWith('language-'));
+			if (langClass) {
+				codeEl.classList.remove(langClass);
+			}
+			if (lang) {
+				codeEl.classList.add(`language-${lang}`);
+			}
+			
+			const divs = codeEl.querySelectorAll('div');
+			for (const div of Array.from(divs)) {
+				const rawLineText = div.textContent || '';
+				div.innerHTML = highlightCode(rawLineText, lang);
+			}
+		}
+		
+		activeCodeLanguage = lang;
+		if (editorRef) {
+			html = editorRef.innerHTML;
+		}
+	}
+
+	function handleToggleCodeWrap() {
+		if (!activeCodeNode) return;
+		activeCodeNode.classList.toggle('whitespace-pre-wrap');
+		activeCodeIsWrapped = activeCodeNode.classList.contains('whitespace-pre-wrap');
+		if (editorRef) {
+			html = editorRef.innerHTML;
+		}
+	}
+
+	function highlightCode(line: string, lang: string): string {
+		if (!line) return '<br>';
+		const l = lang ? lang.toLowerCase() : '';
+		
+		const patterns: { class: string; regex: RegExp }[] = [
+			{ class: 'token-comment', regex: /^\s*(\/\/.*|\/\*.*\*\/|#.*)/ },
+			{ class: 'token-string', regex: /^("[^"]*"|'[^']*')/ },
+			{ class: 'token-number', regex: /^(\b\d+(\.\d+)?\b)/ },
+			{ class: 'token-keyword', regex: /^(\b(const|let|var|function|return|if|else|for|while|do|switch|case|break|continue|import|export|from|class|extends|new|this|typeof|instanceof|void|delete|try|catch|finally|throw|debugger|interface|type|public|private|protected|readonly|static|async|await|yield|package|implements|as|any|number|string|boolean|object|symbol|never|unknown|undefined|null|true|false)\b)/ },
+			{ class: 'token-builtin', regex: /^(\b(console|window|document|process|require|module|exports|Object|Array|String|Number|Boolean|Function|Symbol|Error|RegExp|Map|Set|WeakMap|WeakSet|Promise|JSON|Math|Date)\b)/ },
+			{ class: 'token-operator', regex: /^([+\-*/%&|^~=!<>]+)/ },
+			{ class: 'token-function', regex: /^(\b\w+(?=\s*\())/ }
+		];
+		
+		let result = '';
+		let remaining = line;
+		
+		while (remaining.length > 0) {
+			let matched = false;
+			for (const pattern of patterns) {
+				const match = pattern.regex.exec(remaining);
+				if (match) {
+					result += `<span class="${pattern.class}">${escapeHtml(match[0])}</span>`;
+					remaining = remaining.slice(match[0].length);
+					matched = true;
+					break;
+				}
+			}
+			
+			if (!matched) {
+				result += escapeHtml(remaining.charAt(0));
+				remaining = remaining.slice(1);
+			}
+		}
+		
+		return result;
+	}
+
+	function escapeHtml(text: string): string {
+		return text
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#039;');
+	}
+
+	// Autocomplete Mentions
+	let showAutocomplete = $state(false);
+	let autocompleteQuery = $state('');
+	let autocompleteCoords = $state({ top: 0, left: 0 });
+	let autocompleteSelectedIndex = $state(0);
+
+	// Link Tooltip state
+	let activeLinkNode = $state<HTMLAnchorElement | null>(null);
+	let linkTooltipCoords = $state({ top: 0, left: 0 });
+	let isEditingLink = $state(false);
+	let linkEditUrl = $state('');
+	let linkEditText = $state('');
+	let copySuccess = $state(false);
+
+	// Insert Link Popover state
+	let showInsertLinkPopover = $state(false);
+	let insertLinkUrl = $state('');
+	let insertLinkText = $state('');
+	let savedRange = $state<Range | null>(null);
+
+	// Insert Image Popover state
+	let showInsertImagePopover = $state(false);
+	let insertImageUrl = $state('');
+	let isUploadingImage = $state(false);
+
+	function handleInsertLink() {
+		if (typeof document === 'undefined' || !editorRef || !insertLinkUrl.trim()) return;
+		
+		const url = insertLinkUrl.trim();
+		const text = insertLinkText.trim() || url;
+		
+		editorRef.focus();
+		
+		const selection = window.getSelection();
+		if (selection) {
+			selection.removeAllRanges();
+			if (savedRange) {
+				selection.addRange(savedRange);
+			}
+			
+			const range = selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+			if (range) {
+				range.deleteContents();
+				
+				const anchorNode = document.createElement('a');
+				anchorNode.setAttribute('href', url);
+				anchorNode.textContent = text;
+				
+				range.insertNode(anchorNode);
+				
+				range.setStartAfter(anchorNode);
+				range.setEndAfter(anchorNode);
+				selection.removeAllRanges();
+				selection.addRange(range);
+			} else {
+				const anchorNode = document.createElement('a');
+				anchorNode.setAttribute('href', url);
+				anchorNode.textContent = text;
+				editorRef.appendChild(anchorNode);
+			}
+		}
+		
+		html = editorRef.innerHTML;
+		showInsertLinkPopover = false;
+		savedRange = null;
+		updateActiveFormats();
+	}
+
+	function handleSaveEditLink() {
+		if (activeLinkNode && linkEditUrl.trim()) {
+			activeLinkNode.setAttribute('href', linkEditUrl.trim());
+			activeLinkNode.textContent = linkEditText.trim() || linkEditUrl.trim();
+			if (editorRef) html = editorRef.innerHTML;
+			isEditingLink = false;
+			activeLinkNode = null;
+		}
+	}
+
+	function checkActiveLink() {
+		if (typeof window === 'undefined' || !editorRef) return;
+
+		// Skip auto-closing if currently focusing form fields inside editing tooltip
+		if (isEditingLink && document.activeElement && (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'BUTTON')) {
+			return;
+		}
+
+		const selection = window.getSelection();
+		if (!selection || selection.rangeCount === 0) {
+			activeLinkNode = null;
+			isEditingLink = false;
+			return;
+		}
+
+		let node: Node | null = selection.anchorNode;
+		while (node && node !== editorRef) {
+			if (node.nodeName === 'A') {
+				activeLinkNode = node as HTMLAnchorElement;
+				if (!isEditingLink) {
+					linkEditUrl = activeLinkNode.getAttribute('href') || '';
+					linkEditText = activeLinkNode.textContent || '';
+				}
+				updateLinkTooltipPosition();
+				return;
+			}
+			node = node.parentNode;
+		}
+
+		activeLinkNode = null;
+		isEditingLink = false;
+	}
+
+	function updateLinkTooltipPosition() {
+		if (!activeLinkNode || !editorRef) return;
+		const rect = activeLinkNode.getBoundingClientRect();
+		const parentRect = editorRef.parentElement?.getBoundingClientRect();
+		if (parentRect) {
+			linkTooltipCoords = {
+				top: rect.bottom - parentRect.top + 8,
+				left: rect.left - parentRect.left + (rect.width / 2)
+			};
+		}
+	}
+
+	$effect(() => {
+		if (autocompleteQuery || showAutocomplete) {
+			autocompleteSelectedIndex = 0;
+		}
+	});
+
+	$effect(() => {
+		if (showAutocomplete) {
+			const handleGlobalClick = (e: MouseEvent) => {
+				const target = e.target as HTMLElement;
+				if (
+					autocompleteRef && !autocompleteRef.contains(target) &&
+					editorRef && !editorRef.contains(target)
+				) {
+					showAutocomplete = false;
+				}
+			};
+			document.addEventListener('mousedown', handleGlobalClick);
+			return () => {
+				document.removeEventListener('mousedown', handleGlobalClick);
+			};
+		}
+	});
+
+	function checkAutocomplete() {
+		if (typeof document === 'undefined' || !editorRef) return;
+		const selection = window.getSelection();
+		if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) {
+			showAutocomplete = false;
+			return;
+		}
+
+		let anchorNode = selection.anchorNode;
+		if (!anchorNode || !editorRef.contains(anchorNode)) {
+			showAutocomplete = false;
+			return;
+		}
+
+		const text = anchorNode.textContent || '';
+		const caretOffset = selection.anchorOffset;
+		const lastAtSymbolIndex = text.lastIndexOf('@', caretOffset - 1);
+		if (lastAtSymbolIndex === -1) {
+			showAutocomplete = false;
+			return;
+		}
+
+		const query = text.slice(lastAtSymbolIndex + 1, caretOffset);
+		const hasSpace = /\s/.test(query);
+		if (hasSpace) {
+			showAutocomplete = false;
+			return;
+		}
+
+		showAutocomplete = true;
+		autocompleteQuery = query;
+
+		// Calculate selection coordinates
+		try {
+			const range = selection.getRangeAt(0);
+			const clone = range.cloneRange();
+			clone.setStart(anchorNode, lastAtSymbolIndex);
+			clone.setEnd(anchorNode, caretOffset);
+			
+			const rects = clone.getClientRects();
+			const parentRect = editorRef.parentElement?.getBoundingClientRect();
+			if (rects.length > 0 && parentRect) {
+				const rect = rects[0];
+				autocompleteCoords = {
+					top: rect.bottom - parentRect.top + 5,
+					left: rect.left - parentRect.left
+				};
+			}
+		} catch (err) {
+			debug.error('task-client', 'Error calculating autocomplete coordinates:', err);
+		}
+	}
+
+	function selectAutocompleteOption(member: { id: string; fullName: string; username: string }) {
+		if (typeof document === 'undefined' || !editorRef) return;
+		const selection = window.getSelection();
+		if (!selection || selection.rangeCount === 0) return;
+		const range = selection.getRangeAt(0);
+
+		let anchorNode = selection.anchorNode;
+		if (!anchorNode) return;
+		
+		const text = anchorNode.textContent || '';
+		const caretOffset = selection.anchorOffset;
+		const lastAtSymbolIndex = text.lastIndexOf('@', caretOffset - 1);
+		if (lastAtSymbolIndex === -1) return;
+
+		// Create mention element
+		const span = document.createElement('span');
+		span.contentEditable = 'false';
+		span.setAttribute('data-mention-id', member.id);
+		span.setAttribute('data-username', member.username);
+		
+		if (member.id === 'card') {
+			span.className = 'inline-flex items-center px-1.5 py-0.5 rounded text-xs font-semibold bg-violet-600/20 text-violet-400 border border-violet-500/30';
+		} else if (member.id === 'board') {
+			span.className = 'inline-flex items-center px-1.5 py-0.5 rounded text-xs font-semibold bg-sky-600/20 text-sky-400 border border-sky-500/30';
+		} else {
+			span.className = 'inline-flex items-center px-1.5 py-0.5 rounded text-xs font-semibold bg-blue-600/20 text-blue-400 border border-blue-500/30';
+		}
+		span.innerHTML = `@${member.username}`;
+
+		range.setStart(anchorNode, lastAtSymbolIndex);
+		range.setEnd(anchorNode, caretOffset);
+		range.deleteContents();
+		range.insertNode(span);
+
+		const spaceNode = document.createTextNode('\u00A0');
+		span.after(spaceNode);
+		
+		const newRange = document.createRange();
+		newRange.setStart(spaceNode, 1);
+		newRange.setEnd(spaceNode, 1);
+		selection.removeAllRanges();
+		selection.addRange(newRange);
+
+		html = editorRef.innerHTML;
+		showAutocomplete = false;
+		updateActiveFormats();
+	}
+
+	const filteredAutocompleteOptions = $derived(
+		mentionOptions.filter(m =>
+			m.fullName.toLowerCase().includes(autocompleteQuery.toLowerCase()) ||
+			m.username.toLowerCase().includes(autocompleteQuery.toLowerCase())
+		)
+	);
+
+	function handleEditorKeydown(e: KeyboardEvent) {
+		if (showAutocomplete) {
+			if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				autocompleteSelectedIndex = (autocompleteSelectedIndex + 1) % filteredAutocompleteOptions.length;
+				return;
+			} else if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				autocompleteSelectedIndex = (autocompleteSelectedIndex - 1 + filteredAutocompleteOptions.length) % filteredAutocompleteOptions.length;
+				return;
+			} else if (e.key === 'Enter') {
+				e.preventDefault();
+				const selected = filteredAutocompleteOptions[autocompleteSelectedIndex];
+				if (selected) {
+					selectAutocompleteOption(selected);
+				}
+				return;
+			} else if (e.key === 'Escape') {
+				e.preventDefault();
+				showAutocomplete = false;
+				return;
+			}
+		}
+
+		if (showInsertMenu && insertSubMenu === 'main') {
+			if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				insertSelectedIndex = (insertSelectedIndex + 1) % filteredInsertItems.length;
+				return;
+			} else if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				insertSelectedIndex = (insertSelectedIndex - 1 + filteredInsertItems.length) % filteredInsertItems.length;
+				return;
+			} else if (e.key === 'Enter') {
+				e.preventDefault();
+				const active = filteredInsertItems[insertSelectedIndex];
+				if (active) {
+					active.action();
+				}
+				return;
+			}
+		}
+
+		// Escaping code blocks using ArrowDown / ArrowUp
+		if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+			if (typeof window !== 'undefined') {
+				const selection = window.getSelection();
+				if (selection && selection.rangeCount > 0) {
+					let node: Node | null = selection.anchorNode;
+					let codeBlock: HTMLElement | null = null;
+					let preBlock: HTMLElement | null = null;
+					while (node && node !== editorRef) {
+						if (node.nodeName === 'CODE') {
+							codeBlock = node as HTMLElement;
+						}
+						if (node.nodeName === 'PRE') {
+							preBlock = node as HTMLElement;
+							break;
+						}
+						node = node.parentNode;
+					}
+
+					if (preBlock && codeBlock) {
+						if (e.key === 'ArrowDown') {
+							// Check if we are inside the last line of the code block
+							let isAtLastLine = true;
+							let n: Node | null = selection.anchorNode;
+							while (n && n !== codeBlock) {
+								if (n.nextSibling) {
+									isAtLastLine = false;
+									break;
+								}
+								n = n.parentNode;
+							}
+
+							if (isAtLastLine) {
+								const parent = preBlock.parentNode;
+								if (parent) {
+									const next = preBlock.nextElementSibling;
+									if (next) {
+										const newRange = document.createRange();
+										newRange.selectNodeContents(next);
+										newRange.collapse(true);
+										selection.removeAllRanges();
+										selection.addRange(newRange);
+									} else {
+										const pNode = document.createElement('p');
+										pNode.innerHTML = '<br>';
+										parent.appendChild(pNode);
+										
+										const newRange = document.createRange();
+										newRange.selectNodeContents(pNode);
+										newRange.collapse(true);
+										selection.removeAllRanges();
+										selection.addRange(newRange);
+									}
+									e.preventDefault();
+									if (editorRef) html = editorRef.innerHTML;
+									updateActiveFormats();
+								}
+							}
+						} else if (e.key === 'ArrowUp') {
+							// Check if we are inside the first line of the code block
+							let isAtFirstLine = true;
+							let n: Node | null = selection.anchorNode;
+							while (n && n !== codeBlock) {
+								if (n.previousSibling) {
+									isAtFirstLine = false;
+									break;
+								}
+								n = n.parentNode;
+							}
+
+							if (isAtFirstLine) {
+								const parent = preBlock.parentNode;
+								if (parent) {
+									const prev = preBlock.previousElementSibling;
+									if (prev) {
+										const newRange = document.createRange();
+										newRange.selectNodeContents(prev);
+										newRange.collapse(false); // collapse to end
+										selection.removeAllRanges();
+										selection.addRange(newRange);
+									} else {
+										const pNode = document.createElement('p');
+										pNode.innerHTML = '<br>';
+										parent.insertBefore(pNode, preBlock);
+										
+										const newRange = document.createRange();
+										newRange.selectNodeContents(pNode);
+										newRange.collapse(true);
+										selection.removeAllRanges();
+										selection.addRange(newRange);
+									}
+									e.preventDefault();
+									if (editorRef) html = editorRef.innerHTML;
+									updateActiveFormats();
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		const isMac = typeof navigator !== 'undefined' && navigator.platform.indexOf('Mac') > -1;
+		const modifier = isMac ? e.metaKey : e.ctrlKey;
+
+		if (modifier && e.shiftKey && e.key.toLowerCase() === 's') {
+			e.preventDefault();
+			execEditorCommand('strikeThrough');
+		} else if (modifier && e.shiftKey && e.key.toLowerCase() === 'm') {
+			e.preventDefault();
+			wrapSelectionInCode();
+		} else if (modifier && e.key === '\\') {
+			e.preventDefault();
+			execEditorCommand('removeFormat');
+		}
+	}
+
+	$effect(() => {
+		if (insertSearchQuery || showInsertMenu || insertSubMenu) {
+			insertSelectedIndex = 0;
+		}
+	});
+
+	$effect(() => {
+		if (!showInsertMenu) {
+			insertSearchQuery = '';
+			insertSubMenu = 'main';
+		}
+	});
+</script>
+
+<div class="w-full rounded-xl border border-slate-800 bg-slate-950 relative z-20">
+	<!-- Toolbar -->
+	<div class="flex items-center justify-between px-3 py-2 border-b border-slate-800 bg-slate-900/30 rounded-t-xl select-none">
+		<!-- Left Actions -->
+		<div class="flex items-center gap-1">
+			<!-- Text style -->
+			<button type="button" onmousedown={(e) => e.preventDefault()} onclick={() => execEditorCommand('formatBlock', '<h3>')} class="flex items-center gap-0.5 h-7 px-2 rounded-lg hover:bg-slate-800 text-xs font-semibold border-none cursor-pointer transition-colors {isHeadingActive ? 'bg-slate-800 text-violet-400' : 'text-slate-400 hover:text-slate-200 bg-transparent'}" title="Heading">
+				<span class="font-serif">Tt</span>
+				<Icon name="lucide:chevron-down" class="w-3 h-3" />
+			</button>
+			<div class="h-4 w-[1px] bg-slate-800 mx-1"></div>
+			<!-- Bold -->
+			<button type="button" onmousedown={(e) => e.preventDefault()} onclick={() => execEditorCommand('bold')} class="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-slate-800 cursor-pointer border-none transition-colors {isBoldActive ? 'bg-slate-800 text-violet-400' : 'text-slate-400 hover:text-slate-200 bg-transparent'}" title="Bold">
+				<Icon name="lucide:bold" class="w-3.5 h-3.5" />
+			</button>
+			<!-- Italic -->
+			<button type="button" onmousedown={(e) => e.preventDefault()} onclick={() => execEditorCommand('italic')} class="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-slate-800 cursor-pointer border-none transition-colors {isItalicActive ? 'bg-slate-800 text-violet-400' : 'text-slate-400 hover:text-slate-200 bg-transparent'}" title="Italic">
+				<Icon name="lucide:italic" class="w-3.5 h-3.5" />
+			</button>
+			<!-- More -->
+			<div class="relative flex items-center">
+				<button type="button" onmousedown={(e) => e.preventDefault()} onclick={() => { const wasOpen = showMoreMenu; closeAllEditorMenus(); showMoreMenu = !wasOpen; }} class="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-slate-800 border-none cursor-pointer transition-colors {showMoreMenu || isStrikethroughActive || isCodeActive ? 'bg-slate-800 text-violet-400' : 'text-slate-400 hover:text-slate-200 bg-transparent'}" title="More formatting">
+					<Icon name="lucide:ellipsis" class="w-3.5 h-3.5" />
+				</button>
+				{#if showMoreMenu}
+					<!-- Click outside overlay -->
+					<button
+						type="button"
+						class="fixed inset-0 z-40 bg-transparent cursor-default border-none w-full h-full"
+						onclick={() => showMoreMenu = false}
+						aria-label="Close formatting menu"
+					></button>
+					
+					<!-- Dropdown content -->
+					<div class="absolute top-full left-0 mt-1 z-50 w-56 p-1.5 rounded-lg border border-slate-700 bg-slate-900 shadow-2xl flex flex-col gap-0.5">
+						<!-- Strikethrough -->
+						<button
+							type="button"
+							onmousedown={(e) => e.preventDefault()}
+							onclick={() => { execEditorCommand('strikeThrough'); showMoreMenu = false; }}
+							class="w-full flex items-center justify-between px-2.5 py-1.5 rounded text-xs font-semibold border-none cursor-pointer text-left transition-colors animate-in fade-in zoom-in-95 duration-100 {isStrikethroughActive ? 'bg-slate-800 text-violet-400' : 'text-slate-300 hover:text-slate-100 hover:bg-slate-800 bg-transparent'}"
+						>
+							<span>Strikethrough</span>
+							<span class="text-[10px] text-slate-500 font-mono bg-slate-950 px-1.5 py-0.5 rounded border border-slate-800">⌘⇧S</span>
+						</button>
+						<!-- Code -->
+						<button
+							type="button"
+							onmousedown={(e) => e.preventDefault()}
+							onclick={() => { wrapSelectionInCode(); showMoreMenu = false; }}
+							class="w-full flex items-center justify-between px-2.5 py-1.5 rounded text-xs font-semibold border-none cursor-pointer text-left transition-colors animate-in fade-in zoom-in-95 duration-100 {isCodeActive ? 'bg-slate-800 text-violet-400' : 'text-slate-300 hover:text-slate-100 hover:bg-slate-800 bg-transparent'}"
+						>
+							<span>Code</span>
+							<span class="text-[10px] text-slate-500 font-mono bg-slate-950 px-1.5 py-0.5 rounded border border-slate-800">⌘⇧M</span>
+						</button>
+						<!-- Divider -->
+						<div class="h-[1px] bg-slate-800 my-1"></div>
+						<!-- Clear Formatting -->
+						<button
+							type="button"
+							onmousedown={(e) => e.preventDefault()}
+							onclick={() => { execEditorCommand('removeFormat'); showMoreMenu = false; }}
+							class="w-full flex items-center justify-between px-2.5 py-1.5 rounded text-xs font-semibold text-slate-300 hover:text-slate-100 hover:bg-slate-800 bg-transparent border-none cursor-pointer text-left transition-colors animate-in fade-in zoom-in-95 duration-100"
+						>
+							<span>Clear formatting</span>
+							<span class="text-[10px] text-slate-500 font-mono bg-slate-950 px-1.5 py-0.5 rounded border border-slate-800">⌘\</span>
+						</button>
+					</div>
+				{/if}
+			</div>
+			<div class="h-4 w-[1px] bg-slate-800 mx-1"></div>
+			<!-- Lists -->
+			<div class="relative flex items-center">
+				<button
+					type="button"
+					onmousedown={(e) => e.preventDefault()}
+					onclick={() => { const wasOpen = showListMenu; closeAllEditorMenus(); showListMenu = !wasOpen; }}
+					class="flex items-center gap-0.5 h-7 px-1.5 rounded-lg hover:bg-slate-800 border-none cursor-pointer transition-colors {showListMenu || isListActive ? 'bg-slate-800 text-violet-400' : 'text-slate-400 hover:text-slate-200 bg-transparent'}"
+					title="Lists"
+				>
+					<Icon name="lucide:list" class="w-3.5 h-3.5" />
+					<Icon name="lucide:chevron-down" class="w-3.5 h-3.5" />
+				</button>
+				{#if showListMenu}
+					<!-- Click outside overlay -->
+					<button
+						type="button"
+						class="fixed inset-0 z-40 bg-transparent cursor-default border-none w-full h-full"
+						onclick={() => showListMenu = false}
+						aria-label="Close list menu"
+					></button>
+					
+					<!-- Dropdown content -->
+					<div class="absolute top-full left-0 mt-1 z-50 w-44 p-1.5 rounded-lg border border-slate-700 bg-slate-900 shadow-2xl flex flex-col gap-0.5">
+						<!-- Bullet List -->
+						<button
+							type="button"
+							onmousedown={(e) => e.preventDefault()}
+							onclick={() => { execEditorCommand('insertUnorderedList'); showListMenu = false; }}
+							class="w-full flex items-center gap-2 px-2.5 py-1.5 rounded text-xs font-semibold border-none cursor-pointer text-left transition-colors animate-in fade-in zoom-in-95 duration-100 {isBulletListActive ? 'bg-slate-800 text-violet-400' : 'text-slate-300 hover:text-slate-100 hover:bg-slate-800 bg-transparent'}"
+						>
+							<Icon name="lucide:list" class="w-3.5 h-3.5 shrink-0" />
+							<span>Bullet list</span>
+						</button>
+						<!-- Numbered List -->
+						<button
+							type="button"
+							onmousedown={(e) => e.preventDefault()}
+							onclick={() => { execEditorCommand('insertOrderedList'); showListMenu = false; }}
+							class="w-full flex items-center gap-2 px-2.5 py-1.5 rounded text-xs font-semibold border-none cursor-pointer text-left transition-colors animate-in fade-in zoom-in-95 duration-100 {isNumberedListActive ? 'bg-slate-800 text-violet-400' : 'text-slate-300 hover:text-slate-100 hover:bg-slate-800 bg-transparent'}"
+						>
+							<Icon name="lucide:list-ordered" class="w-3.5 h-3.5 shrink-0" />
+							<span>Numbered list</span>
+						</button>
+					</div>
+				{/if}
+			</div>
+			<div class="h-4 w-[1px] bg-slate-800 mx-1"></div>
+			{#if showDirectLinkImage}
+				<button type="button" onmousedown={(e) => e.preventDefault()} onclick={insertLinkCommand} class="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-slate-800 text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer transition-colors" title="Link">
+					<Icon name="lucide:link" class="w-3.5 h-3.5" />
+				</button>
+				<button type="button" onmousedown={(e) => e.preventDefault()} onclick={insertImageCommand} class="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-slate-800 text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer transition-colors" title="Image">
+					<Icon name="lucide:image" class="w-3.5 h-3.5" />
+				</button>
+			{/if}
+
+			<!-- Insert element -->
+			<div class="relative flex items-center">
+				<button
+					type="button"
+					onmousedown={(e) => e.preventDefault()}
+					onclick={() => { const wasOpen = showInsertMenu; closeAllEditorMenus(); showInsertMenu = !wasOpen; }}
+					class="flex items-center gap-0.5 h-7 px-1.5 rounded-lg hover:bg-slate-800 border-none cursor-pointer transition-colors {showInsertMenu ? 'bg-slate-800 text-violet-400' : 'text-slate-400 hover:text-slate-200 bg-transparent'}"
+					title="Insert element"
+				>
+					<Icon name="lucide:plus" class="w-3.5 h-3.5" />
+					<Icon name="lucide:chevron-down" class="w-3.5 h-3.5" />
+				</button>
+				{#if showInsertMenu}
+					<!-- Click outside overlay -->
+					<button
+						type="button"
+						class="fixed inset-0 z-40 bg-transparent cursor-default border-none w-full h-full"
+						onclick={() => showInsertMenu = false}
+						aria-label="Close insert menu"
+					></button>
+					
+					<!-- Dropdown content -->
+					<div class="absolute top-full mt-1 z-50 w-72 p-2 rounded-xl border border-slate-800 bg-slate-950 shadow-2xl flex flex-col gap-1.5 animate-in fade-in zoom-in-95 duration-150 {dropdownAlign === 'right' ? 'right-0' : 'left-0'}">
+						{#if insertSubMenu === 'main'}
+							<!-- Search Input wrapper -->
+							<div class="relative flex items-center px-2.5 py-1.5 bg-slate-900 rounded-lg border border-slate-800 focus-within:border-slate-700">
+								<Icon name="lucide:search" class="w-3.5 h-3.5 text-slate-500 mr-2 shrink-0" />
+								<input
+									type="text"
+									bind:value={insertSearchQuery}
+									onkeydown={handleEditorKeydown}
+									placeholder="Search"
+									autofocus
+									class="w-full bg-transparent border-none text-xs text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-0 p-0"
+								/>
+								<span class="text-[9px] text-slate-500 font-mono bg-slate-950 px-1 py-0.5 rounded border border-slate-800 shrink-0 ml-2">↵ Enter</span>
+							</div>
+							
+							<!-- Items list -->
+							<div class="flex flex-col max-h-64 overflow-y-auto pr-0.5">
+								{#if filteredInsertItems.length === 0}
+									<div class="text-[11px] text-slate-500 text-center py-4 select-none">No options match query</div>
+								{:else}
+									{#each filteredInsertItems as item, idx}
+										{@const isSelected = idx === insertSelectedIndex}
+										<button
+											type="button"
+											onmousedown={(e) => e.preventDefault()}
+											onclick={item.action}
+											onmouseenter={() => insertSelectedIndex = idx}
+											class="relative w-full flex items-center justify-between gap-3 p-2 rounded-lg border-none cursor-pointer text-left transition-colors {isSelected ? 'bg-slate-850/80 text-violet-400' : 'bg-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-900/40'}"
+										>
+											{#if isSelected}
+												<div class="absolute left-0 top-1 bottom-1 w-[3px] bg-violet-500 rounded-r"></div>
+											{/if}
+											<div class="flex items-start gap-3 min-w-0 flex-grow">
+												<Icon name={item.icon as any} class="w-4 h-4 shrink-0 text-slate-400 mt-0.5" />
+												<div class="flex-grow min-w-0">
+													<span class="text-xs font-semibold block">{item.title}</span>
+													<span class="text-[10px] text-slate-500 block whitespace-normal pr-1">{item.desc}</span>
+												</div>
+											</div>
+											{#if item.shortcut}
+												<span class="text-[10px] text-slate-500 font-mono bg-slate-950 px-1.5 py-0.5 rounded border border-slate-800 shrink-0 self-center">{item.shortcut}</span>
+											{/if}
+										</button>
+									{/each}
+								{/if}
+							</div>
+						{:else if insertSubMenu === 'mention'}
+							<!-- Mentions menu -->
+							<div class="flex flex-col max-h-64 overflow-y-auto pr-0.5">
+								{#each filteredMentionOptions as member, idx}
+									{@const isSelected = idx === autocompleteSelectedIndex}
+									<button
+										type="button"
+										onmousedown={(e) => e.preventDefault()}
+										onclick={() => { insertTextAtCursor(`@${member.username} `); showInsertMenu = false; }}
+										onmouseenter={() => autocompleteSelectedIndex = idx}
+										class="relative w-full flex items-center gap-3 p-2 rounded-lg border-none cursor-pointer text-left transition-colors {isSelected ? 'bg-slate-800/80 text-violet-400' : 'bg-transparent text-slate-300 hover:text-slate-200 hover:bg-slate-900'}"
+									>
+										{#if isSelected}
+											<div class="absolute left-0 top-1 bottom-1 w-[3px] bg-violet-500 rounded-r"></div>
+										{/if}
+										{#if member.avatarUrl}
+											<img src="{member.avatarUrl}/30.png" alt={member.fullName} class="w-8 h-8 rounded-full object-cover shrink-0 border border-slate-800" />
+										{/if}
+										<div class="flex-grow min-w-0">
+											<span class="text-xs font-semibold block truncate">{member.fullName}</span>
+											<span class="text-[10px] text-slate-500 block truncate">@{member.username}</span>
+										</div>
+									</button>
+								{/each}
+							</div>
+						{:else if insertSubMenu === 'emoji'}
+							<!-- Emoji list picker -->
+							<div class="flex flex-col gap-2">
+								<div class="flex items-center gap-1 border-b border-slate-800 pb-1.5">
+									{#each emojiCategories as cat}
+										<button
+											type="button"
+											onmousedown={(e) => e.preventDefault()}
+											onclick={() => { selectedEmojiCategory = cat.id; hoveredEmoji = null; }}
+											class="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-850 border-none cursor-pointer transition-colors {selectedEmojiCategory === cat.id ? 'bg-slate-800 text-violet-400' : 'text-slate-500 hover:text-slate-300 bg-transparent'}"
+											title={cat.label}
+										>
+											<Icon name={cat.icon as any} class="w-4 h-4" />
+										</button>
+									{/each}
+								</div>
+								<div class="grid grid-cols-8 gap-1 max-h-48 overflow-y-auto pr-0.5">
+									{#each emojisData[selectedEmojiCategory] as emoji}
+										<button
+											type="button"
+											onmousedown={(e) => e.preventDefault()}
+											onclick={() => { insertTextAtCursor(emoji.char); showInsertMenu = false; }}
+											onmouseenter={() => hoveredEmoji = emoji}
+											class="w-7 h-7 flex items-center justify-center text-base rounded hover:bg-slate-800 border-none cursor-pointer transition-colors bg-transparent"
+											title={emoji.name}
+										>
+											{emoji.char}
+										</button>
+									{/each}
+								</div>
+								{#if hoveredEmoji}
+									<div class="flex items-center gap-2 border-t border-slate-800 pt-1.5 px-1 select-none">
+										<span class="text-xl shrink-0">{hoveredEmoji.char}</span>
+										<div class="flex-grow min-w-0">
+											<span class="text-[10px] font-semibold text-slate-300 block truncate leading-none mb-1">{hoveredEmoji.name}</span>
+											<span class="text-[9px] font-mono text-slate-500 block truncate leading-none">{hoveredEmoji.code}</span>
+										</div>
+									</div>
+								{/if}
+							</div>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		</div>
+
+		<!-- Right Actions -->
+		<div class="flex items-center gap-2">
+			{#if showAttachmentButton}
+				<button type="button" onmousedown={(e) => e.preventDefault()} onclick={insertLinkCommand} class="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-slate-800 text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer transition-colors" title="Add attachment">
+					<Icon name="lucide:paperclip" class="w-3.5 h-3.5" />
+				</button>
+			{/if}
+
+			{#if showMarkdownIcon}
+				<a href="https://www.markdownguide.org/cheat-sheet/" target="_blank" class="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-slate-800 text-slate-500 hover:text-slate-400 transition-colors" title="Markdown is supported">
+					<span class="text-xs font-bold font-mono">M↓</span>
+				</a>
+			{/if}
+
+			<button type="button" onmousedown={(e) => e.preventDefault()} onclick={() => showFormattingHelp = !showFormattingHelp} class="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-slate-800 text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer transition-colors" title="Formatting help">
+				<Icon name="lucide:circle-question-mark" class="w-3.5 h-3.5" />
+			</button>
+		</div>
+	</div>
+
+	<!-- ContentEditable Area -->
+	<div
+		bind:this={editorRef}
+		contenteditable="true"
+		bind:innerHTML={html}
+		{placeholder}
+		class="w-full min-h-[120px] p-3 bg-transparent border-none text-sm text-slate-100 placeholder-slate-500 focus:outline-none focus:ring-0 focus:border-none resize-y leading-relaxed outline-none empty:before:content-[attr(placeholder)] empty:before:text-slate-500 empty:before:pointer-events-none font-sans selection:bg-violet-500/30 selection:text-white"
+		autofocus
+		onmouseup={handleEditorSelectionOrInput}
+		onkeyup={handleEditorSelectionOrInput}
+		onfocus={handleEditorSelectionOrInput}
+		oninput={handleEditorSelectionOrInput}
+		onkeydown={handleEditorKeydown}
+		onpaste={handlePaste}
+		ondrop={handleDrop}
+	></div>
+
+	{#if showAutocomplete && filteredAutocompleteOptions.length > 0}
+		<div
+			bind:this={autocompleteRef}
+			id="desc-autocomplete-menu"
+			style="top: {autocompleteCoords.top}px; left: {autocompleteCoords.left}px;"
+			class="absolute z-50 w-72 p-2 rounded-xl border border-slate-800 bg-slate-950 shadow-2xl flex flex-col gap-1.5 animate-in fade-in zoom-in-95 duration-150"
+		>
+			<div class="flex flex-col max-h-64 overflow-y-auto pr-0.5">
+				{#each filteredAutocompleteOptions as member, idx}
+					{@const isSelected = idx === autocompleteSelectedIndex}
+					<button
+						type="button"
+						onmousedown={(e) => e.preventDefault()}
+						onclick={() => selectAutocompleteOption(member)}
+						onmouseenter={() => autocompleteSelectedIndex = idx}
+						class="relative w-full flex items-center gap-3 p-2 rounded-lg border-none cursor-pointer text-left transition-colors {isSelected ? 'bg-slate-800/80 text-violet-400' : 'bg-transparent text-slate-300 hover:text-slate-200 hover:bg-slate-900'}"
+					>
+						{#if isSelected}
+							<div class="absolute left-0 top-1 bottom-1 w-[3px] bg-violet-500 rounded-r"></div>
+						{/if}
+						{#if member.avatarUrl}
+							<img src="{member.avatarUrl}/30.png" alt={member.fullName} class="w-8 h-8 rounded-full object-cover shrink-0 border border-slate-800" />
+						{/if}
+						<div class="flex-grow min-w-0">
+							<span class="text-xs font-semibold block truncate">{member.fullName}</span>
+							<span class="text-[10px] text-slate-500 block truncate">@{member.username}</span>
+						</div>
+					</button>
+				{/each}
+			</div>
+		</div>
+	{/if}
+
+	{#if showInsertLinkPopover}
+		<button
+			type="button"
+			onclick={() => showInsertLinkPopover = false}
+			class="fixed inset-0 z-[300] bg-slate-950/40 cursor-default border-none w-full h-full backdrop-blur-[1px]"
+			aria-label="Close insert link popover"
+		></button>
+		<div
+			class="fixed inset-0 z-[310] pointer-events-none flex items-center justify-center"
+		>
+			<form
+				onsubmit={(e) => {
+					e.preventDefault();
+					if (insertLinkUrl.trim()) {
+						handleInsertLink();
+					}
+				}}
+				onmousedown={(e) => e.stopPropagation()}
+				class="pointer-events-auto w-80 p-4.5 rounded-2xl border border-slate-800 bg-slate-950 shadow-2xl flex flex-col gap-4 text-slate-200 animate-in fade-in zoom-in-95 duration-150"
+			>
+				<div class="flex items-center justify-between">
+					<span class="text-xs font-bold text-slate-200">Insert link</span>
+					<button
+						type="button"
+						onclick={() => showInsertLinkPopover = false}
+						class="flex items-center justify-center w-6 h-6 rounded text-slate-400 hover:text-slate-200 hover:bg-slate-850 transition border-none bg-transparent cursor-pointer"
+						aria-label="Close link popover"
+					>
+						<Icon name="lucide:x" class="w-3.5 h-3.5" />
+					</button>
+				</div>
+
+				<div class="flex flex-col gap-1.5">
+					<label class="text-xs font-bold text-slate-200">Link <span class="text-red-400">*</span></label>
+					<input
+						type="text"
+						placeholder="Paste a link"
+						bind:value={insertLinkUrl}
+						class="w-full px-3 py-2 rounded-lg bg-slate-900 border border-slate-800 text-slate-200 text-xs focus:outline-none focus:ring-2 focus:ring-violet-500 placeholder-slate-600"
+						autofocus
+					/>
+				</div>
+				<div class="flex flex-col gap-1.5">
+					<label class="text-xs font-bold text-slate-200">Display text (optional)</label>
+					<input
+						type="text"
+						placeholder="Text to display"
+						bind:value={insertLinkText}
+						class="w-full px-3 py-2 rounded-lg bg-slate-900 border border-slate-800 text-slate-200 text-xs focus:outline-none focus:ring-2 focus:ring-violet-500 placeholder-slate-600"
+					/>
+					<span class="text-[10px] text-slate-500">Give this link a title or description</span>
+				</div>
+				<div class="flex justify-end mt-1">
+					<button
+						type="submit"
+						disabled={!insertLinkUrl.trim()}
+						class="px-5 py-2 text-sm bg-violet-600 hover:bg-violet-700 text-white rounded-lg font-semibold transition cursor-pointer border-none disabled:opacity-50 disabled:cursor-not-allowed"
+					>
+						Insert
+					</button>
+				</div>
+			</form>
+		</div>
+	{/if}
+
+	{#if showInsertImagePopover}
+		<button
+			type="button"
+			onclick={() => showInsertImagePopover = false}
+			class="fixed inset-0 z-[300] bg-slate-950/40 cursor-default border-none w-full h-full backdrop-blur-[1px]"
+			aria-label="Close insert image popover"
+		></button>
+		<div
+			class="fixed inset-0 z-[310] pointer-events-none flex items-center justify-center"
+		>
+			<form
+				onsubmit={(e) => {
+					e.preventDefault();
+					if (insertImageUrl.trim()) {
+						handleInsertImageUrl();
+					}
+				}}
+				onmousedown={(e) => e.stopPropagation()}
+				class="pointer-events-auto w-80 p-4.5 rounded-2xl border border-slate-800 bg-slate-950 shadow-2xl flex flex-col gap-4 text-slate-200 animate-in fade-in zoom-in-95 duration-150"
+			>
+				<div class="flex items-center justify-between">
+					<span class="text-xs font-bold text-slate-200">Select image</span>
+					<button
+						type="button"
+						onclick={() => showInsertImagePopover = false}
+						class="flex items-center justify-center w-6 h-6 rounded text-slate-400 hover:text-slate-200 hover:bg-slate-850 transition border-none bg-transparent cursor-pointer"
+						aria-label="Close image popover"
+					>
+						<Icon name="lucide:x" class="w-3.5 h-3.5" />
+					</button>
+				</div>
+
+				<div class="flex flex-col gap-1.5">
+					<label class="text-xs font-bold text-slate-200">Attach an image link</label>
+					<div class="flex gap-2">
+						<input
+							type="text"
+							placeholder="https://example.com"
+							bind:value={insertImageUrl}
+							class="flex-grow px-3 py-1.5 rounded-lg bg-slate-900 border border-slate-800 text-slate-200 text-xs focus:outline-none focus:ring-2 focus:ring-violet-500 placeholder-slate-600"
+							autofocus
+						/>
+						<button
+							type="submit"
+							disabled={!insertImageUrl.trim()}
+							class="px-4 py-1.5 text-xs bg-slate-850 hover:bg-slate-800 text-slate-200 rounded-lg font-semibold transition cursor-pointer border border-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Submit
+						</button>
+					</div>
+				</div>
+
+				<div class="flex flex-col gap-1.5 mt-1.5">
+					<input
+						type="file"
+						accept="image/*"
+						class="hidden"
+						bind:this={fileInputRef}
+						onchange={(e) => {
+							const file = e.currentTarget.files?.[0];
+							if (file) handleUploadImageFile(file);
+						}}
+					/>
+					<button
+						type="button"
+						disabled={isUploadingImage}
+						onclick={() => fileInputRef?.click()}
+						class="w-full py-2 rounded-lg border border-slate-800 bg-slate-900 hover:bg-slate-850 text-slate-350 hover:text-slate-200 text-xs font-semibold transition cursor-pointer flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+					>
+						{#if isUploadingImage}
+							<Icon name="lucide:loader" class="w-3.5 h-3.5 animate-spin" />
+							<span>Uploading...</span>
+						{:else}
+							<Icon name="lucide:upload" class="w-3.5 h-3.5" />
+							<span>Upload from your computer</span>
+						{/if}
+					</button>
+				</div>
+			</form>
+		</div>
+	{/if}
+
+	{#if activeLinkNode}
+		<div
+			onmousedown={(e) => { if (!isEditingLink) e.preventDefault(); }}
+			style="top: {linkTooltipCoords.top}px; left: {linkTooltipCoords.left}px; transform: translateX(-50%);"
+			class="absolute z-[60] p-1 rounded-lg border border-slate-800 bg-slate-950 shadow-2xl flex flex-col gap-1 text-xs select-none"
+		>
+			{#if isEditingLink}
+				<!-- Link Edit Form -->
+				<form
+					onsubmit={(e) => {
+						e.preventDefault();
+						handleSaveEditLink();
+					}}
+					class="flex flex-col gap-2 p-3.5 w-64 text-slate-200 animate-in fade-in zoom-in-95 duration-150"
+				>
+					<div class="flex flex-col gap-1.5">
+						<label class="text-[10px] font-bold text-slate-400 uppercase">Link <span class="text-red-400">*</span></label>
+						<input
+							type="text"
+							bind:value={linkEditUrl}
+							class="px-2.5 py-1.5 rounded-lg bg-slate-900 border border-slate-800 text-slate-200 text-xs focus:outline-none focus:ring-2 focus:ring-violet-500"
+						/>
+					</div>
+					<div class="flex flex-col gap-1.5">
+						<label class="text-[10px] font-bold text-slate-400 uppercase">Display text (optional)</label>
+						<input
+							type="text"
+							bind:value={linkEditText}
+							class="px-2.5 py-1.5 rounded-lg bg-slate-900 border border-slate-800 text-slate-200 text-xs focus:outline-none focus:ring-2 focus:ring-violet-500"
+						/>
+					</div>
+					<div class="flex gap-2 justify-end mt-1.5">
+						<button
+							type="button"
+							onclick={() => isEditingLink = false}
+							class="px-3 py-1.5 text-xs bg-transparent hover:bg-slate-800 text-slate-400 hover:text-slate-200 rounded-lg font-semibold transition cursor-pointer border border-slate-850"
+						>
+							Cancel
+						</button>
+						<button
+							type="submit"
+							disabled={!linkEditUrl.trim()}
+							class="px-3.5 py-1.5 text-xs bg-violet-600 hover:bg-violet-700 text-white rounded-lg font-semibold transition cursor-pointer border-none disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Save
+						</button>
+					</div>
+				</form>
+			{:else}
+				<!-- Link Action Bar -->
+				<div class="flex items-center gap-0.5 animate-in fade-in zoom-in-95 duration-100">
+					<button
+						type="button"
+						onclick={() => isEditingLink = true}
+						class="px-2.5 py-1 hover:bg-slate-800 rounded-lg font-semibold text-slate-300 hover:text-slate-100 transition cursor-pointer border-none bg-transparent text-xs"
+					>
+						Edit link
+					</button>
+					
+					<div class="h-4 w-[1px] bg-slate-800 mx-1"></div>
+
+					<a
+						href={linkEditUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-slate-800 text-slate-400 hover:text-slate-200 transition-colors"
+						title="Open link in new tab"
+					>
+						<Icon name="lucide:external-link" class="w-3.5 h-3.5" />
+					</a>
+
+					<button
+						type="button"
+						onclick={() => {
+							if (activeLinkNode) {
+								const text = activeLinkNode.textContent || '';
+								const textNode = document.createTextNode(text);
+								activeLinkNode.replaceWith(textNode);
+								if (editorRef) html = editorRef.innerHTML;
+								activeLinkNode = null;
+							}
+						}}
+						class="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-slate-800 text-slate-400 hover:text-slate-200 transition-colors border-none bg-transparent cursor-pointer"
+						title="Unlink"
+					>
+						<Icon name="lucide:unlink" class="w-3.5 h-3.5" />
+					</button>
+
+					<button
+						type="button"
+						onclick={() => {
+							navigator.clipboard.writeText(linkEditUrl);
+							copySuccess = true;
+							setTimeout(() => copySuccess = false, 1500);
+						}}
+						class="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-slate-800 text-slate-400 hover:text-slate-200 transition-colors border-none bg-transparent cursor-pointer relative"
+						title={copySuccess ? "Copied!" : "Copy link"}
+					>
+						<Icon name={copySuccess ? "lucide:check" : "lucide:copy"} class="w-3.5 h-3.5 {copySuccess ? 'text-green-400' : ''}" />
+					</button>
+
+					<a
+						href="https://id.atlassian.com/manage-profile/link-preferences"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-slate-800 text-slate-400 hover:text-slate-200 transition-colors"
+						title="Go to Link Preferences"
+					>
+						<Icon name="lucide:settings" class="w-3.5 h-3.5" />
+					</a>
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>
+
+{#if activeCodeNode && isCodeActive && enableCodeToolbar}
+	<div
+		bind:this={codeToolbarRef}
+		id="code-block-toolbar"
+		style="top: {codeToolbarCoords.top}px; left: {codeToolbarCoords.left}px; transform: translateX(-50%);"
+		class="absolute z-50 p-1 rounded-lg border border-slate-700 bg-slate-950 shadow-2xl flex items-center gap-1 text-xs select-none"
+	>
+		<!-- Language Dropdown -->
+		<select
+			value={activeCodeLanguage}
+			onchange={(e) => handleSelectCodeLanguage(e.currentTarget.value)}
+			class="px-2 py-1 rounded bg-slate-900 border border-slate-700 text-slate-200 text-xs focus:outline-none focus:ring-1 focus:ring-violet-500 cursor-pointer min-w-28 relative z-50"
+		>
+			{#each codeLanguages as lang}
+				<option value={lang.id}>{lang.name}</option>
+			{/each}
+		</select>
+
+		<div class="h-4 w-[1px] bg-slate-700 mx-1"></div>
+
+		<!-- Wrap toggle -->
+		<button
+			type="button"
+			onmousedown={(e) => e.preventDefault()}
+			onclick={handleToggleCodeWrap}
+			class="p-1 rounded hover:bg-slate-800 border-none cursor-pointer text-slate-400 hover:text-slate-200 flex items-center justify-center transition-colors {activeCodeIsWrapped ? 'bg-slate-850 text-violet-400' : 'bg-transparent'}"
+			title="Wrap lines"
+		>
+			<Icon name="lucide:wrap-text" class="w-4 h-4" />
+		</button>
+		
+		<!-- Delete snippet button -->
+		<button
+			type="button"
+			onmousedown={(e) => e.preventDefault()}
+			onclick={handleDeleteCodeBlock}
+			class="p-1 rounded hover:bg-slate-800 border-none cursor-pointer text-slate-400 hover:text-red-400 flex items-center justify-center transition-colors bg-transparent"
+			title="Delete code block"
+		>
+			<Icon name="lucide:trash" class="w-4 h-4" />
+		</button>
+	</div>
+{/if}
+
+{#if showFormattingHelp}
+	<div class="mt-2 p-3 bg-slate-900 rounded-lg border border-slate-850 text-xs leading-relaxed animate-in fade-in slide-in-from-top-1 duration-200 select-none">
+		<div class="flex items-center justify-between border-b border-slate-800 pb-1.5 mb-2">
+			<span class="font-bold text-slate-300">Formatting help</span>
+			<button type="button" onclick={() => showFormattingHelp = false} class="bg-transparent hover:text-slate-200 text-slate-500 border-none cursor-pointer transition-colors p-0">
+				<Icon name="lucide:x" class="w-3.5 h-3.5" />
+			</button>
+		</div>
+		<div class="grid grid-cols-2 gap-3 text-slate-400 font-medium">
+			<div>
+				<div class="mb-1.5"><span class="text-slate-300 bg-slate-950 px-1 py-0.5 rounded font-mono border border-slate-800 font-bold"># Heading</span> for Header 1</div>
+				<div class="mb-1.5"><span class="text-slate-300 bg-slate-950 px-1 py-0.5 rounded font-mono border border-slate-800 font-bold">## Heading</span> for Header 2</div>
+				<div class="mb-1.5"><span class="text-slate-300 bg-slate-950 px-1 py-0.5 rounded font-mono border border-slate-800 font-bold">**text**</span> for <strong class="text-slate-300">Bold</strong></div>
+				<div class="mb-1.5"><span class="text-slate-300 bg-slate-950 px-1 py-0.5 rounded font-mono border border-slate-800 font-bold">*text*</span> for <em class="text-slate-300">Italic</em></div>
+			</div>
+			<div>
+				<div class="mb-1.5"><span class="text-slate-300 bg-slate-950 px-1 py-0.5 rounded font-mono border border-slate-800 font-bold">~~text~~</span> for <del class="text-slate-300">Strikethrough</del></div>
+				<div class="mb-1.5"><span class="text-slate-300 bg-slate-950 px-1 py-0.5 rounded font-mono border border-slate-800 font-bold">`code`</span> for inline code</div>
+				<div class="mb-1.5"><span class="text-slate-300 bg-slate-950 px-1 py-0.5 rounded font-mono border border-slate-800 font-bold">```</span> on empty line for code snippet block</div>
+				<div class="mb-1.5"><span class="text-slate-300 bg-slate-950 px-1 py-0.5 rounded font-mono border border-slate-800 font-bold">&gt; text</span> for block quote</div>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	[contenteditable="true"] {
+		font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !important;
+	}
+	[contenteditable="true"] :global(h1) {
+		font-size: 1.5rem !important;
+		font-weight: 700 !important;
+		margin-top: 1rem !important;
+		margin-bottom: 0.5rem !important;
+	}
+	[contenteditable="true"] :global(h2) {
+		font-size: 1.25rem !important;
+		font-weight: 700 !important;
+		margin-top: 1rem !important;
+		margin-bottom: 0.5rem !important;
+	}
+	[contenteditable="true"] :global(h3) {
+		font-size: 1.125rem !important;
+		font-weight: 700 !important;
+		margin-top: 1rem !important;
+		margin-bottom: 0.5rem !important;
+	}
+	[contenteditable="true"] :global(p) {
+		margin-top: 0.5rem !important;
+		margin-bottom: 0.5rem !important;
+	}
+	[contenteditable="true"] :global(strong) {
+		font-weight: 700 !important;
+		color: rgb(241 245 249) !important;
+	}
+	[contenteditable="true"] :global(em) {
+		font-style: italic !important;
+	}
+	[contenteditable="true"] :global(ul) {
+		list-style-type: disc !important;
+		padding-left: 1.25rem !important;
+		margin-top: 0.5rem !important;
+		margin-bottom: 0.5rem !important;
+	}
+	[contenteditable="true"] :global(ol) {
+		list-style-type: decimal !important;
+		padding-left: 1.25rem !important;
+		margin-top: 0.5rem !important;
+		margin-bottom: 0.5rem !important;
+	}
+	[contenteditable="true"] :global(li) {
+		display: list-item !important;
+		margin-top: 0.25rem !important;
+		margin-bottom: 0.25rem !important;
+	}
+	[contenteditable="true"] :global(pre) {
+		background-color: rgb(15 23 42) !important;
+		color: rgb(241 245 249) !important;
+		padding: 0.75rem 0.75rem 0.75rem 1.75rem !important;
+		border-radius: 0.5rem !important;
+		border: 1px solid rgb(51 65 85) !important;
+		font-family: monospace !important;
+		font-size: 0.875rem !important;
+		margin: 1rem 0 !important;
+		overflow-x: auto !important;
+		position: relative !important;
+	}
+	[contenteditable="true"] :global(pre)::before {
+		content: "" !important;
+		position: absolute !important;
+		left: 0 !important;
+		top: 0 !important;
+		bottom: 0 !important;
+		width: 1.75rem !important;
+		background-color: rgba(30, 41, 59, 0.4) !important;
+		border-right: 1px solid rgba(71, 85, 105, 0.4) !important;
+		border-radius: 0.5rem 0 0 0.5rem !important;
+		pointer-events: none !important;
+	}
+	[contenteditable="true"] :global(pre code) {
+		background-color: transparent !important;
+		padding: 0 !important;
+		border-radius: 0 !important;
+		font-size: 1em !important;
+		display: block !important;
+		counter-reset: line !important;
+	}
+	[contenteditable="true"] :global(pre code div) {
+		position: relative !important;
+		padding-left: 0.6rem !important;
+	}
+	[contenteditable="true"] :global(pre code div)::before {
+		counter-increment: line !important;
+		content: counter(line) !important;
+		position: absolute !important;
+		top: 0 !important;
+		bottom: 0 !important;
+		left: -1.75rem !important;
+		width: 1.75rem !important;
+		display: inline-flex !important;
+		align-items: center !important;
+		justify-content: center !important;
+		color: rgb(100 116 139) !important;
+		font-size: 0.75rem !important;
+		font-family: monospace !important;
+		pointer-events: none !important;
+		user-select: none !important;
+	}
+	[contenteditable="true"] :global(blockquote) {
+		border-left: 0.25rem solid rgb(139 92 246) !important;
+		padding-left: 1rem !important;
+		color: rgb(148 163 184) !important;
+		margin: 0.5rem 0 !important;
+		font-style: italic !important;
+	}
+	[contenteditable="true"] :global(pre code .token-keyword) {
+		color: #569cd6 !important;
+		font-weight: 500;
+	}
+	[contenteditable="true"] :global(pre code .token-string) {
+		color: #80c990 !important;
+	}
+	[contenteditable="true"] :global(pre code .token-comment) {
+		color: #6a9955 !important;
+		font-style: italic;
+	}
+	[contenteditable="true"] :global(pre code .token-number) {
+		color: #b5cea8 !important;
+	}
+	[contenteditable="true"] :global(pre code .token-function) {
+		color: #dcdcaa !important;
+	}
+	[contenteditable="true"] :global(pre code .token-builtin) {
+		color: #4fc1ff !important;
+	}
+	[contenteditable="true"] :global(pre code .token-operator) {
+		color: #d4d4d4 !important;
+	}
+	[contenteditable="true"] :global(a) {
+		color: #579dff !important;
+		text-decoration: underline !important;
+		cursor: pointer !important;
+	}
+	[contenteditable="true"] :global(a:hover) {
+		color: #85b8ff !important;
+	}
+</style>

--- a/frontend/components/task-client/TaskClientButton.svelte
+++ b/frontend/components/task-client/TaskClientButton.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import Icon from '$frontend/components/common/display/Icon.svelte';
+  interface Props {
+    collapsed?: boolean;
+    mobile?: boolean;
+    onClick: () => void;
+  }
+  const { collapsed = false, mobile = false, onClick }: Props = $props();
+</script>
+
+{#if collapsed}
+  <button
+    type="button"
+    class="flex items-center justify-center bg-transparent border-none text-slate-500 cursor-pointer transition-all duration-150 relative {mobile ? 'w-9 h-8 rounded-md active:bg-violet-500/10' : 'w-9 h-9 rounded-lg hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100'}"
+    onclick={onClick}
+    aria-label="Task Client"
+    title="Task Client"
+  >
+    <Icon name="lucide:list-check" class="w-5 h-5" />
+  </button>
+{:else}
+  <button
+    type="button"
+    class="flex items-center gap-2.5 w-full py-2.5 px-3 bg-transparent border-none rounded-lg text-slate-500 text-sm cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
+    onclick={onClick}
+  >
+    <div class="relative">
+      <Icon name="lucide:list-check" class="w-4 h-4" />
+    </div>
+    <span class="flex-1 text-left">Task Client</span>
+  </button>
+{/if}

--- a/frontend/components/task-client/TaskClientModal.svelte
+++ b/frontend/components/task-client/TaskClientModal.svelte
@@ -1,0 +1,1473 @@
+<script lang="ts">
+	import Modal from '$frontend/components/common/overlay/Modal.svelte';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { taskClientStore, type TrelloBoard } from '$frontend/stores/features/task-client.svelte';
+	import type { IconName } from '$shared/types/ui/icons';
+	import CardDetailModal from './CardDetailModal.svelte';
+
+
+	interface TaskProvider {
+		id: string;
+		name: string;
+		description: string;
+		icon: IconName;
+		color: string;
+		available: boolean;
+	}
+
+	interface Props {
+		isOpen: boolean;
+		onClose: () => void;
+	}
+
+	let { isOpen = $bindable(), onClose }: Props = $props();
+
+	const providers: TaskProvider[] = [
+		{
+			id: 'trello',
+			name: 'Trello',
+			description: 'Trello boards and cards',
+			icon: 'lucide:trello',
+			color: '#0052CC',
+			available: true
+		},
+		{
+			id: 'github',
+			name: 'GitHub Issues',
+			description: 'GitHub issues and pull requests',
+			icon: 'lucide:github',
+			color: '#24292e',
+			available: false
+		},
+		{
+			id: 'linear',
+			name: 'Linear',
+			description: 'Linear issues and projects',
+			icon: 'lucide:zap',
+			color: '#5E6AD2',
+			available: false
+		},
+		{
+			id: 'jira',
+			name: 'Jira',
+			description: 'Atlassian Jira projects',
+			icon: 'lucide:layout-dashboard',
+			color: '#0065FF',
+			available: false
+		}
+	];
+
+	let selectedProviderId = $state<string>('trello');
+	const selectedProvider = $derived(providers.find((p) => p.id === selectedProviderId) ?? providers[0]);
+
+	// Add/Edit account form
+	let showAddForm = $state(false);
+	let editingAccountId = $state<string | null>(null);
+	let addApiKey = $state('');
+	let addToken = $state('');
+	let addName = $state('');
+	let addLoading = $state(false);
+	let addError = $state<string | null>(null);
+
+	// Masking & Edit state for sensitive credentials
+	let isEditingApiKey = $state(false);
+	let isEditingToken = $state(false);
+	let tempApiKey = $state('');
+	let tempToken = $state('');
+
+	// Trello view state
+	type TrelloView = 'accounts' | 'boards' | 'board';
+	let trelloView = $state<TrelloView>('accounts');
+
+	function selectProvider(id: string) {
+		selectedProviderId = id;
+		showAddForm = false;
+		editingAccountId = null;
+		addError = null;
+	}
+
+	function openAddForm() {
+		showAddForm = true;
+		editingAccountId = null;
+		addName = '';
+		addApiKey = '';
+		addToken = '';
+		isEditingApiKey = false;
+		isEditingToken = false;
+		tempApiKey = '';
+		tempToken = '';
+		addError = null;
+	}
+
+	function openEditForm(account: typeof taskClientStore.accounts[0]) {
+		showAddForm = true;
+		editingAccountId = account.id;
+		addName = account.displayName;
+		addApiKey = account.apiKey;
+		addToken = account.token;
+		isEditingApiKey = false;
+		isEditingToken = false;
+		tempApiKey = '';
+		tempToken = '';
+		addError = null;
+	}
+
+	function cancelAdd() {
+		showAddForm = false;
+		editingAccountId = null;
+		addApiKey = '';
+		addToken = '';
+		addName = '';
+		isEditingApiKey = false;
+		isEditingToken = false;
+		tempApiKey = '';
+		tempToken = '';
+		addError = null;
+	}
+
+	async function confirmAdd() {
+		if (!addApiKey.trim() || !addToken.trim()) {
+			addError = 'API Key and Token are required.';
+			return;
+		}
+		addLoading = true;
+		addError = null;
+		try {
+			const account = await taskClientStore.addAccount(addApiKey.trim(), addToken.trim(), addName.trim());
+			if (editingAccountId && editingAccountId !== account.id) {
+				taskClientStore.removeAccount(editingAccountId);
+			}
+			showAddForm = false;
+			editingAccountId = null;
+			addApiKey = '';
+			addToken = '';
+			addName = '';
+		} catch (e) {
+			addError = e instanceof Error ? e.message : 'Failed to connect account.';
+		} finally {
+			addLoading = false;
+		}
+	}
+
+	async function selectAccountAndLoad(id: string) {
+		taskClientStore.selectAccount(id);
+		trelloView = 'boards';
+		// loadBoards is triggered inside selectAccount
+	}
+
+	async function openBoard(boardId: string) {
+		trelloView = 'board';
+		await taskClientStore.selectBoard(boardId);
+	}
+
+	async function selectRecentBoardAndLoad(boardId: string, accountId: string) {
+		trelloView = 'board';
+		await taskClientStore.selectRecentBoard(boardId, accountId);
+	}
+
+	function backToBoards() {
+		trelloView = 'boards';
+	}
+
+	function backToAccounts() {
+		trelloView = 'accounts';
+	}
+
+	const boardBg = $derived(
+		taskClientStore.selectedBoard?.prefs?.backgroundColor ?? '#0052CC'
+	);
+
+	const groupedWorkspaces = $derived.by(() => {
+		const orgMap = new Map<string | null, { name: string; boards: typeof taskClientStore.boards }>();
+		
+		// Initialize org map with known organizations to preserve order
+		for (const org of taskClientStore.organizations) {
+			orgMap.set(org.id, { name: org.displayName, boards: [] });
+		}
+		
+		// Personal boards organization
+		orgMap.set(null, { name: 'Personal Boards', boards: [] });
+		
+		// Distribute boards into organizations
+		for (const board of taskClientStore.boards) {
+			const orgId = board.idOrganization || null;
+			if (!orgMap.has(orgId)) {
+				orgMap.set(orgId, { name: orgId === null ? 'Personal Boards' : 'Other Workspace', boards: [] });
+			}
+			orgMap.get(orgId)!.boards.push(board);
+		}
+		
+		// Filter out organizations that have no boards
+		const groups: { id: string | null; name: string; boards: typeof taskClientStore.boards }[] = [];
+		
+		// Check organizations in list order
+		for (const org of taskClientStore.organizations) {
+			const group = orgMap.get(org.id);
+			if (group && group.boards.length > 0) {
+				groups.push({ id: org.id, name: group.name, boards: group.boards });
+			}
+		}
+		
+		// Append personal boards if there are any
+		const personalGroup = orgMap.get(null);
+		if (personalGroup && personalGroup.boards.length > 0) {
+			groups.push({ id: null, name: personalGroup.name, boards: personalGroup.boards });
+		}
+		
+		// If there are other workspaces not in the list but have boards, add them too
+		for (const [orgId, group] of orgMap.entries()) {
+			if (orgId !== null && !taskClientStore.organizations.some(org => org.id === orgId)) {
+				if (group.boards.length > 0) {
+					groups.push({ id: orgId, name: group.name, boards: group.boards });
+				}
+			}
+		}
+		
+		return groups;
+	});
+
+	const starredBoards = $derived.by(() => {
+		return taskClientStore.boards.filter((b) =>
+			taskClientStore.boardStars.some((s) => s.idBoard === b.id)
+		);
+	});
+
+	// Drag-and-drop state
+	let draggedCardId = $state<string | null>(null);
+	let draggingId = $state<string | null>(null);
+	let activeDropListId = $state<string | null>(null);
+	let activeDropIndex = $state<number | null>(null);
+
+	function handleDragStart(e: DragEvent, cardId: string) {
+		draggedCardId = cardId;
+		if (e.dataTransfer) {
+			e.dataTransfer.setData('text/plain', cardId);
+			e.dataTransfer.effectAllowed = 'move';
+		}
+		// Delay hiding the card so the browser has time to capture the drag image
+		setTimeout(() => {
+			draggingId = cardId;
+		}, 0);
+	}
+
+	function handleDragOver(e: DragEvent, listId: string) {
+		e.preventDefault();
+		if (e.dataTransfer) {
+			e.dataTransfer.dropEffect = 'move';
+		}
+		if (activeDropListId !== listId) {
+			activeDropListId = listId;
+		}
+
+		// Calculate index where we are currently hovering
+		const targetEl = e.target as HTMLElement;
+		const container = targetEl.closest('.cards-list-container') as HTMLElement;
+		if (!container) return;
+
+		const y = e.clientY;
+		const cardElements = [...container.querySelectorAll('[data-card-id]')];
+		
+		let closestIndex = cardElements.length;
+		for (let i = 0; i < cardElements.length; i++) {
+			const box = cardElements[i].getBoundingClientRect();
+			const center = box.top + box.height / 2;
+			if (y < center) {
+				closestIndex = i;
+				break;
+			}
+		}
+		
+		activeDropIndex = closestIndex;
+	}
+
+	function handleDragEnd() {
+		activeDropListId = null;
+		activeDropIndex = null;
+		draggedCardId = null;
+		draggingId = null;
+	}
+
+	function getTargetPosition(e: DragEvent, targetListId: string, dragCardId: string): number {
+		const targetEl = e.target as HTMLElement;
+		const container = targetEl.closest('.cards-list-container') as HTMLElement;
+		if (!container) return 16384;
+
+		const y = e.clientY;
+		const cardElements = [...container.querySelectorAll('[data-card-id]')];
+		
+		let closestIndex = cardElements.length;
+		for (let i = 0; i < cardElements.length; i++) {
+			const box = cardElements[i].getBoundingClientRect();
+			const center = box.top + box.height / 2;
+			if (y < center) {
+				closestIndex = i;
+				break;
+			}
+		}
+
+		const listCards = taskClientStore.getCardsForList(targetListId).filter(c => c.id !== dragCardId);
+		
+		if (listCards.length === 0) {
+			return 16384;
+		}
+		
+		if (closestIndex === 0) {
+			return listCards[0].pos / 2;
+		}
+		
+		if (closestIndex >= listCards.length) {
+			return listCards[listCards.length - 1].pos + 16384;
+		}
+		
+		const prevCard = listCards[closestIndex - 1];
+		const nextCard = listCards[closestIndex];
+		return (prevCard.pos + nextCard.pos) / 2;
+	}
+
+	async function handleDrop(e: DragEvent, targetListId: string) {
+		e.preventDefault();
+		const cardId = e.dataTransfer?.getData('text/plain') || draggedCardId || draggingId;
+		activeDropListId = null;
+		activeDropIndex = null;
+		draggedCardId = null;
+		draggingId = null;
+		if (!cardId) return;
+		const targetPos = getTargetPosition(e, targetListId, cardId);
+		await taskClientStore.moveCard(cardId, targetListId, targetPos);
+	}
+
+	// Create card state
+	let addingCardListId = $state<string | null>(null);
+	let newCardName = $state('');
+	let addCardLoading = $state(false);
+
+	function startAddCard(listId: string) {
+		addingCardListId = listId;
+		newCardName = '';
+	}
+
+	function cancelAddCard() {
+		addingCardListId = null;
+		newCardName = '';
+	}
+
+	async function submitNewCard(listId: string) {
+		if (!newCardName.trim() || addCardLoading) return;
+		addCardLoading = true;
+		try {
+			await taskClientStore.createCard(listId, newCardName);
+			newCardName = '';
+		} catch (e) {
+			// error is handled in store
+		} finally {
+			addCardLoading = false;
+		}
+	}
+
+	function handleAddCardKeydown(e: KeyboardEvent, listId: string) {
+		if (e.key === 'Enter' && !e.shiftKey) {
+			e.preventDefault();
+			submitNewCard(listId);
+		} else if (e.key === 'Escape') {
+			cancelAddCard();
+		}
+	}
+
+	function focusOnMount(node: HTMLTextAreaElement) {
+		node.focus();
+	}
+
+	// List actions state
+	let activeListActionsMenuId = $state<string | null>(null);
+
+	function toggleListActionsMenu(listId: string) {
+		if (activeListActionsMenuId === listId) {
+			activeListActionsMenuId = null;
+		} else {
+			activeListActionsMenuId = listId;
+		}
+	}
+
+	function closeListActionsMenu() {
+		activeListActionsMenuId = null;
+	}
+
+	function triggerAddCardFromMenu(listId: string) {
+		closeListActionsMenu();
+		startAddCard(listId);
+	}
+
+	async function triggerArchiveList(listId: string) {
+		closeListActionsMenu();
+		await taskClientStore.archiveList(listId);
+	}
+
+	async function triggerArchiveAllCards(listId: string) {
+		closeListActionsMenu();
+		await taskClientStore.archiveAllCards(listId);
+	}
+
+	// Active card details modal state
+	let activeDetailCardId = $state<string | null>(null);
+	let isDetailModalOpen = $state(false);
+	let expandedChecklists = $state<Record<string, boolean>>({});
+	let showCardChecklists = $state<Record<string, boolean>>({});
+
+	function formatCardDates(start: string | null, due: string | null): string {
+		if (!due) return '';
+		const formatOption = (d: string) => {
+			const date = new Date(d);
+			return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+		};
+		const dueStr = formatOption(due);
+		if (!start) return dueStr;
+		const startStr = formatOption(start);
+		return `${startStr} - ${dueStr}`;
+	}
+
+	function getDueDateBadgeClass(card: any): string {
+		if (!card.due) return '';
+		if (card.dueComplete) {
+			return 'bg-green-500 border-green-500 text-white hover:bg-green-600';
+		}
+		const dueTime = new Date(card.due).getTime();
+		const nowTime = Date.now();
+		const diffHrs = (dueTime - nowTime) / (1000 * 60 * 60);
+		if (diffHrs < 0) {
+			return 'bg-red-500 border-red-500 text-white hover:bg-red-600';
+		}
+		if (diffHrs < 24) {
+			return 'bg-[#f2d600] border-[#d8be00]/50 text-slate-900 font-semibold hover:bg-yellow-400';
+		}
+		return 'bg-slate-100 hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700/80 border-transparent text-slate-500 dark:text-slate-400';
+	}
+
+	function handleCardClick(e: MouseEvent, cardId: string) {
+		console.log('handleCardClick triggered for cardId:', cardId, 'button:', e.button);
+		if (e.button === 0 && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+			e.preventDefault();
+			activeDetailCardId = cardId;
+			isDetailModalOpen = true;
+			console.log('isDetailModalOpen set to true, activeDetailCardId:', cardId);
+		}
+	}
+
+	function handleWindowKeyDown(e: KeyboardEvent) {
+		if (e.key === 'Escape' && taskClientStore.error) {
+			taskClientStore.error = null;
+		}
+	}
+</script>
+
+<svelte:window onkeydown={handleWindowKeyDown} />
+
+<Modal
+	bind:isOpen
+	{onClose}
+	bare
+	mobileFullscreen
+	ariaLabelledBy="task-client-title"
+	className="flex flex-col w-full max-w-[90vw] h-[85dvh] max-h-[900px] bg-slate-50 dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-2xl overflow-hidden shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)] dark:shadow-[0_25px_50px_-12px_rgba(0,0,0,0.5)]"
+>
+	{#snippet children()}
+		<div class="flex flex-1 min-h-0">
+			<!-- Left sidebar: provider list -->
+			<aside class="flex flex-col w-64 shrink-0 bg-white dark:bg-slate-900/98 border-r border-slate-200 dark:border-slate-800">
+				<header class="flex items-center justify-between py-3 px-4 border-b border-slate-200 dark:border-slate-800 shrink-0">
+					<h2 id="task-client-title" class="text-sm font-bold text-slate-900 dark:text-slate-100 m-0">Task Client</h2>
+					<button
+						type="button"
+						class="flex items-center justify-center w-8 h-8 bg-transparent border-none rounded-lg text-slate-400 cursor-pointer transition-all hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
+						onclick={onClose}
+						aria-label="Close"
+					>
+						<Icon name="lucide:x" class="w-4 h-4" />
+					</button>
+				</header>
+
+				<div class="px-4 py-3 border-b border-slate-200 dark:border-slate-800 shrink-0">
+					<p class="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">
+						Connect accounts and configure providers for your task management.
+					</p>
+				</div>
+
+				<div class="flex-1 overflow-y-auto p-3">
+					<div class="grid grid-cols-2 gap-2">
+						{#each providers as provider}
+							<button
+								type="button"
+								onclick={() => selectProvider(provider.id)}
+								class="relative flex flex-col items-start gap-2 p-3 rounded-xl border text-left transition-all cursor-pointer
+									{selectedProviderId === provider.id
+										? 'border-violet-500 bg-violet-500/8 dark:bg-violet-500/10'
+										: 'border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 hover:border-slate-300 dark:hover:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/60'}
+									{!provider.available ? 'opacity-50' : ''}"
+							>
+								{#if !provider.available}
+									<span class="absolute top-1.5 right-1.5 text-[9px] px-1 py-0.5 bg-slate-100 dark:bg-slate-800 rounded text-slate-400 font-medium">Soon</span>
+								{/if}
+								<div
+									class="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
+									style="background-color: {provider.color}20; color: {provider.color}"
+								>
+									<Icon name={provider.icon} class="w-4 h-4" />
+								</div>
+								<div class="min-w-0 w-full">
+									<div class="text-xs font-semibold text-slate-900 dark:text-slate-100 truncate">{provider.name}</div>
+									{#if provider.id === 'trello'}
+										<div class="text-[10px] text-slate-500 dark:text-slate-400 mt-0.5">
+											{taskClientStore.accounts.length} account{taskClientStore.accounts.length !== 1 ? 's' : ''}
+										</div>
+									{:else}
+										<div class="text-[10px] text-slate-500 dark:text-slate-400 mt-0.5">0 accounts</div>
+									{/if}
+								</div>
+							</button>
+						{/each}
+					</div>
+				</div>
+			</aside>
+
+			<!-- Right panel -->
+			<main class="flex-1 flex flex-col min-w-0 bg-slate-50 dark:bg-slate-950 relative">
+				<!-- Provider header -->
+				<div class="px-6 py-4 border-b border-slate-200 dark:border-slate-800 shrink-0">
+					<div class="flex items-center gap-3">
+						<div
+							class="w-10 h-10 rounded-xl flex items-center justify-center"
+							style="background-color: {selectedProvider.color}20; color: {selectedProvider.color}"
+						>
+							<Icon name={selectedProvider.icon} class="w-5 h-5" />
+						</div>
+						<div class="flex-1 min-w-0">
+							<h3 class="text-base font-bold text-slate-900 dark:text-slate-100">{selectedProvider.name}</h3>
+							<p class="text-xs text-slate-500 dark:text-slate-400">{selectedProvider.description}</p>
+						</div>
+					</div>
+				</div>
+
+				<!-- Floating pill tab bar - bottom center -->
+				{#if selectedProviderId === 'trello'}
+					<div class="absolute bottom-5 left-1/2 -translate-x-1/2 z-30 flex items-center gap-1 bg-slate-900/95 backdrop-blur-md rounded-2xl px-1.5 py-1.5 border border-slate-700/60 shadow-2xl">
+						<!-- Account tab -->
+						<button
+							type="button"
+							onclick={backToAccounts}
+							class="relative flex items-center gap-1.5 px-3.5 py-2 rounded-xl text-xs font-semibold transition-all cursor-pointer border-none {trelloView === 'accounts' ? 'bg-slate-800 text-slate-100' : 'bg-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-800/60'}"
+						>
+							<Icon name="lucide:user" class="w-3.5 h-3.5" />
+							Account
+							{#if trelloView === 'accounts'}
+								<span class="absolute bottom-0.5 left-1/2 -translate-x-1/2 w-4 h-[2px] rounded-full bg-blue-500"></span>
+							{/if}
+						</button>
+
+						<!-- Board tab (shown when past accounts view) -->
+						{#if trelloView === 'boards' || trelloView === 'board'}
+							<button
+								type="button"
+								onclick={backToBoards}
+								class="relative flex items-center gap-1.5 px-3.5 py-2 rounded-xl text-xs font-semibold transition-all cursor-pointer border-none {trelloView === 'boards' ? 'bg-slate-800 text-slate-100' : 'bg-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-800/60'}"
+							>
+								<Icon name="lucide:layout-dashboard" class="w-3.5 h-3.5" />
+								Board
+								{#if trelloView === 'boards'}
+									<span class="absolute bottom-0.5 left-1/2 -translate-x-1/2 w-4 h-[2px] rounded-full bg-blue-500"></span>
+								{/if}
+							</button>
+						{/if}
+
+						<!-- Active board name tab -->
+						{#if trelloView === 'board' && taskClientStore.selectedBoard}
+							<button
+								type="button"
+								class="relative flex items-center gap-1.5 px-3.5 py-2 rounded-xl text-xs font-semibold cursor-pointer border-none bg-slate-800 text-slate-100 max-w-36"
+								disabled
+							>
+								<Icon name="lucide:trello" class="w-3.5 h-3.5 shrink-0" />
+								<span class="truncate">{taskClientStore.selectedBoard.name}</span>
+								<span class="absolute bottom-0.5 left-1/2 -translate-x-1/2 w-4 h-[2px] rounded-full bg-blue-500"></span>
+							</button>
+
+							<!-- Switch boards -->
+							<button
+								type="button"
+								onclick={backToBoards}
+								class="flex items-center gap-1.5 px-3.5 py-2 rounded-xl text-xs font-semibold transition-all cursor-pointer border-none bg-transparent text-slate-400 hover:text-slate-200 hover:bg-slate-800/60"
+							>
+								<Icon name="lucide:arrow-left-right" class="w-3.5 h-3.5" />
+								Switch boards
+							</button>
+						{/if}
+					</div>
+				{/if}
+
+				<!-- Trello content -->
+				{#if selectedProviderId === 'trello'}
+					{#if trelloView === 'accounts'}
+						<!-- Accounts list -->
+						<div class="flex-1 overflow-y-auto p-6">
+							<div class="max-w-xl mx-auto w-full flex flex-col gap-6">
+							{#if taskClientStore.recentBoards.length > 0}
+								<div class="mb-6">
+									<h4 class="text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-3">Recent Boards</h4>
+									<div class="grid grid-cols-2 gap-3">
+										{#each taskClientStore.recentBoards as board}
+											<button
+												type="button"
+												onclick={() => selectRecentBoardAndLoad(board.id, board.accountId)}
+												class="relative flex flex-col items-start gap-1 p-3.5 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 hover:border-violet-400 dark:hover:border-violet-500/60 hover:shadow-md hover:shadow-violet-500/5 transition-all text-left cursor-pointer group overflow-hidden"
+											>
+												<div
+													class="absolute inset-0 opacity-5 dark:opacity-10 pointer-events-none transition-opacity group-hover:opacity-10 dark:group-hover:opacity-15"
+													style="background-color: {board.prefs?.backgroundColor ?? '#0052CC'}; background-image: {board.prefs?.backgroundImage ? `url(${board.prefs.backgroundImage})` : 'none'}; background-size: cover; background-position: center;"
+												></div>
+												
+												<div class="flex items-center gap-2 z-10 w-full min-w-0">
+													<div class="w-2.5 h-2.5 rounded-full shrink-0" style="background-color: {board.prefs?.backgroundColor ?? '#0052CC'}"></div>
+													<span class="text-xs font-bold text-slate-800 dark:text-slate-100 truncate flex-1">{board.name}</span>
+												</div>
+												
+												<div class="flex items-center gap-1 text-[10px] text-slate-400 dark:text-slate-500 z-10 truncate w-full mt-1.5 pl-4">
+													<Icon name="lucide:user" class="w-3 h-3 shrink-0" />
+													<span class="truncate">{board.accountName}</span>
+												</div>
+											</button>
+										{/each}
+									</div>
+								</div>
+							{/if}
+
+							<!-- Section header -->
+							<div class="flex items-center justify-between mb-4">
+								<div>
+									<h4 class="text-sm font-bold text-slate-800 dark:text-slate-100">Connected Accounts</h4>
+									<p class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">Click an account to browse its boards</p>
+								</div>
+								{#if taskClientStore.accounts.length > 0}
+									<span class="text-xs font-medium text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-800 px-2.5 py-1 rounded-full">
+										{taskClientStore.accounts.length} connected
+									</span>
+								{/if}
+							</div>
+
+							{#if taskClientStore.accounts.length > 0}
+								<div class="grid grid-cols-1 gap-3">
+									{#each taskClientStore.accounts as account}
+										<div class="group relative">
+											<!-- Main card button -->
+											<button
+												type="button"
+												onclick={() => selectAccountAndLoad(account.id)}
+												class="w-full flex items-center gap-4 p-4 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 hover:border-violet-400 dark:hover:border-violet-500/60 hover:shadow-md hover:shadow-violet-500/5 transition-all text-left cursor-pointer"
+											>
+												<!-- Avatar -->
+												<div class="relative shrink-0">
+													{#if account.me?.avatarUrl}
+														<img src="{account.me.avatarUrl}/50.png" alt={account.displayName} class="w-10 h-10 rounded-full object-cover ring-2 ring-slate-200 dark:ring-slate-700" />
+													{:else}
+														<div class="w-10 h-10 rounded-full bg-gradient-to-br from-violet-500 to-violet-700 flex items-center justify-center ring-2 ring-violet-500/20">
+															<Icon name="lucide:user" class="w-5 h-5 text-white" />
+														</div>
+													{/if}
+													<!-- Online indicator -->
+													<span class="absolute bottom-0 right-0 w-2.5 h-2.5 bg-emerald-500 rounded-full ring-2 ring-white dark:ring-slate-900"></span>
+												</div>
+
+												<!-- Info -->
+												<div class="flex-1 min-w-0">
+													<div class="flex items-center gap-2">
+														<span class="text-sm font-semibold text-slate-800 dark:text-slate-100 truncate">{account.displayName}</span>
+														<span class="shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20">Connected</span>
+													</div>
+													{#if account.me?.username}
+														<div class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">@{account.me.username}</div>
+													{/if}
+												</div>
+
+												<!-- Spacing placeholder for Arrow & Action buttons -->
+												<div class="w-18 h-8 shrink-0 flex items-center justify-end">
+													<!-- Arrow (fades out on hover) -->
+													<Icon name="lucide:arrow-right" class="w-4 h-4 text-slate-300 dark:text-slate-600 group-hover:opacity-0 group-hover:scale-75 transition-all duration-200 shrink-0" />
+												</div>
+											</button>
+
+											<!-- Actions container - appears on hover, perfectly aligned over the arrow -->
+											<div class="absolute right-4 top-1/2 -translate-y-1/2 opacity-0 scale-75 group-hover:opacity-100 group-hover:scale-100 flex items-center gap-1.5 transition-all duration-200 z-10">
+												<!-- Edit button -->
+												<button
+													type="button"
+													onclick={(e) => { e.stopPropagation(); openEditForm(account); }}
+													aria-label="Edit account"
+													class="flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-500 hover:bg-violet-500/10 hover:text-violet-600 dark:hover:text-violet-400 transition-all duration-200 border-none cursor-pointer"
+												>
+													<Icon name="lucide:pencil" class="w-3.5 h-3.5" />
+												</button>
+
+												<!-- Delete button -->
+												<button
+													type="button"
+													onclick={(e) => { e.stopPropagation(); taskClientStore.removeAccount(account.id); }}
+													aria-label="Remove account"
+													class="flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-500 hover:bg-red-500/10 hover:text-red-500 transition-all duration-200 border-none cursor-pointer"
+												>
+													<Icon name="lucide:trash-2" class="w-3.5 h-3.5" />
+												</button>
+											</div>
+										</div>
+									{/each}
+								</div>
+							{:else if !showAddForm}
+								<!-- Empty state -->
+								<div class="flex flex-col items-center justify-center py-16 text-center">
+									<div class="w-16 h-16 rounded-2xl bg-slate-100 dark:bg-slate-800/60 flex items-center justify-center mb-4">
+										<Icon name="lucide:trello" class="w-8 h-8 text-slate-400" />
+									</div>
+									<p class="text-sm font-semibold text-slate-700 dark:text-slate-300">No accounts connected</p>
+									<p class="text-xs text-slate-400 dark:text-slate-500 mt-1">Add your Trello account to get started</p>
+								</div>
+							{/if}
+
+							<!-- Add Account button (always visible below cards) -->
+							{#if !showAddForm}
+								<div class="mt-4">
+									<button
+										type="button"
+										onclick={openAddForm}
+										class="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl border border-dashed border-slate-200 dark:border-slate-800 text-sm text-slate-500 dark:text-slate-400 hover:text-violet-600 dark:hover:text-violet-400 hover:bg-violet-500/5 hover:border-violet-400 dark:hover:border-violet-500/50 transition-all cursor-pointer bg-transparent"
+									>
+										<Icon name="lucide:plus" class="w-4 h-4" />
+										<span>Add Account</span>
+									</button>
+								</div>
+							{/if}
+
+							<!-- Add/Edit account form -->
+							{#if showAddForm}
+								<div class="mt-4 p-4 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 flex flex-col gap-3">
+									<h5 class="text-xs font-bold text-slate-800 dark:text-slate-200 m-0">
+										{editingAccountId ? 'Edit Account' : 'Connect Account'}
+									</h5>
+
+									<div class="text-xs text-slate-500 dark:text-slate-400 space-y-1.5">
+										<p class="m-0">
+											1. Get your <strong>API Key</strong> from
+											<a href="https://trello.com/power-ups/admin" target="_blank" rel="noopener noreferrer" class="text-violet-600 hover:underline">trello.com/power-ups/admin</a>.
+										</p>
+										<p class="m-0">
+											2. After entering your API Key below, click the authorization button to generate a token with <strong>Read & Write</strong> permissions (required for Trello stars & edit capabilities):
+										</p>
+									</div>
+
+									<!-- Display Name Input -->
+									<div class="flex flex-col gap-1.5">
+										<label for="trello-display-name" class="text-xs font-semibold text-slate-600 dark:text-slate-400">
+											Display Name (optional)
+										</label>
+										<input id="trello-display-name" type="text" placeholder="e.g. My Work Account" bind:value={addName} class="w-full px-3 py-2 text-sm rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-500/40 focus:border-violet-500 transition" />
+									</div>
+
+									<!-- API Key Input -->
+									{#if editingAccountId}
+										{#if !isEditingApiKey}
+											<div class="flex flex-col gap-1.5">
+												<label class="text-xs font-semibold text-slate-600 dark:text-slate-400">
+													API Key
+												</label>
+												<div class="flex items-center justify-between px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/40 text-slate-800 dark:text-slate-200 font-mono text-sm h-9">
+													<span>••••••••{addApiKey.slice(-4)}</span>
+													<button
+														type="button"
+														onclick={() => { isEditingApiKey = true; tempApiKey = ''; }}
+														class="text-xs font-bold text-violet-600 dark:text-violet-400 hover:text-violet-700 hover:underline border-none bg-transparent cursor-pointer"
+													>
+														Change
+													</button>
+												</div>
+											</div>
+										{:else}
+											<div class="flex flex-col gap-1.5">
+												<label for="trello-api-key" class="text-xs font-semibold text-slate-600 dark:text-slate-400">
+													New API Key
+												</label>
+												<div class="flex items-center gap-2">
+													<input
+														id="trello-api-key"
+														type="text"
+														placeholder="Enter new Trello API Key"
+														bind:value={tempApiKey}
+														class="flex-1 px-3 py-2 text-sm rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-500/40 focus:border-violet-500 transition font-mono"
+													/>
+													<button
+														type="button"
+														onclick={() => { if (tempApiKey.trim()) { addApiKey = tempApiKey.trim(); isEditingApiKey = false; } }}
+														class="px-3.5 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg text-xs font-semibold cursor-pointer border-none transition-colors shrink-0"
+													>
+														Save
+													</button>
+													<button
+														type="button"
+														onclick={() => { isEditingApiKey = false; }}
+														class="px-3.5 py-2 border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 rounded-lg text-xs font-semibold cursor-pointer bg-transparent hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors shrink-0"
+													>
+														Cancel
+													</button>
+												</div>
+											</div>
+										{/if}
+									{:else}
+										<div class="flex flex-col gap-1.5">
+											<label for="trello-api-key" class="text-xs font-semibold text-slate-600 dark:text-slate-400">
+												API Key
+											</label>
+											<input id="trello-api-key" type="text" placeholder="Enter Trello API Key" bind:value={addApiKey} class="w-full px-3 py-2 text-sm rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-500/40 focus:border-violet-500 transition font-mono" />
+										</div>
+									{/if}
+									
+									{#if addApiKey.trim()}
+										<a
+											href="https://trello.com/1/authorize?expiration=never&name=Clopen&scope=read,write&response_type=token&key={addApiKey.trim()}"
+											target="_blank"
+											rel="noopener noreferrer"
+											class="flex items-center justify-center gap-1.5 px-3.5 py-2 rounded-xl bg-violet-500/10 text-violet-600 dark:text-violet-400 hover:bg-violet-500/15 text-xs font-semibold text-center transition decoration-none border border-violet-500/20"
+										>
+											<Icon name="lucide:key-round" class="w-3.5 h-3.5" />
+											Authorize Token (Read & Write)
+										</a>
+									{:else}
+										<div class="text-[10px] text-slate-400 bg-slate-50 dark:bg-slate-800/40 p-2.5 rounded-xl border border-slate-200/50 dark:border-slate-800 flex items-center gap-1.5">
+											<Icon name="lucide:info" class="w-3.5 h-3.5 shrink-0 text-slate-400" />
+											<span>Enter your API Key first to display the token authorization link.</span>
+										</div>
+									{/if}
+
+									<!-- Token Input -->
+									{#if editingAccountId}
+										{#if !isEditingToken}
+											<div class="flex flex-col gap-1.5">
+												<label class="text-xs font-semibold text-slate-600 dark:text-slate-400">
+													Token
+												</label>
+												<div class="flex items-center justify-between px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/40 text-slate-800 dark:text-slate-200 font-mono text-sm h-9">
+													<span>••••••••{addToken.slice(-4)}</span>
+													<button
+														type="button"
+														onclick={() => { isEditingToken = true; tempToken = ''; }}
+														class="text-xs font-bold text-violet-600 dark:text-violet-400 hover:text-violet-700 hover:underline border-none bg-transparent cursor-pointer"
+													>
+														Change
+													</button>
+												</div>
+											</div>
+										{:else}
+											<div class="flex flex-col gap-1.5">
+												<label for="trello-token" class="text-xs font-semibold text-slate-600 dark:text-slate-400">
+													New Token
+												</label>
+												<div class="flex items-center gap-2">
+													<input
+														id="trello-token"
+														type="password"
+														placeholder="Enter new Trello Token"
+														bind:value={tempToken}
+														class="flex-1 px-3 py-2 text-sm rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-500/40 focus:border-violet-500 transition font-mono"
+													/>
+													<button
+														type="button"
+														onclick={() => { if (tempToken.trim()) { addToken = tempToken.trim(); isEditingToken = false; } }}
+														class="px-3.5 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg text-xs font-semibold cursor-pointer border-none transition-colors shrink-0"
+													>
+														Save
+													</button>
+													<button
+														type="button"
+														onclick={() => { isEditingToken = false; }}
+														class="px-3.5 py-2 border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 rounded-lg text-xs font-semibold cursor-pointer bg-transparent hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors shrink-0"
+													>
+														Cancel
+													</button>
+												</div>
+											</div>
+										{/if}
+									{:else}
+										<div class="flex flex-col gap-1.5">
+											<label for="trello-token" class="text-xs font-semibold text-slate-600 dark:text-slate-400">
+												Token
+											</label>
+											<input id="trello-token" type="password" placeholder="Enter Trello Token" bind:value={addToken} class="w-full px-3 py-2 text-sm rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-500/40 focus:border-violet-500 transition font-mono" />
+										</div>
+									{/if}
+									{#if addError}
+										<p class="text-xs text-red-500">{addError}</p>
+									{/if}
+									<div class="flex gap-2 justify-end">
+										<button type="button" onclick={cancelAdd} disabled={addLoading} class="px-3 py-1.5 text-xs rounded-lg border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition cursor-pointer bg-transparent disabled:opacity-50">Cancel</button>
+										<button type="button" onclick={confirmAdd} disabled={addLoading} class="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg bg-violet-600 hover:bg-violet-700 text-white font-medium transition cursor-pointer border-none disabled:opacity-50">
+											{#if addLoading}
+												<Icon name="lucide:loader" class="w-3 h-3 animate-spin" /> {editingAccountId ? 'Updating…' : 'Connecting…'}
+											{:else}
+												{editingAccountId ? 'Update Account' : 'Connect Account'}
+											{/if}
+										</button>
+									</div>
+								</div>
+							{/if}
+							</div>
+						</div>
+
+					{:else if trelloView === 'boards'}
+						<!-- Boards list -->
+						{#if taskClientStore.loadingBoards}
+							<div class="flex-1 flex flex-col items-center justify-center p-6 gap-3 text-slate-500 dark:text-slate-400">
+								<Icon name="lucide:loader" class="w-6 h-6 animate-spin text-violet-500" />
+								<span class="text-sm font-semibold">Loading boards…</span>
+							</div>
+						{:else}
+							<div class="flex-1 overflow-y-auto p-6">
+								{#snippet boardCard(board: TrelloBoard)}
+									<div
+										role="button"
+										tabindex="0"
+										onclick={() => openBoard(board.id)}
+										onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openBoard(board.id); } }}
+										class="relative flex flex-col justify-end w-full h-24 p-3.5 rounded-xl hover:shadow-md transition-all text-left cursor-pointer group overflow-hidden border-none text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+										style="background-color: {board.prefs?.backgroundColor ?? '#0052CC'}; background-image: {board.prefs?.backgroundImage ? `url(${board.prefs.backgroundImage})` : 'none'}; background-size: cover; background-position: center;"
+									>
+										<div class="absolute inset-0 bg-gradient-to-t from-black/50 via-black/20 to-black/10 group-hover:from-black/60 group-hover:via-black/35 group-hover:to-black/20 transition-all duration-200"></div>
+										
+										<!-- Star Toggle Button -->
+										<button
+											type="button"
+											onclick={(e) => {
+												e.stopPropagation();
+												taskClientStore.toggleBoardStar(board.id);
+											}}
+											class="absolute top-2.5 right-2.5 z-20 flex items-center justify-center w-7 h-7 rounded-lg text-white hover:bg-white/20 transition-all cursor-pointer border-none bg-transparent"
+											aria-label={taskClientStore.boardStars.some(s => s.idBoard === board.id) ? "Unstar board" : "Star board"}
+										>
+											<Icon
+												name="lucide:star"
+												class="w-4 h-4 transition-all {taskClientStore.boardStars.some(s => s.idBoard === board.id) ? 'text-amber-400 fill-amber-400 opacity-100 scale-110' : 'text-white opacity-0 group-hover:opacity-100 hover:scale-110'}"
+											/>
+										</button>
+
+										<div class="relative z-10 w-full min-w-0">
+											<div class="text-sm font-bold line-clamp-2 leading-tight drop-shadow-sm">{board.name}</div>
+											{#if board.desc}
+												<div class="text-[10px] text-white/80 line-clamp-1 mt-0.5 font-normal leading-normal">{board.desc}</div>
+											{/if}
+										</div>
+									</div>
+								{/snippet}
+
+								{#if taskClientStore.boards.length === 0}
+									<div class="flex flex-col items-center justify-center py-16 text-center">
+										<div class="w-16 h-16 rounded-2xl bg-slate-100 dark:bg-slate-800/60 flex items-center justify-center mb-4">
+											<Icon name="lucide:trello" class="w-8 h-8 text-slate-400" />
+										</div>
+										<p class="text-sm font-semibold text-slate-700 dark:text-slate-300">No boards found</p>
+									</div>
+								{:else}
+									<div class="flex flex-col gap-6">
+										{#if starredBoards.length > 0}
+											<div>
+												<!-- Starred Boards Header -->
+												<div class="flex items-center gap-2 mb-3 px-1">
+													<div class="w-6 h-6 rounded-lg bg-amber-500/10 dark:bg-amber-500/20 flex items-center justify-center text-amber-500">
+														<Icon name="lucide:star" class="w-3.5 h-3.5 fill-amber-500" />
+													</div>
+													<h4 class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">Starred Boards</h4>
+													<span class="text-[10px] font-bold px-2 py-0.5 rounded-full bg-slate-200/50 dark:bg-slate-800/40 text-slate-500 dark:text-slate-400">{starredBoards.length}</span>
+												</div>
+												
+												<!-- Starred Boards Grid -->
+												<div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+													{#each starredBoards as board}
+														{@render boardCard(board)}
+													{/each}
+												</div>
+											</div>
+										{/if}
+
+										{#each groupedWorkspaces as group}
+											<div>
+												<!-- Workspace Header -->
+												<div class="flex items-center gap-2 mb-3 px-1">
+													<div class="w-6 h-6 rounded-lg bg-slate-200/50 dark:bg-slate-800/40 flex items-center justify-center text-slate-500 dark:text-slate-400">
+														<Icon name="lucide:briefcase" class="w-3.5 h-3.5" />
+													</div>
+													<h4 class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">{group.name}</h4>
+													<span class="text-[10px] font-bold px-2 py-0.5 rounded-full bg-slate-200/50 dark:bg-slate-800/40 text-slate-500 dark:text-slate-400">{group.boards.length}</span>
+												</div>
+												
+												<!-- Boards Grid -->
+												<div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+													{#each group.boards as board}
+														{@render boardCard(board)}
+													{/each}
+												</div>
+											</div>
+										{/each}
+									</div>
+								{/if}
+							</div>
+						{/if}
+
+					{:else if trelloView === 'board'}
+						<!-- Board kanban view wrapper -->
+						<div
+							class="flex-1 flex flex-col min-h-0 relative"
+							style="background-color: {taskClientStore.selectedBoard?.prefs?.backgroundColor ?? '#0052CC'}; background-image: {taskClientStore.selectedBoard?.prefs?.backgroundImage ? `url(${taskClientStore.selectedBoard.prefs.backgroundImage})` : 'none'}; background-size: cover; background-position: center;"
+						>
+							{#if taskClientStore.loadingCards}
+								<div class="absolute inset-0 flex flex-col items-center justify-center gap-3 text-white bg-black/25 backdrop-blur-xs">
+									<div class="p-4 rounded-2xl bg-slate-900/60 backdrop-blur-md border border-slate-700/30 flex items-center gap-3 shadow-2xl">
+										<Icon name="lucide:loader" class="w-5 h-5 animate-spin text-violet-400" />
+										<span class="text-sm font-semibold">Loading board…</span>
+									</div>
+								</div>
+							{/if}
+
+							<div class="flex-1 overflow-x-auto p-4 pb-20">
+								<div class="flex gap-3 items-start h-full min-w-max">
+									{#each taskClientStore.lists as list}
+										{@const listCards = taskClientStore.getCardsForList(list.id)}
+										{@const visibleCards = listCards.filter(c => c.id !== draggingId)}
+										<div
+											class="flex flex-col w-64 shrink-0 rounded-xl border transition-all max-h-full
+												{activeDropListId === list.id
+													? 'border-violet-500 bg-violet-50/50 dark:bg-violet-950/20 shadow-md ring-2 ring-violet-500/10'
+													: 'border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900'}"
+											ondragover={(e) => handleDragOver(e, list.id)}
+											ondrop={(e) => handleDrop(e, list.id)}
+										>
+											<div class="relative flex items-center justify-between px-3 py-2 shrink-0 rounded-t-xl">
+												<div class="flex items-center gap-1.5 min-w-0">
+													<h5 class="text-xs font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider truncate">{list.name}</h5>
+													<span class="text-[10px] text-slate-400 bg-slate-100 dark:bg-slate-800 rounded-full px-1.5 py-0.5 shrink-0">{listCards.length}</span>
+												</div>
+												<button
+													type="button"
+													onclick={() => toggleListActionsMenu(list.id)}
+													class="flex items-center justify-center w-6 h-6 rounded text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/80 transition-colors border-none bg-transparent cursor-pointer shrink-0"
+													aria-label="List actions"
+												>
+													<Icon name="lucide:ellipsis" class="w-3.5 h-3.5" />
+												</button>
+
+												<!-- Dropdown Actions Menu -->
+												{#if activeListActionsMenuId === list.id}
+													<!-- Transparent click-outside backdrop overlay -->
+													<button
+														type="button"
+														class="fixed inset-0 z-40 bg-transparent cursor-default border-none w-full h-full"
+														onclick={closeListActionsMenu}
+														aria-label="Close menu"
+													></button>
+
+													<div
+														class="absolute -right-52 top-full mt-1.5 z-50 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl shadow-xl p-2.5 text-left flex flex-col w-60"
+													>
+														<!-- Menu Header -->
+														<div class="flex items-center justify-between pb-2 border-b border-slate-100 dark:border-slate-800 mb-2 shrink-0">
+															<span class="text-xs font-bold text-slate-500 dark:text-slate-400">List actions</span>
+															<button
+																type="button"
+																onclick={closeListActionsMenu}
+																class="flex items-center justify-center w-5 h-5 rounded hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 border-none bg-transparent cursor-pointer"
+															>
+																<Icon name="lucide:x" class="w-3.5 h-3.5" />
+															</button>
+														</div>
+
+														<!-- Action Links -->
+														<div class="flex flex-col gap-0.5 text-xs text-slate-700 dark:text-slate-300">
+															<button
+																type="button"
+																onclick={() => triggerAddCardFromMenu(list.id)}
+																class="w-full text-left px-2 py-1.5 rounded hover:bg-slate-100 dark:hover:bg-slate-800 transition cursor-pointer border-none bg-transparent"
+															>
+																Add card
+															</button>
+
+															<hr class="border-slate-100 dark:border-slate-800 my-1" />
+
+															<!-- Archive Options -->
+															<button
+																type="button"
+																onclick={() => triggerArchiveList(list.id)}
+																class="w-full text-left px-2 py-1.5 rounded hover:bg-red-500/10 hover:text-red-500 transition cursor-pointer border-none bg-transparent"
+															>
+																Archive this list
+															</button>
+															<button
+																type="button"
+																onclick={() => triggerArchiveAllCards(list.id)}
+																class="w-full text-left px-2 py-1.5 rounded hover:bg-red-500/10 hover:text-red-500 transition cursor-pointer border-none bg-transparent"
+															>
+																Archive all cards in this list
+															</button>
+														</div>
+													</div>
+												{/if}
+											</div>
+											{#if visibleCards.length > 0 || activeDropListId === list.id || addingCardListId === list.id}
+												<div class="flex-1 overflow-y-auto p-2 flex flex-col gap-2 cards-list-container">
+													{#each visibleCards as card, idx}
+														{@const cardChecklists = taskClientStore.boardChecklists.filter(cl => cl.idCard === card.id)}
+														<!-- Visual drag placeholder slot before the card -->
+														{#if activeDropListId === list.id && activeDropIndex === idx}
+															<div class="h-16 rounded-lg border-2 border-dashed border-violet-400 dark:border-violet-800/85 bg-violet-500/5 transition-all shrink-0"></div>
+														{/if}
+
+														<a
+															href={card.url}
+															target="_blank"
+															rel="noopener noreferrer"
+															onclick={(e) => handleCardClick(e, card.id)}
+															draggable="true"
+															ondragstart={(e) => handleDragStart(e, card.id)}
+															ondragend={handleDragEnd}
+															data-card-id={card.id}
+															class="block p-2.5 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 hover:border-slate-300 dark:hover:border-slate-600 hover:shadow-sm transition-all cursor-pointer active:cursor-grabbing group"
+														>
+															<!-- Labels -->
+															{#if card.labels.length > 0}
+																<div class="flex flex-wrap gap-1 mb-2">
+																	{#each card.labels as label}
+																		{@const labelColorMap: Record<string, string> = {
+																			'green': '#61bd4f', 'yellow': '#f2d600', 'orange': '#ff9f1a',
+																			'red': '#eb5a46', 'purple': '#c377e0', 'blue': '#0079bf',
+																			'sky': '#00c2e0', 'lime': '#51e898', 'pink': '#ff78cb', 'black': '#344563'
+																		}}
+																		{@const bg = labelColorMap[label.color] ?? label.color ?? '#6b7280'}
+																		<button
+																			type="button"
+																			onclick={(e) => {
+																				e.stopPropagation();
+																				e.preventDefault();
+																				taskClientStore.toggleLabelsExpanded();
+																			}}
+																			class="transition-all cursor-pointer shadow-xs shrink-0 select-none border-none
+																				{taskClientStore.labelsExpanded
+																					? 'inline-flex items-center justify-center min-w-[40px] h-4 text-[9px] font-bold px-1.5 rounded text-white leading-none hover:brightness-110 active:scale-95'
+																					: 'inline-block w-10 h-2 rounded hover:brightness-110 active:scale-95'}
+																				{taskClientStore.colorblindMode ? `colorblind-pattern-${label.color}` : ''}"
+																			style="background-color: {bg}"
+																			title={label.name || label.color}
+																		>
+																			{#if taskClientStore.labelsExpanded}
+																				{label.name || ''}
+																			{/if}
+																		</button>
+																	{/each}
+																</div>
+															{/if}
+
+															<!-- Title -->
+															<div class="flex items-start mb-2 min-w-0">
+																<button
+																	type="button"
+																	class="flex items-center justify-center rounded-full border shrink-0 mt-0.5 transition-all duration-200 ease-in-out overflow-hidden
+																		{card.dueComplete
+																			? 'w-4 h-4 bg-green-500 border-green-500 text-white hover:bg-green-600 hover:border-green-600 opacity-100 mr-2'
+																			: 'w-0 h-4 border-slate-300 dark:border-slate-600 text-transparent hover:text-slate-400 dark:hover:text-slate-500 hover:border-slate-400 dark:hover:border-slate-500 hover:bg-slate-50 dark:hover:bg-slate-700 bg-transparent opacity-0 mr-0 group-hover:opacity-100 group-hover:w-4 group-hover:mr-2'}"
+																	title={card.dueComplete ? "Mark incomplete" : "Mark complete"}
+																	onclick={(e) => {
+																		e.stopPropagation();
+																		e.preventDefault();
+																		taskClientStore.toggleDueComplete(card.id, !card.dueComplete);
+																	}}
+																>
+																	<Icon name="lucide:check" class="w-2.5 h-2.5 stroke-[3]" />
+																</button>
+																<p class="text-[13px] font-medium leading-snug flex-1 {card.dueComplete ? 'line-through text-slate-400 dark:text-slate-500' : 'text-slate-800 dark:text-slate-200'}">{card.name}</p>
+															</div>
+
+															<!-- Bottom row: badges + avatars -->
+															<div class="flex items-center justify-between gap-1 mt-1">
+																<div class="flex items-center gap-1.5 flex-wrap">
+																	<!-- Due date -->
+																	{#if card.due}
+																		<span class="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border border-transparent transition-all {getDueDateBadgeClass(card)}">
+																			<Icon name="lucide:clock" class="w-3.5 h-3.5 shrink-0" />
+																			<span>{formatCardDates(card.start, card.due)}</span>
+																		</span>
+																	{/if}
+
+																	<!-- Description -->
+																	{#if card.badges?.description || card.desc}
+																		<span class="flex items-center text-slate-400 dark:text-slate-500 py-0.5" title="This card has a description.">
+																			<Icon name="lucide:align-left" class="w-3.5 h-3.5" />
+																		</span>
+																	{/if}
+
+																	<!-- Checklist -->
+																	{#if card.badges?.checkItems > 0}
+																		<button
+																			type="button"
+																			class="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded transition-all cursor-pointer select-none active:scale-95 border
+																				{showCardChecklists[card.id]
+																					? 'bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-400 font-semibold border-blue-200 dark:border-blue-800/80 shadow-xs'
+																					: card.badges.checkItemsChecked === card.badges.checkItems
+																						? 'bg-green-100 border-green-200/50 dark:bg-green-900/40 dark:border-green-800/30 text-green-600 dark:text-green-400 hover:bg-green-200 dark:hover:bg-green-900/60 hover:border-green-300 dark:hover:border-green-800'
+																						: 'border-transparent text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 hover:border-slate-300 dark:hover:border-slate-700'}"
+																			onclick={(e) => {
+																				e.stopPropagation();
+																				e.preventDefault();
+																				showCardChecklists[card.id] = !showCardChecklists[card.id];
+																			}}
+																		>
+																			<Icon name="lucide:square-check" class="w-3 h-3" />
+																			<span>{card.badges.checkItemsChecked}/{card.badges.checkItems}</span>
+																		</button>
+																	{/if}
+
+																	<!-- Subscribed/watch -->
+																	{#if card.badges?.subscribed}
+																		<span class="flex items-center text-slate-400 dark:text-slate-500 py-0.5" title="You are watching this card.">
+																			<Icon name="lucide:eye" class="w-3.5 h-3.5" />
+																		</span>
+																	{/if}
+
+																	<!-- Attachments -->
+																	{#if card.badges?.attachments > 0}
+																		<span class="flex items-center gap-0.5 text-[10px] text-slate-400">
+																			<Icon name="lucide:paperclip" class="w-3.5 h-3.5" />
+																			<span>{card.badges.attachments}</span>
+																		</span>
+																	{/if}
+
+																	<!-- Comments -->
+																	{#if card.badges?.comments > 0}
+																		<span class="flex items-center gap-0.5 text-[10px] text-slate-400">
+																			<Icon name="lucide:message-square" class="w-3.5 h-3.5" />
+																			<span>{card.badges.comments}</span>
+																		</span>
+																	{/if}
+																</div>
+
+																<!-- Member avatars -->
+																{#if card.members?.length > 0}
+																	<div class="flex items-center -space-x-1.5 shrink-0">
+																		{#each card.members.slice(0, 3) as member}
+																			{#if member.avatarUrl}
+																				<img
+																					src="{member.avatarUrl}/30.png"
+																					alt={member.fullName}
+																					title={member.fullName}
+																					class="w-6 h-6 rounded-full border-2 border-white dark:border-slate-800 object-cover"
+																				/>
+																			{:else}
+																				<div class="w-6 h-6 rounded-full border-2 border-white dark:border-slate-800 bg-violet-500 flex items-center justify-center text-[9px] font-bold text-white" title={member.fullName}>
+																					{member.fullName.charAt(0).toUpperCase()}
+																				</div>
+																			{/if}
+																		{/each}
+																		{#if card.members.length > 3}
+																			<div class="w-6 h-6 rounded-full border-2 border-white dark:border-slate-800 bg-slate-300 dark:bg-slate-600 flex items-center justify-center text-[9px] font-bold text-slate-600 dark:text-slate-300">
+																				+{card.members.length - 3}
+																			</div>
+																		{/if}
+																	</div>
+																{/if}
+															</div>
+
+															<!-- Checklists Accordions -->
+															{#if showCardChecklists[card.id] && cardChecklists.length > 0}
+																<div class="border-t border-slate-100 dark:border-slate-700/60 mt-2 pt-2 flex flex-col gap-1">
+																	{#each cardChecklists as checklist}
+																		{@const isExpanded = expandedChecklists[checklist.id] ?? false}
+																		<div class="flex flex-col">
+																			<button
+																				type="button"
+																				class="flex items-center justify-between w-full text-left text-[11px] font-semibold py-1 px-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800/80 transition-colors group/header text-slate-600 dark:text-slate-400"
+																				onclick={(e) => {
+																					e.stopPropagation();
+																					e.preventDefault();
+																					expandedChecklists[checklist.id] = !expandedChecklists[checklist.id];
+																				}}
+																			>
+																				<div class="flex items-center gap-1 min-w-0">
+																					<Icon
+																						name={isExpanded ? "lucide:chevron-down" : "lucide:chevron-right"}
+																						class="w-3.5 h-3.5 shrink-0 text-slate-400"
+																					/>
+																					<span class="truncate">{checklist.name}</span>
+																				</div>
+																				<span class="text-[10px] text-slate-400 font-medium shrink-0 ml-2">
+																					{checklist.checkItems?.filter(i => i.state === 'complete').length ?? 0}/{checklist.checkItems?.length ?? 0}
+																				</span>
+																			</button>
+																			{#if isExpanded && checklist.checkItems && checklist.checkItems.length > 0}
+																				<div class="flex flex-col gap-1 pl-4 pr-1 py-1">
+																					{#each checklist.checkItems as item}
+																						{@const isItemComplete = item.state === 'complete'}
+																						<button
+																							type="button"
+																							class="flex items-center gap-1.5 text-left text-[11px] py-0.5 w-full hover:bg-slate-50 dark:hover:bg-slate-700/50 rounded transition-colors group/item"
+																							onclick={(e) => {
+																								e.stopPropagation();
+																								e.preventDefault();
+																								const newState = isItemComplete ? 'incomplete' : 'complete';
+																								taskClientStore.updateCheckItemState(card.id, checklist.id, item.id, newState);
+																							}}
+																						>
+																							<div class="flex items-center justify-center w-3.5 h-3.5 rounded border shrink-0 transition-all
+																								{isItemComplete
+																									? 'bg-blue-500 border-blue-500 text-white dark:bg-blue-600 dark:border-blue-600'
+																									: 'border-slate-300 dark:border-slate-600 bg-transparent text-transparent group-hover/item:border-slate-400 group-hover/item:dark:border-slate-500'}"
+																							>
+																								{#if isItemComplete}
+																									<Icon name="lucide:check" class="w-2.5 h-2.5 stroke-[3]" />
+																								{/if}
+																							</div>
+																							<span class="truncate leading-tight flex-1 {isItemComplete ? 'line-through text-slate-400 dark:text-slate-500' : 'text-slate-700 dark:text-slate-300'}">
+																								{item.name}
+																							</span>
+																						</button>
+																					{/each}
+																				</div>
+																			{/if}
+																		</div>
+																	{/each}
+																</div>
+															{/if}
+														</a>
+													{/each}
+
+													<!-- Visual drag placeholder slot at the end of list -->
+													{#if activeDropListId === list.id && activeDropIndex === visibleCards.length}
+														<div class="h-16 rounded-lg border-2 border-dashed border-violet-400 dark:border-violet-800/85 bg-violet-500/5 transition-all shrink-0"></div>
+													{/if}
+
+													<!-- Add Card Input Form -->
+													{#if addingCardListId === list.id}
+														<div class="flex flex-col gap-2 p-2.5 rounded-lg border border-violet-200 dark:border-violet-800 bg-white dark:bg-slate-900 shadow-sm shrink-0">
+															<textarea
+																use:focusOnMount
+																bind:value={newCardName}
+																placeholder="Enter a title for this card..."
+																class="w-full text-[13px] bg-transparent border-none resize-none text-slate-800 dark:text-slate-200 placeholder:text-slate-400 focus:outline-none leading-snug p-0"
+																rows="2"
+																disabled={addCardLoading}
+																onkeydown={(e) => handleAddCardKeydown(e, list.id)}
+															></textarea>
+															<div class="flex items-center gap-1.5 mt-1 shrink-0">
+																<button
+																	type="button"
+																	onclick={() => submitNewCard(list.id)}
+																	disabled={addCardLoading || !newCardName.trim()}
+																	class="flex items-center gap-1 px-3 py-1.5 text-xs rounded bg-violet-600 hover:bg-violet-700 text-white font-medium transition cursor-pointer border-none disabled:opacity-50 disabled:cursor-not-allowed"
+																>
+																	{#if addCardLoading}
+																		<Icon name="lucide:loader" class="w-3 h-3 animate-spin" />
+																	{/if}
+																	Add card
+																</button>
+																<button
+																	type="button"
+																	onclick={cancelAddCard}
+																	disabled={addCardLoading}
+																	class="flex items-center justify-center w-7 h-7 rounded text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition cursor-pointer border-none bg-transparent"
+																	aria-label="Cancel"
+																>
+																	<Icon name="lucide:x" class="w-4 h-4" />
+																</button>
+															</div>
+														</div>
+													{/if}
+												</div>
+											{/if}
+
+											<!-- Add card button footer -->
+											{#if addingCardListId !== list.id}
+												<div class="p-2 shrink-0 rounded-b-xl">
+													<button
+														type="button"
+														onclick={() => startAddCard(list.id)}
+														class="w-full flex items-center justify-between px-3 py-1.5 text-xs font-medium text-slate-500 dark:text-slate-400 hover:text-violet-600 dark:hover:text-violet-400 hover:bg-violet-500/5 dark:hover:bg-violet-500/8 transition rounded-lg cursor-pointer bg-transparent border-none"
+													>
+														<div class="flex items-center gap-1.5">
+															<Icon name="lucide:plus" class="w-3.5 h-3.5" />
+															<span>Add a card</span>
+														</div>
+														<Icon name="lucide:square-plus" class="w-3.5 h-3.5 opacity-60 hover:opacity-100 transition-opacity" />
+													</button>
+												</div>
+											{/if}
+										</div>
+									{/each}
+									{#if taskClientStore.lists.length === 0}
+										<div class="flex items-center justify-center w-full text-slate-500 dark:text-slate-400">
+											<p class="text-sm">No lists in this board</p>
+										</div>
+									{/if}
+								</div>
+							</div>
+						</div>
+					{/if}
+
+				{:else}
+					<!-- Coming soon for other providers -->
+					<div class="flex-1 flex flex-col items-center justify-center gap-3 p-6">
+						<div
+							class="w-16 h-16 rounded-2xl flex items-center justify-center"
+							style="background-color: {selectedProvider.color}15; color: {selectedProvider.color}"
+						>
+							<Icon name={selectedProvider.icon} class="w-8 h-8" />
+						</div>
+						<h4 class="text-base font-semibold text-slate-800 dark:text-slate-200">{selectedProvider.name}</h4>
+						<p class="text-sm text-slate-500 dark:text-slate-400 text-center max-w-xs">
+							{selectedProvider.name} integration is coming soon.
+						</p>
+						<span class="text-xs px-3 py-1.5 bg-slate-100 dark:bg-slate-800 rounded-full text-slate-500 dark:text-slate-400 font-medium">Coming Soon</span>
+					</div>
+				{/if}
+			</main>
+		</div>
+
+		<CardDetailModal
+			cardId={activeDetailCardId}
+			isOpen={isDetailModalOpen}
+			onClose={() => {
+				isDetailModalOpen = false;
+				activeDetailCardId = null;
+			}}
+		/>
+
+		{#if taskClientStore.error}
+
+			<!-- Backdrop -->
+			<button
+				type="button"
+				class="fixed inset-0 z-[400] bg-slate-950/60 backdrop-blur-sm cursor-default border-none w-full h-full animate-in fade-in duration-200"
+				onclick={() => taskClientStore.error = null}
+				aria-label="Close error message"
+			></button>
+
+			<!-- Modal box -->
+			<div class="fixed inset-0 z-[410] pointer-events-none flex items-center justify-center p-4">
+				<div class="pointer-events-auto w-full max-w-md bg-slate-900 border border-slate-800 rounded-2xl shadow-2xl p-6 flex flex-col items-center text-center animate-in fade-in zoom-in-95 duration-200">
+					<div class="w-12 h-12 rounded-full bg-red-500/10 flex items-center justify-center text-red-500 mb-4 border border-red-500/20">
+						<Icon name="lucide:triangle-alert" class="w-6 h-6 animate-pulse" />
+					</div>
+					
+					<h3 class="text-base font-bold text-slate-100 mb-2">An Error Occurred</h3>
+					
+					<p class="text-sm text-slate-400 mb-6 break-words leading-relaxed max-w-full">
+						{taskClientStore.error}
+					</p>
+					
+					<button
+						type="button"
+						onclick={() => taskClientStore.error = null}
+						class="w-full py-2.5 px-4 bg-red-600 hover:bg-red-700 text-white font-semibold rounded-xl transition-colors cursor-pointer border-none text-sm focus:outline-none focus:ring-2 focus:ring-red-500/50"
+					>
+						Dismiss
+					</button>
+				</div>
+			</div>
+		{/if}
+	{/snippet}
+</Modal>

--- a/frontend/components/task-client/TaskClientModal.svelte
+++ b/frontend/components/task-client/TaskClientModal.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import Modal from '$frontend/components/common/overlay/Modal.svelte';
 	import Icon from '$frontend/components/common/display/Icon.svelte';
-	import { taskClientStore, type TrelloBoard } from '$frontend/stores/features/task-client.svelte';
+	import { taskClientStore, type TrelloBoard, type TrelloCard } from '$frontend/stores/features/task-client.svelte';
 	import type { IconName } from '$shared/types/ui/icons';
 	import CardDetailModal from './CardDetailModal.svelte';
+	import { debug } from '$shared/utils/logger';
 
 
 	interface TaskProvider {
@@ -172,10 +173,6 @@
 	function backToAccounts() {
 		trelloView = 'accounts';
 	}
-
-	const boardBg = $derived(
-		taskClientStore.selectedBoard?.prefs?.backgroundColor ?? '#0052CC'
-	);
 
 	const groupedWorkspaces = $derived.by(() => {
 		const orgMap = new Map<string | null, { name: string; boards: typeof taskClientStore.boards }>();
@@ -412,6 +409,456 @@
 	let isDetailModalOpen = $state(false);
 	let expandedChecklists = $state<Record<string, boolean>>({});
 	let showCardChecklists = $state<Record<string, boolean>>({});
+	let initialSection = $state<'labels' | 'members' | 'dates' | null>(null);
+
+	// Inline editing state
+	let editingCardId = $state<string | null>(null);
+	let editingCardTitle = $state('');
+	let isCancelling = false;
+	let editingCardRect = $state<{ top: number; left: number; width: number; height: number } | null>(null);
+	let editingCardSide = $state<'left' | 'right'>('right');
+	let copiedLink = $state(false);
+
+	let activePopover = $state<'actions' | 'labels' | 'members' | 'dates' | null>(null);
+	let searchLabelQuery = $state('');
+	let searchMemberQuery = $state('');
+
+	// Labels popover sub-states
+	let labelsPopoverMode = $state<'list' | 'create' | 'edit'>('list');
+	let editingLabelId = $state<string | null>(null);
+	let labelFormName = $state('');
+	let labelFormColor = $state('green');
+	const labelColors = ['green', 'yellow', 'orange', 'red', 'purple', 'blue', 'sky', 'lime', 'pink', 'black'];
+
+	let hasStartDate = $state(false);
+	let hasDueDate = $state(false);
+	let startDateVal = $state('');
+	let dueDateVal = $state('');
+
+	// Dates popover sub-states (mirroring CardDetailModal)
+	let calendarYear = $state(new Date().getFullYear());
+	let calendarMonth = $state(new Date().getMonth());
+	let activeDateField = $state<'start' | 'due'>('due');
+	let recurringVal = $state('Never');
+	let dueReminderVal = $state(-1);
+
+	const initDates = (card: TrelloCard) => {
+		if (card.start) {
+			hasStartDate = true;
+			const d = new Date(card.start);
+			const tzoffset = d.getTimezoneOffset() * 60000;
+			startDateVal = (new Date(d.getTime() - tzoffset)).toISOString().slice(0, 16);
+		} else {
+			hasStartDate = false;
+			startDateVal = '';
+		}
+
+		if (card.due) {
+			hasDueDate = true;
+			const d = new Date(card.due);
+			const tzoffset = d.getTimezoneOffset() * 60000;
+			dueDateVal = (new Date(d.getTime() - tzoffset)).toISOString().slice(0, 16);
+		} else {
+			hasDueDate = false;
+			dueDateVal = '';
+		}
+
+		if (card.dueReminder !== undefined) {
+			dueReminderVal = card.dueReminder ?? -1;
+		} else {
+			dueReminderVal = -1;
+		}
+
+		const savedRecurring = localStorage.getItem(`clopen_trello_card_recurring_${card.id}`);
+		recurringVal = savedRecurring || 'Never';
+
+		const initialDate = card.due ? new Date(card.due) : (card.start ? new Date(card.start) : new Date());
+		calendarYear = initialDate.getFullYear();
+		calendarMonth = initialDate.getMonth();
+		activeDateField = card.due ? 'due' : (card.start ? 'start' : 'due');
+	};
+
+	const startInlineEdit = (card: TrelloCard, event: MouseEvent) => {
+		editingCardId = card.id;
+		editingCardTitle = card.name;
+		isCancelling = false;
+		copiedLink = false;
+		activePopover = 'actions';
+
+		const button = event.currentTarget as HTMLElement;
+		const cardEl = button.closest('[data-card-id]') as HTMLElement;
+		if (cardEl) {
+			const rect = cardEl.getBoundingClientRect();
+			editingCardRect = {
+				top: rect.top,
+				left: rect.left,
+				width: rect.width,
+				height: rect.height
+			};
+
+			const actionWidth = 256;
+			const gap = 8;
+			const spaceRight = window.innerWidth - rect.right;
+			editingCardSide = spaceRight < (actionWidth + gap) ? 'left' : 'right';
+		} else {
+			editingCardRect = null;
+			editingCardSide = 'right';
+		}
+	};
+
+	const cancelInlineEdit = () => {
+		isCancelling = true;
+		editingCardId = null;
+		editingCardTitle = '';
+		editingCardRect = null;
+		activePopover = null;
+	};
+
+	const saveInlineEdit = async (cardId: string) => {
+		if (isCancelling) {
+			isCancelling = false;
+			return;
+		}
+		if (editingCardId !== cardId) return;
+
+		const name = editingCardTitle.trim();
+		editingCardId = null;
+		editingCardTitle = '';
+		editingCardRect = null;
+		activePopover = null;
+
+		if (!name) return;
+
+		const card = taskClientStore.cards.find((c) => c.id === cardId);
+		if (card && name === card.name) {
+			return;
+		}
+
+		try {
+			await taskClientStore.updateCardName(cardId, name);
+		} catch (e) {
+			debug.error('task-client', 'Failed to save card title inline:', e);
+		}
+	};
+
+	const handleInlineEditKeyDown = (e: KeyboardEvent, cardId: string) => {
+		if (e.key === 'Enter' && !e.shiftKey) {
+			e.preventDefault();
+			saveInlineEdit(cardId);
+		} else if (e.key === 'Escape') {
+			e.preventDefault();
+			cancelInlineEdit();
+		}
+	};
+
+	const focusTextarea = (el: HTMLTextAreaElement) => {
+		el.focus();
+		el.select();
+	};
+
+	const handleWindowMouseDown = (e: MouseEvent) => {
+		if (!editingCardId) return;
+
+		const target = e.target as HTMLElement;
+		const clickedCard = target.closest(`[data-card-id="${editingCardId}"]`);
+		const clickedDropdown = target.closest('.quick-actions-dropdown');
+		const clickedFloatingCard = target.closest('.floating-card-edit-container');
+
+		if (!clickedCard && !clickedDropdown && !clickedFloatingCard) {
+			saveInlineEdit(editingCardId);
+		}
+	};
+
+	const startCreateLabel = () => {
+		labelsPopoverMode = 'create';
+		editingLabelId = null;
+		labelFormName = '';
+		labelFormColor = 'green';
+	};
+
+	const startEditLabel = (labelId: string, name: string, color: string) => {
+		labelsPopoverMode = 'edit';
+		editingLabelId = labelId;
+		labelFormName = name;
+		labelFormColor = color;
+	};
+
+	const handleSaveLabelInline = async () => {
+		if (!labelFormColor) return;
+		try {
+			if (labelsPopoverMode === 'create') {
+				await taskClientStore.createLabel(labelFormName, labelFormColor);
+			} else if (labelsPopoverMode === 'edit' && editingLabelId) {
+				await taskClientStore.updateLabel(editingLabelId, labelFormName, labelFormColor);
+			}
+			labelsPopoverMode = 'list';
+			editingLabelId = null;
+			labelFormName = '';
+		} catch (err) {
+			debug.error('task-client', 'Failed to save label inline:', err);
+		}
+	};
+
+	const handleDeleteLabelInline = async (labelId: string) => {
+		try {
+			await taskClientStore.deleteLabel(labelId);
+			labelsPopoverMode = 'list';
+			editingLabelId = null;
+			labelFormName = '';
+		} catch (err) {
+			debug.error('task-client', 'Failed to delete label inline:', err);
+		}
+	};
+
+	const handleToggleLabel = async (cardId: string, labelId: string) => {
+		const card = taskClientStore.cards.find(c => c.id === cardId);
+		if (!card) return;
+
+		const isAssigned = card.labels.some(l => l.id === labelId);
+		try {
+			if (isAssigned) {
+				await taskClientStore.removeLabelFromCard(cardId, labelId);
+			} else {
+				await taskClientStore.addLabelToCard(cardId, labelId);
+			}
+		} catch (e) {
+			debug.error('task-client', 'Failed to toggle label inline:', e);
+		}
+	};
+
+	const handleToggleMember = async (cardId: string, memberId: string) => {
+		const card = taskClientStore.cards.find(c => c.id === cardId);
+		if (!card) return;
+
+		const isAssigned = card.members.some(m => m.id === memberId);
+		try {
+			if (isAssigned) {
+				await taskClientStore.removeMemberFromCard(cardId, memberId);
+			} else {
+				await taskClientStore.addMemberToCard(cardId, memberId);
+			}
+		} catch (e) {
+			debug.error('task-client', 'Failed to toggle member inline:', e);
+		}
+	};
+
+	const monthNames = [
+		'January', 'February', 'March', 'April', 'May', 'June',
+		'July', 'August', 'September', 'October', 'November', 'December'
+	];
+
+	const prevMonth = () => {
+		if (calendarMonth === 0) {
+			calendarMonth = 11;
+			calendarYear -= 1;
+		} else {
+			calendarMonth -= 1;
+		}
+	};
+
+	const nextMonth = () => {
+		if (calendarMonth === 11) {
+			calendarMonth = 0;
+			calendarYear += 1;
+		} else {
+			calendarMonth += 1;
+		}
+	};
+
+	const prevYear = () => {
+		calendarYear -= 1;
+	};
+
+	const nextYear = () => {
+		calendarYear += 1;
+	};
+
+	const selectCalendarDay = (day: number, month: number, year: number) => {
+		const pad = (n: number) => String(n).padStart(2, '0');
+		const dateStr = `${year}-${pad(month + 1)}-${pad(day)}`;
+		
+		if (activeDateField === 'start') {
+			hasStartDate = true;
+			const existingTime = startDateVal ? startDateVal.split('T')[1] : '09:00';
+			startDateVal = `${dateStr}T${existingTime}`;
+		} else {
+			hasDueDate = true;
+			const existingTime = dueDateVal ? dueDateVal.split('T')[1] : '12:00';
+			dueDateVal = `${dateStr}T${existingTime}`;
+		}
+	};
+
+	const isCellSelected = (day: number, month: number, year: number) => {
+		const val = activeDateField === 'start' ? startDateVal : dueDateVal;
+		if (!val) return false;
+		const d = new Date(val);
+		return d.getDate() === day && d.getMonth() === month && d.getFullYear() === year;
+	};
+
+	const calendarDays = $derived.by(() => {
+		const firstDayIndex = new Date(calendarYear, calendarMonth, 1).getDay();
+		const totalDays = new Date(calendarYear, calendarMonth + 1, 0).getDate();
+		const prevMonthTotalDays = new Date(calendarYear, calendarMonth, 0).getDate();
+
+		const cells = [];
+
+		for (let i = firstDayIndex - 1; i >= 0; i--) {
+			const d = prevMonthTotalDays - i;
+			const m = calendarMonth === 0 ? 11 : calendarMonth - 1;
+			const y = calendarMonth === 0 ? calendarYear - 1 : calendarYear;
+			cells.push({ day: d, month: m, year: y, current: false });
+		}
+
+		for (let d = 1; d <= totalDays; d++) {
+			cells.push({ day: d, month: calendarMonth, year: calendarYear, current: true });
+		}
+
+		const remaining = 42 - cells.length;
+		for (let d = 1; d <= remaining; d++) {
+			const m = calendarMonth === 11 ? 0 : calendarMonth + 1;
+			const y = calendarMonth === 11 ? calendarYear + 1 : calendarYear;
+			cells.push({ day: d, month: m, year: y, current: false });
+		}
+
+		return cells;
+	});
+
+	const recurringDayNumber = $derived.by(() => {
+		const d = dueDateVal ? new Date(dueDateVal) : new Date();
+		const dateNum = d.getDate();
+		const suffix = (n: number) => {
+			if (n > 3 && n < 21) return 'th';
+			switch (n % 10) {
+				case 1:  return "st";
+				case 2:  return "nd";
+				case 3:  return "rd";
+				default: return "th";
+			}
+		};
+		return `${dateNum}${suffix(dateNum)}`;
+	});
+
+	const recurringDayOfWeekDesc = $derived.by(() => {
+		const d = dueDateVal ? new Date(dueDateVal) : new Date();
+		const daysOfWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+		const dayName = daysOfWeek[d.getDay()];
+		
+		const dateNum = d.getDate();
+		const occurrence = Math.ceil(dateNum / 7);
+		
+		const temp = new Date(d.getTime());
+		temp.setDate(temp.getDate() + 7);
+		const isLast = temp.getMonth() !== d.getMonth();
+		
+		const ordinals = ['first', 'second', 'third', 'fourth', 'fifth'];
+		const occurrenceWord = ordinals[occurrence - 1] ?? 'first';
+		
+		if (isLast) {
+			return `Monthly on the last ${dayName}`;
+		}
+		return `Monthly on the ${occurrenceWord} ${dayName}`;
+	});
+
+	const recurringYearlyDesc = $derived.by(() => {
+		const d = dueDateVal ? new Date(dueDateVal) : new Date();
+		const monthName = monthNames[d.getMonth()];
+		const dateNum = d.getDate();
+		const suffix = (n: number) => {
+			if (n > 3 && n < 21) return 'th';
+			switch (n % 10) {
+				case 1:  return "st";
+				case 2:  return "nd";
+				case 3:  return "rd";
+				default: return "th";
+			}
+		};
+		return `Yearly on ${monthName} ${dateNum}${suffix(dateNum)}`;
+	});
+
+	const handleSaveDatesInline = async (cardId: string) => {
+		try {
+			const startStr = hasStartDate && startDateVal ? new Date(startDateVal).toISOString() : null;
+			const dueStr = hasDueDate && dueDateVal ? new Date(dueDateVal).toISOString() : null;
+			await taskClientStore.updateCardDates(cardId, startStr, dueStr, dueReminderVal);
+			localStorage.setItem(`clopen_trello_card_recurring_${cardId}`, recurringVal);
+			cancelInlineEdit();
+		} catch (e) {
+			debug.error('task-client', 'Failed to save dates inline:', e);
+		}
+	};
+
+	const handleRemoveDatesInline = async (cardId: string) => {
+		try {
+			await taskClientStore.updateCardDates(cardId, null, null, -1);
+			localStorage.removeItem(`clopen_trello_card_recurring_${cardId}`);
+			cancelInlineEdit();
+		} catch (e) {
+			debug.error('task-client', 'Failed to remove dates inline:', e);
+		}
+	};
+
+	const handleQuickEditAction = async (
+		action: 'open' | 'labels' | 'members' | 'dates' | 'move' | 'copy' | 'copy-link' | 'mirror' | 'archive',
+		cardId: string
+	) => {
+		const card = taskClientStore.cards.find(c => c.id === cardId);
+		if (!card) return;
+
+		if (action === 'copy-link') {
+			try {
+				await navigator.clipboard.writeText(card.url);
+				copiedLink = true;
+				setTimeout(() => { copiedLink = false; }, 1500);
+			} catch (e) {
+				debug.error('task-client', 'Failed to copy card link:', e);
+			}
+			return;
+		} else if (action === 'mirror') {
+			try {
+				await navigator.clipboard.writeText(`[${card.name}](${card.url})`);
+				copiedLink = true;
+				setTimeout(() => { copiedLink = false; }, 1500);
+			} catch (e) {
+				debug.error('task-client', 'Failed to mirror card:', e);
+			}
+			return;
+		}
+
+		if (action === 'labels') {
+			searchLabelQuery = '';
+			activePopover = 'labels';
+		} else if (action === 'members') {
+			searchMemberQuery = '';
+			activePopover = 'members';
+		} else if (action === 'dates') {
+			initDates(card);
+			activePopover = 'dates';
+		} else {
+			cancelInlineEdit();
+
+			if (action === 'open') {
+				activeDetailCardId = card.id;
+				initialSection = null;
+				isDetailModalOpen = true;
+			} else if (action === 'move') {
+				activeDetailCardId = card.id;
+				initialSection = null;
+				isDetailModalOpen = true;
+			} else if (action === 'copy') {
+				try {
+					await taskClientStore.createCard(card.idList, `${card.name} (Copy)`);
+				} catch (e) {
+					debug.error('task-client', 'Failed to copy card:', e);
+				}
+			} else if (action === 'archive') {
+				try {
+					await taskClientStore.archiveCard(card.id);
+				} catch (e) {
+					debug.error('task-client', 'Failed to archive card:', e);
+				}
+			}
+		}
+	};
 
 	function formatCardDates(start: string | null, due: string | null): string {
 		if (!due) return '';
@@ -442,7 +889,12 @@
 		return 'bg-slate-100 hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700/80 border-transparent text-slate-500 dark:text-slate-400';
 	}
 
-	function handleCardClick(e: MouseEvent, cardId: string) {
+	const handleCardClick = (e: MouseEvent, cardId: string) => {
+		if (editingCardId === cardId) {
+			e.preventDefault();
+			e.stopPropagation();
+			return;
+		}
 		console.log('handleCardClick triggered for cardId:', cardId, 'button:', e.button);
 		if (e.button === 0 && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
 			e.preventDefault();
@@ -450,16 +902,22 @@
 			isDetailModalOpen = true;
 			console.log('isDetailModalOpen set to true, activeDetailCardId:', cardId);
 		}
-	}
+	};
 
-	function handleWindowKeyDown(e: KeyboardEvent) {
-		if (e.key === 'Escape' && taskClientStore.error) {
-			taskClientStore.error = null;
+	const handleWindowKeyDown = (e: KeyboardEvent) => {
+		if (e.key === 'Escape') {
+			if (editingCardId) {
+				cancelInlineEdit();
+				e.preventDefault();
+				e.stopPropagation();
+			} else if (taskClientStore.error) {
+				taskClientStore.error = null;
+			}
 		}
-	}
+	};
 </script>
 
-<svelte:window onkeydown={handleWindowKeyDown} />
+<svelte:window onkeydown={handleWindowKeyDown} onmousedown={handleWindowMouseDown} />
 
 <Modal
 	bind:isOpen
@@ -1125,12 +1583,27 @@
 															target="_blank"
 															rel="noopener noreferrer"
 															onclick={(e) => handleCardClick(e, card.id)}
-															draggable="true"
+															draggable={editingCardId !== card.id}
 															ondragstart={(e) => handleDragStart(e, card.id)}
 															ondragend={handleDragEnd}
 															data-card-id={card.id}
-															class="block p-2.5 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 hover:border-slate-300 dark:hover:border-slate-600 hover:shadow-sm transition-all cursor-pointer active:cursor-grabbing group"
+															class="relative block p-2.5 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 hover:border-slate-300 dark:hover:border-slate-600 hover:shadow-sm transition-all cursor-pointer active:cursor-grabbing group {editingCardId === card.id ? 'opacity-0 pointer-events-none' : ''}"
 														>
+															<!-- Edit Button (Pencil Icon) -->
+															{#if editingCardId !== card.id}
+																<button
+																	type="button"
+																	onclick={(e) => {
+																		e.stopPropagation();
+																		e.preventDefault();
+																		startInlineEdit(card, e);
+																	}}
+																	class="absolute top-2 right-2 w-6 h-6 rounded bg-slate-100 hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700 text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 flex items-center justify-center border border-slate-200/50 dark:border-slate-700/50 cursor-pointer shadow-xs z-10 opacity-0 group-hover:opacity-100 transition-opacity"
+																	title="Quick edit card"
+																>
+																	<Icon name="lucide:pencil" class="w-3.5 h-3.5" />
+																</button>
+															{/if}
 															<!-- Labels -->
 															{#if card.labels.length > 0}
 																<div class="flex flex-wrap gap-1 mb-2">
@@ -1165,7 +1638,7 @@
 															{/if}
 
 															<!-- Title -->
-															<div class="flex items-start mb-2 min-w-0">
+															<div class="flex items-start mb-2 min-w-0 pr-6 w-full">
 																<button
 																	type="button"
 																	class="flex items-center justify-center rounded-full border shrink-0 mt-0.5 transition-all duration-200 ease-in-out overflow-hidden
@@ -1430,11 +1903,638 @@
 		<CardDetailModal
 			cardId={activeDetailCardId}
 			isOpen={isDetailModalOpen}
+			initialSection={initialSection}
 			onClose={() => {
 				isDetailModalOpen = false;
 				activeDetailCardId = null;
+				initialSection = null;
 			}}
 		/>
+
+		{#if editingCardId && editingCardRect}
+			{@const card = taskClientStore.cards.find(c => c.id === editingCardId)}
+			<!-- Backdrop overlay -->
+			<button
+				type="button"
+				class="fixed inset-0 z-[300] bg-black/60 cursor-default border-none w-full h-full animate-in fade-in duration-150"
+				onclick={cancelInlineEdit}
+				aria-label="Close inline edit"
+			></button>
+
+			<!-- Floating Card Edit Container (Left side / over the card) -->
+			<div
+				class="fixed z-[310] flex flex-col pointer-events-auto floating-card-edit-container"
+				style="
+					top: {editingCardRect.top}px;
+					left: {editingCardRect.left}px;
+					width: {editingCardRect.width}px;
+				"
+			>
+				<div class="bg-white dark:bg-slate-800 p-2.5 rounded-lg border border-slate-200/80 dark:border-slate-700/80 shadow-2xl flex flex-col gap-1.5">
+					<!-- Re-render the labels above the title -->
+					{#if card && card.labels.length > 0}
+						<div class="flex flex-wrap gap-1 mb-1.5 select-none">
+							{#each card.labels as label}
+								{@const labelColorMap: Record<string, string> = {
+									'green': '#61bd4f', 'yellow': '#f2d600', 'orange': '#ff9f1a',
+									'red': '#eb5a46', 'purple': '#c377e0', 'blue': '#0079bf',
+									'sky': '#00c2e0', 'lime': '#51e898', 'pink': '#ff78cb', 'black': '#344563'
+								}}
+								{@const bg = labelColorMap[label.color] ?? label.color ?? '#6b7280'}
+								<span
+									style="background-color: {bg}"
+									class="inline-block w-10 h-2 rounded {taskClientStore.colorblindMode ? `colorblind-pattern-${label.color}` : ''}"
+									title={label.name || label.color}
+								></span>
+							{/each}
+						</div>
+					{/if}
+
+					<textarea
+						bind:value={editingCardTitle}
+						use:focusTextarea
+						class="w-full bg-transparent border-none outline-none text-[13px] font-medium leading-snug text-slate-800 dark:text-slate-200 resize-none p-0 focus:ring-0 focus:outline-none"
+						rows="3"
+						onkeydown={(e) => handleInlineEditKeyDown(e, editingCardId!)}
+					></textarea>
+				</div>
+
+				<button
+					type="button"
+					onclick={() => saveInlineEdit(editingCardId!)}
+					class="mt-2 px-4 py-2 bg-violet-600 hover:bg-violet-700 text-white text-xs font-semibold rounded-lg shadow-md transition-colors cursor-pointer border-none self-start"
+				>
+					Save
+				</button>
+			</div>
+
+			<!-- Quick edit actions panel -->
+			{#if activePopover}
+				{#if activePopover === 'actions'}
+					<!-- Stack of individual floaty buttons next to card -->
+					<div
+						class="fixed z-[310] flex flex-col gap-1.5 quick-actions-dropdown"
+						style="
+							top: {editingCardRect.top}px;
+							left: {editingCardSide === 'right' ? editingCardRect.left + editingCardRect.width + 8 : Math.max(8, editingCardRect.left - 150 - 8)}px;
+							width: 150px;
+						"
+					>
+						<button
+							type="button"
+							onclick={() => handleQuickEditAction('open', editingCardId!)}
+							class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs font-semibold text-slate-200 bg-slate-800 hover:bg-slate-700 rounded-md border-none cursor-pointer transition-all hover:translate-x-1 duration-150 shadow-md"
+						>
+							<Icon name="lucide:external-link" class="w-3.5 h-3.5 text-slate-400" />
+							<span>Open card</span>
+						</button>
+						<button
+							type="button"
+							onclick={() => handleQuickEditAction('labels', editingCardId!)}
+							class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs font-semibold text-slate-200 bg-slate-800 hover:bg-slate-700 rounded-md border-none cursor-pointer transition-all hover:translate-x-1 duration-150 shadow-md"
+						>
+							<Icon name="lucide:tag" class="w-3.5 h-3.5 text-slate-400" />
+							<span>Edit labels</span>
+						</button>
+						<button
+							type="button"
+							onclick={() => handleQuickEditAction('members', editingCardId!)}
+							class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs font-semibold text-slate-200 bg-slate-800 hover:bg-slate-700 rounded-md border-none cursor-pointer transition-all hover:translate-x-1 duration-150 shadow-md"
+						>
+							<Icon name="lucide:users" class="w-3.5 h-3.5 text-slate-400" />
+							<span>Change members</span>
+						</button>
+						<button
+							type="button"
+							onclick={() => handleQuickEditAction('dates', editingCardId!)}
+							class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs font-semibold text-slate-200 bg-slate-800 hover:bg-slate-700 rounded-md border-none cursor-pointer transition-all hover:translate-x-1 duration-150 shadow-md"
+						>
+							<Icon name="lucide:clock" class="w-3.5 h-3.5 text-slate-400" />
+							<span>Edit dates</span>
+						</button>
+						<button
+							type="button"
+							onclick={() => handleQuickEditAction('move', editingCardId!)}
+							class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs font-semibold text-slate-200 bg-slate-800 hover:bg-slate-700 rounded-md border-none cursor-pointer transition-all hover:translate-x-1 duration-150 shadow-md"
+						>
+							<Icon name="lucide:arrow-right" class="w-3.5 h-3.5 text-slate-400" />
+							<span>Move</span>
+						</button>
+						<button
+							type="button"
+							onclick={() => handleQuickEditAction('copy', editingCardId!)}
+							class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs font-semibold text-slate-200 bg-slate-800 hover:bg-slate-700 rounded-md border-none cursor-pointer transition-all hover:translate-x-1 duration-150 shadow-md"
+						>
+							<Icon name="lucide:copy" class="w-3.5 h-3.5 text-slate-400" />
+							<span>Copy card</span>
+						</button>
+						<button
+							type="button"
+							onclick={() => handleQuickEditAction('copy-link', editingCardId!)}
+							class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs font-semibold text-slate-200 bg-slate-800 hover:bg-slate-700 rounded-md border-none cursor-pointer transition-all hover:translate-x-1 duration-150 shadow-md"
+						>
+							<Icon name={copiedLink ? "lucide:check" : "lucide:link"} class="w-3.5 h-3.5 {copiedLink ? 'text-emerald-500' : 'text-slate-400'}" />
+							<span>{copiedLink ? 'Copied!' : 'Copy link'}</span>
+						</button>
+						<button
+							type="button"
+							onclick={() => handleQuickEditAction('mirror', editingCardId!)}
+							class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs font-semibold text-slate-200 bg-slate-800 hover:bg-slate-700 rounded-md border-none cursor-pointer transition-all hover:translate-x-1 duration-150 shadow-md"
+						>
+							<Icon name="lucide:copy-plus" class="w-3.5 h-3.5 text-slate-400" />
+							<span>Mirror</span>
+						</button>
+						<button
+							type="button"
+							onclick={() => handleQuickEditAction('archive', editingCardId!)}
+							class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs font-semibold text-red-400 bg-slate-800 hover:bg-red-950/30 rounded-md border-none cursor-pointer transition-all hover:translate-x-1 duration-150 shadow-md"
+						>
+							<Icon name="lucide:archive" class="w-3.5 h-3.5 text-red-400" />
+							<span>Archive</span>
+						</button>
+					</div>
+				{:else}
+					<!-- Sub-popover settings card (e.g. edit labels checklist/dates picker/members selector) -->
+					<div
+						class="fixed z-[310] flex flex-col gap-3 bg-slate-800 backdrop-blur-md p-3.5 rounded-xl border border-slate-700/80 shadow-2xl quick-actions-dropdown text-slate-200"
+						style="
+							top: {Math.max(16, Math.min(editingCardRect.top, window.innerHeight - (activePopover === 'dates' ? 490 : 380)))}px;
+							left: {editingCardSide === 'right' ? editingCardRect.left + editingCardRect.width + 8 : Math.max(8, editingCardRect.left - 256 - 8)}px;
+							width: 256px;
+						"
+					>
+						{#if activePopover === 'labels'}
+					{@const card = taskClientStore.cards.find(c => c.id === editingCardId)}
+					{@const filteredLabels = taskClientStore.boardLabels.filter(label => 
+						!searchLabelQuery.trim() || 
+						(label.name || label.color).toLowerCase().includes(searchLabelQuery.toLowerCase())
+					)}
+					<!-- Header -->
+					<div class="flex items-center justify-between border-b border-slate-800 pb-2 mb-1 shrink-0">
+						<div class="flex items-center gap-1">
+							<button
+								type="button"
+								onclick={() => { 
+									if (labelsPopoverMode === 'list') {
+										activePopover = 'actions';
+									} else {
+										labelsPopoverMode = 'list';
+									}
+								}}
+								class="text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer p-0.5 rounded hover:bg-slate-800 transition-colors flex items-center justify-center"
+								title="Back"
+							>
+								<Icon name="lucide:chevron-left" class="w-4 h-4" />
+							</button>
+							<span class="text-xs font-bold text-slate-200">
+								{#if labelsPopoverMode === 'list'}
+									Labels
+								{:else if labelsPopoverMode === 'create'}
+									Create label
+								{:else if labelsPopoverMode === 'edit'}
+									Change label
+								{/if}
+							</span>
+						</div>
+						<button
+							type="button"
+							onclick={cancelInlineEdit}
+							class="text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer p-0.5 rounded hover:bg-slate-800 transition-colors flex items-center justify-center"
+							aria-label="Close labels popover"
+						>
+							<Icon name="lucide:x" class="w-3.5 h-3.5" />
+						</button>
+					</div>
+
+					{#if labelsPopoverMode === 'list'}
+						<!-- Search box -->
+						<div class="relative shrink-0">
+							<input
+								type="text"
+								placeholder="Search labels..."
+								bind:value={searchLabelQuery}
+								class="w-full bg-slate-900 border border-slate-700 focus:border-slate-600 text-slate-200 rounded px-2.5 py-1.5 text-xs placeholder-slate-500 focus:outline-none focus:ring-0"
+							/>
+						</div>
+
+						<!-- Labels List -->
+						<div class="flex flex-col gap-1.5 max-h-56 overflow-y-auto pr-1">
+							{#if filteredLabels.length === 0}
+								<div class="text-slate-500 text-xs py-2 text-center">No labels found</div>
+							{:else}
+								{#each filteredLabels as label}
+									{@const isAssigned = card?.labels.some(l => l.id === label.id)}
+									{@const labelColorMap: Record<string, string> = {
+										'green': '#61bd4f', 'yellow': '#f2d600', 'orange': '#ff9f1a',
+										'red': '#eb5a46', 'purple': '#c377e0', 'blue': '#0079bf',
+										'sky': '#00c2e0', 'lime': '#51e898', 'pink': '#ff78cb', 'black': '#344563'
+									}}
+									{@const bg = labelColorMap[label.color] ?? label.color ?? '#6b7280'}
+									<div class="flex items-center gap-2 group/row w-full">
+										<!-- Toggle checkbox -->
+										<button
+											type="button"
+											onclick={() => handleToggleLabel(editingCardId!, label.id)}
+											class="flex items-center justify-center w-5 h-5 rounded border transition cursor-pointer shrink-0
+												{isAssigned 
+													? 'border-violet-500 bg-slate-900 text-violet-400' 
+													: 'border-slate-700 bg-slate-900 text-transparent hover:border-slate-500'}"
+										>
+											{#if isAssigned}
+												<Icon name="lucide:check" class="w-3.5 h-3.5 stroke-[3]" />
+											{/if}
+										</button>
+
+										<!-- Colored label bar -->
+										<button
+											type="button"
+											onclick={() => handleToggleLabel(editingCardId!, label.id)}
+											style="background-color: {bg};"
+											class="flex-1 flex items-center text-left px-3 h-8 rounded-lg text-white font-bold text-xs transition cursor-pointer min-w-0 select-none shadow-sm hover:brightness-110 active:brightness-95 {taskClientStore.colorblindMode ? `colorblind-pattern-${label.color}` : ''}"
+										>
+											<span class="truncate pr-1">{label.name || ''}</span>
+										</button>
+
+										<!-- Edit pencil button -->
+										<button
+											type="button"
+											onclick={() => startEditLabel(label.id, label.name, label.color)}
+											class="w-8 h-8 flex items-center justify-center text-slate-400 hover:text-slate-200 hover:bg-slate-800 rounded transition cursor-pointer shrink-0 border-none bg-transparent"
+											title="Edit label"
+										>
+											<Icon name="lucide:pencil" class="w-3.5 h-3.5" />
+										</button>
+									</div>
+								{/each}
+							{/if}
+						</div>
+
+						<!-- Action buttons -->
+						<div class="flex flex-col gap-2 pt-2 border-t border-slate-800 shrink-0">
+							<button
+								type="button"
+								onclick={startCreateLabel}
+								class="w-full py-1.5 bg-slate-900 hover:bg-slate-800 border border-slate-700 hover:border-slate-600 text-slate-300 font-semibold rounded text-xs transition cursor-pointer text-center"
+							>
+								Create a new label
+							</button>
+							<button
+								type="button"
+								onclick={() => taskClientStore.toggleColorblindMode()}
+								class="w-full py-1.5 bg-slate-900 hover:bg-slate-800 border border-slate-700 hover:border-slate-600 text-slate-300 font-semibold rounded text-xs transition cursor-pointer text-center"
+							>
+								{taskClientStore.colorblindMode ? 'Disable' : 'Enable'} colorblind friendly mode
+							</button>
+						</div>
+					{:else if labelsPopoverMode === 'create' || labelsPopoverMode === 'edit'}
+						<!-- Title / Name Input -->
+						<div class="flex flex-col gap-1.5 text-xs shrink-0">
+							<label for="inline-label-name-input" class="text-[10px] font-bold text-slate-500 uppercase tracking-wider">Title</label>
+							<input
+								id="inline-label-name-input"
+								type="text"
+								placeholder="Label title..."
+								bind:value={labelFormName}
+								class="w-full bg-slate-900 border border-slate-700 focus:border-slate-600 text-slate-200 rounded px-2.5 py-1.5 text-xs focus:outline-none focus:ring-0"
+							/>
+						</div>
+
+						<!-- Color Selector Grid -->
+						<div class="flex flex-col gap-1.5 text-xs shrink-0">
+							<span class="text-[10px] font-bold text-slate-500 uppercase tracking-wider">Select a color</span>
+							<div class="grid grid-cols-5 gap-2">
+								{#each labelColors as color}
+									{@const labelColorMap: Record<string, string> = {
+										'green': '#61bd4f', 'yellow': '#f2d600', 'orange': '#ff9f1a',
+										'red': '#eb5a46', 'purple': '#c377e0', 'blue': '#0079bf',
+										'sky': '#00c2e0', 'lime': '#51e898', 'pink': '#ff78cb', 'black': '#344563'
+									}}
+									{@const bg = labelColorMap[color] ?? color}
+									{@const isSelected = labelFormColor === color}
+									<button
+										type="button"
+										onclick={() => { labelFormColor = color; }}
+										style="background-color: {bg};"
+										class="w-10 h-8 rounded relative transition-transform cursor-pointer shadow-sm hover:scale-105 active:scale-95 flex items-center justify-center border-none
+											{isSelected ? 'ring-2 ring-violet-500 ring-offset-2 ring-offset-slate-950' : ''}
+											{taskClientStore.colorblindMode ? `colorblind-pattern-${color}` : ''}"
+										title={color}
+									>
+										{#if isSelected}
+											<Icon name="lucide:check" class="w-4 h-4 text-white drop-shadow" />
+										{/if}
+									</button>
+								{/each}
+							</div>
+						</div>
+
+						<!-- Form Actions -->
+						<div class="flex items-center gap-2 pt-2 border-t border-slate-800 shrink-0">
+							{#if labelsPopoverMode === 'create'}
+								<button
+									type="button"
+									onclick={handleSaveLabelInline}
+									class="flex-1 py-1.5 bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded text-xs transition cursor-pointer border-none"
+								>
+									Create
+								</button>
+							{:else}
+								<button
+									type="button"
+									onclick={handleSaveLabelInline}
+									class="flex-1 py-1.5 bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded text-xs transition cursor-pointer border-none"
+								>
+									Save
+								</button>
+								<button
+									type="button"
+									onclick={() => handleDeleteLabelInline(editingLabelId!)}
+									class="flex-1 py-1.5 bg-red-600 hover:bg-red-700 text-white font-semibold rounded text-xs transition cursor-pointer border-none"
+								>
+									Delete
+								</button>
+							{/if}
+						</div>
+					{/if}
+				{:else if activePopover === 'members'}
+					{@const card = taskClientStore.cards.find(c => c.id === editingCardId)}
+					{@const filteredMembers = taskClientStore.boardMembers.filter(m => 
+						!searchMemberQuery.trim() || 
+						m.fullName.toLowerCase().includes(searchMemberQuery.toLowerCase()) ||
+						m.username?.toLowerCase().includes(searchMemberQuery.toLowerCase())
+					)}
+					<!-- Header -->
+					<div class="flex items-center justify-between border-b border-slate-800 pb-2 mb-1 shrink-0">
+						<div class="flex items-center gap-1">
+							<button
+								type="button"
+								onclick={() => { activePopover = 'actions'; }}
+								class="text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer p-0.5 rounded hover:bg-slate-800 transition-colors flex items-center justify-center"
+								title="Back"
+							>
+								<Icon name="lucide:chevron-left" class="w-4 h-4" />
+							</button>
+							<span class="text-xs font-bold text-slate-200">Members</span>
+						</div>
+						<button
+							type="button"
+							onclick={cancelInlineEdit}
+							class="text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer p-0.5 rounded hover:bg-slate-800 transition-colors flex items-center justify-center"
+							aria-label="Close members popover"
+						>
+							<Icon name="lucide:x" class="w-3.5 h-3.5" />
+						</button>
+					</div>
+
+					<!-- Search box -->
+					<div class="relative shrink-0">
+						<input
+							type="text"
+							placeholder="Search members..."
+							bind:value={searchMemberQuery}
+							class="w-full px-3 py-2 rounded-lg bg-slate-900 border border-slate-700 text-slate-200 text-xs focus:outline-none focus:ring-2 focus:ring-violet-500 placeholder-slate-500"
+						/>
+					</div>
+
+					<!-- Members List -->
+					<div class="flex flex-col gap-1 max-h-60 overflow-y-auto pr-1">
+						{#if filteredMembers.length === 0}
+							<div class="text-slate-500 text-xs py-2 text-center">No members found</div>
+						{:else}
+							{#each filteredMembers as member}
+								{@const isAssigned = card?.members.some(m => m.id === member.id)}
+								<button
+									type="button"
+									onclick={() => handleToggleMember(editingCardId!, member.id)}
+									class="flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-slate-800 transition cursor-pointer border-none bg-transparent w-full text-left {isAssigned ? 'bg-slate-800/50' : ''}"
+								>
+									<!-- Avatar -->
+									{#if member.avatarUrl}
+										<img
+											src="{member.avatarUrl}/30.png"
+											alt={member.fullName}
+											class="w-7 h-7 rounded-full object-cover border border-slate-700 shrink-0"
+										/>
+									{:else}
+										<div class="w-7 h-7 rounded-full bg-violet-600 flex items-center justify-center text-[11px] font-bold text-white border border-slate-700 shrink-0">
+											{member.fullName.charAt(0).toUpperCase()}
+										</div>
+									{/if}
+									<!-- Name -->
+									<span class="flex-1 text-xs text-slate-200 truncate">{member.fullName}</span>
+									<!-- Check if assigned -->
+									{#if isAssigned}
+										<div class="w-4 h-4 rounded-full bg-violet-600 flex items-center justify-center shrink-0">
+											<Icon name="lucide:check" class="w-2.5 h-2.5 text-white stroke-[3]" />
+										</div>
+									{/if}
+								</button>
+							{/each}
+						{/if}
+					</div>
+				{:else if activePopover === 'dates'}
+					<!-- Header -->
+					<div class="flex items-center justify-between border-b border-slate-800 pb-2 mb-1 shrink-0">
+						<div class="flex items-center gap-1">
+							<button
+								type="button"
+								onclick={() => { activePopover = 'actions'; }}
+								class="text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer p-0.5 rounded hover:bg-slate-800 transition-colors flex items-center justify-center"
+								title="Back"
+							>
+								<Icon name="lucide:chevron-left" class="w-4 h-4" />
+							</button>
+							<span class="text-xs font-bold text-slate-200">Dates</span>
+						</div>
+						<button
+							type="button"
+							onclick={cancelInlineEdit}
+							class="text-slate-400 hover:text-slate-200 bg-transparent border-none cursor-pointer p-0.5 rounded hover:bg-slate-800 transition-colors flex items-center justify-center"
+							aria-label="Close dates popover"
+						>
+							<Icon name="lucide:x" class="w-3.5 h-3.5" />
+						</button>
+					</div>
+
+					<!-- Calendar month/year navigation -->
+					<div class="flex items-center justify-between text-xs text-slate-200 font-semibold bg-slate-900/50 py-1 px-1.5 rounded border border-slate-800 shrink-0">
+						<div class="flex items-center gap-0.5">
+							<button
+								type="button"
+								onclick={prevYear}
+								class="p-1 hover:bg-slate-800 rounded text-slate-400 hover:text-slate-200 cursor-pointer border-none bg-transparent"
+								title="Previous year"
+							>
+								<Icon name="lucide:chevrons-left" class="w-3.5 h-3.5" />
+							</button>
+							<button
+								type="button"
+								onclick={prevMonth}
+								class="p-1 hover:bg-slate-800 rounded text-slate-400 hover:text-slate-200 cursor-pointer border-none bg-transparent"
+								title="Previous month"
+							>
+								<Icon name="lucide:chevron-left" class="w-3.5 h-3.5" />
+							</button>
+						</div>
+						
+						<span class="select-none">{monthNames[calendarMonth]} {calendarYear}</span>
+
+						<div class="flex items-center gap-0.5">
+							<button
+								type="button"
+								onclick={nextMonth}
+								class="p-1 hover:bg-slate-800 rounded text-slate-400 hover:text-slate-200 cursor-pointer border-none bg-transparent"
+								title="Next month"
+							>
+								<Icon name="lucide:chevron-right" class="w-3.5 h-3.5" />
+							</button>
+							<button
+								type="button"
+								onclick={nextYear}
+								class="p-1 hover:bg-slate-800 rounded text-slate-400 hover:text-slate-200 cursor-pointer border-none bg-transparent"
+								title="Next year"
+							>
+								<Icon name="lucide:chevrons-right" class="w-3.5 h-3.5" />
+							</button>
+						</div>
+					</div>
+
+					<!-- Weekday Headers -->
+					<div class="grid grid-cols-7 text-center text-[10px] font-bold text-slate-500 select-none shrink-0">
+						<span>Su</span>
+						<span>Mo</span>
+						<span>Tu</span>
+						<span>We</span>
+						<span>Th</span>
+						<span>Fr</span>
+						<span>Sa</span>
+					</div>
+
+					<!-- Day cells grid -->
+					<div class="grid grid-cols-7 gap-1 text-center text-xs shrink-0">
+						{#each calendarDays as cell}
+							{@const isSelected = isCellSelected(cell.day, cell.month, cell.year)}
+							<button
+								type="button"
+								onclick={() => selectCalendarDay(cell.day, cell.month, cell.year)}
+								class="aspect-square flex items-center justify-center rounded-full text-xs cursor-pointer border-none transition-colors
+									{cell.current ? 'text-slate-200' : 'text-slate-600'}
+									{isSelected 
+										? 'bg-violet-600 text-white font-bold' 
+										: cell.current 
+											? 'bg-transparent hover:bg-slate-800' 
+											: 'bg-transparent hover:bg-slate-900/50'}"
+							>
+								{cell.day}
+							</button>
+						{/each}
+					</div>
+
+					<!-- Scrollable options list -->
+					<div class="flex flex-col gap-3 overflow-y-auto pr-1 max-h-56">
+						<!-- Start date row -->
+						<div class="flex flex-col gap-1">
+							<span class="text-[10px] text-slate-400 font-semibold select-none">Start date</span>
+							<div class="flex items-center gap-2">
+								<input
+									type="checkbox"
+									bind:checked={hasStartDate}
+									class="w-4 h-4 accent-violet-600 rounded bg-slate-900 border border-slate-700 cursor-pointer shrink-0"
+								/>
+								<input
+									type="datetime-local"
+									bind:value={startDateVal}
+									disabled={!hasStartDate}
+									onfocus={() => activeDateField = 'start'}
+									class="flex-1 px-2.5 py-1.5 rounded bg-slate-900 text-slate-200 text-xs focus:outline-none focus:ring-1 focus:ring-violet-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all
+										{activeDateField === 'start' ? 'border border-violet-500 ring-1 ring-violet-500' : 'border border-slate-700'}"
+								/>
+							</div>
+						</div>
+
+						<!-- Due date row -->
+						<div class="flex flex-col gap-1">
+							<span class="text-[10px] text-slate-400 font-semibold select-none">Due date</span>
+							<div class="flex items-center gap-2">
+								<input
+									type="checkbox"
+									bind:checked={hasDueDate}
+									class="w-4 h-4 accent-violet-600 rounded bg-slate-900 border border-slate-700 cursor-pointer shrink-0"
+								/>
+								<input
+									type="datetime-local"
+									bind:value={dueDateVal}
+									disabled={!hasDueDate}
+									onfocus={() => activeDateField = 'due'}
+									class="flex-1 px-2.5 py-1.5 rounded bg-slate-900 text-slate-200 text-xs focus:outline-none focus:ring-1 focus:ring-violet-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all
+										{activeDateField === 'due' ? 'border border-violet-500 ring-1 ring-violet-500' : 'border border-slate-700'}"
+								/>
+							</div>
+						</div>
+
+						<!-- Recurring -->
+						<div class="flex flex-col gap-1">
+							<span class="text-[10px] text-slate-400 font-semibold select-none">Recurring</span>
+							<select
+								bind:value={recurringVal}
+								class="w-full px-2.5 py-1.5 rounded bg-slate-900 border border-slate-700 text-slate-200 text-xs focus:outline-none focus:ring-1 focus:ring-violet-500 cursor-pointer"
+							>
+								<option>Never</option>
+								<option>Daily</option>
+								<option>Monday to Friday</option>
+								<option>Weekly</option>
+								<option>Monthly on the {recurringDayNumber}</option>
+								<option>{recurringDayOfWeekDesc}</option>
+								<option>{recurringYearlyDesc}</option>
+							</select>
+						</div>
+
+						<!-- Set due date reminder -->
+						<div class="flex flex-col gap-1">
+							<span class="text-[10px] text-slate-400 font-semibold select-none">Set due date reminder</span>
+							<select
+								bind:value={dueReminderVal}
+								class="w-full px-2.5 py-1.5 rounded bg-slate-900 border border-slate-700 text-slate-200 text-xs focus:outline-none focus:ring-1 focus:ring-violet-500 cursor-pointer"
+							>
+								<option value={-1}>None</option>
+								<option value={0}>At time of due date</option>
+								<option value={5}>5 Minutes before</option>
+								<option value={10}>10 Minutes before</option>
+								<option value={15}>15 Minutes before</option>
+								<option value={60}>1 Hour before</option>
+								<option value={120}>2 Hours before</option>
+								<option value={1440}>1 Day before</option>
+								<option value={2880}>2 Days before</option>
+								<option value={10080}>1 Week before</option>
+								<option value={20160}>2 Weeks before</option>
+							</select>
+						</div>
+					</div>
+
+					<!-- Actions -->
+					<div class="flex gap-2 text-[10px] mt-1 shrink-0 pt-2 border-t border-slate-800">
+						<button
+							type="button"
+							onclick={() => handleSaveDatesInline(editingCardId!)}
+							class="flex-1 py-1.5 bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded transition cursor-pointer border-none"
+						>
+							Save
+						</button>
+						<button
+							type="button"
+							onclick={() => handleRemoveDatesInline(editingCardId!)}
+							class="flex-1 py-1.5 bg-slate-800 hover:bg-slate-700 border border-slate-750 text-slate-300 font-semibold rounded transition cursor-pointer"
+						>
+							Remove
+						</button>
+					</div>
+				{/if}
+			</div>
+		{/if}
+	{/if}
+{/if}
+
+
 
 		{#if taskClientStore.error}
 

--- a/frontend/components/workspace/DesktopNavigator.svelte
+++ b/frontend/components/workspace/DesktopNavigator.svelte
@@ -24,6 +24,8 @@
 	import TunnelModal from '$frontend/components/tunnel/TunnelModal.svelte';
 	import DbClientButton from '$frontend/components/db-client/DbClientButton.svelte';
 	import DbClientModal from '$frontend/components/db-client/DbClientModal.svelte';
+	import TaskClientButton from '$frontend/components/task-client/TaskClientButton.svelte';
+	import TaskClientModal from '$frontend/components/task-client/TaskClientModal.svelte';
 	import ProjectUserAvatars from '$frontend/components/common/display/ProjectUserAvatars.svelte';
 	import ws from '$frontend/utils/ws';
 
@@ -34,6 +36,7 @@
 	let searchQuery = $state('');
 	let showTunnelModal = $state(false);
 	let showDbClientModal = $state(false);
+	let showTaskClientModal = $state(false);
 	let hoveredProject = $state<Project | null>(null);
 	let tooltipY = $state(0);
 	let tooltipX = $state(0);
@@ -363,6 +366,7 @@
 				<ViewMenu />
 				<TunnelButton onClick={() => (showTunnelModal = true)} />
 				<DbClientButton onClick={() => (showDbClientModal = true)} />
+		<TaskClientButton onClick={() => (showTaskClientModal = true)} />
 
 				<button
 					type="button"
@@ -522,3 +526,4 @@
 
 <!-- DB Client Modal -->
 <DbClientModal bind:isOpen={showDbClientModal} onClose={() => (showDbClientModal = false)} />
+<TaskClientModal bind:isOpen={showTaskClientModal} onClose={() => (showTaskClientModal = false)} />

--- a/frontend/components/workspace/MobileNavigator.svelte
+++ b/frontend/components/workspace/MobileNavigator.svelte
@@ -10,6 +10,8 @@
 	import TunnelModal from '$frontend/components/tunnel/TunnelModal.svelte';
 	import DbClientButton from '$frontend/components/db-client/DbClientButton.svelte';
 	import DbClientModal from '$frontend/components/db-client/DbClientModal.svelte';
+	import TaskClientButton from '$frontend/components/task-client/TaskClientButton.svelte';
+	import TaskClientModal from '$frontend/components/task-client/TaskClientModal.svelte';
 	import type { Project } from '$shared/types/database/schema';
 	import FolderBrowser from '$frontend/components/common/form/FolderBrowser.svelte';
 	import ProjectUserAvatars from '$frontend/components/common/display/ProjectUserAvatars.svelte';
@@ -20,6 +22,7 @@
 	// Modal states
 	let showTunnelModal = $state(false);
 	let showDbClientModal = $state(false);
+	let showTaskClientModal = $state(false);
 
 	// Project dropdown state
 	let showProjectMenu = $state(false);
@@ -165,6 +168,7 @@
 
 		<!-- DB Client Button -->
 		<DbClientButton collapsed={true} onClick={() => (showDbClientModal = true)} mobile={true} />
+		<TaskClientButton collapsed={true} onClick={() => (showTaskClientModal = true)} mobile={true} />
 
 		<!-- Settings Button -->
 		<button
@@ -403,3 +407,4 @@
 
 <!-- DB Client Modal -->
 <DbClientModal bind:isOpen={showDbClientModal} onClose={() => (showDbClientModal = false)} />
+<TaskClientModal bind:isOpen={showTaskClientModal} onClose={() => (showTaskClientModal = false)} />

--- a/frontend/stores/features/settings.svelte.ts
+++ b/frontend/stores/features/settings.svelte.ts
@@ -48,8 +48,11 @@ const defaultSettings: AppSettings = {
 		modelName: 'Haiku 4.5',
 		format: 'single-line',
 		branchSeparator: DEFAULT_BRANCH_SEPARATOR,
+		ticketSource: 'none',
+		ticketPrefix: 'short-link',
+		ticketLanguage: 'auto',
 		commitConfig: { style: 'technical', subjectLength: 72, allowedTypes: '', context: '' },
-		branchConfig: { maxWords: 3, allowedPrefixes: '', context: '' }
+		branchConfig: { maxWords: 3, allowedPrefixes: '', context: '', branchMessageSeparator: '-' }
 	},
 	pinnedModels: []
 };

--- a/frontend/stores/features/task-client.svelte.ts
+++ b/frontend/stores/features/task-client.svelte.ts
@@ -1,0 +1,1622 @@
+/**
+ * task-client store — Trello integration with accounts, boards, lists, cards.
+ */
+
+import { debug } from '$shared/utils/logger';
+
+export interface TrelloAccount {
+	id: string;
+	displayName: string;
+	apiKey: string;
+	token: string;
+	me?: TrelloMember;
+}
+
+export interface TrelloMember {
+	id: string;
+	fullName: string;
+	username: string;
+	avatarUrl: string | null;
+}
+
+export interface TrelloBoard {
+	id: string;
+	name: string;
+	desc: string;
+	closed: boolean;
+	url: string;
+	idOrganization?: string | null;
+	prefs?: {
+		backgroundColor?: string;
+		backgroundImage?: string;
+	};
+}
+
+export interface TrelloOrganization {
+	id: string;
+	name: string;
+	displayName: string;
+}
+
+export interface TrelloBoardStar {
+	id: string;
+	idBoard: string;
+	pos: number;
+}
+
+export interface TrelloLabel {
+	id: string;
+	idBoard: string;
+	name: string;
+	color: string;
+}
+
+
+export interface RecentBoard {
+	id: string;
+	name: string;
+	accountId: string;
+	accountName: string;
+	prefs?: {
+		backgroundColor?: string;
+		backgroundImage?: string;
+	};
+	lastOpened: number;
+}
+
+
+export interface TrelloList {
+	id: string;
+	name: string;
+	closed: boolean;
+	idBoard: string;
+	pos: number;
+}
+
+export interface TrelloCard {
+	id: string;
+	name: string;
+	desc: string;
+	closed: boolean;
+	idList: string;
+	idBoard: string;
+	due: string | null;
+	dueComplete: boolean;
+	dueReminder?: number | null;
+	start: string | null;
+	url: string;
+	labels: { id: string; name: string; color: string }[];
+	members: { id: string; fullName: string; username?: string; avatarUrl: string | null }[];
+	pos: number;
+	badges: {
+		checkItems: number;
+		checkItemsChecked: number;
+		attachments: number;
+		description: boolean;
+		subscribed: boolean;
+		comments: number;
+	};
+}
+
+export interface TrelloCheckItem {
+	id: string;
+	idChecklist: string;
+	name: string;
+	state: 'complete' | 'incomplete';
+	pos: number;
+}
+
+export interface TrelloChecklist {
+	id: string;
+	name: string;
+	idCard: string;
+	pos: number;
+	checkItems: TrelloCheckItem[];
+}
+
+export interface TrelloAction {
+	id: string;
+	idMemberCreator: string;
+	data: {
+		text?: string;
+		card?: { id: string; name: string; idList?: string };
+		list?: { id: string; name: string };
+		listBefore?: { id: string; name: string };
+		listAfter?: { id: string; name: string };
+	};
+	type: string;
+	date: string;
+	memberCreator: {
+		id: string;
+		fullName: string;
+		username: string;
+		avatarUrl: string | null;
+	};
+}
+
+
+function trelloBase(apiKey: string, token: string) {
+	return `https://api.trello.com/1`;
+}
+
+async function trelloFetch<T>(
+	apiKey: string,
+	token: string,
+	path: string,
+	options: RequestInit = {}
+): Promise<T> {
+	const sep = path.includes('?') ? '&' : '?';
+	const url = `https://api.trello.com/1${path}${sep}key=${apiKey}&token=${token}`;
+	const res = await fetch(url, options);
+	if (!res.ok) {
+		const text = await res.text().catch(() => res.statusText);
+		throw new Error(`Trello API error ${res.status}: ${text}`);
+	}
+	return res.json() as Promise<T>;
+}
+
+function createTaskClientStore() {
+	// Persisted accounts
+	let accounts = $state<TrelloAccount[]>(loadAccounts());
+	let selectedAccountId = $state<string | null>(accounts[0]?.id ?? null);
+
+	// Per-account data
+	let boards = $state<TrelloBoard[]>([]);
+	let organizations = $state<TrelloOrganization[]>([]);
+	let starredBoardIds = $state<string[]>(selectedAccountId ? loadStarredBoardIdsForAccount(selectedAccountId) : []);
+	let selectedBoardId = $state<string | null>(null);
+	let lists = $state<TrelloList[]>([]);
+	let cards = $state<TrelloCard[]>([]);
+
+	// Loading states
+	let loadingBoards = $state(false);
+	let loadingCards = $state(false);
+	let error = $state<string | null>(null);
+
+	// Board checklists, labels & members
+	let boardChecklists = $state<TrelloChecklist[]>([]);
+	let boardLabels = $state<TrelloLabel[]>([]);
+	let boardMembers = $state<{ id: string; fullName: string; username?: string; avatarUrl: string | null }[]>([]);
+
+	// Active card details
+	let activeCardId = $state<string | null>(null);
+	const activeCardChecklists = $derived(boardChecklists.filter((cl) => cl.idCard === activeCardId));
+	let activeCardActions = $state<TrelloAction[]>([]);
+	let activeCardAttachments = $state<{ id: string; name: string; url: string; date: string; mimeType: string; bytes?: number; previews: { url: string; width: number; height: number }[] }[]>([]);
+	let loadingDetails = $state(false);
+
+	// Recent boards
+	let recentBoards = $state<RecentBoard[]>(loadRecentBoards());
+
+	// Colorblind mode
+	let colorblindMode = $state(
+		typeof localStorage !== 'undefined' &&
+		localStorage.getItem('clopen:task-client:colorblind-mode') === 'true'
+	);
+
+	function toggleColorblindMode() {
+		colorblindMode = !colorblindMode;
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem('clopen:task-client:colorblind-mode', String(colorblindMode));
+		}
+	}
+
+	// Labels expanded
+	let labelsExpanded = $state(
+		typeof localStorage !== 'undefined' &&
+		localStorage.getItem('clopen:task-client:labels-expanded') === 'true'
+	);
+
+	function toggleLabelsExpanded() {
+		labelsExpanded = !labelsExpanded;
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem('clopen:task-client:labels-expanded', String(labelsExpanded));
+		}
+	}
+
+
+	function loadRecentBoards(): RecentBoard[] {
+		if (typeof localStorage === 'undefined') return [];
+		try {
+			return JSON.parse(localStorage.getItem('clopen:task-client:recent-boards') ?? '[]');
+		} catch {
+			return [];
+		}
+	}
+
+	function saveRecentBoards(list: RecentBoard[]) {
+		if (typeof localStorage === 'undefined') return;
+		localStorage.setItem('clopen:task-client:recent-boards', JSON.stringify(list));
+	}
+
+	function addToRecentBoards(rb: Omit<RecentBoard, 'lastOpened'>) {
+		const newRb: RecentBoard = { ...rb, lastOpened: Date.now() };
+		const filtered = recentBoards.filter((b) => b.id !== rb.id);
+		recentBoards = [newRb, ...filtered].slice(0, 4); // Keep at most 4 recent boards
+		saveRecentBoards(recentBoards);
+	}
+
+	function loadAccounts(): TrelloAccount[] {
+		if (typeof localStorage === 'undefined') return [];
+		try {
+			return JSON.parse(localStorage.getItem('clopen:task-client:accounts') ?? '[]');
+		} catch {
+			return [];
+		}
+	}
+
+	function saveAccounts(list: TrelloAccount[]) {
+		if (typeof localStorage === 'undefined') return;
+		localStorage.setItem('clopen:task-client:accounts', JSON.stringify(list));
+	}
+
+	function loadBoardStars(): Record<string, string[]> {
+		if (typeof localStorage === 'undefined') return {};
+		try {
+			return JSON.parse(localStorage.getItem('clopen:task-client:board-stars') ?? '{}');
+		} catch {
+			return {};
+		}
+	}
+
+	function saveBoardStars(stars: Record<string, string[]>) {
+		if (typeof localStorage === 'undefined') return;
+		localStorage.setItem('clopen:task-client:board-stars', JSON.stringify(stars));
+	}
+
+	function loadStarredBoardIdsForAccount(accountId: string): string[] {
+		const allStars = loadBoardStars();
+		return allStars[accountId] ?? [];
+	}
+
+	async function addAccount(apiKey: string, token: string, displayName?: string): Promise<TrelloAccount> {
+		const me = await trelloFetch<TrelloMember>(apiKey, token, '/members/me?fields=id,fullName,username,avatarUrl');
+		const account: TrelloAccount = {
+			id: me.id,
+			displayName: displayName?.trim() || me.fullName,
+			apiKey,
+			token,
+			me
+		};
+		// Replace if same id, otherwise append
+		const existing = accounts.findIndex((a) => a.id === account.id);
+		if (existing >= 0) {
+			accounts[existing] = account;
+		} else {
+			accounts.push(account);
+		}
+		saveAccounts(accounts);
+		selectedAccountId = account.id;
+		starredBoardIds = loadStarredBoardIdsForAccount(account.id);
+		return account;
+	}
+
+	function removeAccount(id: string) {
+		const idx = accounts.findIndex((a) => a.id === id);
+		if (idx >= 0) accounts.splice(idx, 1);
+		saveAccounts(accounts);
+		
+		// Clean up recent boards belonging to the removed account
+		recentBoards = recentBoards.filter((b) => b.accountId !== id);
+		saveRecentBoards(recentBoards);
+
+		// Clean up board stars belonging to the removed account
+		const stars = loadBoardStars();
+		delete stars[id];
+		saveBoardStars(stars);
+
+		if (selectedAccountId === id) {
+			selectedAccountId = accounts[0]?.id ?? null;
+			starredBoardIds = selectedAccountId ? loadStarredBoardIdsForAccount(selectedAccountId) : [];
+			boards = [];
+			selectedBoardId = null;
+			lists = [];
+			cards = [];
+		}
+	}
+
+	function selectAccount(id: string) {
+		selectedAccountId = id;
+		starredBoardIds = loadStarredBoardIdsForAccount(id);
+		boards = [];
+		selectedBoardId = null;
+		lists = [];
+		cards = [];
+		error = null;
+		loadBoards().catch((e) => {
+			debug.error('task-client', 'loadBoards failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+		});
+	}
+
+	async function loadBoards(): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+		loadingBoards = true;
+		error = null;
+		try {
+			const [fetchedBoards, fetchedOrgs] = await Promise.all([
+				trelloFetch<TrelloBoard[]>(
+					account.apiKey,
+					account.token,
+					'/members/me/boards?filter=open&fields=id,name,desc,closed,url,prefs,idOrganization'
+				),
+				trelloFetch<TrelloOrganization[]>(
+					account.apiKey,
+					account.token,
+					'/members/me/organizations?fields=id,name,displayName'
+				)
+			]);
+			boards = fetchedBoards;
+			organizations = fetchedOrgs;
+		} finally {
+			loadingBoards = false;
+		}
+	}
+
+	async function selectBoard(boardId: string): Promise<void> {
+		selectedBoardId = boardId;
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+		loadingCards = true;
+		error = null;
+		try {
+			const [fetchedLists, fetchedCards, fetchedChecklists, fetchedLabels, fetchedMembers] = await Promise.all([
+				trelloFetch<TrelloList[]>(
+					account.apiKey,
+					account.token,
+					`/boards/${boardId}/lists?filter=open&fields=id,name,closed,idBoard,pos`
+				),
+				trelloFetch<TrelloCard[]>(
+					account.apiKey,
+					account.token,
+					`/boards/${boardId}/cards?filter=open&fields=id,name,desc,closed,idList,idBoard,due,dueComplete,dueReminder,start,url,labels,badges,pos&members=true&member_fields=id,fullName,username,avatarUrl`
+				),
+				trelloFetch<TrelloChecklist[]>(
+					account.apiKey,
+					account.token,
+					`/boards/${boardId}/checklists?checkItems=all`
+				).catch((e) => {
+					debug.error('task-client', 'Failed to prefetch board checklists, defaulting to empty:', e);
+					return [];
+				}),
+				trelloFetch<TrelloLabel[]>(
+					account.apiKey,
+					account.token,
+					`/boards/${boardId}/labels?fields=all&limit=1000`
+				).catch((e) => {
+					debug.error('task-client', 'Failed to prefetch board labels, defaulting to empty:', e);
+					return [];
+				}),
+				trelloFetch<{ id: string; fullName: string; username?: string; avatarUrl: string | null }[]>(
+					account.apiKey,
+					account.token,
+					`/boards/${boardId}/members?fields=id,fullName,username,avatarUrl`
+				).catch((e) => {
+					debug.error('task-client', 'Failed to prefetch board members, defaulting to empty:', e);
+					return [];
+				})
+			]);
+			lists = fetchedLists.sort((a, b) => a.pos - b.pos);
+			cards = fetchedCards.sort((a, b) => a.pos - b.pos);
+			
+			for (const cl of fetchedChecklists) {
+				if (cl.checkItems) {
+					cl.checkItems.sort((a, b) => a.pos - b.pos);
+				}
+			}
+			boardChecklists = fetchedChecklists;
+			boardLabels = fetchedLabels;
+			boardMembers = fetchedMembers;
+
+			// Save to recent boards
+			const board = boards.find((b) => b.id === boardId);
+			if (board) {
+				addToRecentBoards({
+					id: board.id,
+					name: board.name,
+					accountId: account.id,
+					accountName: account.displayName,
+					prefs: board.prefs
+				});
+			}
+		} finally {
+			loadingCards = false;
+		}
+	}
+
+	async function selectRecentBoard(boardId: string, accountId: string): Promise<void> {
+		selectedAccountId = accountId;
+		starredBoardIds = loadStarredBoardIdsForAccount(accountId);
+		selectedBoardId = boardId;
+		const account = accounts.find((a) => a.id === accountId);
+		if (!account) return;
+		loadingCards = true;
+		error = null;
+		try {
+			const [fetchedLists, fetchedCards, fetchedBoards, fetchedOrgs, fetchedChecklists, fetchedLabels, fetchedMembers] = await Promise.all([
+				trelloFetch<TrelloList[]>(
+					account.apiKey,
+					account.token,
+					`/boards/${boardId}/lists?filter=open&fields=id,name,closed,idBoard,pos`
+				),
+				trelloFetch<TrelloCard[]>(
+					account.apiKey,
+					account.token,
+					`/boards/${boardId}/cards?filter=open&fields=id,name,desc,closed,idList,idBoard,due,dueComplete,dueReminder,start,url,labels,badges,pos&members=true&member_fields=id,fullName,username,avatarUrl`
+				),
+				trelloFetch<TrelloBoard[]>(
+					account.apiKey,
+					account.token,
+					'/members/me/boards?filter=open&fields=id,name,desc,closed,url,prefs,idOrganization'
+				),
+				trelloFetch<TrelloOrganization[]>(
+					account.apiKey,
+					account.token,
+					'/members/me/organizations?fields=id,name,displayName'
+				),
+				trelloFetch<TrelloChecklist[]>(
+					account.apiKey,
+					account.token,
+					`/boards/${boardId}/checklists?checkItems=all`
+				).catch((e) => {
+					debug.error('task-client', 'Failed to prefetch board checklists, defaulting to empty:', e);
+					return [];
+				}),
+				trelloFetch<TrelloLabel[]>(
+					account.apiKey,
+					account.token,
+					`/boards/${boardId}/labels?fields=all&limit=1000`
+				).catch((e) => {
+					debug.error('task-client', 'Failed to prefetch board labels, defaulting to empty:', e);
+					return [];
+				}),
+				trelloFetch<{ id: string; fullName: string; username?: string; avatarUrl: string | null }[]>(
+					account.apiKey,
+					account.token,
+					`/boards/${boardId}/members?fields=id,fullName,username,avatarUrl`
+				).catch((e) => {
+					debug.error('task-client', 'Failed to prefetch board members, defaulting to empty:', e);
+					return [];
+				})
+			]);
+			lists = fetchedLists.sort((a, b) => a.pos - b.pos);
+			cards = fetchedCards.sort((a, b) => a.pos - b.pos);
+			boards = fetchedBoards;
+			organizations = fetchedOrgs;
+
+			for (const cl of fetchedChecklists) {
+				if (cl.checkItems) {
+					cl.checkItems.sort((a, b) => a.pos - b.pos);
+				}
+			}
+			boardChecklists = fetchedChecklists;
+			boardLabels = fetchedLabels;
+			boardMembers = fetchedMembers;
+
+			// Save/update to recent boards
+			const board = boards.find((b) => b.id === boardId);
+			if (board) {
+				addToRecentBoards({
+					id: board.id,
+					name: board.name,
+					accountId: account.id,
+					accountName: account.displayName,
+					prefs: board.prefs
+				});
+			}
+		} finally {
+			loadingCards = false;
+		}
+	}
+
+	function toggleBoardStar(boardId: string): void {
+		if (!selectedAccountId) return;
+		
+		const stars = loadBoardStars();
+		const current = stars[selectedAccountId] ?? [];
+		let updated: string[];
+		if (current.includes(boardId)) {
+			updated = current.filter((id) => id !== boardId);
+		} else {
+			updated = [...current, boardId];
+		}
+		stars[selectedAccountId] = updated;
+		saveBoardStars(stars);
+		starredBoardIds = updated;
+	}
+
+
+	async function moveCard(cardId: string, targetListId: string, targetPos: number): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const cardIdx = cards.findIndex((c) => c.id === cardId);
+		if (cardIdx === -1) return;
+
+		const originalListId = cards[cardIdx].idList;
+		const originalPos = cards[cardIdx].pos;
+		if (originalListId === targetListId && originalPos === targetPos) return;
+
+		// Optimistic update
+		cards[cardIdx] = { ...cards[cardIdx], idList: targetListId, pos: targetPos };
+		cards = cards.sort((a, b) => a.pos - b.pos);
+		error = null;
+
+		try {
+			await trelloFetch<TrelloCard>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}?idList=${targetListId}&pos=${targetPos}`,
+				{ method: 'PUT' }
+			);
+		} catch (e) {
+			debug.error('task-client', 'moveCard failed, reverting:', e);
+			// Revert on error
+			const revertIdx = cards.findIndex((c) => c.id === cardId);
+			if (revertIdx !== -1) {
+				cards[revertIdx] = { ...cards[revertIdx], idList: originalListId, pos: originalPos };
+				cards = cards.sort((a, b) => a.pos - b.pos);
+			}
+			error = e instanceof Error ? e.message : String(e);
+		}
+	}
+
+	async function createCard(listId: string, name: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		error = null;
+		try {
+			const newCard = await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				'/cards',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json'
+					},
+					body: JSON.stringify({
+						idList: listId,
+						name: name.trim()
+					})
+				}
+			);
+			
+			// Normalize/ensure all expected fields are present
+			const normalizedCard: TrelloCard = {
+				id: newCard.id,
+				name: newCard.name || '',
+				desc: newCard.desc || '',
+				closed: newCard.closed ?? false,
+				idList: newCard.idList,
+				idBoard: newCard.idBoard,
+				due: newCard.due || null,
+				dueComplete: newCard.dueComplete ?? false,
+				dueReminder: newCard.dueReminder ?? null,
+				start: newCard.start || null,
+				url: newCard.url || `https://trello.com/c/${newCard.id}`,
+				labels: newCard.labels || [],
+				members: newCard.members || [],
+				pos: newCard.pos ?? 16384,
+				badges: newCard.badges || {
+					checkItems: 0,
+					checkItemsChecked: 0,
+					attachments: 0,
+					description: false,
+					subscribed: false,
+					comments: 0
+				}
+			};
+			
+			cards.push(normalizedCard);
+			cards = cards.sort((a, b) => a.pos - b.pos);
+		} catch (e) {
+			debug.error('task-client', 'createCard failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function archiveList(listId: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		error = null;
+		try {
+			await trelloFetch<TrelloList>(
+				account.apiKey,
+				account.token,
+				`/lists/${listId}?closed=true`,
+				{ method: 'PUT' }
+			);
+			lists = lists.filter((l) => l.id !== listId);
+			cards = cards.filter((c) => c.idList !== listId);
+		} catch (e) {
+			debug.error('task-client', 'archiveList failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function archiveAllCards(listId: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		error = null;
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/lists/${listId}/archiveAllCards`,
+				{ method: 'POST' }
+			);
+			cards = cards.filter((c) => c.idList !== listId);
+		} catch (e) {
+			debug.error('task-client', 'archiveAllCards failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+
+	async function fetchCardDetails(cardId: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		activeCardId = cardId;
+		boardChecklists = boardChecklists.filter((cl) => cl.idCard !== cardId);
+		activeCardActions = [];
+		loadingDetails = true;
+		error = null;
+
+		try {
+			const [checklistsData, actionsData, attachmentsData] = await Promise.all([
+				trelloFetch<TrelloChecklist[]>(
+					account.apiKey,
+					account.token,
+					`/cards/${cardId}/checklists`
+				),
+				trelloFetch<TrelloAction[]>(
+					account.apiKey,
+					account.token,
+					`/cards/${cardId}/actions?filter=commentCard,createCard,updateCard,addChecklistToCard,updateCheckItemStateOnCard&limit=50`
+				),
+				trelloFetch<{ id: string; name: string; url: string; date: string; mimeType: string; bytes?: number; previews: { url: string; width: number; height: number }[] }[]>(
+					account.apiKey,
+					account.token,
+					`/cards/${cardId}/attachments`
+				).catch(() => [])
+			]);
+			for (const cl of checklistsData) {
+				if (cl.checkItems) {
+					cl.checkItems.sort((a, b) => a.pos - b.pos);
+				}
+			}
+			boardChecklists = boardChecklists.filter((cl) => cl.idCard !== cardId).concat(checklistsData);
+			activeCardActions = actionsData;
+			activeCardAttachments = attachmentsData;
+		} catch (e) {
+			debug.error('task-client', 'fetchCardDetails failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+		} finally {
+			loadingDetails = false;
+		}
+	}
+
+	async function updateCardDescription(cardId: string, desc: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const cardIdx = cards.findIndex((c) => c.id === cardId);
+		let originalDesc = '';
+		if (cardIdx !== -1) {
+			originalDesc = cards[cardIdx].desc;
+			cards[cardIdx].desc = desc;
+		}
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}`,
+				{
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ desc })
+				}
+			);
+		} catch (e) {
+			debug.error('task-client', 'updateCardDescription failed, reverting:', e);
+			if (cardIdx !== -1) {
+				cards[cardIdx].desc = originalDesc;
+			}
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function updateCheckItemState(
+		cardId: string,
+		checklistId: string,
+		checkItemId: string,
+		state: 'complete' | 'incomplete'
+	): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const clIdx = boardChecklists.findIndex((cl) => cl.id === checklistId);
+		let originalState: 'complete' | 'incomplete' = 'incomplete';
+		if (clIdx !== -1) {
+			const itemIdx = boardChecklists[clIdx].checkItems.findIndex((item) => item.id === checkItemId);
+			if (itemIdx !== -1) {
+				originalState = boardChecklists[clIdx].checkItems[itemIdx].state;
+				boardChecklists[clIdx].checkItems[itemIdx].state = state;
+			}
+		}
+
+		const cardIdx = cards.findIndex((c) => c.id === cardId);
+		let originalCheckItemsChecked = 0;
+		if (cardIdx !== -1) {
+			originalCheckItemsChecked = cards[cardIdx].badges.checkItemsChecked;
+			if (state === 'complete' && originalState === 'incomplete') {
+				cards[cardIdx].badges.checkItemsChecked += 1;
+			} else if (state === 'incomplete' && originalState === 'complete') {
+				cards[cardIdx].badges.checkItemsChecked -= 1;
+			}
+		}
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}/checkItem/${checkItemId}`,
+				{
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ state })
+				}
+			);
+		} catch (e) {
+			debug.error('task-client', 'updateCheckItemState failed, reverting:', e);
+			if (clIdx !== -1) {
+				const itemIdx = boardChecklists[clIdx].checkItems.findIndex((item) => item.id === checkItemId);
+				if (itemIdx !== -1) {
+					boardChecklists[clIdx].checkItems[itemIdx].state = originalState;
+				}
+			}
+			if (cardIdx !== -1) {
+				cards[cardIdx].badges.checkItemsChecked = originalCheckItemsChecked;
+			}
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function addCheckItem(checklistId: string, name: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		try {
+			const newItem = await trelloFetch<TrelloCheckItem>(
+				account.apiKey,
+				account.token,
+				`/checklists/${checklistId}/checkItems`,
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ name: name.trim() })
+				}
+			);
+			
+			const clIdx = boardChecklists.findIndex((cl) => cl.id === checklistId);
+			if (clIdx !== -1) {
+				boardChecklists[clIdx].checkItems.push(newItem);
+				const cardIdx = cards.findIndex((c) => c.id === boardChecklists[clIdx].idCard);
+				if (cardIdx !== -1) {
+					cards[cardIdx].badges.checkItems += 1;
+				}
+			}
+		} catch (e) {
+			debug.error('task-client', 'addCheckItem failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function addComment(cardId: string, text: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		try {
+			const newAction = await trelloFetch<TrelloAction>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}/actions/comments?text=${encodeURIComponent(text.trim())}`,
+				{
+					method: 'POST'
+				}
+			);
+			activeCardActions.unshift(newAction);
+			
+			const cardIdx = cards.findIndex((c) => c.id === cardId);
+			if (cardIdx !== -1) {
+				cards[cardIdx].badges.comments += 1;
+			}
+		} catch (e) {
+			debug.error('task-client', 'addComment failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function toggleDueComplete(cardId: string, complete: boolean): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const cardIdx = cards.findIndex((c) => c.id === cardId);
+		let original = false;
+		let originalDue: string | null = null;
+		const nowStr = new Date().toISOString();
+
+		if (cardIdx !== -1) {
+			original = cards[cardIdx].dueComplete;
+			originalDue = cards[cardIdx].due;
+			cards[cardIdx].dueComplete = complete;
+			if (complete && !cards[cardIdx].due) {
+				cards[cardIdx].due = nowStr;
+			}
+		}
+
+		try {
+			const body: any = { dueComplete: complete };
+			if (complete && originalDue === null) {
+				body.due = nowStr;
+			}
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}`,
+				{
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify(body)
+				}
+			);
+		} catch (e) {
+			debug.error('task-client', 'toggleDueComplete failed, reverting:', e);
+			if (cardIdx !== -1) {
+				cards[cardIdx].dueComplete = original;
+				cards[cardIdx].due = originalDue;
+			}
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function addChecklist(cardId: string, name: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		try {
+			const newChecklist = await trelloFetch<TrelloChecklist>(
+				account.apiKey,
+				account.token,
+				`/checklists?idCard=${cardId}&name=${encodeURIComponent(name.trim())}`,
+				{ method: 'POST' }
+			);
+			boardChecklists.push(newChecklist);
+		} catch (e) {
+			debug.error('task-client', 'addChecklist failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function deleteChecklist(checklistId: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const clIdx = boardChecklists.findIndex((cl) => cl.id === checklistId);
+		let checklist: TrelloChecklist | null = null;
+		if (clIdx !== -1) {
+			checklist = boardChecklists[clIdx];
+		}
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/checklists/${checklistId}`,
+				{ method: 'DELETE' }
+			);
+			boardChecklists = boardChecklists.filter((cl) => cl.id !== checklistId);
+			if (checklist) {
+				const numItems = checklist.checkItems.length;
+				const numChecked = checklist.checkItems.filter((item) => item.state === 'complete').length;
+				const cardIdx = cards.findIndex((c) => c.id === checklist!.idCard);
+				if (cardIdx !== -1) {
+					cards[cardIdx].badges.checkItems = Math.max(0, cards[cardIdx].badges.checkItems - numItems);
+					cards[cardIdx].badges.checkItemsChecked = Math.max(0, cards[cardIdx].badges.checkItemsChecked - numChecked);
+				}
+			}
+		} catch (e) {
+			debug.error('task-client', 'deleteChecklist failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function deleteCheckItem(cardId: string, checklistId: string, itemId: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const clIdx = boardChecklists.findIndex((cl) => cl.id === checklistId);
+		let removedItem: TrelloCheckItem | null = null;
+		if (clIdx !== -1) {
+			const originalItems = boardChecklists[clIdx].checkItems;
+			const found = originalItems.find(item => item.id === itemId);
+			if (found) {
+				removedItem = found;
+			}
+		}
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}/checkItem/${itemId}`,
+				{ method: 'DELETE' }
+			);
+			if (clIdx !== -1 && removedItem) {
+				boardChecklists[clIdx].checkItems = boardChecklists[clIdx].checkItems.filter((item) => item.id !== itemId);
+				const cardIdx = cards.findIndex((c) => c.id === cardId);
+				if (cardIdx !== -1) {
+					cards[cardIdx].badges.checkItems = Math.max(0, cards[cardIdx].badges.checkItems - 1);
+					if (removedItem.state === 'complete') {
+						cards[cardIdx].badges.checkItemsChecked = Math.max(0, cards[cardIdx].badges.checkItemsChecked - 1);
+					}
+				}
+			}
+		} catch (e) {
+			debug.error('task-client', 'deleteCheckItem failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function deleteComment(cardId: string, actionId: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/actions/${actionId}`,
+				{ method: 'DELETE' }
+			);
+			activeCardActions = activeCardActions.filter((a) => a.id !== actionId);
+			const cardIdx = cards.findIndex((c) => c.id === cardId);
+			if (cardIdx !== -1) {
+				cards[cardIdx].badges.comments = Math.max(0, cards[cardIdx].badges.comments - 1);
+			}
+		} catch (e) {
+			debug.error('task-client', 'deleteComment failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function updateComment(actionId: string, text: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		try {
+			const updatedAction = await trelloFetch<TrelloAction>(
+				account.apiKey,
+				account.token,
+				`/actions/${actionId}/text?text=${encodeURIComponent(text.trim())}`,
+				{ method: 'PUT' }
+			);
+			const idx = activeCardActions.findIndex((a) => a.id === actionId);
+			if (idx !== -1) {
+				activeCardActions[idx] = updatedAction;
+			}
+		} catch (e) {
+			debug.error('task-client', 'updateComment failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function updateCardDates(
+		cardId: string,
+		start: string | null,
+		due: string | null,
+		dueReminder: number | null = null
+	): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const cardIdx = cards.findIndex((c) => c.id === cardId);
+		let originalStart: string | null = null;
+		let originalDue: string | null = null;
+		let originalDueReminder: number | null = null;
+		if (cardIdx !== -1) {
+			originalStart = cards[cardIdx].start;
+			originalDue = cards[cardIdx].due;
+			originalDueReminder = cards[cardIdx].dueReminder ?? null;
+			cards[cardIdx].start = start;
+			cards[cardIdx].due = due;
+			cards[cardIdx].dueReminder = dueReminder;
+		}
+
+		try {
+			const queryParams = new URLSearchParams();
+			const reminderVal = dueReminder !== null ? dueReminder : -1;
+			queryParams.append('dueReminder', String(reminderVal));
+
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}?${queryParams.toString()}`,
+				{
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ start, due })
+				}
+			);
+		} catch (e) {
+			debug.error('task-client', 'updateCardDates failed, reverting:', e);
+			if (cardIdx !== -1) {
+				cards[cardIdx].start = originalStart;
+				cards[cardIdx].due = originalDue;
+				cards[cardIdx].dueReminder = originalDueReminder;
+			}
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function addLabelToCard(cardId: string, labelId: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const cardIdx = cards.findIndex((c) => c.id === cardId);
+		if (cardIdx === -1) return;
+
+		const label = boardLabels.find((l) => l.id === labelId);
+		if (!label) return;
+
+		const originalLabels = [...cards[cardIdx].labels];
+		cards[cardIdx].labels.push({ id: label.id, name: label.name, color: label.color });
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}/idLabels`,
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ value: labelId })
+				}
+			);
+		} catch (e) {
+			debug.error('task-client', 'addLabelToCard failed, reverting:', e);
+			if (cardIdx !== -1) {
+				cards[cardIdx].labels = originalLabels;
+			}
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function removeLabelFromCard(cardId: string, labelId: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const cardIdx = cards.findIndex((c) => c.id === cardId);
+		if (cardIdx === -1) return;
+
+		const originalLabels = [...cards[cardIdx].labels];
+		cards[cardIdx].labels = cards[cardIdx].labels.filter((l) => l.id !== labelId);
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}/idLabels/${labelId}`,
+				{ method: 'DELETE' }
+			);
+		} catch (e) {
+			debug.error('task-client', 'removeLabelFromCard failed, reverting:', e);
+			if (cardIdx !== -1) {
+				cards[cardIdx].labels = originalLabels;
+			}
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function createLabel(name: string, color: string): Promise<TrelloLabel> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account || !selectedBoardId) throw new Error('No active board');
+
+		try {
+			const newLabel = await trelloFetch<TrelloLabel>(
+				account.apiKey,
+				account.token,
+				`/labels?name=${encodeURIComponent(name.trim())}&color=${color}&idBoard=${selectedBoardId}`,
+				{ method: 'POST' }
+			);
+			boardLabels.push(newLabel);
+			return newLabel;
+		} catch (e) {
+			debug.error('task-client', 'createLabel failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function updateLabel(labelId: string, name: string, color: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const labelIdx = boardLabels.findIndex((l) => l.id === labelId);
+		if (labelIdx === -1) return;
+
+		const originalName = boardLabels[labelIdx].name;
+		const originalColor = boardLabels[labelIdx].color;
+		boardLabels[labelIdx].name = name;
+		boardLabels[labelIdx].color = color;
+
+		const originalCardsLabels = cards.map((c) => ({ cardId: c.id, labels: [...c.labels] }));
+		for (const card of cards) {
+			const lIdx = card.labels.findIndex((l) => l.id === labelId);
+			if (lIdx !== -1) {
+				card.labels[lIdx].name = name;
+				card.labels[lIdx].color = color;
+			}
+		}
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/labels/${labelId}?name=${encodeURIComponent(name.trim())}&color=${color}`,
+				{ method: 'PUT' }
+			);
+		} catch (e) {
+			debug.error('task-client', 'updateLabel failed, reverting:', e);
+			if (labelIdx !== -1) {
+				boardLabels[labelIdx].name = originalName;
+				boardLabels[labelIdx].color = originalColor;
+			}
+			for (const orig of originalCardsLabels) {
+				const cIdx = cards.findIndex((c) => c.id === orig.cardId);
+				if (cIdx !== -1) {
+					cards[cIdx].labels = orig.labels;
+				}
+			}
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function deleteLabel(labelId: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const labelIdx = boardLabels.findIndex((l) => l.id === labelId);
+		if (labelIdx === -1) return;
+
+		const originalLabel = boardLabels[labelIdx];
+		const originalCardsLabels = cards.map((c) => ({ cardId: c.id, labels: [...c.labels] }));
+
+		boardLabels = boardLabels.filter((l) => l.id !== labelId);
+		for (const card of cards) {
+			card.labels = card.labels.filter((l) => l.id !== labelId);
+		}
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/labels/${labelId}`,
+				{ method: 'DELETE' }
+			);
+		} catch (e) {
+			debug.error('task-client', 'deleteLabel failed, reverting:', e);
+			boardLabels.push(originalLabel);
+			for (const orig of originalCardsLabels) {
+				const cIdx = cards.findIndex((c) => c.id === orig.cardId);
+				if (cIdx !== -1) {
+					cards[cIdx].labels = orig.labels;
+				}
+			}
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function archiveCard(cardId: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}`,
+				{
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ closed: true })
+				}
+			);
+			cards = cards.filter((c) => c.id !== cardId);
+		} catch (e) {
+			debug.error('task-client', 'archiveCard failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function deleteCard(cardId: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}`,
+				{ method: 'DELETE' }
+			);
+			cards = cards.filter((c) => c.id !== cardId);
+		} catch (e) {
+			debug.error('task-client', 'deleteCard failed:', e);
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function updateChecklistName(checklistId: string, name: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const clIdx = boardChecklists.findIndex((cl) => cl.id === checklistId);
+		let originalName = '';
+		if (clIdx !== -1) {
+			originalName = boardChecklists[clIdx].name;
+			boardChecklists[clIdx].name = name;
+		}
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/checklists/${checklistId}?name=${encodeURIComponent(name.trim())}`,
+				{ method: 'PUT' }
+			);
+		} catch (e) {
+			debug.error('task-client', 'updateChecklistName failed, reverting:', e);
+			if (clIdx !== -1) {
+				boardChecklists[clIdx].name = originalName;
+			}
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function updateCheckItemName(
+		cardId: string,
+		checklistId: string,
+		itemId: string,
+		name: string
+	): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const clIdx = boardChecklists.findIndex((cl) => cl.id === checklistId);
+		let originalName = '';
+		if (clIdx !== -1) {
+			const itemIdx = boardChecklists[clIdx].checkItems.findIndex((item) => item.id === itemId);
+			if (itemIdx !== -1) {
+				originalName = boardChecklists[clIdx].checkItems[itemIdx].name;
+				boardChecklists[clIdx].checkItems[itemIdx].name = name;
+			}
+		}
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}/checkItem/${itemId}`,
+				{
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ name })
+				}
+			);
+		} catch (e) {
+			debug.error('task-client', 'updateCheckItemName failed, reverting:', e);
+			if (clIdx !== -1) {
+				const itemIdx = boardChecklists[clIdx].checkItems.findIndex((item) => item.id === itemId);
+				if (itemIdx !== -1) {
+					boardChecklists[clIdx].checkItems[itemIdx].name = originalName;
+				}
+			}
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function updateListName(listId: string, name: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const listIdx = lists.findIndex((l) => l.id === listId);
+		let originalName = '';
+		if (listIdx !== -1) {
+			originalName = lists[listIdx].name;
+			lists[listIdx].name = name;
+		}
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/lists/${listId}?name=${encodeURIComponent(name.trim())}`,
+				{ method: 'PUT' }
+			);
+		} catch (e) {
+			debug.error('task-client', 'updateListName failed, reverting:', e);
+			if (listIdx !== -1) {
+				lists[listIdx].name = originalName;
+			}
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	function getCardsForList(listId: string): TrelloCard[] {
+		return cards.filter((c) => c.idList === listId);
+	}
+
+	async function fetchBoardChecklists(): Promise<TrelloChecklist[]> {
+		if (!selectedAccountId || !selectedBoardId) return [];
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return [];
+		try {
+			return await trelloFetch<TrelloChecklist[]>(
+				account.apiKey,
+				account.token,
+				`/boards/${selectedBoardId}/checklists?checkItems=all`
+			);
+		} catch (e) {
+			debug.error('task-client', 'Failed to fetch board checklists:', e);
+			return [];
+		}
+	}
+
+	async function addMemberToCard(cardId: string, memberId: string): Promise<void> {
+		if (!selectedAccountId) return;
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+		const cardIdx = cards.findIndex((c) => c.id === cardId);
+		if (cardIdx === -1) return;
+		const member = boardMembers.find((m) => m.id === memberId);
+		if (!member) return;
+		// Optimistic update
+		const originalMembers = [...cards[cardIdx].members];
+		cards[cardIdx].members = [...originalMembers, { id: member.id, fullName: member.fullName, username: member.username, avatarUrl: member.avatarUrl }];
+		try {
+			const allMemberIds = cards[cardIdx].members.map((m) => m.id);
+			await trelloFetch<unknown>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}/idMembers`,
+				{ method: 'PUT', body: JSON.stringify({ value: allMemberIds.join(',') }), headers: { 'Content-Type': 'application/json' } }
+			);
+		} catch (e) {
+			debug.error('task-client', 'addMemberToCard failed, reverting:', e);
+			cards[cardIdx].members = originalMembers;
+			throw e;
+		}
+	}
+
+	async function removeMemberFromCard(cardId: string, memberId: string): Promise<void> {
+		if (!selectedAccountId) return;
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+		const cardIdx = cards.findIndex((c) => c.id === cardId);
+		if (cardIdx === -1) return;
+		// Optimistic update
+		const originalMembers = [...cards[cardIdx].members];
+		cards[cardIdx].members = originalMembers.filter((m) => m.id !== memberId);
+		try {
+			await trelloFetch<unknown>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}/idMembers/${memberId}`,
+				{ method: 'DELETE' }
+			);
+		} catch (e) {
+			debug.error('task-client', 'removeMemberFromCard failed, reverting:', e);
+			cards[cardIdx].members = originalMembers;
+			throw e;
+		}
+	}
+
+	async function addAttachmentFile(cardId: string, file: File): Promise<{ id: string; name: string; url: string; date: string; mimeType: string; bytes?: number; previews: { url: string; width: number; height: number }[] } | undefined> {
+		if (!selectedAccountId) return;
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+		const cardIdx = cards.findIndex((c) => c.id === cardId);
+		// Optimistic badge update
+		if (cardIdx !== -1) cards[cardIdx].badges.attachments++;
+		try {
+			const form = new FormData();
+			form.append('file', file);
+			form.append('name', file.name);
+			const sep = '?';
+			const url = `https://api.trello.com/1/cards/${cardId}/attachments${sep}key=${account.apiKey}&token=${account.token}`;
+			const res = await fetch(url, { method: 'POST', body: form });
+			if (!res.ok) {
+				const text = await res.text().catch(() => res.statusText);
+				throw new Error(`Trello API error ${res.status}: ${text}`);
+			}
+			const created = await res.json() as { id: string; name: string; url: string; date: string; mimeType: string; bytes?: number; previews: { url: string; width: number; height: number }[] };
+			if (activeCardId === cardId) activeCardAttachments = [created, ...activeCardAttachments];
+			return created;
+		} catch (e) {
+			if (cardIdx !== -1) cards[cardIdx].badges.attachments = Math.max(0, cards[cardIdx].badges.attachments - 1);
+			debug.error('task-client', 'addAttachmentFile failed:', e);
+			throw e;
+		}
+	}
+
+	async function addAttachmentUrl(cardId: string, url: string, name?: string): Promise<void> {
+		if (!selectedAccountId) return;
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+		const cardIdx = cards.findIndex((c) => c.id === cardId);
+		// Optimistic badge update
+		if (cardIdx !== -1) cards[cardIdx].badges.attachments++;
+		try {
+			const created = await trelloFetch<{ id: string; name: string; url: string; date: string; mimeType: string; bytes?: number; previews: { url: string; width: number; height: number }[] }>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}/attachments`,
+				{ method: 'POST', body: JSON.stringify({ url, name: name || url }), headers: { 'Content-Type': 'application/json' } }
+			);
+			if (activeCardId === cardId) activeCardAttachments = [created, ...activeCardAttachments];
+		} catch (e) {
+			if (cardIdx !== -1) cards[cardIdx].badges.attachments = Math.max(0, cards[cardIdx].badges.attachments - 1);
+			debug.error('task-client', 'addAttachmentUrl failed:', e);
+			throw e;
+		}
+	}
+
+	async function deleteAttachment(cardId: string, attachmentId: string): Promise<void> {
+		if (!selectedAccountId) return;
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+		const cardIdx = cards.findIndex((c) => c.id === cardId);
+		const originalAttachments = [...activeCardAttachments];
+		// Optimistic remove
+		activeCardAttachments = activeCardAttachments.filter((a) => a.id !== attachmentId);
+		if (cardIdx !== -1) cards[cardIdx].badges.attachments = Math.max(0, cards[cardIdx].badges.attachments - 1);
+		try {
+			await trelloFetch<unknown>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}/attachments/${attachmentId}`,
+				{ method: 'DELETE' }
+			);
+		} catch (e) {
+			activeCardAttachments = originalAttachments;
+			if (cardIdx !== -1) cards[cardIdx].badges.attachments++;
+			debug.error('task-client', 'deleteAttachment failed:', e);
+			throw e;
+		}
+	}
+
+	async function renameAttachment(cardId: string, attachmentId: string, name: string): Promise<void> {
+		if (!selectedAccountId) return;
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+		const originalName = activeCardAttachments.find((a) => a.id === attachmentId)?.name ?? '';
+		// Optimistic update
+		activeCardAttachments = activeCardAttachments.map((a) => a.id === attachmentId ? { ...a, name } : a);
+		try {
+			await trelloFetch<unknown>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}/attachments/${attachmentId}`,
+				{ method: 'PUT', body: JSON.stringify({ name }), headers: { 'Content-Type': 'application/json' } }
+			);
+		} catch (e) {
+			activeCardAttachments = activeCardAttachments.map((a) => a.id === attachmentId ? { ...a, name: originalName } : a);
+			debug.error('task-client', 'renameAttachment failed:', e);
+			throw e;
+		}
+	}
+
+	return {
+		get accounts() { return accounts; },
+		get selectedAccountId() { return selectedAccountId; },
+		get selectedAccount() { return accounts.find((a) => a.id === selectedAccountId) ?? null; },
+		get boards() { return boards; },
+		get selectedBoardId() { return selectedBoardId; },
+		get selectedBoard() { return boards.find((b) => b.id === selectedBoardId) ?? null; },
+		get organizations() { return organizations; },
+		get lists() { return lists; },
+		get cards() { return cards; },
+		get boardChecklists() { return boardChecklists; },
+		get boardLabels() { return boardLabels; },
+		get loadingBoards() { return loadingBoards; },
+		get loadingCards() { return loadingCards; },
+		get error() { return error; },
+		set error(val: string | null) { error = val; },
+		get activeCardId() { return activeCardId; },
+		get activeCardChecklists() { return activeCardChecklists; },
+		get activeCardActions() { return activeCardActions; },
+		get activeCardAttachments() { return activeCardAttachments; },
+		get loadingDetails() { return loadingDetails; },
+		get recentBoards() { return recentBoards; },
+		get boardStars() { return starredBoardIds.map((id) => ({ id, idBoard: id, pos: 0 })); },
+		get colorblindMode() { return colorblindMode; },
+		toggleColorblindMode,
+		get labelsExpanded() { return labelsExpanded; },
+		toggleLabelsExpanded,
+		addAccount,
+		removeAccount,
+		selectAccount,
+		loadBoards,
+		selectBoard,
+		selectRecentBoard,
+		toggleBoardStar,
+		getCardsForList,
+		moveCard,
+		createCard,
+		archiveList,
+		archiveAllCards,
+		fetchCardDetails,
+		updateCardDescription,
+		updateCheckItemState,
+		addCheckItem,
+		addComment,
+		toggleDueComplete,
+		addChecklist,
+		deleteChecklist,
+		deleteCheckItem,
+		deleteComment,
+		updateComment,
+		updateCardDates,
+		archiveCard,
+		deleteCard,
+		updateChecklistName,
+		updateCheckItemName,
+		updateListName,
+		fetchBoardChecklists,
+		addLabelToCard,
+		removeLabelFromCard,
+		createLabel,
+		updateLabel,
+		deleteLabel,
+		get boardMembers() { return boardMembers; },
+		addMemberToCard,
+		removeMemberFromCard,
+		addAttachmentFile,
+		addAttachmentUrl,
+		deleteAttachment,
+		renameAttachment
+	};
+}
+
+export const taskClientStore = createTaskClientStore();

--- a/frontend/stores/features/task-client.svelte.ts
+++ b/frontend/stores/features/task-client.svelte.ts
@@ -75,6 +75,8 @@ export interface TrelloList {
 
 export interface TrelloCard {
 	id: string;
+	idShort?: number;
+	shortLink?: string;
 	name: string;
 	desc: string;
 	closed: boolean;
@@ -158,13 +160,13 @@ async function trelloFetch<T>(
 function createTaskClientStore() {
 	// Persisted accounts
 	let accounts = $state<TrelloAccount[]>(loadAccounts());
-	let selectedAccountId = $state<string | null>(accounts[0]?.id ?? null);
+	let selectedAccountId = $state<string | null>(loadSelectedAccountId() ?? accounts[0]?.id ?? null);
 
 	// Per-account data
 	let boards = $state<TrelloBoard[]>([]);
 	let organizations = $state<TrelloOrganization[]>([]);
 	let starredBoardIds = $state<string[]>(selectedAccountId ? loadStarredBoardIdsForAccount(selectedAccountId) : []);
-	let selectedBoardId = $state<string | null>(null);
+	let selectedBoardId = $state<string | null>(loadSelectedBoardId());
 	let lists = $state<TrelloList[]>([]);
 	let cards = $state<TrelloCard[]>([]);
 
@@ -179,7 +181,7 @@ function createTaskClientStore() {
 	let boardMembers = $state<{ id: string; fullName: string; username?: string; avatarUrl: string | null }[]>([]);
 
 	// Active card details
-	let activeCardId = $state<string | null>(null);
+	let activeCardId = $state<string | null>(loadActiveCardId());
 	const activeCardChecklists = $derived(boardChecklists.filter((cl) => cl.idCard === activeCardId));
 	let activeCardActions = $state<TrelloAction[]>([]);
 	let activeCardAttachments = $state<{ id: string; name: string; url: string; date: string; mimeType: string; bytes?: number; previews: { url: string; width: number; height: number }[] }[]>([]);
@@ -236,6 +238,21 @@ function createTaskClientStore() {
 		saveRecentBoards(recentBoards);
 	}
 
+	function loadSelectedAccountId(): string | null {
+		if (typeof localStorage === 'undefined') return null;
+		return localStorage.getItem('clopen:task-client:selected-account-id');
+	}
+
+	function loadSelectedBoardId(): string | null {
+		if (typeof localStorage === 'undefined') return null;
+		return localStorage.getItem('clopen:task-client:selected-board-id');
+	}
+
+	function loadActiveCardId(): string | null {
+		if (typeof localStorage === 'undefined') return null;
+		return localStorage.getItem('clopen:task-client:active-card-id');
+	}
+
 	function loadAccounts(): TrelloAccount[] {
 		if (typeof localStorage === 'undefined') return [];
 		try {
@@ -287,6 +304,9 @@ function createTaskClientStore() {
 		}
 		saveAccounts(accounts);
 		selectedAccountId = account.id;
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem('clopen:task-client:selected-account-id', account.id);
+		}
 		starredBoardIds = loadStarredBoardIdsForAccount(account.id);
 		return account;
 	}
@@ -307,9 +327,19 @@ function createTaskClientStore() {
 
 		if (selectedAccountId === id) {
 			selectedAccountId = accounts[0]?.id ?? null;
+			if (typeof localStorage !== 'undefined') {
+				if (selectedAccountId) {
+					localStorage.setItem('clopen:task-client:selected-account-id', selectedAccountId);
+				} else {
+					localStorage.removeItem('clopen:task-client:selected-account-id');
+				}
+				localStorage.removeItem('clopen:task-client:selected-board-id');
+				localStorage.removeItem('clopen:task-client:active-card-id');
+			}
 			starredBoardIds = selectedAccountId ? loadStarredBoardIdsForAccount(selectedAccountId) : [];
 			boards = [];
 			selectedBoardId = null;
+			activeCardId = null;
 			lists = [];
 			cards = [];
 		}
@@ -317,9 +347,15 @@ function createTaskClientStore() {
 
 	function selectAccount(id: string) {
 		selectedAccountId = id;
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem('clopen:task-client:selected-account-id', id);
+			localStorage.removeItem('clopen:task-client:selected-board-id');
+			localStorage.removeItem('clopen:task-client:active-card-id');
+		}
 		starredBoardIds = loadStarredBoardIdsForAccount(id);
 		boards = [];
 		selectedBoardId = null;
+		activeCardId = null;
 		lists = [];
 		cards = [];
 		error = null;
@@ -354,8 +390,25 @@ function createTaskClientStore() {
 		}
 	}
 
-	async function selectBoard(boardId: string): Promise<void> {
+	async function selectBoard(boardId: string | null): Promise<void> {
 		selectedBoardId = boardId;
+		if (typeof localStorage !== 'undefined') {
+			if (boardId) {
+				localStorage.setItem('clopen:task-client:selected-board-id', boardId);
+			} else {
+				localStorage.removeItem('clopen:task-client:selected-board-id');
+				localStorage.removeItem('clopen:task-client:active-card-id');
+			}
+		}
+		if (!boardId) {
+			lists = [];
+			cards = [];
+			boardChecklists = [];
+			boardLabels = [];
+			boardMembers = [];
+			activeCardId = null;
+			return;
+		}
 		const account = accounts.find((a) => a.id === selectedAccountId);
 		if (!account) return;
 		loadingCards = true;
@@ -370,7 +423,7 @@ function createTaskClientStore() {
 				trelloFetch<TrelloCard[]>(
 					account.apiKey,
 					account.token,
-					`/boards/${boardId}/cards?filter=open&fields=id,name,desc,closed,idList,idBoard,due,dueComplete,dueReminder,start,url,labels,badges,pos&members=true&member_fields=id,fullName,username,avatarUrl`
+					`/boards/${boardId}/cards?filter=open&fields=id,idShort,shortLink,name,desc,closed,idList,idBoard,due,dueComplete,dueReminder,start,url,labels,badges,pos&members=true&member_fields=id,fullName,username,avatarUrl`
 				),
 				trelloFetch<TrelloChecklist[]>(
 					account.apiKey,
@@ -427,6 +480,10 @@ function createTaskClientStore() {
 
 	async function selectRecentBoard(boardId: string, accountId: string): Promise<void> {
 		selectedAccountId = accountId;
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem('clopen:task-client:selected-account-id', accountId);
+			localStorage.setItem('clopen:task-client:selected-board-id', boardId);
+		}
 		starredBoardIds = loadStarredBoardIdsForAccount(accountId);
 		selectedBoardId = boardId;
 		const account = accounts.find((a) => a.id === accountId);
@@ -443,7 +500,7 @@ function createTaskClientStore() {
 				trelloFetch<TrelloCard[]>(
 					account.apiKey,
 					account.token,
-					`/boards/${boardId}/cards?filter=open&fields=id,name,desc,closed,idList,idBoard,due,dueComplete,dueReminder,start,url,labels,badges,pos&members=true&member_fields=id,fullName,username,avatarUrl`
+					`/boards/${boardId}/cards?filter=open&fields=id,idShort,shortLink,name,desc,closed,idList,idBoard,due,dueComplete,dueReminder,start,url,labels,badges,pos&members=true&member_fields=id,fullName,username,avatarUrl`
 				),
 				trelloFetch<TrelloBoard[]>(
 					account.apiKey,
@@ -731,6 +788,38 @@ function createTaskClientStore() {
 			debug.error('task-client', 'updateCardDescription failed, reverting:', e);
 			if (cardIdx !== -1) {
 				cards[cardIdx].desc = originalDesc;
+			}
+			error = e instanceof Error ? e.message : String(e);
+			throw e;
+		}
+	}
+
+	async function updateCardName(cardId: string, name: string): Promise<void> {
+		const account = accounts.find((a) => a.id === selectedAccountId);
+		if (!account) return;
+
+		const cardIdx = cards.findIndex((c) => c.id === cardId);
+		let originalName = '';
+		if (cardIdx !== -1) {
+			originalName = cards[cardIdx].name;
+			cards[cardIdx].name = name;
+		}
+
+		try {
+			await trelloFetch<any>(
+				account.apiKey,
+				account.token,
+				`/cards/${cardId}`,
+				{
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ name })
+				}
+			);
+		} catch (e) {
+			debug.error('task-client', 'updateCardName failed, reverting:', e);
+			if (cardIdx !== -1) {
+				cards[cardIdx].name = originalName;
 			}
 			error = e instanceof Error ? e.message : String(e);
 			throw e;
@@ -1547,6 +1636,23 @@ function createTaskClientStore() {
 		}
 	}
 
+	// Auto-load boards and cards if we have saved account/board IDs on start
+	if (typeof window !== 'undefined') {
+		setTimeout(() => {
+			if (selectedAccountId) {
+				loadBoards().then(() => {
+					if (selectedBoardId) {
+						selectBoard(selectedBoardId).catch((e) => {
+							debug.error('task-client', 'Auto-load cards failed:', e);
+						});
+					}
+				}).catch((e) => {
+					debug.error('task-client', 'Auto-load boards failed:', e);
+				});
+			}
+		}, 0);
+	}
+
 	return {
 		get accounts() { return accounts; },
 		get selectedAccountId() { return selectedAccountId; },
@@ -1564,6 +1670,16 @@ function createTaskClientStore() {
 		get error() { return error; },
 		set error(val: string | null) { error = val; },
 		get activeCardId() { return activeCardId; },
+		set activeCardId(val: string | null) {
+			activeCardId = val;
+			if (typeof localStorage !== 'undefined') {
+				if (val) {
+					localStorage.setItem('clopen:task-client:active-card-id', val);
+				} else {
+					localStorage.removeItem('clopen:task-client:active-card-id');
+				}
+			}
+		},
 		get activeCardChecklists() { return activeCardChecklists; },
 		get activeCardActions() { return activeCardActions; },
 		get activeCardAttachments() { return activeCardAttachments; },
@@ -1588,6 +1704,7 @@ function createTaskClientStore() {
 		archiveAllCards,
 		fetchCardDetails,
 		updateCardDescription,
+		updateCardName,
 		updateCheckItemState,
 		addCheckItem,
 		addComment,

--- a/shared/types/stores/settings.ts
+++ b/shared/types/stores/settings.ts
@@ -12,6 +12,7 @@ export interface BranchNameConfig {
 	maxWords: 1 | 2 | 3;
 	allowedPrefixes: string;
 	context: string;
+	branchMessageSeparator?: string;
 }
 
 /** AI commit message generator settings */
@@ -25,6 +26,9 @@ export interface CommitGeneratorSettings {
 	format: CommitMessageFormat;
 	/** Separator between prefix and generated description, e.g. '/', '#', '-'. */
 	branchSeparator: string;
+	ticketLanguage?: 'auto' | 'en';
+	ticketSource?: 'none' | 'trello';
+	ticketPrefix?: 'short-link' | 'id-short';
 	commitConfig: CommitMessageConfig;
 	branchConfig: BranchNameConfig;
 }

--- a/shared/utils/logger.ts
+++ b/shared/utils/logger.ts
@@ -37,6 +37,7 @@ export type LogLabel =
 	| 'engine'
 	| 'tunnel'
 	| 'db-client'
+	| 'task-client'
 	
 	// User
 	| 'user'


### PR DESCRIPTION
# Add Card Detail Modal and colorblind patterns to task client

## Summary

This PR introduces implement a full Trello integration inside the app, including account management, board browsing, a kanban-style card view with drag-and-drop, and a detailed card modal with checklists, comments, labels, attachments, due dates, and member assignment. A rich text editor with formatting toolbar, code syntax highlighting, mentions, and emoji support replaces Markdown input for descriptions and comments. Also add colorblind-friendly label patterns and wire the task client toggle into both desktop and mobile navigators.

## Changes

- Added `CardDetailModal.svelte` for detailed card view, editing, and activity.
- Implemented field editing, checklist item management, and comment input with mentions and custom highlighting.
- Included code syntax highlighting for common programming languages in markdown fields.
- Added utility CSS for colorblind-friendly patterns for all major Trello label colors.
- Minor style improvements and modularity in modal structure.