### PR TITLE
fix(profiles): scope artifacts per-session on non-native engines

### DIFF
--- a/backend/artifacts/index.ts
+++ b/backend/artifacts/index.ts
@@ -20,7 +20,7 @@ export type {
 } from './types';
 export { ARTIFACT_ENGINES } from './types';
 
-export { resolveArtifact, isBestEffortTarget, memoryFileName } from './matrix';
+export { resolveArtifact, isBestEffortTarget, isPromptScopedEngine, PROMPT_SCOPED_ENGINES, memoryFileName } from './matrix';
 export { materializeArtifacts } from './sync';
 export type { MaterializeInput } from './sync';
 export { detectArtifacts, adoptArtifact } from './detect';

--- a/backend/artifacts/matrix.ts
+++ b/backend/artifacts/matrix.ts
@@ -216,6 +216,23 @@ function unsupported(): ArtifactResolution {
 	};
 }
 
+/**
+ * Engines whose runtime reads artifacts through a channel that is SHARED across
+ * sessions and NOT reliably re-read per turn — a persistent server/client
+ * (OpenCode `opencode serve`, Codex/Copilot long-lived clients) and/or a shared
+ * global memory file. For these, an on-disk/global-file filter can't express a
+ * per-session Profile choice (it leaks across concurrent sessions and/or is
+ * served stale), so the adapter ALSO advertises the profile-scoped set
+ * per-session by injecting a preamble into the prompt (see
+ * `buildArtifactsPromptContext`). Claude and Qwen are excluded: each spawns a
+ * fresh per-query CLI over an isolated/pruned dir, so the on-disk filter alone
+ * already scopes correctly.
+ */
+export const PROMPT_SCOPED_ENGINES: readonly ArtifactEngine[] = ['opencode', 'codex', 'copilot'];
+export function isPromptScopedEngine(engine: ArtifactEngine): boolean {
+	return PROMPT_SCOPED_ENGINES.includes(engine);
+}
+
 /** Whether a synthetic (non-native) target is best-effort/unverified for the UI. */
 export function isBestEffortTarget(type: ArtifactType, engine: ArtifactEngine): boolean {
 	if (type === 'instruction') return engine !== 'claude';

--- a/backend/commands/index.ts
+++ b/backend/commands/index.ts
@@ -5,5 +5,5 @@
 
 export { commandService } from './service';
 export type { CommandDTO, CommandInputFields } from './service';
-export { syncCommands, syncCommandsAllEngines } from './sync';
+export { syncCommands, syncCommandsAllEngines, buildCommandsPromptContext } from './sync';
 export { detectCommands } from './detect';

--- a/backend/commands/sync.ts
+++ b/backend/commands/sync.ts
@@ -9,7 +9,7 @@
 
 import { commandQueries } from '$backend/database/queries';
 import { debug } from '$shared/utils/logger';
-import { materializeArtifacts, parseDoc, serializeDoc, parseEngineMap, artifactEngineToType, type ManagedArtifact, type ArtifactEngine } from '$backend/artifacts';
+import { materializeArtifacts, resolveArtifact, isPromptScopedEngine, parseDoc, serializeDoc, parseEngineMap, artifactEngineToType, type ManagedArtifact, type ArtifactEngine } from '$backend/artifacts';
 import { artifactFilter } from '$backend/profiles';
 import { readCommandMd } from './store';
 
@@ -36,12 +36,37 @@ function buildCommandsPreamble(items: ManagedArtifact[]): string {
 	return lines.join('\n');
 }
 
+/** The commands active for a stream, narrowed by the active Profile (metadata only). */
+function resolveEnabledCommandsMeta(profileId?: number): ManagedArtifact[] {
+	const filter = artifactFilter(profileId, 'command');
+	return (filter ? commandQueries.getAll() : commandQueries.getEnabled())
+		.filter(r => !filter || filter.has(r.slug))
+		.map(r => ({ slug: r.slug, name: r.name, description: r.description }));
+}
+
+/**
+ * The profile-scoped commands preamble for PER-SESSION injection into a
+ * prompt-scoped engine's prompt (OpenCode/Codex/Copilot). Returns '' when none
+ * apply. Advisory: it scopes what the model surfaces/uses, on top of whatever the
+ * engine's own (possibly stale/shared) command registry exposes.
+ */
+export function buildCommandsPromptContext(profileId?: number): string {
+	return buildCommandsPreamble(resolveEnabledCommandsMeta(profileId));
+}
+
 export async function syncCommands(engine: ArtifactEngine, profileId?: number): Promise<void> {
 	try {
+		// On a prompt-scoped engine, a SYNTHETIC command target (no native command
+		// dir — Copilot) is delivered per-session via prompt injection instead, so
+		// materialize an empty set to strip any shared global block that would leak
+		// across sessions. NATIVE command engines (Claude/OpenCode/Codex) keep the
+		// filtered files on disk; Qwen (per-query) keeps its synthetic preamble.
+		const synthetic = resolveArtifact('command', { engine, scope: 'global' }).format === 'preamble-region';
+		const viaPrompt = synthetic && isPromptScopedEngine(engine);
 		const filter = artifactFilter(profileId, 'command');
 		// A profile activates the commands it references even if globally disabled;
 		// with no profile filter, only the enabled set applies (unchanged).
-		const rows = (filter ? commandQueries.getAll() : commandQueries.getEnabled())
+		const rows = viaPrompt ? [] : (filter ? commandQueries.getAll() : commandQueries.getEnabled())
 			.filter(r => !filter || filter.has(r.slug));
 		const engineType = artifactEngineToType(engine);
 		const enabled: ManagedArtifact[] = [];

--- a/backend/engine/adapters/codex/stream.ts
+++ b/backend/engine/adapters/codex/stream.ts
@@ -28,8 +28,9 @@ import { resolveOsPath } from '$backend/utils/paths';
 import { resolveBinary } from '$backend/utils/cli';
 import { getCleanSpawnEnv } from '$backend/utils/index.js';
 import { getCodexMcpConfig } from '../../../mcp';
+import { artifactFilter } from '$backend/profiles';
 import { syncSkills } from '$backend/skills';
-import { syncEngineArtifacts } from '$backend/engine/artifact-sync';
+import { syncEngineArtifacts, buildArtifactsPromptContext } from '$backend/engine/artifact-sync';
 import { CODEX_MODELS } from './models';
 import { debug } from '$shared/utils/logger';
 import { handleStreamError, buildTurnError } from './error-handler';
@@ -63,6 +64,13 @@ export class CodexEngine implements AIEngine {
 	private activeController: AbortController | null = null;
 	/** Account ID currently baked into `this.codex`. Same trade-off as Copilot. */
 	private currentAccountId: number | null = null;
+	/**
+	 * Profile connector-filter signature baked into `this.codex`. Codex takes its
+	 * MCP set at construction, so scoping connectors to a Profile means rebuilding
+	 * the client when the filter changes (same trade-off as an account switch).
+	 * `'*'` = unfiltered (no profile constraint). `null` = not initialized.
+	 */
+	private currentMcpFilterKey: string | null = null;
 
 	get isInitialized(): boolean {
 		return this._isInitialized;
@@ -72,8 +80,9 @@ export class CodexEngine implements AIEngine {
 		return this.activeController !== null;
 	}
 
-	async initialize(accountId?: number): Promise<void> {
-		if (this._isInitialized && (accountId == null || accountId === this.currentAccountId)) {
+	async initialize(accountId?: number, mcpProfileFilter?: Set<string>): Promise<void> {
+		const mcpKey = mcpProfileFilter ? [...mcpProfileFilter].sort().join(',') : '*';
+		if (this._isInitialized && (accountId == null || accountId === this.currentAccountId) && mcpKey === this.currentMcpFilterKey) {
 			return;
 		}
 
@@ -95,7 +104,7 @@ export class CodexEngine implements AIEngine {
 		applyAccountAuth(account);
 
 		const codexBinary = resolveBinary('codex');
-		const mcpConfig = getCodexMcpConfig();
+		const mcpConfig = getCodexMcpConfig(mcpProfileFilter);
 
 		// Codex SDK takes config at construction. We pass `show_raw_agent_reasoning`
 		// (so the SDK forwards reasoning text events) and forward the Clopen MCP
@@ -120,14 +129,16 @@ export class CodexEngine implements AIEngine {
 			},
 		});
 		this.currentAccountId = account.id;
+		this.currentMcpFilterKey = mcpKey;
 		this._isInitialized = true;
-		debug.log('engine', `Codex engine initialized (account ${account.id}, mode=${credential.kind})`);
+		debug.log('engine', `Codex engine initialized (account ${account.id}, mode=${credential.kind}, mcpFilter=${mcpKey})`);
 	}
 
 	async dispose(): Promise<void> {
 		await this.cancel();
 		this.codex = null;
 		this.currentAccountId = null;
+		this.currentMcpFilterKey = null;
 		this._isInitialized = false;
 		debug.log('engine', 'Codex engine disposed');
 	}
@@ -140,25 +151,28 @@ export class CodexEngine implements AIEngine {
 	async *streamQuery(options: EngineQueryOptions): AsyncGenerator<EngineOutput, void, unknown> {
 		const { projectPath, prompt, resume, modelId, abortController, accountId } = options;
 
-		// Active Profile for this stream — scopes the materialized artifact set.
-		// Note: Codex MCP config is baked in at client construction (see
-		// initialize()), so per-stream profile filtering of CONNECTORS is not
-		// applied here — consistent with Codex's existing best-effort MCP status
-		// (Prompt 2). Skills/Commands/Subagents ARE scoped, since they re-sync here.
+		// Active Profile for this stream — scopes the materialized artifact set AND
+		// (below) the MCP connector set baked into the Codex client.
 		const profileId = options.mcpContext?.profileId;
 		// Refresh the synthetic skills preamble in CODEX_HOME before the turn.
 		await syncSkills('codex', profileId);
 		await syncEngineArtifacts('codex', profileId);
 
-		// Per-stream account override — same shape as Copilot. The SDK takes
-		// the apiKey at construction time, so an account switch requires
-		// re-creating the Codex client.
-		if (this._isInitialized && accountId != null && accountId !== this.currentAccountId) {
-			debug.log('engine', `Codex account switch ${this.currentAccountId} → ${accountId}; re-initialising`);
+		// Per-stream account/profile override — the SDK bakes both the apiKey and the
+		// MCP set at construction, so a change in either requires re-creating the
+		// client. The connector filter narrows MCP to the Profile's set (like Claude/
+		// Qwen/Copilot do per stream); `undefined` = unfiltered → no change for the
+		// common no-profile path.
+		const mcpProfileFilter = artifactFilter(profileId, 'mcp') ?? undefined;
+		const mcpKey = mcpProfileFilter ? [...mcpProfileFilter].sort().join(',') : '*';
+		const accountChanged = this._isInitialized && accountId != null && accountId !== this.currentAccountId;
+		const mcpChanged = this._isInitialized && mcpKey !== this.currentMcpFilterKey;
+		if (accountChanged || mcpChanged) {
+			debug.log('engine', `Codex re-initialising (accountChanged=${accountChanged}, mcpChanged=${mcpChanged})`);
 			await this.dispose();
 		}
 		if (!this._isInitialized || !this.codex) {
-			await this.initialize(accountId);
+			await this.initialize(accountId, mcpProfileFilter);
 		}
 		if (!this.codex) {
 			throw new Error('Codex client unavailable.');
@@ -215,7 +229,11 @@ export class CodexEngine implements AIEngine {
 
 			this.activeThread = thread;
 
-			const input = await buildCodexInput(prompt);
+			// Prompt-scoped engine: advertise the profile-scoped Skills/Commands/
+			// Subagents PER-SESSION via the prompt (not the shared global AGENTS.md /
+			// persistent client) so the active Profile scopes them correctly.
+			const artifactsContext = buildArtifactsPromptContext(profileId);
+			const input = await buildCodexInput(prompt, artifactsContext || undefined);
 			const { events } = await thread.runStreamed(input, {
 				signal: this.activeController.signal,
 			});
@@ -365,8 +383,14 @@ export class CodexEngine implements AIEngine {
 // Helpers
 // ============================================================================
 
-async function buildCodexInput(prompt: EngineQueryOptions['prompt']): Promise<CodexInput> {
+async function buildCodexInput(prompt: EngineQueryOptions['prompt'], prefixText?: string): Promise<CodexInput> {
 	const items: Array<{ type: 'text'; text: string } | { type: 'local_image'; path: string }> = [];
+
+	// Optional per-session context (e.g. the profile-scoped skills preamble),
+	// prepended so it leads the turn.
+	if (prefixText) {
+		items.push({ type: 'text', text: prefixText });
+	}
 
 	for (const block of prompt.content) {
 		if (block.type === 'text') {

--- a/backend/engine/adapters/copilot/stream.ts
+++ b/backend/engine/adapters/copilot/stream.ts
@@ -25,7 +25,7 @@ import { debug } from '$shared/utils/logger';
 import { getCopilotMcpConfig } from '../../../mcp';
 import { artifactFilter } from '$backend/profiles';
 import { syncSkills } from '$backend/skills';
-import { syncEngineArtifacts } from '$backend/engine/artifact-sync';
+import { syncEngineArtifacts, buildArtifactsPromptContext } from '$backend/engine/artifact-sync';
 import { resolvePermissionsFromDb, isToolAllowed, type ResolvedPermissions } from '$backend/permissions';
 import { handleStreamError, buildSessionError } from './error-handler';
 import { fetchCopilotModels } from './models';
@@ -234,6 +234,15 @@ export class CopilotEngine implements AIEngine {
 		await syncSkills('copilot', profileId);
 		await syncEngineArtifacts('copilot', profileId);
 
+		// Copilot's skills dir (`~/.copilot/skills`) is SHARED across sessions and
+		// read by a PERSISTENT runtime, and its Commands/Subagents ride a synthetic
+		// global block — none can reliably scope to THIS session's Profile. Inject
+		// the profile-scoped Skills/Commands/Subagents preamble into the prompt as
+		// the authoritative per-session signal (synthetic commands/subagents are
+		// stripped from the global file; the native skill mirror still loads the
+		// filtered folders).
+		const artifactsContext = buildArtifactsPromptContext(profileId);
+
 		// Resolve the permission policy once per stream; onPermissionRequest below
 		// enforces it (Copilot otherwise approves every tool via approveAll).
 		const permissions = resolvePermissionsFromDb('copilot', options.mcpContext?.projectId, profileId);
@@ -387,7 +396,10 @@ export class CopilotEngine implements AIEngine {
 			state.sessionId = session.sessionId;
 
 			// Send the prompt — fire-and-forget; events arrive via the queue.
-			const sendPromise = session.send({ prompt: extractPromptText(prompt) }).catch(error => {
+			const promptText = artifactsContext
+				? `${artifactsContext}\n\n${extractPromptText(prompt)}`
+				: extractPromptText(prompt);
+			const sendPromise = session.send({ prompt: promptText }).catch(error => {
 				debug.error('engine', 'Copilot session.send error:', error);
 				pushEvent({
 					type: 'session.error',

--- a/backend/engine/adapters/opencode/server.ts
+++ b/backend/engine/adapters/opencode/server.ts
@@ -1,48 +1,78 @@
 /**
- * Open Code Server & Client Manager
+ * Open Code Server & Client Pool
  *
- * Manages the `opencode serve` child process and provides an OpencodeClient
- * singleton for all engine instances.
+ * Open Code runs as a persistent `opencode serve` child process that bakes its
+ * MCP set and agent registry at boot. A single shared server therefore CANNOT
+ * express a per-session Profile (excluded connectors/subagents leak, and the
+ * registry is served stale). So instead of one server we keep a POOL keyed by a
+ * config SIGNATURE — the Profile's filtered MCP set + inline agent set — and
+ * route each stream to the server matching its Profile. Two sessions on the same
+ * Profile share a server; different Profiles get isolated servers, concurrently.
  *
- * Strategy:
- * 1. Check DB for previously stored server URL → health-check → reuse if alive
- * 2. Otherwise spawn `opencode serve` via Bun.spawn (port 0, OS-assigned) and persist URL
- * 3. On every ensureClient() call, verify the server is still alive.
- *    If it died mid-session, automatically recover through the same flow.
+ * Strategy per key:
+ * 1. Reuse the pooled server if it is still alive.
+ * 2. Otherwise spawn `opencode serve` (port 0) with the key's config content and
+ *    add it to the pool. Profile servers beyond a small cap are LRU-evicted.
+ * 3. Health-check on every access; a dead server is dropped and respawned.
+ *
+ * The DEFAULT key (`*|*`, no Profile constraint) is the server used for model
+ * listing and unprofiled streams. The pool is in-memory only — a Clopen restart
+ * respawns servers (a legacy single-server URL persisted by older builds is
+ * shut down once on first use).
  */
 
+import { join } from 'path';
 import type { OpencodeClient } from '@opencode-ai/sdk';
 import type { Subprocess } from 'bun';
 import { getOpenCodeMcpConfig } from '../../../mcp';
 import { settingsQueries } from '../../../database/queries';
 import { generateOpenCodeProviderConfig } from './config';
+import type { OpenCodeInlineAgent } from '$backend/subagents';
 import { resolveBinaryWithRefresh } from '$backend/utils/cli';
 import { getEngineUserConfigDir } from '$backend/utils/paths';
 import { debug } from '$shared/utils/logger';
 
 const OPENCODE_HOST = '127.0.0.1';
-const DB_KEY = 'opencode.server.url';
-// The isolated data dir the persisted server was spawned with. A reused server
-// inherits the env it was spawned with, so if our target dir has changed (code
-// update that moves the isolation path, or a server left over from before
-// isolation existed) we must NOT reuse it — respawn into the right dir instead.
-const DB_KEY_DATADIR = 'opencode.server.datadir';
+/** Legacy single-server keys persisted by pre-pool builds — cleaned up once. */
+const LEGACY_DB_KEY = 'opencode.server.url';
+const LEGACY_DB_KEY_DATADIR = 'opencode.server.datadir';
 const HEALTH_TIMEOUT = 1500;
 const SERVER_START_TIMEOUT = 30_000; // 30s — generous for slow devices
+/** Config signature for a stream with no Profile constraint. */
+export const DEFAULT_SERVER_KEY = '*|*';
+/** Max concurrently-pooled Profile servers (the default server is never evicted). */
+const MAX_POOL_SERVERS = 4;
 
-let serverProc: Subprocess | null = null;
-let serverHandle: { url: string; close(): void } | null = null;
-let client: OpencodeClient | null = null;
-let initPromise: Promise<void> | null = null;
-let ready = false;
-let ownsProcess = false;
+export interface ServerInstance {
+	key: string;
+	url: string;
+	client: OpencodeClient;
+	proc: Subprocess | null;
+	ownsProcess: boolean;
+	lastUsed: number;
+}
 
-function clearClientState(): void {
-	client = null;
-	ready = false;
-	serverHandle = null;
-	serverProc = null;
-	ownsProcess = false;
+/** What distinguishes one Profile's server from another. */
+export interface ServerConfigSpec {
+	/** Allowed MCP connector slugs (undefined = unconstrained → all enabled). */
+	mcpProfileFilter?: Set<string>;
+	/** Inline agent definitions (undefined/empty = the engine's default set). */
+	inlineAgents?: Record<string, OpenCodeInlineAgent>;
+}
+
+const pool = new Map<string, ServerInstance>();
+const initPromises = new Map<string, Promise<ServerInstance>>();
+let legacyCleaned = false;
+
+/** Short, stable FNV-1a hex hash — folds variable config (e.g. inline agent
+ *  content) into a compact server-key segment so an edit spawns a fresh server. */
+export function hashConfig(s: string): string {
+	let h = 0x811c9dc5;
+	for (let i = 0; i < s.length; i++) {
+		h ^= s.charCodeAt(i);
+		h = Math.imul(h, 0x01000193);
+	}
+	return (h >>> 0).toString(16);
 }
 
 async function isServerAlive(url: string): Promise<boolean> {
@@ -54,109 +84,92 @@ async function isServerAlive(url: string): Promise<boolean> {
 	}
 }
 
-/**
- * Get (or create) the OpenCode client.
- * Concurrency-safe: multiple callers share a single init promise.
- *
- * When the server is already initialized, a lightweight health check runs.
- * If the server died (bun --watch restart, crash, etc.), state is reset and
- * init() is re-invoked — the same DB-check → reuse-or-spawn flow handles
- * recovery automatically.
- *
- * Race-condition guard: after any `await` (health check), we re-check
- * `initPromise` before starting a new init — another caller may have
- * already kicked one off during our async gap.
- */
-export async function ensureClient(): Promise<OpencodeClient> {
-	// Wait for any in-progress init first
-	if (initPromise) {
-		try { await initPromise; } catch { /* handled below */ }
-		if (client && ready) return client;
-	}
-
-	// Fast path: server is up and healthy
-	if (client && ready && serverHandle) {
-		if (await isServerAlive(serverHandle.url)) return client;
-
-		// Server disconnected — purge stale DB entry
-		// Do NOT clear initPromise — another caller may have started one
-		debug.log('engine', 'Open Code server disconnected, recovering...');
-		settingsQueries.delete(DB_KEY);
-		settingsQueries.delete(DB_KEY_DATADIR);
-		clearClientState();
-	}
-
-	// Re-check after async gap — another caller may have started init
-	if (initPromise) {
-		try { await initPromise; } catch { /* handled below */ }
-		if (client && ready) return client;
-	}
-
-	// Start init — no other caller is initializing at this point
-	initPromise = init();
-	try {
-		await initPromise;
-		return client!;
-	} catch (error) {
-		initPromise = null;
-		throw error;
+/** One-time shutdown of a server spawned by an older single-server build. */
+async function cleanupLegacyServer(): Promise<void> {
+	if (legacyCleaned) return;
+	legacyCleaned = true;
+	const stored = settingsQueries.get(LEGACY_DB_KEY)?.value;
+	if (stored) {
+		try {
+			await fetch(`${stored}/shutdown`, { method: 'POST', signal: AbortSignal.timeout(2000) });
+		} catch { /* endpoint may not exist / already dead */ }
+		settingsQueries.delete(LEGACY_DB_KEY);
+		settingsQueries.delete(LEGACY_DB_KEY_DATADIR);
+		debug.log('engine', `Open Code: shut down legacy single-server (${stored})`);
 	}
 }
 
-async function init(): Promise<void> {
-	debug.log('engine', 'Initializing Open Code client...');
+function killInstance(inst: ServerInstance): void {
+	if (inst.ownsProcess && inst.proc) {
+		try { inst.proc.kill(); } catch { /* already gone */ }
+	}
+}
 
-	// Isolate OpenCode's state (opencode.db, snapshots, logs, config) to
-	// {clopenDir}/engine/opencode/user/ instead of the shared XDG dirs
-	// (~/.local/share/opencode, ~/.config/opencode) so Clopen never mixes with
-	// the user's own OpenCode CLI usage. OpenCode follows the XDG base-dir spec
-	// and appends `/opencode` to each base. Credentials + MCP config are injected
-	// via OPENCODE_CONFIG_CONTENT, so no auth file needs to carry over.
-	const opencodeUserDir = getEngineUserConfigDir('opencode');
+/** Evict the least-recently-used PROFILE server when the pool is over cap. */
+function evictIfNeeded(): void {
+	const evictable = [...pool.values()].filter(s => s.key !== DEFAULT_SERVER_KEY);
+	if (evictable.length <= MAX_POOL_SERVERS) return;
+	evictable.sort((a, b) => a.lastUsed - b.lastUsed);
+	for (const victim of evictable.slice(0, evictable.length - MAX_POOL_SERVERS)) {
+		debug.log('engine', `Open Code: evicting idle Profile server (${victim.key}) at ${victim.url}`);
+		killInstance(victim);
+		pool.delete(victim.key);
+	}
+}
 
-	// 1. Try to reuse an existing server persisted in DB — but only if it was
-	// spawned with the SAME isolated data dir we'd use now. A mismatch means the
-	// stored server points at a stale location (pre-isolation, or a moved path);
-	// reusing it would silently keep writing to the wrong dir.
-	const stored = settingsQueries.get(DB_KEY);
-	const storedDataDir = settingsQueries.get(DB_KEY_DATADIR)?.value;
-	if (stored?.value) {
-		debug.log('engine', `Found stored Open Code server: ${stored.value}, checking...`);
+/**
+ * Get (or spawn) the pooled Open Code server for a config signature. The `spec`
+ * is only consulted when a server for `key` must be spawned; callers must pass a
+ * `key` that uniquely captures the spec (see the adapter's signature builder).
+ */
+export async function ensureServer(key: string, spec: ServerConfigSpec): Promise<ServerInstance> {
+	await cleanupLegacyServer();
 
-		if (storedDataDir === opencodeUserDir && await isServerAlive(stored.value)) {
-			const { createOpencodeClient } = await import('@opencode-ai/sdk');
-			client = createOpencodeClient({ baseUrl: stored.value });
-			serverHandle = { url: stored.value, close() {} };
-			ownsProcess = false;
-			ready = true;
-			debug.log('engine', `Reusing existing Open Code server at ${stored.value}`);
-			return;
+	const existing = pool.get(key);
+	if (existing) {
+		if (await isServerAlive(existing.url)) {
+			existing.lastUsed = Date.now();
+			return existing;
 		}
-
-		if (storedDataDir !== opencodeUserDir) {
-			debug.log('engine', `Stored Open Code server data dir mismatch (${storedDataDir ?? 'unknown'} ≠ ${opencodeUserDir}), spawning fresh...`);
-		} else {
-			debug.log('engine', 'Stored server not responding, spawning new one...');
-		}
-		settingsQueries.delete(DB_KEY);
-		settingsQueries.delete(DB_KEY_DATADIR);
+		killInstance(existing);
+		pool.delete(key);
 	}
 
-	// 2. Spawn a new server via Bun.spawn with absolute binary path.
-	// Re-harvest PATH and fall back to known install locations so freshly
-	// installed binaries are picked up without a clopen restart.
+	const inFlight = initPromises.get(key);
+	if (inFlight) return inFlight;
+
+	const p = spawnServer(key, spec)
+		.then(inst => {
+			pool.set(key, inst);
+			evictIfNeeded();
+			return inst;
+		})
+		.finally(() => { initPromises.delete(key); });
+	initPromises.set(key, p);
+	return p;
+}
+
+async function spawnServer(key: string, spec: ServerConfigSpec): Promise<ServerInstance> {
+	debug.log('engine', `Spawning Open Code server for key "${key}"...`);
+
+	// Isolate Open Code state under Clopen's dir (XDG overrides) — never mixes with
+	// the user's own CLI usage. CONFIG is shared across pooled servers (commands +
+	// instructions live there; agents come INLINE via OPENCODE_CONFIG_CONTENT, not
+	// the on-disk agent dir). DATA/STATE/CACHE (incl. opencode.db, sessions,
+	// snapshots) are per-key so concurrent Profile servers never share one SQLite
+	// db. The DEFAULT server keeps the base dir for back-compat with old sessions.
+	const configDir = getEngineUserConfigDir('opencode');
+	const dataDir = key === DEFAULT_SERVER_KEY
+		? configDir
+		: join(configDir, 'pool', Buffer.from(key).toString('base64url'));
+
 	const command = await resolveBinaryWithRefresh('opencode');
 	if (!command) throw new Error('opencode binary not found on PATH');
 	const args = [command, 'serve', `--hostname=${OPENCODE_HOST}`, '--port=0'];
 
-	// Build MCP config — but only inject remote servers whose endpoint is
-	// actually reachable. The opencode binary may initialize MCP connections
-	// synchronously before printing "opencode server listening", so an
-	// unreachable/slow remote endpoint can stall startup. Drop ONLY the
-	// unreachable remote entries; stdio/local servers (no `url`) are independent
-	// of the HTTP bridge and must always survive — they were previously thrown
-	// out together with the bridge when it wasn't reachable yet.
-	const mcpConfig = getOpenCodeMcpConfig();
+	// MCP: only inject remote servers whose endpoint is reachable — an unreachable
+	// remote can stall startup. stdio/local servers (no `url`) always survive.
+	const mcpConfig = getOpenCodeMcpConfig(spec.mcpProfileFilter);
 	if (Object.keys(mcpConfig).length > 0) {
 		const entries = Object.entries(mcpConfig);
 		const reachability = await Promise.all(
@@ -167,36 +180,22 @@ async function init(): Promise<void> {
 		);
 		entries.forEach(([name, config], i) => {
 			if (reachability[i]) {
-				debug.log('engine', `Open Code server: injecting MCP server → ${name}: ${config.type} (${(config as any).url || (config as any).command?.join(' ')})`);
+				debug.log('engine', `Open Code[${key}]: MCP → ${name}: ${config.type} (${(config as any).url || (config as any).command?.join(' ')})`);
 			} else {
-				debug.warn('engine', `Open Code server: MCP endpoint for "${name}" not reachable, skipping it`);
+				debug.warn('engine', `Open Code[${key}]: MCP endpoint for "${name}" not reachable, skipping it`);
 				delete mcpConfig[name];
 			}
 		});
 	}
 
-	// Build provider config from DB (enabled providers + env vars)
 	const providerConfig = generateOpenCodeProviderConfig();
-	if (providerConfig.enabledProviders.length > 0) {
-		debug.log('engine', `Open Code server: enabling ${providerConfig.enabledProviders.length} provider(s): ${providerConfig.enabledProviders.join(', ')}`);
-	}
-	if (Object.keys(providerConfig.envVars).length > 0) {
-		debug.log('engine', `Open Code server: injecting ${Object.keys(providerConfig.envVars).length} env var(s): ${Object.keys(providerConfig.envVars).join(', ')}`);
-	}
 
-	// Merge MCP config + enabled_providers into a single OPENCODE_CONFIG_CONTENT
+	// Merge MCP + providers + inline agents into a single OPENCODE_CONFIG_CONTENT.
 	const mergedConfig: Record<string, unknown> = {};
-	if (Object.keys(mcpConfig).length > 0) {
-		mergedConfig.mcp = mcpConfig;
-	}
-	if (providerConfig.enabledProviders.length > 0) {
-		mergedConfig.enabled_providers = providerConfig.enabledProviders;
-	}
-	const configContent = Object.keys(mergedConfig).length > 0
-		? JSON.stringify(mergedConfig)
-		: '{}';
-
-	debug.log('engine', `Spawning: ${args.join(' ')} (data dir: ${opencodeUserDir})`);
+	if (Object.keys(mcpConfig).length > 0) mergedConfig.mcp = mcpConfig;
+	if (providerConfig.enabledProviders.length > 0) mergedConfig.enabled_providers = providerConfig.enabledProviders;
+	if (spec.inlineAgents && Object.keys(spec.inlineAgents).length > 0) mergedConfig.agent = spec.inlineAgents;
+	const configContent = Object.keys(mergedConfig).length > 0 ? JSON.stringify(mergedConfig) : '{}';
 
 	const proc = Bun.spawn(args, {
 		stdout: 'pipe',
@@ -204,15 +203,15 @@ async function init(): Promise<void> {
 		env: {
 			...process.env,
 			...providerConfig.envVars,
-			XDG_DATA_HOME: opencodeUserDir,
-			XDG_CONFIG_HOME: opencodeUserDir,
-			XDG_STATE_HOME: opencodeUserDir,
-			XDG_CACHE_HOME: opencodeUserDir,
+			XDG_CONFIG_HOME: configDir,
+			XDG_DATA_HOME: dataDir,
+			XDG_STATE_HOME: dataDir,
+			XDG_CACHE_HOME: dataDir,
 			OPENCODE_CONFIG_CONTENT: configContent,
 		},
 	});
 
-	// Parse server URL from stdout — opencode prints "opencode server listening on <url>"
+	// Parse the URL from "opencode server listening on <url>".
 	const url = await new Promise<string>((resolve, reject) => {
 		const timeout = setTimeout(() => {
 			proc.kill();
@@ -220,7 +219,6 @@ async function init(): Promise<void> {
 		}, SERVER_START_TIMEOUT);
 
 		let output = '';
-
 		const readStream = async (stream: ReadableStream<Uint8Array>, label: string) => {
 			const reader = stream.getReader();
 			const decoder = new TextDecoder();
@@ -228,30 +226,20 @@ async function init(): Promise<void> {
 				while (true) {
 					const { done, value } = await reader.read();
 					if (done) break;
-					const chunk = decoder.decode(value, { stream: true });
-					output += chunk;
-
+					output += decoder.decode(value, { stream: true });
 					if (label === 'stdout') {
 						for (const line of output.split('\n')) {
 							if (line.startsWith('opencode server listening')) {
 								const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
-								if (match) {
-									clearTimeout(timeout);
-									resolve(match[1]);
-									return;
-								}
+								if (match) { clearTimeout(timeout); resolve(match[1]); return; }
 							}
 						}
 					}
 				}
-			} catch {
-				// stream closed
-			}
+			} catch { /* stream closed */ }
 		};
-
 		readStream(proc.stdout as ReadableStream<Uint8Array>, 'stdout');
 		readStream(proc.stderr as ReadableStream<Uint8Array>, 'stderr');
-
 		proc.exited.then((code) => {
 			clearTimeout(timeout);
 			let msg = `opencode server exited with code ${code}`;
@@ -260,72 +248,40 @@ async function init(): Promise<void> {
 		});
 	});
 
-	serverProc = proc;
 	const { createOpencodeClient } = await import('@opencode-ai/sdk');
-	client = createOpencodeClient({ baseUrl: url });
-	serverHandle = {
-		url,
-		close() { proc.kill(); },
-	};
-	ownsProcess = true;
-	ready = true;
-
-	settingsQueries.set(DB_KEY, url);
-	settingsQueries.set(DB_KEY_DATADIR, opencodeUserDir);
-	debug.log('engine', `Open Code client ready (server: ${url}, data dir: ${opencodeUserDir})`);
-}
-
-export function getClient(): OpencodeClient | null {
-	return ready ? client : null;
-}
-
-export function getServerUrl(): string | null {
-	return serverHandle?.url ?? null;
+	const client = createOpencodeClient({ baseUrl: url });
+	debug.log('engine', `Open Code server ready (key "${key}", ${url}, data dir: ${dataDir})`);
+	return { key, url, client, proc, ownsProcess: true, lastUsed: Date.now() };
 }
 
 /**
- * Dispose the OpenCode client and stop the server.
- *
- * @param forRestart — When true, always kills the server process (even if
- *   we didn't spawn it) and purges the stored URL so the next init() spawns
- *   a fresh server with updated config. Used by the Restart Server flow.
- *
- *   When false (default), only kills the child process when we spawned it.
- *   Reused servers stay alive so the next session can pick them up.
+ * The DEFAULT (no-Profile) client — used for model listing, one-shot structured
+ * generation, and warm-up. Concurrency-safe via the shared init promise.
  */
-export async function disposeOpenCodeClient(forRestart = false): Promise<void> {
-	if (serverHandle) {
-		if (ownsProcess || forRestart) {
-			try {
-				debug.log('engine', `Stopping Open Code server (${serverHandle.url}, forRestart=${forRestart})...`);
-				if (ownsProcess) {
-					serverHandle.close();
-				} else if (forRestart) {
-					// Server we didn't spawn — kill it by sending a request or just
-					// purging the stored URL. The server process may be external, but
-					// clearing DB ensures we spawn a new one on next init().
-					try {
-						await fetch(`${serverHandle.url}/shutdown`, {
-							method: 'POST',
-							signal: AbortSignal.timeout(2000),
-						});
-					} catch {
-						// shutdown endpoint may not exist — that's fine
-					}
-				}
-				settingsQueries.delete(DB_KEY);
-				settingsQueries.delete(DB_KEY_DATADIR);
-			} catch (error) {
-				debug.error('engine', 'Error stopping Open Code server:', error);
-			}
-		}
-	} else if (forRestart) {
-		// No active handle but forRestart requested — ensure DB is clean
-		settingsQueries.delete(DB_KEY);
-		settingsQueries.delete(DB_KEY_DATADIR);
-	}
+export async function ensureClient(): Promise<OpencodeClient> {
+	return (await ensureServer(DEFAULT_SERVER_KEY, {})).client;
+}
 
-	clearClientState();
-	initPromise = null;
-	debug.log('engine', 'Open Code client disposed');
+/** The DEFAULT server's client, if up (back-compat for callers with no stream context). */
+export function getClient(): OpencodeClient | null {
+	return pool.get(DEFAULT_SERVER_KEY)?.client ?? null;
+}
+
+/** The DEFAULT server's URL, if up. */
+export function getServerUrl(): string | null {
+	return pool.get(DEFAULT_SERVER_KEY)?.url ?? null;
+}
+
+/**
+ * Dispose the whole pool. `forRestart` is accepted for signature compatibility
+ * with the previous single-server API; every pooled server we own is killed
+ * either way (there is no external-server-reuse path anymore).
+ */
+export async function disposeOpenCodeClient(_forRestart = false): Promise<void> {
+	for (const inst of pool.values()) killInstance(inst);
+	pool.clear();
+	initPromises.clear();
+	settingsQueries.delete(LEGACY_DB_KEY);
+	settingsQueries.delete(LEGACY_DB_KEY_DATADIR);
+	debug.log('engine', 'Open Code pool disposed');
 }

--- a/backend/engine/adapters/opencode/stream.ts
+++ b/backend/engine/adapters/opencode/stream.ts
@@ -41,9 +41,12 @@ import {
 	mapToolName,
 	TOOL_NAME_MAP,
 } from './message-converter';
-import { ensureClient, getClient, getServerUrl } from './server';
+import { ensureClient, ensureServer, hashConfig, getClient, getServerUrl, type ServerInstance } from './server';
 import { syncSkills } from '$backend/skills';
-import { syncEngineArtifacts } from '$backend/engine/artifact-sync';
+import { syncEngineArtifacts, buildArtifactsPromptContext } from '$backend/engine/artifact-sync';
+import { artifactFilter } from '$backend/profiles';
+import { buildOpenCodeInlineAgents } from '$backend/subagents';
+import { getOpenCodeProfileDisabledToolIds } from '$backend/mcp';
 import { resolvePermissionsFromDb, matchesAny, type ResolvedPermissions } from '$backend/permissions';
 import { formatSessionError, handleStreamError } from './error-handler';
 import { buildJsonPrompt, extractJson } from '../../structured-helpers';
@@ -102,6 +105,8 @@ export class OpenCodeEngine implements AIEngine {
 	private activeAbortController: AbortController | null = null;
 	private activeSessionId: string | null = null;
 	private activeProjectPath: string | null = null;
+	/** The pooled per-Profile server this instance's active stream is bound to. */
+	private activeServer: ServerInstance | null = null;
 	/** Pending question requests keyed by tool callID → { requestId, questions } */
 	private pendingQuestions = new Map<string, { requestId: string; questions: Array<{ question: string }> }>();
 
@@ -132,6 +137,7 @@ export class OpenCodeEngine implements AIEngine {
 	async dispose(): Promise<void> {
 		await this.cancel();
 		this.pendingQuestions.clear();
+		this.activeServer = null;
 		this._isInitialized = false;
 		debug.log('engine', 'Open Code engine instance disposed');
 	}
@@ -152,8 +158,6 @@ export class OpenCodeEngine implements AIEngine {
 	 * This ensures no events are missed between sending and subscribing.
 	 */
 	async *streamQuery(options: EngineQueryOptions): AsyncGenerator<EngineOutput, void, unknown> {
-		const client = await ensureClient();
-
 		const {
 			projectPath,
 			prompt,
@@ -167,14 +171,32 @@ export class OpenCodeEngine implements AIEngine {
 		this._isActive = true;
 		this.activeProjectPath = projectPath;
 
-		// Active Profile for this stream — scopes the materialized artifact set.
-		// (OpenCode MCP config lives on the persistent server, not per-stream, so
-		// connector filtering by profile is not applied here — best-effort, like
-		// Codex. Skills/Commands/Subagents + permissions ARE profile-scoped.)
+		// Active Profile for this stream. Skills go into the prompt and commands
+		// into shared dirs; materialize those first, then bind to the per-Profile
+		// server that bakes the rest.
 		const profileId = options.mcpContext?.profileId;
-		// Refresh the synthetic skills preamble in OpenCode's config dir.
 		await syncSkills('opencode', profileId);
 		await syncEngineArtifacts('opencode', profileId);
+
+		// Bind this stream to the pooled server whose baked config matches the
+		// Profile: MCP narrowed to the Profile's connectors (drops excluded EXTERNAL
+		// servers) plus the Profile's subagents INLINE — Open Code caches its agent
+		// registry from a shared dir at boot, so an isolated server is the only way
+		// to scope it. The signature keys the pool: identical scoping reuses one
+		// server, different Profiles get isolated servers, concurrently.
+		const mcpProfileFilter = artifactFilter(profileId, 'mcp') ?? undefined;
+		const subagentFilter = artifactFilter(profileId, 'subagent') ?? undefined;
+		const inlineAgents = await buildOpenCodeInlineAgents(profileId);
+		// Key = filtered MCP set + subagent set + a hash of the agents' CONTENT, so
+		// editing a subagent's prompt/model (same set) also spawns a fresh server
+		// rather than reusing a stale one. `subagentFilter` is subsumed by the
+		// content hash but kept for a readable key.
+		const mcpKey = mcpProfileFilter ? [...mcpProfileFilter].sort().join(',') : '*';
+		const agentKey = subagentFilter ? [...subagentFilter].sort().join(',') : '*';
+		const serverKey = `mcp:${mcpKey}|agents:${agentKey}:${hashConfig(JSON.stringify(inlineAgents))}`;
+		const server = await ensureServer(serverKey, { mcpProfileFilter, inlineAgents });
+		this.activeServer = server;
+		const client = server.client;
 
 		// Resolve the permission policy once per stream; the permission event
 		// handler enforces it (OpenCode otherwise auto-approves every tool). Tool
@@ -187,6 +209,16 @@ export class OpenCodeEngine implements AIEngine {
 
 		try {
 			const promptParts = this.extractPromptParts(prompt);
+
+			// Prompt-scoped engine: the persistent server reads Skills/Commands/
+			// Subagents through shared channels it doesn't reliably re-read per turn,
+			// so advertise the profile-scoped set PER-SESSION by prepending it as a
+			// leading context part each turn (authoritative for synthetic skills;
+			// advisory on top of the native command/agent dirs).
+			const artifactsContext = buildArtifactsPromptContext(profileId);
+			if (artifactsContext) {
+				promptParts.unshift({ type: 'text', text: artifactsContext });
+			}
 
 			// Create or fork a session
 			// When resuming, fork the session to create a new branch
@@ -229,6 +261,15 @@ export class OpenCodeEngine implements AIEngine {
 			// the deny policy up front (covers read-only + MCP tools that never fire
 			// a permission event — see buildOpenCodeToolDisableMap).
 			const disabledTools = buildOpenCodeToolDisableMap(permissions);
+			// Profile connector scoping (INTERNAL): the shared `clopen-mcp` bridge is
+			// all-or-nothing, so disable — for THIS session only (per-prompt `tools`
+			// map → concurrency-safe) — the tools of every internal connector the
+			// active Profile excludes. External connectors are already absent from
+			// this Profile's server (see the pooled server config). No-op when the
+			// profile doesn't constrain connectors.
+			for (const toolId of getOpenCodeProfileDisabledToolIds(mcpProfileFilter)) {
+				disabledTools[toolId] = false;
+			}
 			client.session.promptAsync({
 				path: { id: sessionId },
 				body: {
@@ -780,7 +821,7 @@ export class OpenCodeEngine implements AIEngine {
 		//    This is a courtesy cleanup — local processing is already stopped.
 		//    The server-side session would otherwise keep running (consuming
 		//    LLM API calls and compute resources) until it naturally completes.
-		const client = getClient();
+		const client = this.activeServer?.client ?? getClient();
 		if (client && sessionId) {
 			try {
 				await Promise.race([
@@ -802,7 +843,7 @@ export class OpenCodeEngine implements AIEngine {
 	 * Used by stream-manager for per-project isolation (instead of global cancel).
 	 */
 	async cancelSession(sessionId: string, projectPath?: string): Promise<void> {
-		const client = getClient();
+		const client = this.activeServer?.client ?? getClient();
 		if (!client || !sessionId) return;
 		try {
 			await Promise.race([
@@ -857,7 +898,7 @@ export class OpenCodeEngine implements AIEngine {
 	 * POST /question/{requestID}/reply to send user answers back to the OpenCode server.
 	 */
 	private replyToQuestion(requestId: string, orderedAnswers: string[][]): void {
-		const serverUrl = getServerUrl();
+		const serverUrl = this.activeServer?.url ?? getServerUrl();
 		if (!serverUrl) {
 			debug.warn('engine', 'replyToQuestion: Server URL not available');
 			return;
@@ -887,7 +928,7 @@ export class OpenCodeEngine implements AIEngine {
 	 * Fallback: GET /question to list pending questions, find the matching one, and reply.
 	 */
 	private async fetchAndReplyToQuestion(toolUseId: string, answers: Record<string, string>): Promise<void> {
-		const serverUrl = getServerUrl();
+		const serverUrl = this.activeServer?.url ?? getServerUrl();
 		if (!serverUrl) {
 			debug.warn('engine', 'fetchAndReplyToQuestion: Server URL not available');
 			return;
@@ -930,7 +971,7 @@ export class OpenCodeEngine implements AIEngine {
 	 * the v2 permission.reply method.
 	 */
 	private replyPermission(permissionId: string, sessionId: string, response: 'once' | 'reject'): void {
-		const serverUrl = getServerUrl();
+		const serverUrl = this.activeServer?.url ?? getServerUrl();
 		if (!serverUrl) return;
 		const verb = response === 'reject' ? 'rejected' : 'approved';
 
@@ -945,7 +986,7 @@ export class OpenCodeEngine implements AIEngine {
 				return;
 			}
 			// v2 endpoint not available — try v1
-			const client = getClient();
+			const client = this.activeServer?.client ?? getClient();
 			if (client) {
 				client.postSessionIdPermissionsPermissionId({
 					path: { id: sessionId, permissionID: permissionId },

--- a/backend/engine/artifact-sync.ts
+++ b/backend/engine/artifact-sync.ts
@@ -12,9 +12,10 @@
  * Each underlying sync swallows its own errors, so this never throws.
  */
 
-import { syncCommands } from '$backend/commands';
-import { syncSubagents } from '$backend/subagents';
+import { syncCommands, buildCommandsPromptContext } from '$backend/commands';
+import { syncSubagents, buildSubagentsPromptContext } from '$backend/subagents';
 import { syncInstructions } from '$backend/instructions';
+import { buildSkillsPromptContext } from '$backend/skills';
 import type { ArtifactEngine } from '$backend/artifacts';
 
 export async function syncEngineArtifacts(engine: ArtifactEngine, profileId?: number): Promise<void> {
@@ -29,4 +30,22 @@ export async function syncEngineArtifacts(engine: ArtifactEngine, profileId?: nu
 	await syncCommands(engine, profileId);
 	await syncSubagents(engine, profileId);
 	await syncInstructions(engine);
+}
+
+/**
+ * The combined, profile-scoped Skills + Commands + Subagents preamble that
+ * prompt-scoped engines (OpenCode/Codex/Copilot) inject into each turn's prompt.
+ *
+ * Their runtimes read these artifacts through a channel that is SHARED across
+ * sessions and not reliably re-read per turn (a persistent server/client and/or
+ * a global memory file), so the on-disk/global-file filter can't express a
+ * per-session Profile. Injecting the scoped set into the prompt is the one
+ * channel that is genuinely per-session. Returns '' when nothing applies.
+ */
+export function buildArtifactsPromptContext(profileId?: number): string {
+	return [
+		buildSkillsPromptContext(profileId),
+		buildCommandsPromptContext(profileId),
+		buildSubagentsPromptContext(profileId)
+	].filter(Boolean).join('\n\n');
 }

--- a/backend/mcp/index.ts
+++ b/backend/mcp/index.ts
@@ -152,3 +152,17 @@ export function getQwenMcpConfig(profileFilter?: Set<string>) {
 export function resolveOpenCodeToolName(toolName: string): string | null {
 	return internal.resolveOpenCodeToolName(toolName) ?? external.resolveExternalToolName(toolName);
 }
+
+/**
+ * Open Code tool ids to DISABLE for INTERNAL connectors excluded by an active
+ * Profile, for the per-prompt `tools` map (per-session → concurrency-safe). All
+ * internal tools ride the single `clopen-mcp` bridge, which is all-or-nothing at
+ * the MCP-config level, so per-connector scoping must happen here. EXTERNAL
+ * connectors are handled at the server level instead — each is its own MCP entry,
+ * dropped from the per-Profile server's config when excluded (see
+ * `getOpenCodeMcpConfig(profileFilter)` in the server pool). `undefined` filter
+ * (profile doesn't constrain connectors) → none.
+ */
+export function getOpenCodeProfileDisabledToolIds(profileFilter?: Set<string>): string[] {
+	return internal.getOpenCodeProfileDisabledInternalToolIds(profileFilter);
+}

--- a/backend/mcp/internal/config.ts
+++ b/backend/mcp/internal/config.ts
@@ -329,6 +329,28 @@ export function getEnabledToolsForServer(serverName: string): string[] {
 }
 
 /**
+ * Open Code tool ids (`clopen-mcp_<tool>`) for INTERNAL connectors EXCLUDED by an
+ * active Profile — every globally-enabled internal server whose slug is NOT in the
+ * profile's connector set. Fed to Open Code's per-prompt `tools` disable map so
+ * those tools are removed for THIS session, even though the persistent server was
+ * built with every enabled connector. `undefined` filter (profile doesn't
+ * constrain connectors) → none. All internal tools share the single `clopen-mcp`
+ * bridge namespace, so the id is `clopen-mcp_<tool>` regardless of owning server.
+ */
+export function getOpenCodeProfileDisabledInternalToolIds(profileFilter?: Set<string>): string[] {
+	if (!profileFilter) return [];
+	const ids: string[] = [];
+	for (const [serverName, serverConfig] of Object.entries(mcpServers)) {
+		if (!serverEnabled(serverName)) continue;   // not in the running config anyway
+		if (profileFilter.has(serverName)) continue; // allowed by the profile
+		for (const toolName of serverConfig.tools as readonly string[]) {
+			ids.push(`clopen-mcp_${toolName}`);
+		}
+	}
+	return ids;
+}
+
+/**
  * Get statistics about MCP servers and tools
  */
 export function getMcpStats() {

--- a/backend/skills/index.ts
+++ b/backend/skills/index.ts
@@ -17,5 +17,5 @@ export type { SkillDTO, ParsedSkillPreview } from './service';
 export { listMarketplaceSkills, fetchMarketplaceSkill } from './marketplace';
 export type { MarketplaceSkill, MarketplacePage } from './marketplace';
 
-export { syncSkills, syncSkillsAllEngines } from './sync';
+export { syncSkills, syncSkillsAllEngines, buildSkillsPromptContext } from './sync';
 export type { SkillEngine } from './sync';

--- a/backend/skills/sync.ts
+++ b/backend/skills/sync.ts
@@ -17,7 +17,7 @@
 
 import { skillQueries } from '$backend/database/queries';
 import { debug } from '$shared/utils/logger';
-import { materializeArtifacts, type ManagedArtifact, type ArtifactEngine } from '$backend/artifacts';
+import { materializeArtifacts, resolveArtifact, isPromptScopedEngine, type ManagedArtifact, type ArtifactEngine } from '$backend/artifacts';
 import { artifactFilter } from '$backend/profiles';
 import { getSkillMdPath, getSkillDir } from './store';
 import { stat } from 'node:fs/promises';
@@ -59,39 +59,77 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 /**
+ * The skills that apply to a stream, already narrowed by the active Profile.
+ * Shared by the native file materializer ({@link syncSkills}) and the synthetic
+ * per-session prompt injection ({@link buildSkillsPromptContext}) so both see an
+ * identical set.
+ *
+ * A profile is the source of truth for what's active: an item it references is
+ * included even if globally disabled, and its enable toggle is ignored. With no
+ * profile filter, only the globally-enabled set applies (unchanged behaviour).
+ */
+export function resolveEnabledSkills(profileId?: number): ManagedArtifact[] {
+	const filter = artifactFilter(profileId, 'skill');
+	const source = filter
+		? skillQueries.getAll().map(r => ({ slug: r.slug, name: r.name, description: r.description }))
+		: getEnabledSkills();
+	return source
+		.filter(s => !filter || filter.has(s.slug))
+		.map(s => ({
+			slug: s.slug,
+			name: s.name,
+			description: s.description,
+			sourceDir: getSkillDir(s.slug)
+		}));
+}
+
+/**
+ * Whether skills for this engine are delivered per-session via prompt injection
+ * INSTEAD of the shared global memory file — true only for a synthetic (no native
+ * dir) skill target on a prompt-scoped engine. Native skill engines
+ * (Claude/Qwen/Copilot) keep the folder mirror+prune.
+ */
+function skillsViaPromptInjection(engine: SkillEngine): boolean {
+	const synthetic = resolveArtifact('skill', { engine, scope: 'global' }).format === 'preamble-region';
+	return synthetic && isPromptScopedEngine(engine);
+}
+
+/**
+ * The profile-scoped skills preamble for PER-SESSION injection into a synthetic
+ * engine's prompt (OpenCode/Codex). Returns '' when no skill applies. Uses the
+ * exact wording of the old global block, so model behaviour is unchanged apart
+ * from now being correctly scoped to the session's active Profile.
+ */
+export function buildSkillsPromptContext(profileId?: number): string {
+	return buildSkillsPreamble(resolveEnabledSkills(profileId));
+}
+
+/**
  * Sync enabled skills for one engine. Safe to call at every stream start.
  * Never throws: failures are logged and swallowed so streaming is unaffected.
  *
- * `profileId` (when a Profile is active for the stream) narrows the enabled set
- * to the skills the profile references; a profile that references no skill at
- * all leaves the full enabled set untouched (presence-per-type — see
- * `backend/profiles`). The eager all-engines re-sync passes no profile, so the
- * on-disk resting state stays the full enabled set.
+ * NATIVE engines (Claude/Qwen/Copilot) mirror the profile-narrowed skill folders
+ * into the engine's skills dir and prune the rest — a per-query-correct filter.
+ *
+ * SYNTHETIC engines (OpenCode/Codex) do NOT advertise skills through the shared
+ * global memory file here: a single global file can't encode a per-session
+ * profile choice and would leak across concurrent sessions (and their persistent
+ * server may not re-read it). Instead they inject the resolved preamble into each
+ * turn's prompt (see the adapters + {@link buildSkillsPromptContext}). We still
+ * materialize an EMPTY set for them so any legacy `CLOPEN:SKILLS` block left in
+ * AGENTS.md is stripped.
  */
 export async function syncSkills(engine: SkillEngine, profileId?: number): Promise<void> {
 	try {
-		const filter = artifactFilter(profileId, 'skill');
-		// A profile is the source of truth for what's active: an item it references
-		// is materialized even if globally disabled, and its enable toggle is
-		// ignored. Without a profile filter, only the enabled set applies (unchanged).
-		const source = filter
-			? skillQueries.getAll().map(r => ({ slug: r.slug, name: r.name, description: r.description }))
-			: getEnabledSkills();
-		const enabled: ManagedArtifact[] = source
-			.filter(s => !filter || filter.has(s.slug))
-			.map(s => ({
-				slug: s.slug,
-				name: s.name,
-				description: s.description,
-				sourceDir: getSkillDir(s.slug)
-			}));
+		const viaPrompt = skillsViaPromptInjection(engine);
+		const enabled: ManagedArtifact[] = viaPrompt ? [] : resolveEnabledSkills(profileId);
 		const managedSlugs = skillQueries.getAll().map(s => s.slug);
 		await materializeArtifacts('skill', { engine, scope: 'global' }, {
 			enabled,
 			managedSlugs,
 			buildPreamble: buildSkillsPreamble
 		});
-		debug.log('skills', `🧩 Synced ${enabled.length} skill(s) → ${engine}`);
+		debug.log('skills', `🧩 Synced ${enabled.length} skill(s) → ${engine}${viaPrompt ? ' (per-session injection)' : ''}`);
 	} catch (error) {
 		debug.warn('skills', `⚠️ Skill sync for ${engine} failed (continuing without):`, error);
 	}

--- a/backend/subagents/index.ts
+++ b/backend/subagents/index.ts
@@ -5,5 +5,6 @@
 
 export { subagentService } from './service';
 export type { SubagentDTO, SubagentInputFields } from './service';
-export { syncSubagents, syncSubagentsAllEngines } from './sync';
+export { syncSubagents, syncSubagentsAllEngines, buildSubagentsPromptContext, buildOpenCodeInlineAgents } from './sync';
+export type { OpenCodeInlineAgent } from './sync';
 export { detectSubagents } from './detect';

--- a/backend/subagents/sync.ts
+++ b/backend/subagents/sync.ts
@@ -9,7 +9,7 @@
 
 import { subagentQueries } from '$backend/database/queries';
 import { debug } from '$shared/utils/logger';
-import { materializeArtifacts, parseDoc, serializeDoc, parseEngineMap, artifactEngineToType, type ManagedArtifact, type ArtifactEngine } from '$backend/artifacts';
+import { materializeArtifacts, resolveArtifact, isPromptScopedEngine, parseDoc, serializeDoc, parseEngineMap, artifactEngineToType, type ManagedArtifact, type ArtifactEngine } from '$backend/artifacts';
 import { artifactFilter } from '$backend/profiles';
 import { readSubagentMd } from './store';
 
@@ -46,12 +46,76 @@ function buildSubagentsPreamble(items: ManagedArtifact[]): string {
 	return lines.join('\n');
 }
 
+/** The subagents active for a stream, narrowed by the active Profile (metadata only). */
+function resolveEnabledSubagentsMeta(profileId?: number): ManagedArtifact[] {
+	const filter = artifactFilter(profileId, 'subagent');
+	return (filter ? subagentQueries.getAll() : subagentQueries.getEnabled())
+		.filter(r => !filter || filter.has(r.slug))
+		.map(r => ({ slug: r.slug, name: r.name, description: r.description }));
+}
+
+/**
+ * The profile-scoped subagents preamble for PER-SESSION injection into a
+ * prompt-scoped engine's prompt (OpenCode/Codex/Copilot). Returns '' when none
+ * apply. Advisory: it steers which subagents the model delegates to, on top of
+ * whatever the engine's own (possibly stale/shared) agent registry exposes.
+ */
+export function buildSubagentsPromptContext(profileId?: number): string {
+	return buildSubagentsPreamble(resolveEnabledSubagentsMeta(profileId));
+}
+
+/** One inline Open Code agent definition (an `AgentConfig` in its config content). */
+export interface OpenCodeInlineAgent {
+	description?: string;
+	mode: 'subagent';
+	prompt: string;
+	model?: string;
+}
+
+/**
+ * The profile-scoped subagents as INLINE Open Code agent definitions, keyed by
+ * slug. Open Code caches its agent registry from a shared dir at server boot, so
+ * a per-session dir prune can't scope it; instead each per-Profile server is
+ * built with exactly these agents inline (see the server pool). Returns the
+ * enabled set narrowed by the active Profile (a referenced subagent counts even
+ * if globally disabled — same presence-per-type rule as everywhere else).
+ */
+export async function buildOpenCodeInlineAgents(profileId?: number): Promise<Record<string, OpenCodeInlineAgent>> {
+	const filter = artifactFilter(profileId, 'subagent');
+	const rows = (filter ? subagentQueries.getAll() : subagentQueries.getEnabled())
+		.filter(r => !filter || filter.has(r.slug));
+	const out: Record<string, OpenCodeInlineAgent> = {};
+	for (const row of rows) {
+		const raw = await readSubagentMd(row.slug);
+		if (raw == null) continue;
+		const { frontmatter, body } = parseDoc(raw);
+		const model = parseEngineMap(row.model_by_engine).opencode;
+		out[row.slug] = {
+			description: frontmatter.description || row.description,
+			mode: 'subagent',
+			prompt: body,
+			...(model ? { model } : {})
+		};
+	}
+	return out;
+}
+
 export async function syncSubagents(engine: ArtifactEngine, profileId?: number): Promise<void> {
 	try {
+		// Deliver subagents OUT-OF-BAND (not via the shared engine dir/block) when:
+		//   - the target is SYNTHETIC on a prompt-scoped engine (Codex/Copilot) →
+		//     injected into the prompt as a preamble; OR
+		//   - the engine is OpenCode → each per-Profile server is built with the
+		//     agents INLINE in its config (Open Code caches its agent registry from
+		//     the shared dir at boot, so a per-session dir prune can't scope it).
+		// In both cases materialize an EMPTY set so any stale dir/block is stripped.
+		// Claude keeps its native filtered files; Qwen (per-query) keeps its preamble.
+		const synthetic = resolveArtifact('subagent', { engine, scope: 'global' }).format === 'preamble-region';
+		const viaPrompt = (synthetic && isPromptScopedEngine(engine)) || engine === 'opencode';
 		const filter = artifactFilter(profileId, 'subagent');
 		// A profile activates the subagents it references even if globally disabled;
 		// with no profile filter, only the enabled set applies (unchanged).
-		const rows = (filter ? subagentQueries.getAll() : subagentQueries.getEnabled())
+		const rows = viaPrompt ? [] : (filter ? subagentQueries.getAll() : subagentQueries.getEnabled())
 			.filter(r => !filter || filter.has(r.slug));
 		const engineType = artifactEngineToType(engine);
 		const enabled: ManagedArtifact[] = [];

--- a/conv.md
+++ b/conv.md
@@ -1,0 +1,325 @@
+
+# Diskusi Bug Profile Clopen
+**Tanggal:** 11 Juli 2026
+
+---
+
+## 🕧 12:35 — Agung
+
+Saya mencoba fitur **Profile**. Lalu saya bertanya ke AI mengenai skill apa saja yang aktif sesuai profile yang dipilih. Saat diminta melakukan investigasi, AI memberikan hasil berikut:
+
+### 🔴 BUG: Memilih Profile "Frontend" Tidak Tersimpan ke Database
+
+**Lokasi file:**
+- `frontend/components/chat/input/components/ProfilePicker.svelte` (baris 77–88)
+- `backend/ws/chat/stream.ts` (baris 865–882)
+
+### Alur yang seharusnya terjadi
+
+1. Pengguna memilih profile **Frontend** pada dropdown.
+2. Nilai `chatModelState.profileId` berubah menjadi `1` (tersimpan di memori).
+3. Nilai tersebut seharusnya dikirim ke server melalui WebSocket `chat:profile-sync`.
+4. Server kemudian menjalankan query:
+
+```sql
+UPDATE chat_sessions
+SET profile_id = 1;
+```
+
+Namun kenyataannya, data di database tidak berubah.
+
+Semua session masih memiliki:
+
+```text
+profile_id = NULL
+```
+
+### Yang sudah dicek
+
+- ✅ Profile **Frontend** (`id = 1`) sudah ada di tabel `profiles`.
+- ✅ Profile **Backend** (`id = 2`) juga sudah ada di tabel `profiles`.
+
+---
+
+## 🕧 12:36
+
+**Agung**
+
+Sepertinya `profile_id` tidak ikut dimuat ke dalam session.
+
+**Arga**
+
+Pakai model apa, Gung?
+
+**Agung**
+
+Opencode.
+
+---
+
+## 🕧 12:37
+
+**Arga**
+
+Sudah coba restart engine?
+
+**Agung**
+
+Sudah.
+
+---
+
+## 🕧 12:38
+
+**Agung**
+
+Masih **0 dari 12 session** yang berhasil menggunakan profile.
+
+Data di database juga belum berubah.
+
+Berarti bug-nya memang benar ada.
+
+Kemungkinan event `chat:profile-sync` tidak sampai atau gagal diproses oleh server.
+
+---
+
+## 🕧 12:39
+
+**Arga**
+
+Coba tes dengan pertanyaan berikut:
+
+```text
+Apa saja skills dan MCP yang tersedia?
+```
+
+---
+
+## 🕧 12:40
+
+**Arga**
+
+Kemarin saya coba menggunakan Claude Code dan Opencode, hasilnya bisa mendeteksi dengan benar saat ditanya seperti itu.
+
+**Agung**
+
+AI menjawab:
+
+### Skills (7)
+
+- browser-use
+- caveman
+- fix
+- frontend-design
+- pdf
+- read-only-sql-investigation
+- typescript-write
+
+### MCP (1)
+
+- browser-automation
+
+### Lainnya
+
+**Commands**
+
+- kill-port
+
+**Subagents**
+
+- diff-review-ux
+- diff-reviewer
+
+---
+
+## 🕧 12:41
+
+**Agung**
+
+Semua skill ikut dimuat.
+
+Padahal `read-only-sql-investigation` adalah skill milik profile **Backend**, sedangkan saya sedang menggunakan profile **Frontend**.
+
+Skill itu seharusnya tidak muncul.
+
+**Arga**
+
+Skill `read-only-sql` itu dikonfigurasi di Clopen atau di luar Clopen?
+
+*(mengirim foto)*
+
+Oh begitu.
+
+---
+
+## 🕧 12:42
+
+**Agung**
+
+Skill `read-only` itu memang baru dibuat.
+
+---
+
+## 🕧 12:43
+
+**Arga**
+
+Kalau skill tersebut dinonaktifkan melalui menu **Settings → Skills**, apakah ada pengaruhnya?
+
+---
+
+## 🕧 12:44
+
+**Arga**
+
+Kalau berpengaruh, berarti memang masalahnya ada pada fitur **Profile**.
+
+---
+
+## 🕧 12:49
+
+**Agung**
+
+Saya juga mencoba membuka session baru.
+
+Namun skill dan MCP milik Clopen justru tidak muncul.
+
+Prompt:
+
+```text
+Apa saja skills dan MCP yang tersedia?
+```
+
+Jawaban AI:
+
+# 🎖️ Kapten — Skills & MCP Inventory
+
+## Skills (11)
+
+- caveman
+- codegen-patterns
+- coding-standards
+- customize-opencode
+- design-system
+- find-skills
+- paperclip
+- paperclip-create-agent
+- paperclip-create-plugin
+- para-memory-files
+- ui-ux
+
+## MCP Tools (10)
+
+- analyze_dom
+- take_screenshot
+- navigate
+- dan lain-lain
+
+---
+
+## 🕧 12:50
+
+**Agung**
+
+Kemudian saya meminta Clopen mengecek setelah skill SQL saya nonaktifkan.
+
+Hasilnya:
+
+```text
+Clopen Only
+
+CLOPEN:SKILLS (6)
+
+- frontend-design
+- typescript-write
+- pdf
+- fix
+- browser-use
+- caveman
+
+MCP Tools (10)
+
+- analyze_dom
+- take_screenshot
+- navigate
+- actions
+- open_new_tab
+- switch_tab
+- close_tab
+- list_tabs
+- execute_console
+- get_console_logs
+
+Commands
+
+- kill-port
+
+Subagents
+
+- diff-review-ux
+- diff-reviewer
+```
+
+---
+
+## 🕧 12:53
+
+**Arga**
+
+Kadang daftar skill memang tidak ditampilkan secara lengkap.
+
+Coba tanyakan lagi:
+
+```text
+Apakah skill read-only-sql-investigation tersedia?
+```
+
+---
+
+## 🕧 12:54
+
+**Arga**
+
+Kalau hasilnya tetap seperti sebelumnya, berarti sudah terkonfirmasi.
+
+Yang benar-benar berpengaruh hanyalah pengaturan **Skills**, sedangkan **Profile** sama sekali tidak diterapkan.
+
+---
+
+## 🕧 12:54
+
+**Arga**
+
+Nanti saya coba perbaiki lagi.
+
+---
+
+## 🕧 12:55
+
+**Agung**
+
+Skill `read-only-sql-investigation` memang ada di filesystem:
+
+```text
+skills/read-only-sql-investigation/SKILL.md
+```
+
+Tetapi belum terdaftar pada blok `CLOPEN:SKILLS` di file `AGENTS.md`.
+
+---
+
+## 🕧 12:55
+
+**Arga**
+
+Oke, terima kasih Gung. 👍
+
+---
+
+# Kesimpulan
+
+- ✅ Pengaturan **Skills** berfungsi dengan baik.
+- ❌ Fitur **Profile** tidak diterapkan saat chat berlangsung.
+- ❌ `profile_id` tidak tersimpan ke tabel `chat_sessions`.
+- ❌ Session tetap menggunakan skill bawaan/default, bukan skill sesuai profile yang dipilih.
+- 🔍 Dugaan utama adalah event WebSocket `chat:profile-sync` tidak terkirim atau gagal diproses oleh server.

--- a/frontend/components/settings/SettingsModal.svelte
+++ b/frontend/components/settings/SettingsModal.svelte
@@ -46,6 +46,7 @@
 	let isMobileMenuOpen = $state(false);
 	let windowWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 1024);
 	let searchQuery = $state('');
+	let searchInputRef = $state<HTMLInputElement>();
 
 	const isMobile = $derived(windowWidth < 768);
 	const activeSection = $derived(settingsModalState.activeSection);
@@ -103,6 +104,16 @@
 		const isVisible = visibleSections.some(s => s.id === activeSection);
 		if (!isVisible && visibleSections.length > 0) {
 			setActiveSection(visibleSections[0].id);
+		}
+	});
+
+	// Focus the search input on open. Modal's own generic focus grabs the
+	// first focusable element (the close button) after a 50ms delay, so this
+	// runs slightly later to win the race. Skipped on mobile since the search
+	// field sits off-canvas until the menu is opened.
+	$effect(() => {
+		if (settingsModalState.isOpen && !isMobile) {
+			setTimeout(() => searchInputRef?.focus(), 60);
 		}
 	});
 
@@ -201,6 +212,7 @@
 							type="text"
 							placeholder="Search settings"
 							bind:value={searchQuery}
+							bind:this={searchInputRef}
 							class="w-full py-2 pl-8.5 pr-3 bg-slate-100 dark:bg-slate-800/60 border border-transparent rounded-lg text-sm text-slate-900 dark:text-slate-100 placeholder:text-slate-400 dark:placeholder:text-slate-500 outline-none transition-colors duration-150 focus:border-violet-500/40 focus:bg-white dark:focus:bg-slate-900"
 						/>
 					</div>

--- a/frontend/components/settings/instructions/InstructionsSettings.svelte
+++ b/frontend/components/settings/instructions/InstructionsSettings.svelte
@@ -3,6 +3,7 @@
 	import Button from '$frontend/components/common/display/Button.svelte';
 	import ArtifactGenerateBar from '$frontend/components/settings/common/ArtifactGenerateBar.svelte';
 	import { instructionsStore } from '$frontend/stores/features/instructions.svelte';
+	import { setActiveSection } from '$frontend/stores/ui/settings-modal.svelte';
 
 	interface Props {
 		showHeader?: boolean;
@@ -54,6 +55,7 @@
 	<ArtifactGenerateBar
 		artifactType="instruction"
 		placeholder={'Describe the instructions, e.g. "always answer concisely and prefer TypeScript"'}
+		onNavigateArtifacts={() => setActiveSection('artifacts')}
 		onGenerated={(f) => { if (typeof f.content === 'string') content = f.content; }}
 	/>
 


### PR DESCRIPTION
Profile resolution (profile_id persistence + resolveActiveProfileId) was correct, and Claude Code scoped artifacts because it spawns a fresh per-query CLI over isolated, pruned dirs. Every other engine read artifacts through channels SHARED across sessions and served by a PERSISTENT runtime, so an active Profile leaked: excluded skills, commands, subagents and connectors still surfaced in profiled sessions.

Skills, Commands, Subagents (OpenCode, Codex, Copilot)
  - Advertise the profile-scoped set PER-SESSION by injecting a preamble into each turn's prompt (buildArtifactsPromptContext) — the one channel that is genuinely per-session. Synthetic targets stop writing their shared global block (strip legacy); native targets keep their filtered files. New isPromptScopedEngine() predicate centralises it. Claude/Qwen unchanged (per-query CLI + pruned dir already correct).

Connectors / MCP
  - Claude/Qwen/Copilot already filtered MCP per stream — unchanged.
  - Codex: rebuild the client with a profile-filtered MCP set when the filter signature changes (same trade-off as an account switch).
  - OpenCode: internal connectors ride one all-or-nothing bridge, so disable the excluded ones per-prompt (concurrency-safe `tools` map).

OpenCode per-Profile server pool
  - OpenCode's `opencode serve` bakes its MCP set and caches its agent registry at boot, so a single shared server cannot express a per-session Profile (excluded connectors/subagents leak, registry is served stale). Replace the singleton with a pool keyed by a config signature (filtered MCP + inline agents + agent-content hash): each stream binds to the server matching its Profile. Subagents are baked INLINE per server (the on-disk agent dir is stripped); excluded external connectors are dropped from the server's MCP config. Servers are isolated by data dir (no shared opencode.db), LRU-capped, and health-checked; the default (no-Profile) server serves model listing and one-shot work.

Injection happens at the adapter layer, so the stored/displayed user message is untouched.