### PR TITLE
fix(markdown): trigger raw terminal fallback only on ANSI codes

### DIFF
--- a/frontend/components/chat/formatters/TextMessage.svelte
+++ b/frontend/components/chat/formatters/TextMessage.svelte
@@ -4,4 +4,4 @@
 	const { content }: { content: string } = $props();
 </script>
 
-<Markdown variant="chat" html="escape" terminalFallback {content} class="wrap-break-word" />
+<Markdown variant="chat" html="escape" {content} class="wrap-break-word" />

--- a/frontend/components/common/display/Markdown.svelte
+++ b/frontend/components/common/display/Markdown.svelte
@@ -15,8 +15,6 @@
 		variant?: 'chat' | 'preview' | 'compact';
 		// Raw inline HTML handling — see RenderMarkdownOptions. Default 'sanitize'.
 		html?: 'sanitize' | 'escape';
-		// Render a whole-message terminal dump as monospace instead of markdown. Chat-only.
-		terminalFallback?: boolean;
 		// Override the internal file-link action (e.g. resolve relative paths in a file preview).
 		// Defaults to revealing the path in the Files panel when that panel is visible.
 		onFileLink?: (path: string) => void;
@@ -28,12 +26,11 @@
 		content,
 		variant = 'preview',
 		html = 'sanitize',
-		terminalFallback = false,
 		onFileLink,
 		class: className = ''
 	}: Props = $props();
 
-	const rendered = $derived(renderMarkdown(content || '', { html, terminalFallback }));
+	const rendered = $derived(renderMarkdown(content || '', { html }));
 
 	let root: HTMLElement | null = $state(null);
 

--- a/frontend/utils/markdown-renderer.ts
+++ b/frontend/utils/markdown-renderer.ts
@@ -6,13 +6,7 @@
 
 import { marked, type Token, type Tokens } from 'marked';
 import DOMPurify from 'dompurify';
-import {
-	escapeHtml,
-	hasAnsiCodes,
-	processAnsiCodes,
-	isTerminalOutput,
-	formatTerminalOutput
-} from './terminal-formatter';
+import { escapeHtml, hasAnsiCodes, processAnsiCodes, formatTerminalOutput } from './terminal-formatter';
 
 type InlineParser = { parseInline(tokens: Token[]): string };
 
@@ -127,23 +121,21 @@ export interface RenderMarkdownOptions {
 	// literally (right for chat, where unknown pseudo-tags like <thinking> must stay visible).
 	// Default 'sanitize'.
 	html?: 'sanitize' | 'escape';
-	// When true, a whole message that is a raw terminal dump (ANSI, or shell-like output without
-	// code fences) is rendered as monospace terminal output instead of markdown. Chat-only.
-	// Default false.
-	terminalFallback?: boolean;
 }
 
 // Single entry point for rendering markdown to an HTML string. Links are classified uniformly:
 // external → new tab; '#frag' → [data-md-fragment]; local/relative → [data-md-file]. Consumers
 // wire what a [data-md-file] click does (reveal in Files panel, open in preview, etc.).
 export function renderMarkdown(content: string, options: RenderMarkdownOptions = {}): string {
-	const { html = 'sanitize', terminalFallback = false } = options;
+	const { html = 'sanitize' } = options;
 
 	configureMarked();
 
-	// A whole-message terminal dump is preserved as monospace (alignment, box drawing) rather than
-	// parsed as markdown. Only when explicitly requested and there are no code fences to honor.
-	if (terminalFallback && (hasAnsiCodes(content) || isTerminalOutput(content)) && !content.includes('```')) {
+	// Preserve a genuine terminal dump (ANSI-colored output) as monospace, since markdown would
+	// collapse its alignment. ANSI escape codes never occur in real markdown prose, so this is the
+	// ONLY trigger — markdown is never forced into a raw block by prose syntax like '#' or '>'.
+	// (Fenced content is left to the normal code-block path.)
+	if (hasAnsiCodes(content) && !content.includes('```')) {
 		return formatTerminalOutput(content);
 	}
 


### PR DESCRIPTION
renderMarkdown used the fuzzy isTerminalOutput heuristic (shell prompts, box drawing, ...) to decide whether to render a whole message as a raw monospace block. That heuristic collides with markdown syntax — ATX headings ('# ') and blockquotes ('> ') — forcing prose into a raw dump.

Trigger the fallback only on ANSI escape codes, which never occur in real markdown prose, and drop the terminalFallback option and <Markdown> prop. Markdown prose is now never forced into raw output; genuine ANSI-colored terminal dumps are still preserved as monospace. isTerminalOutput stays for its remaining consumers (the CodeBlock tool variants).