### PR TITLE
feat(settings): add release notes viewer to update settings

### DIFF
--- a/backend/ws/system/operations.ts
+++ b/backend/ws/system/operations.ts
@@ -88,6 +88,29 @@ export const operationsHandler = createRouter()
 		};
 	})
 
+	// Fetch release notes from GitHub
+	.http('system:get-release-notes', {
+		data: t.Object({}),
+		response: t.Object({
+			tag_name: t.String(),
+			body: t.String(),
+			html_url: t.String(),
+			published_at: t.String()
+		})
+	}, async () => {
+		const response = await fetch('https://api.github.com/repos/myrialabs/clopen/releases/latest');
+		if (!response.ok) {
+			throw new Error(`GitHub API returned ${response.status}`);
+		}
+		const data = await response.json() as { tag_name: string; body: string; html_url: string; published_at: string };
+		return {
+			tag_name: data.tag_name,
+			body: data.body || '',
+			html_url: data.html_url,
+			published_at: data.published_at
+		};
+	})
+
 	// Run package update
 	.http('system:run-update', {
 		data: t.Object({}),

--- a/frontend/components/settings/general/UpdateSettings.svelte
+++ b/frontend/components/settings/general/UpdateSettings.svelte
@@ -1,7 +1,18 @@
 <script lang="ts">
+	import { marked } from 'marked';
+	import DOMPurify from 'dompurify';
 	import { systemSettings, updateSystemSettings } from '$frontend/stores/features/settings.svelte';
-	import { updateState, checkForUpdate, runUpdate, showRestartModal } from '$frontend/stores/ui/update.svelte';
+	import { updateState, checkForUpdate, runUpdate, showRestartModal, fetchReleaseNotes } from '$frontend/stores/ui/update.svelte';
 	import Icon from '../../common/display/Icon.svelte';
+	import { configureMarked } from '$frontend/utils/markdown-renderer';
+
+	let showReleaseNotes = $state(false);
+
+	configureMarked();
+
+	const renderedReleaseNotes = $derived(
+		updateState.releaseNotes ? (marked.parse(updateState.releaseNotes.body, { async: false }) as string) : ''
+	);
 
 	function toggleAutoUpdate() {
 		updateSystemSettings({ autoUpdate: !systemSettings.autoUpdate });
@@ -13,6 +24,13 @@
 
 	function handleUpdateNow() {
 		runUpdate();
+	}
+
+	function handleToggleReleaseNotes() {
+		showReleaseNotes = !showReleaseNotes;
+		if (showReleaseNotes && !updateState.releaseNotes && !updateState.releaseNotesLoading) {
+			fetchReleaseNotes();
+		}
 	}
 </script>
 
@@ -103,6 +121,56 @@
 			{/if}
 		</div>
 
+		<!-- Release Notes -->
+		<div class="p-4 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-xl">
+			<button
+				type="button"
+				onclick={handleToggleReleaseNotes}
+				class="flex items-center justify-between w-full text-left cursor-pointer"
+			>
+				<div class="flex items-center gap-3">
+					<div class="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-amber-400/15 text-amber-500">
+						<Icon name="lucide:book-marked" class="w-5 h-5" />
+					</div>
+					<div>
+						<div class="text-sm font-semibold text-slate-900 dark:text-slate-100">Release Notes</div>
+						<div class="text-xs text-slate-600 dark:text-slate-500">
+							{updateState.releaseNotes?.tag_name ? updateState.releaseNotes.tag_name : 'What\'s new in the latest version'}
+						</div>
+					</div>
+				</div>
+				<Icon name={showReleaseNotes ? 'lucide:chevron-up' : 'lucide:chevron-down'} class="w-4.5 h-4.5 text-slate-500" />
+			</button>
+
+			{#if showReleaseNotes}
+				<div class="mt-3 pt-3 border-t border-slate-200 dark:border-slate-700">
+					{#if updateState.releaseNotesLoading}
+						<div class="flex items-center gap-2 text-xs text-slate-500">
+							<div class="w-3.5 h-3.5 border-2 border-slate-500/30 border-t-slate-500 rounded-full animate-spin"></div>
+							Loading release notes...
+						</div>
+					{:else if updateState.releaseNotes}
+						<div class="release-notes-content text-xs text-slate-700 dark:text-slate-300 leading-relaxed">
+							{@html DOMPurify.sanitize(renderedReleaseNotes, { USE_PROFILES: { html: true } })}
+						</div>
+						<div class="mt-3">
+							<a
+								href={updateState.releaseNotes.html_url}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="inline-flex items-center gap-1.5 text-xs font-semibold text-violet-600 dark:text-violet-400 hover:underline"
+							>
+								<Icon name="lucide:external-link" class="w-3.5 h-3.5" />
+								View on GitHub
+							</a>
+						</div>
+					{:else}
+						<div class="text-xs text-slate-500">Could not load release notes. Check your internet connection.</div>
+					{/if}
+				</div>
+			{/if}
+		</div>
+
 		<!-- Auto-Update Toggle -->
 		<div class="flex items-center justify-between gap-4 py-3 px-4 bg-slate-100/50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700/50 rounded-lg">
 			<div class="flex items-center gap-3">
@@ -128,3 +196,84 @@
 		</div>
 	</div>
 </div>
+
+<style>
+	.release-notes-content :global(h1),
+	.release-notes-content :global(h2),
+	.release-notes-content :global(h3) {
+		font-weight: 600;
+		margin-top: 0.75rem;
+		margin-bottom: 0.375rem;
+		font-size: inherit;
+	}
+	.release-notes-content :global(h1) { font-size: 1rem; }
+	.release-notes-content :global(h2) { font-size: 0.875rem; }
+	.release-notes-content :global(h3) { font-size: 0.8125rem; }
+	.release-notes-content :global(ul),
+	.release-notes-content :global(ol) {
+		padding-left: 1.25rem;
+		margin-top: 0.25rem;
+		margin-bottom: 0.25rem;
+		list-style-position: outside;
+	}
+	.release-notes-content :global(ul) { list-style-type: disc; }
+	.release-notes-content :global(ol) { list-style-type: decimal; }
+	.release-notes-content :global(li) { margin-bottom: 0.125rem; }
+	.release-notes-content :global(p) { margin-top: 0.375rem; margin-bottom: 0.375rem; }
+	.release-notes-content :global(code) {
+		font-size: 0.75rem;
+		padding: 0.125rem 0.25rem;
+		border-radius: 0.25rem;
+		background: rgb(148 163 184 / 0.15);
+	}
+	.release-notes-content :global(pre) {
+		margin-top: 0.5rem;
+		margin-bottom: 0.5rem;
+		padding: 0.75rem;
+		border-radius: 0.5rem;
+		overflow-x: auto;
+		background: rgb(148 163 184 / 0.1);
+	}
+	.release-notes-content :global(pre code) {
+		padding: 0;
+		background: none;
+	}
+	.release-notes-content :global(a) {
+		color: rgb(139 92 246);
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+	.release-notes-content :global(a:hover) {
+		color: rgb(124 58 237);
+	}
+	.release-notes-content :global(blockquote) {
+		border-left: 2px solid rgb(148 163 184 / 0.3);
+		padding-left: 0.75rem;
+		margin-top: 0.5rem;
+		margin-bottom: 0.5rem;
+		color: rgb(100 116 139);
+	}
+	.release-notes-content :global(hr) {
+		margin-top: 0.75rem;
+		margin-bottom: 0.75rem;
+		border-color: rgb(148 163 184 / 0.2);
+	}
+	.release-notes-content :global(img) {
+		max-width: 100%;
+		border-radius: 0.5rem;
+		margin-top: 0.5rem;
+		margin-bottom: 0.5rem;
+	}
+	.release-notes-content :global(table) {
+		width: 100%;
+		border-collapse: collapse;
+		margin-top: 0.5rem;
+		margin-bottom: 0.5rem;
+	}
+	.release-notes-content :global(th),
+	.release-notes-content :global(td) {
+		padding: 0.375rem 0.5rem;
+		border: 1px solid rgb(148 163 184 / 0.2);
+		text-align: left;
+	}
+</style>

--- a/frontend/components/settings/general/UpdateSettings.svelte
+++ b/frontend/components/settings/general/UpdateSettings.svelte
@@ -4,14 +4,48 @@
 	import { systemSettings, updateSystemSettings } from '$frontend/stores/features/settings.svelte';
 	import { updateState, checkForUpdate, runUpdate, showRestartModal, fetchReleaseNotes } from '$frontend/stores/ui/update.svelte';
 	import Icon from '../../common/display/Icon.svelte';
-	import { configureMarked } from '$frontend/utils/markdown-renderer';
+	import { escapeHtml } from '$frontend/utils/terminal-formatter';
+	import { configureMarked, renderCodeBlock, renderInlineCode, renderTable } from '$frontend/utils/markdown-renderer';
 
 	let showReleaseNotes = $state(false);
 
 	configureMarked();
 
+	// Follow the shared markdown pattern (MarkdownPreview / TextMessage): sanitize at the token
+	// level via a custom renderer rather than post-sanitizing the whole document. Release notes
+	// come from GitHub, so all links open externally.
+	const renderer = new marked.Renderer();
+	renderer.html = (token) => DOMPurify.sanitize(token.text, { USE_PROFILES: { html: true } });
+	renderer.code = (token) => renderCodeBlock(token);
+	renderer.codespan = (token) => renderInlineCode(token);
+	renderer.link = function (token) {
+		const href = escapeHtml(token.href || '');
+		const text = this.parser.parseInline(token.tokens);
+		const titleAttr = token.title ? ` title="${escapeHtml(token.title)}"` : '';
+		return `<a href="${href}" target="_blank" rel="noopener noreferrer"${titleAttr}>${text}</a>`;
+	};
+	renderer.table = function (token) {
+		return renderTable(token, this.parser);
+	};
+
 	const renderedReleaseNotes = $derived(
-		updateState.releaseNotes ? (marked.parse(updateState.releaseNotes.body, { async: false }) as string) : ''
+		updateState.releaseNotes ? (marked.parse(updateState.releaseNotes.body, { renderer }) as string) : ''
+	);
+
+	const releaseDate = $derived(
+		updateState.releaseNotes?.published_at
+			? new Date(updateState.releaseNotes.published_at).toLocaleDateString(undefined, {
+					year: 'numeric',
+					month: 'short',
+					day: 'numeric'
+				})
+			: ''
+	);
+
+	const releaseSubtitle = $derived(
+		updateState.releaseNotes
+			? [updateState.releaseNotes.tag_name, releaseDate].filter(Boolean).join(' · ')
+			: "What's new in the latest version"
 	);
 
 	function toggleAutoUpdate() {
@@ -32,6 +66,10 @@
 			fetchReleaseNotes();
 		}
 	}
+
+	function handleRetryReleaseNotes() {
+		fetchReleaseNotes();
+	}
 </script>
 
 <div class="py-1">
@@ -40,12 +78,12 @@
 
 	<div class="flex flex-col gap-3.5">
 		<!-- Version Info -->
-		<div class="p-4 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-xl">
-			<div class="flex items-start gap-3.5">
+		<div class="px-4 py-3 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-xl">
+			<div class="flex items-center gap-3.5">
 				<div class="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-violet-400/15 text-violet-500">
 					<Icon name="lucide:package" class="w-5 h-5" />
 				</div>
-				<div class="flex flex-col gap-1 min-w-0 flex-1">
+				<div class="flex flex-col gap-0.5 min-w-0 flex-1">
 					<div class="text-sm font-semibold text-slate-900 dark:text-slate-100">
 						@myrialabs/clopen
 					</div>
@@ -122,10 +160,11 @@
 		</div>
 
 		<!-- Release Notes -->
-		<div class="p-4 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-xl">
+		<div class="px-4 py-3 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-xl">
 			<button
 				type="button"
 				onclick={handleToggleReleaseNotes}
+				aria-expanded={showReleaseNotes}
 				class="flex items-center justify-between w-full text-left cursor-pointer"
 			>
 				<div class="flex items-center gap-3">
@@ -135,7 +174,7 @@
 					<div>
 						<div class="text-sm font-semibold text-slate-900 dark:text-slate-100">Release Notes</div>
 						<div class="text-xs text-slate-600 dark:text-slate-500">
-							{updateState.releaseNotes?.tag_name ? updateState.releaseNotes.tag_name : 'What\'s new in the latest version'}
+							{releaseSubtitle}
 						</div>
 					</div>
 				</div>
@@ -151,7 +190,7 @@
 						</div>
 					{:else if updateState.releaseNotes}
 						<div class="release-notes-content text-xs text-slate-700 dark:text-slate-300 leading-relaxed">
-							{@html DOMPurify.sanitize(renderedReleaseNotes, { USE_PROFILES: { html: true } })}
+							{@html renderedReleaseNotes}
 						</div>
 						<div class="mt-3">
 							<a
@@ -164,8 +203,21 @@
 								View on GitHub
 							</a>
 						</div>
-					{:else}
-						<div class="text-xs text-slate-500">Could not load release notes. Check your internet connection.</div>
+					{:else if updateState.releaseNotesError}
+						<div class="flex items-center justify-between gap-3">
+							<div class="flex items-center gap-2 min-w-0">
+								<Icon name="lucide:circle-alert" class="w-4 h-4 text-red-500 shrink-0" />
+								<span class="text-xs text-red-600 dark:text-red-400 truncate">Could not load release notes. Check your connection.</span>
+							</div>
+							<button
+								type="button"
+								onclick={handleRetryReleaseNotes}
+								class="inline-flex items-center gap-1.5 shrink-0 text-xs font-semibold text-violet-600 dark:text-violet-400 hover:underline cursor-pointer"
+							>
+								<Icon name="lucide:refresh-cw" class="w-3.5 h-3.5" />
+								Retry
+							</button>
+						</div>
 					{/if}
 				</div>
 			{/if}
@@ -264,11 +316,15 @@
 		margin-top: 0.5rem;
 		margin-bottom: 0.5rem;
 	}
+	.release-notes-content :global(.table-responsive) {
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+		margin-top: 0.5rem;
+		margin-bottom: 0.5rem;
+	}
 	.release-notes-content :global(table) {
 		width: 100%;
 		border-collapse: collapse;
-		margin-top: 0.5rem;
-		margin-bottom: 0.5rem;
 	}
 	.release-notes-content :global(th),
 	.release-notes-content :global(td) {

--- a/frontend/stores/ui/update.svelte.ts
+++ b/frontend/stores/ui/update.svelte.ts
@@ -7,6 +7,13 @@ import ws from '$frontend/utils/ws';
 import { systemSettings } from '$frontend/stores/features/settings.svelte';
 import { debug } from '$shared/utils/logger';
 
+interface ReleaseNotes {
+	tag_name: string;
+	body: string;
+	html_url: string;
+	published_at: string;
+}
+
 interface UpdateState {
 	currentVersion: string;
 	latestVersion: string;
@@ -21,6 +28,8 @@ interface UpdateState {
 	pendingRestart: boolean;
 	pendingVersions: { from: string; to: string } | null;
 	showRestartModal: boolean;
+	releaseNotes: ReleaseNotes | null;
+	releaseNotesLoading: boolean;
 }
 
 export const updateState = $state<UpdateState>({
@@ -36,7 +45,9 @@ export const updateState = $state<UpdateState>({
 	updateSuccess: false,
 	pendingRestart: false,
 	pendingVersions: null,
-	showRestartModal: false
+	showRestartModal: false,
+	releaseNotes: null,
+	releaseNotesLoading: false
 });
 
 let checkInterval: ReturnType<typeof setInterval> | null = null;
@@ -104,6 +115,20 @@ export async function runUpdate(): Promise<void> {
 		debug.error('server', 'Update failed:', err);
 	} finally {
 		updateState.updating = false;
+	}
+}
+
+/** Fetch latest release notes from GitHub */
+export async function fetchReleaseNotes(): Promise<void> {
+	if (updateState.releaseNotesLoading) return;
+	updateState.releaseNotesLoading = true;
+	try {
+		const data = await ws.http('system:get-release-notes', {});
+		updateState.releaseNotes = data as ReleaseNotes;
+	} catch (err) {
+		debug.error('server', 'Failed to fetch release notes:', err);
+	} finally {
+		updateState.releaseNotesLoading = false;
 	}
 }
 

--- a/frontend/stores/ui/update.svelte.ts
+++ b/frontend/stores/ui/update.svelte.ts
@@ -30,6 +30,7 @@ interface UpdateState {
 	showRestartModal: boolean;
 	releaseNotes: ReleaseNotes | null;
 	releaseNotesLoading: boolean;
+	releaseNotesError: string | null;
 }
 
 export const updateState = $state<UpdateState>({
@@ -47,7 +48,8 @@ export const updateState = $state<UpdateState>({
 	pendingVersions: null,
 	showRestartModal: false,
 	releaseNotes: null,
-	releaseNotesLoading: false
+	releaseNotesLoading: false,
+	releaseNotesError: null
 });
 
 let checkInterval: ReturnType<typeof setInterval> | null = null;
@@ -122,10 +124,12 @@ export async function runUpdate(): Promise<void> {
 export async function fetchReleaseNotes(): Promise<void> {
 	if (updateState.releaseNotesLoading) return;
 	updateState.releaseNotesLoading = true;
+	updateState.releaseNotesError = null;
 	try {
 		const data = await ws.http('system:get-release-notes', {});
 		updateState.releaseNotes = data as ReleaseNotes;
 	} catch (err) {
+		updateState.releaseNotesError = err instanceof Error ? err.message : 'Failed to load release notes';
 		debug.error('server', 'Failed to fetch release notes:', err);
 	} finally {
 		updateState.releaseNotesLoading = false;


### PR DESCRIPTION
Fetch and display latest GitHub release notes in the update settings panel, rendering Markdown content with DOMPurify sanitization so users can see what's new before or after updating.