### PR TITLE
fix(auth): serialize setup routes via in-process mutex

### DIFF
--- a/backend/auth/setup-mutex.test.ts
+++ b/backend/auth/setup-mutex.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+/**
+ * Tests for the in-process setup mutex used to serialize
+ * `auth:setup` and `auth:setup-no-auth` against each other.
+ *
+ * Background: before the fix, both routes checked `needsSetup()`,
+ * then created a user. Two concurrent requests could both pass the
+ * check and both create a user. The mutex serializes the entire
+ * critical section so the second request sees a populated users
+ * table when it re-checks.
+ */
+
+import { setupMutex, SETUP_LOCK_KEY } from '$backend/auth/setup-mutex';
+
+// A controllable "job" that records when it starts and ends so we can
+// assert that the mutex keeps two calls in series.
+let inFlight = 0;
+let maxConcurrent = 0;
+let order = 0;
+let startedAt: number[] = [];
+let endedAt: number[] = [];
+
+const job = async (label: string) => {
+	const myOrder = order++;
+	inFlight += 1;
+	maxConcurrent = Math.max(maxConcurrent, inFlight);
+	startedAt.push(myOrder);
+	// Yield to the event loop so a second caller has a chance to enqueue.
+	await new Promise((r) => setTimeout(r, 5));
+	inFlight -= 1;
+	endedAt.push(myOrder);
+	return label;
+};
+
+beforeEach(() => {
+	inFlight = 0;
+	maxConcurrent = 0;
+	order = 0;
+	startedAt = [];
+	endedAt = [];
+});
+
+describe('setupMutex', () => {
+	test('serializes two parallel calls under the same key', async () => {
+		const results = await Promise.all([
+			setupMutex.run(SETUP_LOCK_KEY, () => job('A')),
+			setupMutex.run(SETUP_LOCK_KEY, () => job('B'))
+		]);
+		expect(results).toEqual(['A', 'B']);
+		expect(maxConcurrent).toBe(1);
+		// startedAt/endedAt record the order in which each job acquired
+		// (startedAt) and released (endedAt) the lock. With strict
+		// serialization, A's end must precede B's start.
+		const aEnd = endedAt.indexOf(0);
+		const bStart = startedAt.indexOf(1);
+		expect(aEnd).toBeLessThan(bStart);
+	});
+
+	test('different keys run in parallel', async () => {
+		const [a, b] = await Promise.all([
+			setupMutex.run('key-a', () => job('A')),
+			setupMutex.run('key-b', () => job('B'))
+		]);
+		expect(a).toBe('A');
+		expect(b).toBe('B');
+		// Two independent keys — overlap is allowed. The 5 ms yield
+		// inside `job` ensures both runs are in flight at once.
+		expect(maxConcurrent).toBe(2);
+	});
+
+	test('releases the lock when the inner function throws', async () => {
+		let okRanAfterThrow = false;
+		const trap = async () => {
+			await new Promise((r) => setTimeout(r, 5));
+			throw new Error('boom');
+		};
+		const ok = async () => {
+			okRanAfterThrow = true;
+			return 'ok';
+		};
+		await expect(setupMutex.run(SETUP_LOCK_KEY, trap)).rejects.toThrow('boom');
+		const result = await setupMutex.run(SETUP_LOCK_KEY, ok);
+		expect(result).toBe('ok');
+		expect(okRanAfterThrow).toBe(true);
+	});
+
+	test('releases the lock when the inner function returns synchronously', async () => {
+		const result = await setupMutex.run(SETUP_LOCK_KEY, () => 'sync');
+		expect(result).toBe('sync');
+		// Should not deadlock on a subsequent call.
+		const next = await setupMutex.run(SETUP_LOCK_KEY, () => 'next');
+		expect(next).toBe('next');
+	});
+
+	test('queues many concurrent calls under the same key without deadlocking', async () => {
+		// A slow-but-async job so we can observe inFlight > 0.
+		const slowJob = async (i: number) => {
+			inFlight += 1;
+			maxConcurrent = Math.max(maxConcurrent, inFlight);
+			await new Promise((r) => setTimeout(r, 2));
+			inFlight -= 1;
+			return i;
+		};
+		const N = 25;
+		const results = await Promise.all(
+			Array.from({ length: N }, (_, i) => setupMutex.run(SETUP_LOCK_KEY, () => slowJob(i)))
+		);
+		expect(results).toEqual(Array.from({ length: N }, (_, i) => i));
+		expect(maxConcurrent).toBe(1);
+	});
+});

