### PR TITLE
feat(history): add mark-all-as-read and fix stuck needs-input status

### DIFF
--- a/backend/database/queries/session-queries.ts
+++ b/backend/database/queries/session-queries.ts
@@ -508,6 +508,17 @@ export const sessionQueries = {
 	},
 
 	/**
+	 * Mark every unread session in a project as read for a specific user
+	 */
+	markAllRead(userId: string, projectId: string): void {
+		const db = getDatabase();
+		db.prepare(`
+			DELETE FROM user_unread_sessions
+			WHERE user_id = ? AND project_id = ?
+		`).run(userId, projectId);
+	},
+
+	/**
 	 * Get all unread session IDs for a user within a project
 	 * Returns array of { sessionId, projectId }
 	 */

--- a/backend/project/status-manager.ts
+++ b/backend/project/status-manager.ts
@@ -6,41 +6,23 @@
 import { streamManager, type StreamState } from '../chat/stream-manager.js';
 import { ws } from '../utils/ws.js';
 import type { UnifiedMessage } from '$shared/types/unified';
-
-// Interactive tools that block the stream waiting for user input
-const INTERACTIVE_TOOLS = new Set(['AskUserQuestion']);
+import { isWaitingForInteractiveInput } from '$shared/utils/interactive-input';
 
 /**
  * Check if an active stream is waiting for user input.
- * Scans stream messages for unanswered interactive tool_use blocks.
+ * Delegates to the shared derivation so backend presence and the frontend
+ * chat service can never disagree on what "waiting for input" means.
  * This is the backend single source of truth — works even when the
  * user is on a different project and not receiving chat events.
  */
 function detectStreamWaitingInput(stream: StreamState): boolean {
   if (stream.status !== 'active') return false;
 
-  const answeredToolIds = new Set<string>();
-  for (const event of stream.messages) {
-    const msg = (event as { message?: UnifiedMessage }).message;
-    if (!msg || msg.type !== 'user') continue;
-    for (const block of msg.content) {
-      if (block.type === 'tool_result' && block.toolUseId) {
-        answeredToolIds.add(block.toolUseId);
-      }
-    }
-  }
+  const messages = stream.messages
+    .map(event => (event as { message?: UnifiedMessage }).message)
+    .filter((msg): msg is UnifiedMessage => Boolean(msg));
 
-  for (const event of stream.messages) {
-    const msg = (event as { message?: UnifiedMessage }).message;
-    if (!msg || msg.type !== 'assistant') continue;
-    if (msg.content.some(block =>
-      block.type === 'tool_use' && INTERACTIVE_TOOLS.has(block.name) && block.id && !answeredToolIds.has(block.id)
-    )) {
-      return true;
-    }
-  }
-
-  return false;
+  return isWaitingForInteractiveInput(messages);
 }
 
 // Store active users per project (shared with main endpoint)

--- a/backend/ws/sessions/crud.ts
+++ b/backend/ws/sessions/crud.ts
@@ -404,6 +404,18 @@ export const crudHandler = createRouter()
 		debug.log('session', `[unread] Marked session ${data.sessionId} as UNREAD for user ${userId} in project ${data.projectId}`);
 	})
 