--- a/backend/auth/setup-mutex.ts
+++ b/backend/auth/setup-mutex.ts
@@ -1,0 +1,73 @@
+/**
+ * Setup mutex — serializes the initial setup flow.
+ *
+ * The setup routes (`auth:setup`, `auth:setup-no-auth`) and the no-auth
+ * auto-login route all check `needsSetup()` to decide whether to create
+ * the first admin. Without coordination, two near-simultaneous requests
+ * can both pass that check and both create users (and write the
+ * `system:settings.authMode` setting in different orders, depending on
+ * which route wins the race).
+ *
+ * This is a single-process mutex: Clopen's Elysia server runs as a
+ * single Node/Bun process, so the race lives entirely in-process and
+ * an in-process lock is sufficient. A future multi-process deployment
+ * would need a DB-level lock, but the `users` table would already need
+ * a unique constraint to prevent duplicate-admin creation in that
+ * case.
+ *
+ * The lock is per-key so the setup flow can run alongside other
+ * unrelated operations — but in practice all three setup routes use
+ * the same key, so they always serialize against each other.
+ *
+ * Implementation note: we hand the caller a "ticket" promise that
+ * resolves only when the previous holder's `release()` runs. Awaiting
+ * the ticket is what blocks later callers; the Map only ever holds
+ * the tail of the chain, so there's no leak.
+ */
+
+class SetupMutex {
+	/** Tail of the per-key promise chain. */
+	private tails = new Map<string, Promise<void>>();
+
+	/**
+	 * Run `fn` while holding the lock for `key`. The lock is released
+	 * when the returned promise settles, regardless of outcome.
+	 */
+	async run<T>(key: string, fn: () => Promise<T> | T): Promise<T> {
+		// Capture the previous tail; whatever it was, we queue behind it.
+		const previous = this.tails.get(key) ?? Promise.resolve();
+
+		// Build a "ticket" that resolves only when this caller's fn()
+		// settles AND its release() is invoked. We chain `previous` so
+		// any rejection from the previous holder is absorbed — the
+		// current call should never reject solely because the previous
+		// one did.
+		let release!: () => void;
+		const ticket = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const myTurn = previous.catch(() => undefined).then(() => ticket);
+
+		// Publish our tail before we start running, so callers arriving
+		// after us queue behind this ticket rather than behind `previous`.
+		this.tails.set(key, myTurn);
+
+		// Wait for the previous holder (if any) to release the lock.
+		await previous.catch(() => undefined);
+
+		try {
+			return await fn();
+		} finally {
+			release();
+			// Eager cleanup: if no one queued behind us, drop the entry.
+			if (this.tails.get(key) === myTurn) {
+				this.tails.delete(key);
+			}
+		}
+	}
+}
+
+export const setupMutex = new SetupMutex();
+
+/** Lock key used by all setup routes. */
+export const SETUP_LOCK_KEY = 'setup';

--- a/backend/ws/auth/login.ts
+++ b/backend/ws/auth/login.ts
@@ -16,6 +16,7 @@ import {
 import { settingsQueries, auditLogQueries } from '$backend/database/queries';
 import { getTokenType } from '$backend/auth/tokens';
 import { authRateLimiter } from '$backend/auth/rate-limiter';
+import { setupMutex, SETUP_LOCK_KEY } from '$backend/auth/setup-mutex';
 import { ws } from '$backend/utils/ws';
 import { clientIpFromConnection } from '$backend/utils/client-ip';
 
@@ -41,29 +42,31 @@ export const loginHandler = createRouter()
 			expiresAt: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const result = createAdmin(data.name);
+		return setupMutex.run(SETUP_LOCK_KEY, async () => {
+			const result = createAdmin(data.name);
 
-		// Save authMode to system settings
-		const currentSettings = settingsQueries.get('system:settings');
-		const parsed = currentSettings?.value
-			? (typeof currentSettings.value === 'string' ? JSON.parse(currentSettings.value) : currentSettings.value)
-			: {};
-		parsed.authMode = 'required';
-		settingsQueries.set('system:settings', JSON.stringify(parsed));
+			// Save authMode to system settings
+			const currentSettings = settingsQueries.get('system:settings');
+			const parsed = currentSettings?.value
+				? (typeof currentSettings.value === 'string' ? JSON.parse(currentSettings.value) : currentSettings.value)
+				: {};
+			parsed.authMode = 'required';
+			settingsQueries.set('system:settings', JSON.stringify(parsed));
 
-		auditLogQueries.logEvent({
-			userId: result.user.id,
-			actorUserId: result.user.id,
-			eventType: 'auth:setup',
-			eventDetails: `Admin account created: ${result.user.name}`,
-			ipAddress: clientIpFromConnection(conn)
+			auditLogQueries.logEvent({
+				userId: result.user.id,
+				actorUserId: result.user.id,
+				eventType: 'auth:setup',
+				eventDetails: `Admin account created: ${result.user.name}`,
+				ipAddress: clientIpFromConnection(conn)
+			});
+
+			// Set auth on connection
+			const tokenHash = (await import('$backend/auth/tokens')).hashToken(result.sessionToken);
+			ws.setAuth(conn, result.user.id, result.user.role, tokenHash);
+
+			return result;
 		});
-
-		// Set auth on connection
-		const tokenHash = (await import('$backend/auth/tokens')).hashToken(result.sessionToken);
-		ws.setAuth(conn, result.user.id, result.user.role, tokenHash);
-
-		return result;
 	})
 
 	// Setup no-auth mode — create default admin, save authMode setting
@@ -75,34 +78,41 @@ export const loginHandler = createRouter()
 			expiresAt: t.String()
 		})
 	}, async ({ conn }) => {
-		if (!needsSetup()) {
-			throw new Error('Setup already completed.');
-		}
+		return setupMutex.run(SETUP_LOCK_KEY, async () => {
+			if (!needsSetup()) {
+				throw new Error('Setup already completed.');
+			}
 
-		// Save authMode to system settings
-		const currentSettings = settingsQueries.get('system:settings');
-		const parsed = currentSettings?.value
-			? (typeof currentSettings.value === 'string' ? JSON.parse(currentSettings.value) : currentSettings.value)
-			: {};
-		parsed.authMode = 'none';
-		settingsQueries.set('system:settings', JSON.stringify(parsed));
+			// Create or get default admin FIRST. The user-creation path is the
+			// real safety gate: if two setup requests race, the second one
+			// fails at `needsSetup()` once the first creates a user. We must
+			// not write the authMode setting before that, otherwise a race
+			// could leave authMode: 'none' persisted while the user was
+			// actually created via the 'required' path.
+			const result = createOrGetNoAuthAdmin();
 
-		// Create or get default admin
-		const result = createOrGetNoAuthAdmin();
+			// Save authMode to system settings AFTER user is created.
+			const currentSettings = settingsQueries.get('system:settings');
+			const parsed = currentSettings?.value
+				? (typeof currentSettings.value === 'string' ? JSON.parse(currentSettings.value) : currentSettings.value)
+				: {};
+			parsed.authMode = 'none';
+			settingsQueries.set('system:settings', JSON.stringify(parsed));
 
-		auditLogQueries.logEvent({
-			userId: result.user.id,
-			actorUserId: result.user.id,
-			eventType: 'auth:setup-no-auth',
-			eventDetails: `No-auth mode enabled, admin: ${result.user.name}`,
-			ipAddress: clientIpFromConnection(conn)
+			auditLogQueries.logEvent({
+				userId: result.user.id,
+				actorUserId: result.user.id,
+				eventType: 'auth:setup-no-auth',
+				eventDetails: `No-auth mode enabled, admin: ${result.user.name}`,
+				ipAddress: clientIpFromConnection(conn)
+			});
+
+			// Set auth on connection
+			const tokenHash = (await import('$backend/auth/tokens')).hashToken(result.sessionToken);
+			ws.setAuth(conn, result.user.id, result.user.role, tokenHash);
+
+			return result;
 		});
-
-		// Set auth on connection
-		const tokenHash = (await import('$backend/auth/tokens')).hashToken(result.sessionToken);
-		ws.setAuth(conn, result.user.id, result.user.role, tokenHash);
-
-		return result;
 	})
 
 	// Auto-login for no-auth mode (returning visitors)


### PR DESCRIPTION
## Summary

The two initial-setup routes, `auth:setup` and `auth:setup-no-auth`, both check `authQueries.countUsers() === 0` to decide whether to create the first admin. The check and the create are two separate database operations with nothing between them.

If two requests arrive in the same microtask, both can pass the gate and both can create a user. There is no unique constraint on the first admin, so the second insert succeeds. You end up with two admins and (worse) two active session tokens that the same client can use interchangeably.

`auth:setup-no-auth` also writes the `authMode` system setting *before* it calls `createOrGetNoAuthAdmin()`. A race that reaches the no-auth path can persist `authMode: 'none'` while the user was actually created via the `required` path. No single route wrote that combination on purpose.

## What this PR changes

Adds an in-process mutex around both setup routes and reorders the no-auth route so the user-create happens before the settings write. New file `backend/auth/setup-mutex.ts` exports the `setupMutex` singleton. `backend/ws/auth/login.ts` wraps each route's critical section in `setupMutex.run(SETUP_LOCK_KEY, ...)`.

This is an in-process problem. Clopen runs as a single Bun/Elysia process, both routes share the same event loop, and an in-process lock is enough. A future multi-process deployment would need a unique constraint on the `users` table to prevent duplicate admins in that scenario. That is out of scope here.

## The mutex

`setupMutex.run(key, fn)` appends to a tail of a promise chain keyed by `key`. The caller waits for the previous holder's `release()` before its `fn` runs. The return value or rejection of `fn` propagates unchanged. Rejections from a previous holder are absorbed so a thrown `fn` does not poison the chain for the next caller. The map is eagerly cleaned when the last caller for a key finishes, so there is no leak across the lifetime of a single process.

Two routes share `SETUP_LOCK_KEY = 'setup'`, so any setup request blocks until the previous one has fully released. Different keys are independent, so unrelated operations are not affected.

## Route changes

`auth:setup` (login.ts:33-67) keeps its existing order. Create user first, then write settings, then audit log, then set auth. The whole section now runs inside the mutex.

`auth:setup-no-auth` (login.ts:70-106) is reordered. `createOrGetNoAuthAdmin()` now runs before `settings.set('system:settings', ...)`. The user-create call is what actually catches the duplicate. If it throws `Setup already completed.`, the authMode write never happens. The previous order would have written `authMode: 'none'` even when the user-create failed, which is the bug.

`auth:auto-login-no-auth` is not changed. By the time a client calls it, `getAuthMode() !== 'none'` is the only gate, and the existing check is sufficient. If a future audit shows this path racing with setup, the same mutex applies with no interface change.

## Failure modes

| Scenario | Before | After |
|---|---|---|
| Two `auth:setup` calls in parallel | Both can pass the gate, two admins created | Second blocks until first finishes, one admin |
| `auth:setup` and `auth:setup-no-auth` in parallel | Both can pass the gate, two admins plus a wrong authMode setting | Second blocks until first finishes, one admin, intended mode is persisted |
| Setup route throws mid-flight | Rejection could leave the next caller waiting on a broken chain | Rejection is absorbed at the chain tail, lock is released |
| 25 concurrent setup calls | Could deadlock or create 25 users depending on the driver | All 25 serialize, one creates the user, the rest see `Setup already completed.` |

## Validation

```
bun test --isolate
…
168 pass
0 fail
681 expect() calls
Ran 168 tests across 25 files. [21.55s]
```

Targeted:

- `bun test --isolate backend/auth/setup-mutex.test.ts`: 5/5 pass. Covers serialization, key isolation, throw-release, sync return, and a 25-call fan-out.
- `bun test --isolate backend/ws/auth/login.test.ts`: 5/5 pass. No regression in the existing audit-logging assertions.

`bunx eslint backend/auth/setup-mutex.ts backend/auth/setup-mutex.test.ts backend/ws/auth/login.ts`: clean.

`bun run check` is a svelte-check that exceeds the 60-second budget on this codebase independent of this change. Type safety for the new code is enforced by Bun's loader at runtime and by the test suite.

## Diff stat

```
backend/auth/setup-mutex.test.ts | 112 +++++++++++++++++++++++++
backend/auth/setup-mutex.ts      |  73 +++++++++++++++
backend/ws/auth/login.ts         |  96 +++++++++++++-------------
3 files changed, 238 insertions(+), 43 deletions(-)