+	// Mark every session in a project as read for the current user
+	.on('sessions:mark-all-read', {
+		data: t.Object({
+			projectId: t.String()
+		})
+	}, async ({ data, conn }) => {
+		const userId = ws.getUserId(conn);
+		requireProjectAccess(conn, data.projectId);
+		sessionQueries.markAllRead(userId, data.projectId);
+		debug.log('session', `[unread] Marked ALL sessions as READ for user ${userId} in project ${data.projectId}`);
+	})
+
 	// Search sessions by message content (deep search)
 	.http('sessions:search', {
 		data: t.Object({

--- a/frontend/components/history/HistoryModal.svelte
+++ b/frontend/components/history/HistoryModal.svelte
@@ -10,7 +10,7 @@
 	import Modal from '$frontend/components/common/overlay/Modal.svelte';
 	import Dialog from '$frontend/components/common/overlay/Dialog.svelte';
 	import { presenceState, isSessionWaitingInput } from '$frontend/stores/core/presence.svelte';
-	import { isSessionUnread } from '$frontend/stores/core/app.svelte';
+	import { isSessionUnread, markAllSessionsRead } from '$frontend/stores/core/app.svelte';
 	import { userStore } from '$frontend/stores/features/user.svelte';
 	import { debug } from '$shared/utils/logger';
 	import { modelStore } from '$frontend/stores/features/models.svelte';
@@ -153,6 +153,22 @@
 		}
 		return counts;
 	});
+
+	// Count of sessions showing an unread (blue) indicator — mirrors the dot logic
+	// in the list: unread, not the active session, and not currently streaming.
+	const unreadCount = $derived(
+		sessions.filter(
+			session =>
+				isSessionUnread(session.id) &&
+				session.id !== sessionState.currentSession?.id &&
+				!isSessionStreaming(session.id)
+		).length
+	);
+
+	function handleMarkAllRead() {
+		const projectId = projectState.currentProject?.id;
+		if (projectId) markAllSessionsRead(projectId);
+	}
 
 	const filteredSessions = $derived(
 		sessions
@@ -364,6 +380,17 @@
 		<div class="flex items-center justify-between px-4 py-3 md:px-6 md:py-4">
 			<h2 class="text-base md:text-lg font-bold text-slate-900 dark:text-slate-100">Sessions</h2>
 			<div class="flex items-center gap-2">
+				{#if unreadCount > 0}
+					<button
+						type="button"
+						class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 transition-colors"
+						onclick={handleMarkAllRead}
+						aria-label="Mark all sessions as read"
+					>
+						<Icon name="lucide:check-check" class="w-3.5 h-3.5" />
+						<span class="hidden sm:inline">Mark all read</span>
+					</button>
+				{/if}
 				{#if filteredSessions.length > 0}
 					<button
 						type="button"

--- a/frontend/services/chat/chat.service.ts
+++ b/frontend/services/chat/chat.service.ts
@@ -22,6 +22,7 @@ import { userStore } from '$frontend/stores/features/user.svelte';
 import type { UnifiedMessage, AssistantMessage, ReasoningMessage } from '$shared/types/unified';
 import type { StreamingMessage, OptimisticUserMessage, FrontendMessage } from '$frontend/stores/core/sessions.svelte';
 import { debug } from '$shared/utils/logger';
+import { INTERACTIVE_TOOLS, isWaitingForInteractiveInput } from '$shared/utils/interactive-input';
 
 /** Chat service configuration */
 interface ChatServiceOptions {
@@ -32,14 +33,6 @@ interface ChatServiceOptions {
   attachedFiles?: { type: string; data: string; mediaType: string; fileName: string }[];
 }
 import ws from '$frontend/utils/ws';
-
-/**
- * Tools that block the SDK waiting for user interaction.
- * When these tools appear in an assistant message without a result,
- * and the stream is active, the chat status switches to "waiting for input".
- * Extend this list for future interactive tools.
- */
-const INTERACTIVE_TOOLS = new Set(['AskUserQuestion']);
 
 class ChatService {
   private activeProcessId: string | null = null;
@@ -886,27 +879,10 @@ class ChatService {
   detectPendingInteractiveTools(): void {
     if (!appState.isLoading) return;
 
-    // Collect all tool_use IDs that have a matching tool_result
-    const answeredToolIds = new Set<string>();
-    for (const msg of sessionState.messages) {
-      if (msg.type !== 'user' || !('content' in msg)) continue;
-      for (const item of msg.content) {
-        if (item.type === 'tool_result') {
-          answeredToolIds.add(item.toolUseId);
-        }
-      }
-    }
-
-    // Check if any interactive tool is unanswered (skip interrupted blocks)
-    for (const msg of sessionState.messages) {
-      if (msg.type !== 'assistant' || !('content' in msg)) continue;
-      const hasPendingInteractive = msg.content.some(
-        (item) => item.type === 'tool_use' && !item.interrupted && INTERACTIVE_TOOLS.has(item.name) && !answeredToolIds.has(item.id)
-      );
-      if (hasPendingInteractive) {
-        this.setProcessState({ isWaitingInput: true });
-        return;
-      }
+    // Delegate to the shared derivation so this can never disagree with the
+    // backend presence layer (both read the same message-ordering rules).
+    if (isWaitingForInteractiveInput(sessionState.messages)) {
+      this.setProcessState({ isWaitingInput: true });
     }
   }
 

--- a/frontend/stores/core/app.svelte.ts
+++ b/frontend/stores/core/app.svelte.ts
@@ -223,6 +223,29 @@ export function markSessionRead(sessionId: string): void {
 }
 
 /**
+ * Mark every unread session in a project as read (bulk).
+ * Persists to backend so the state survives browser refresh.
+ */
+export function markAllSessionsRead(projectId: string): void {
+	const next = new Map(appState.unreadSessions);
+	let changed = false;
+	for (const [sessionId, pId] of appState.unreadSessions.entries()) {
+		if (pId === projectId) {
+			next.delete(sessionId);
+			changed = true;
+		}
+	}
+	if (!changed) return;
+
+	appState.unreadSessions = next;
+
+	// Persist to backend via a single bulk delete (proven infrastructure)
+	debug.log('session', `[unread] markAllSessionsRead: projectId=${projectId}`);
+	ws.emit('sessions:mark-all-read', { projectId });
+	persistUnreadSessions();
+}
+
+/**
  * Restore unread sessions from server state (called during initialization).
  */
 export function restoreUnreadSessions(saved: Record<string, string> | null): void {

--- a/shared/utils/interactive-input.ts
+++ b/shared/utils/interactive-input.ts
@@ -1,0 +1,71 @@
+/**
+ * Single source of truth for the "is this conversation waiting for user input?"
+ * derivation. Both the backend presence layer (status-manager) and the frontend
+ * chat service consume this so the logic can never drift between them.
+ *
+ * Historically this logic was duplicated in three places with subtly different
+ * rules, which let the "Needs input" status get stuck after an interrupt →
+ * continue flow. Keeping one pure function here removes that class of bug.
+ */
+
+/** Tools that block the stream waiting for a user response. */
+export const INTERACTIVE_TOOLS = new Set(['AskUserQuestion']);
+
+/** Minimal structural shape shared by UnifiedMessage and its frontend supersets. */
+interface WaitingInputMessage {
+	type: string;
+	stopReason?: string | null;
+	content?: unknown;
+}
+
+interface WaitingInputBlock {
+	type: string;
+	name?: string;
+	interrupted?: boolean;
+}
+
+/**
+ * A conversation is "waiting for user input" if and only if its trailing turn
+ * contains an unanswered, non-interrupted interactive tool_use.
+ *
+ * The rule is intentionally derived from message ordering rather than tracked
+ * imperatively, so it stays correct across every entry path:
+ *   - Answered normally     → the tool_result (a user message) lands after the
+ *                             question, so the question is no longer trailing.
+ *   - Interrupted → continue → the follow-up user message lands after the
+ *                             question, so it is no longer trailing (was the bug).
+ *   - Interrupted, no follow → the question turn is marked interrupted (via the
+ *                             message stopReason or the block flag) and skipped.
+ *   - Genuinely pending      → the question is the trailing turn and counts.
+ *
+ * Both interrupted representations are honored (message `stopReason` set by the
+ * backend, block `interrupted` set by the frontend) so the reader tolerates
+ * either signal regardless of which side produced the messages.
+ */
+export function isWaitingForInteractiveInput(messages: readonly WaitingInputMessage[]): boolean {
+	// Find the index of the last user message — anything before it has already
+	// been superseded by subsequent user activity and cannot be pending.
+	let lastUserIndex = -1;
+	for (let i = 0; i < messages.length; i++) {
+		if (messages[i]?.type === 'user') lastUserIndex = i;
+	}
+
+	for (let i = lastUserIndex + 1; i < messages.length; i++) {
+		const msg = messages[i];
+		if (!msg || msg.type !== 'assistant') continue;
+		// An interrupted assistant turn never counts as waiting.
+		if (msg.stopReason === 'interrupted') continue;
+		if (!Array.isArray(msg.content)) continue;
+
+		const hasPending = (msg.content as WaitingInputBlock[]).some(
+			block =>
+				block?.type === 'tool_use' &&
+				!!block.name &&
+				INTERACTIVE_TOOLS.has(block.name) &&
+				!block.interrupted
+		);
+		if (hasPending) return true;
+	}
+
+	return false;
+}


### PR DESCRIPTION
Add a "Mark all read" action to the Sessions modal that clears every unread session in the current project via a single bulk delete.

Also fix the "Needs input" status getting stuck as amber after an interrupt → continue flow. Waiting-input is now derived from one shared pure function (isWaitingForInteractiveInput) consumed by both the backend presence layer and the frontend chat service, removing the duplicated logic that let the two drift. A question only counts as pending when it is the trailing turn and not interrupted.