### PR TITLE
feat(workspace): improve responsive layout for compact panels

### DIFF
--- a/frontend/components/chat/message/ChatNavigationRail.svelte
+++ b/frontend/components/chat/message/ChatNavigationRail.svelte
@@ -25,6 +25,7 @@
 	let activeId = $state<string | null>(null);
 	let rafId = 0;
 	let lockUntil = 0;
+	let bandHeight = $state(0);
 
 	const activeIdx = $derived(
 		activeId ? items.findIndex(i => i.messageId === activeId) : -1
@@ -40,6 +41,37 @@
 	const downTarget = $derived<NavItem | null>(
 		!canGoDown ? null : activeIdx === -1 ? items[0] : items[activeIdx + 1]
 	);
+
+	// --- Windowing: cap visible dots to the available band height ---
+	const PER_DOT = 15; // px per dot row (line + py-1.5 + gap)
+	const CHROME = 68; // px for chevrons + pill/container padding
+	const ELLIPSIS = 18; // px per ellipsis marker
+
+	const capacity = $derived.by(() => {
+		if (bandHeight <= 0) return Number.MAX_SAFE_INTEGER;
+		return Math.max(1, Math.floor((bandHeight - CHROME) / PER_DOT));
+	});
+
+	const isWindowed = $derived(items.length > capacity);
+
+	const windowSize = $derived.by(() => {
+		if (!isWindowed) return items.length;
+		const forDots = bandHeight - CHROME - 2 * ELLIPSIS;
+		return Math.max(1, Math.min(items.length, Math.floor(forDots / PER_DOT)));
+	});
+
+	const windowStart = $derived.by(() => {
+		const total = items.length;
+		if (!isWindowed) return 0;
+		const center = activeIdx === -1 ? total - 1 : activeIdx;
+		const start = center - Math.floor(windowSize / 2);
+		return Math.max(0, Math.min(start, total - windowSize));
+	});
+
+	const visibleItems = $derived(items.slice(windowStart, windowStart + windowSize));
+	const moreAbove = $derived(windowStart);
+	const moreBelow = $derived(items.length - (windowStart + windowSize));
+	const pageStep = $derived(Math.max(1, windowSize - 1));
 
 	function updateActive() {
 		if (!scrollEl || items.length === 0) return;
@@ -137,6 +169,15 @@
 	function goDown() {
 		if (downTarget) jumpTo(downTarget);
 	}
+
+	// Page the window up/down by ~one window when an ellipsis marker is clicked
+	function pageBy(delta: number) {
+		const total = items.length;
+		if (total === 0) return;
+		const center = activeIdx === -1 ? total - 1 : activeIdx;
+		const target = Math.max(0, Math.min(total - 1, center + delta));
+		jumpTo(items[target]);
+	}
 </script>
 
 {#snippet tooltip(item: NavItem)}
@@ -160,6 +201,7 @@
 	<div
 		class="absolute right-3 lg:right-4 top-3 bottom-14 lg:bottom-16 w-8 pointer-events-none z-20 flex flex-col items-center justify-center"
 		aria-hidden="false"
+		bind:clientHeight={bandHeight}
 	>
 		<div
 			class="pointer-events-auto flex flex-col items-center rounded-full py-2 bg-white/30 dark:bg-slate-900/20 backdrop-blur-sm ring-1 ring-slate-200/40 dark:ring-slate-700/40 opacity-40 hover:opacity-100 transition-opacity duration-200"
@@ -184,7 +226,19 @@
 		</div>
 
 		<div class="flex flex-col items-center gap-0.5 py-1.5">
-			{#each items as item, idx (item.messageId)}
+			{#if moreAbove > 0}
+				<button
+					type="button"
+					onclick={() => pageBy(-pageStep)}
+					class="flex items-center justify-center w-6 mb-1 text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+					aria-label="Show {moreAbove} earlier user message{moreAbove === 1 ? '' : 's'}"
+					title="{moreAbove} more above"
+				>
+					<Icon name="lucide:ellipsis-vertical" class="w-3.5 h-3.5" />
+				</button>
+			{/if}
+			{#each visibleItems as item, i (item.messageId)}
+				{@const idx = windowStart + i}
 				{@const active = activeId === item.messageId}
 				<div class="relative">
 					<button
@@ -209,6 +263,17 @@
 					{/if}
 				</div>
 			{/each}
+			{#if moreBelow > 0}
+				<button
+					type="button"
+					onclick={() => pageBy(pageStep)}
+					class="flex items-center justify-center w-6 mt-1 text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+					aria-label="Show {moreBelow} later user message{moreBelow === 1 ? '' : 's'}"
+					title="{moreBelow} more below"
+				>
+					<Icon name="lucide:ellipsis-vertical" class="w-3.5 h-3.5" />
+				</button>
+			{/if}
 		</div>
 
 		<div class="relative">

--- a/frontend/components/chat/widgets/ContextIndicator.svelte
+++ b/frontend/components/chat/widgets/ContextIndicator.svelte
@@ -38,6 +38,21 @@
 		return 'bg-emerald-500';
 	});
 
+	// Stroke variant of the threshold color for the compact ring gauge
+	const ringColor = $derived.by(() => {
+		if (!usage) return 'stroke-slate-400';
+		if (usage.percentage >= 90) return 'stroke-red-500';
+		if (usage.percentage >= 80) return 'stroke-amber-500';
+		if (usage.percentage >= 60) return 'stroke-yellow-500';
+		return 'stroke-emerald-500';
+	});
+
+	// Ring geometry — radius 8 in a 20x20 viewBox
+	const RING_CIRCUMFERENCE = 2 * Math.PI * 8;
+	const ringOffset = $derived(
+		usage ? RING_CIRCUMFERENCE * (1 - Math.min(usage.percentage, 100) / 100) : RING_CIRCUMFERENCE
+	);
+
 	const textColor = $derived.by(() => {
 		if (!usage) return 'text-slate-400';
 		if (usage.percentage >= 90) return 'text-red-500';
@@ -84,20 +99,42 @@
 	<div class="relative" bind:this={containerRef}>
 		<button
 			type="button"
-			class="flex items-center gap-1.5 {isMobile ? 'px-2.5 h-9' : 'px-2 h-6'} bg-transparent border-none rounded-md cursor-pointer transition-all duration-150 hover:bg-violet-500/10 group"
+			class="flex items-center justify-center px-2 @max-[26rem]:px-0 {isMobile ? 'h-8 @max-[26rem]:w-9' : 'h-6 @max-[26rem]:w-7'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100 group"
 			onclick={togglePopover}
 			title="Context: {formatTokens(usage.current)} / {formatTokens(usage.max)} ({Math.round(usage.percentage)}%)"
 		>
 			<div class="flex items-center gap-1.5">
-				<div class="{isMobile ? 'w-14' : 'w-12'} h-2 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden">
-					<div
-						class="{barColor} h-full transition-all duration-500"
-						style="width: {Math.min(usage.percentage, 100)}%"
-					></div>
+				<!-- Default: linear bar + %. Collapses to a ring-only when the panel/dock is narrow (container query on PanelHeader). -->
+				<div class="flex items-center gap-1.5 @max-[26rem]:hidden">
+					<div class="{isMobile ? 'w-14' : 'w-12'} h-2 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden">
+						<div
+							class="{barColor} h-full transition-all duration-500"
+							style="width: {Math.min(usage.percentage, 100)}%"
+						></div>
+					</div>
+					<span class="text-2xs font-medium {textColor} tabular-nums group-hover:text-slate-900 dark:group-hover:text-slate-100 transition-colors">
+						{Math.round(usage.percentage)}%
+					</span>
 				</div>
-				<span class="text-2xs font-medium {textColor} tabular-nums group-hover:text-slate-900 dark:group-hover:text-slate-100 transition-colors">
-					{Math.round(usage.percentage)}%
-				</span>
+
+				<!-- Narrow / dock kecil: ring only -->
+				<svg
+					class="hidden @max-[26rem]:block {isMobile ? 'w-4.5 h-4.5' : 'w-4 h-4'} -rotate-90 shrink-0"
+					viewBox="0 0 20 20"
+					fill="none"
+				>
+					<circle cx="10" cy="10" r="8" stroke-width="2.5" class="stroke-slate-200 dark:stroke-slate-700" />
+					<circle
+						cx="10"
+						cy="10"
+						r="8"
+						stroke-width="2.5"
+						stroke-linecap="round"
+						class="{ringColor} transition-all duration-500"
+						stroke-dasharray={RING_CIRCUMFERENCE}
+						stroke-dashoffset={ringOffset}
+					/>
+				</svg>
 			</div>
 		</button>
 

--- a/frontend/components/chat/widgets/TaskProgress.svelte
+++ b/frontend/components/chat/widgets/TaskProgress.svelte
@@ -230,10 +230,7 @@
 				<div class="task-list max-h-56 overflow-y-auto px-3 py-2 space-y-1">
 					{#each latestTodos as todo, index}
 						<div
-							class="flex items-start gap-2.5 px-2 py-1.5 rounded-md transition-colors
-								{todo.status === 'in_progress' ? 'bg-violet-50 dark:bg-violet-900/20' : ''}
-								{todo.status === 'completed' ? 'bg-green-50/60 dark:bg-green-900/10' : ''}"
-						>
+							class="flex items-start gap-2.5 px-2 py-1.5 rounded-md transition-colors">
 							<Icon
 								name={getStatusIcon(todo.status)}
 								class="w-3.5 h-3.5 mt-0.5 shrink-0 {getStatusColor(todo.status)} {todo.status === 'in_progress' && appState.isLoading ? 'animate-spin' : ''}"

--- a/frontend/components/db-client/DbClientButton.svelte
+++ b/frontend/components/db-client/DbClientButton.svelte
@@ -25,7 +25,7 @@
 		aria-label="DB Client"
 		title="DB Client"
 	>
-		<Icon name="lucide:database" class="w-5 h-5" />
+		<Icon name="lucide:database" class="{mobile ? 'w-4.5 h-4.5' : 'w-5 h-5'}" />
 		{#if hasLive}
 			<span
 				class="absolute top-0.5 right-0.5 min-w-4 h-4 px-0.5 rounded-full bg-emerald-500 text-white text-3xs font-bold flex items-center justify-center border-2 border-slate-50 dark:border-slate-900/95"

--- a/frontend/components/settings/SettingButton.svelte
+++ b/frontend/components/settings/SettingButton.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+
+	interface Props {
+		collapsed?: boolean;
+		mobile?: boolean;
+		onClick: () => void;
+	}
+
+	const { collapsed = false, mobile = false, onClick }: Props = $props();
+</script>
+
+{#if collapsed}
+	<!-- Collapsed: Icon Only -->
+	<button
+		type="button"
+		class="flex items-center justify-center bg-transparent border-none text-slate-500 cursor-pointer transition-all duration-150 relative
+			{mobile
+			? 'w-9 h-8 rounded-md active:bg-violet-500/10'
+			: 'w-9 h-9 rounded-lg hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100'}"
+		onclick={onClick}
+		aria-label="Settings"
+		title="Settings"
+	>
+		<Icon name="lucide:settings" class="{mobile ? 'w-4.5 h-4.5' : 'w-5 h-5'}" />
+	</button>
+{:else}
+	<!-- Expanded: Full Width -->
+	<button
+		type="button"
+		class="flex items-center gap-2.5 w-full py-2.5 px-3 bg-transparent border-none rounded-lg text-slate-500 text-sm cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
+		onclick={onClick}
+	>
+		<Icon name="lucide:settings" class="w-4 h-4" />
+		<span class="flex-1 text-left">Settings</span>
+	</button>
+{/if}

--- a/frontend/components/tunnel/TunnelButton.svelte
+++ b/frontend/components/tunnel/TunnelButton.svelte
@@ -26,7 +26,7 @@
 		aria-label="Public Tunnel"
 		title="Public Tunnel"
 	>
-		<Icon name="lucide:cloud-upload" class="w-5 h-5" />
+		<Icon name="lucide:cloud-upload" class="{mobile ? 'w-4.5 h-4.5' : 'w-5 h-5'}" />
 		{#if hasActiveTunnels}
 			<span
 				class="absolute top-0.5 right-0.5 min-w-4 h-4 px-0.5 rounded-full bg-green-500 text-white text-3xs font-bold flex items-center justify-center border-2 border-slate-50 dark:border-slate-900/95"

--- a/frontend/components/workspace/DesktopNavigator.svelte
+++ b/frontend/components/workspace/DesktopNavigator.svelte
@@ -24,6 +24,7 @@
 	import TunnelModal from '$frontend/components/tunnel/TunnelModal.svelte';
 	import DbClientButton from '$frontend/components/db-client/DbClientButton.svelte';
 	import DbClientModal from '$frontend/components/db-client/DbClientModal.svelte';
+	import SettingButton from '$frontend/components/settings/SettingButton.svelte';
 	import ProjectUserAvatars from '$frontend/components/common/display/ProjectUserAvatars.svelte';
 	import ws from '$frontend/utils/ws';
 
@@ -363,15 +364,7 @@
 				<ViewMenu />
 				<TunnelButton onClick={() => (showTunnelModal = true)} />
 				<DbClientButton onClick={() => (showDbClientModal = true)} />
-
-				<button
-					type="button"
-					class="flex items-center gap-2.5 w-full py-2.5 px-3 bg-transparent border-none rounded-lg text-slate-500 text-sm cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
-					onclick={() => openSettingsModal()}
-				>
-					<Icon name="lucide:settings" class="w-4 h-4" />
-					<span>Settings</span>
-				</button>
+				<SettingButton onClick={() => openSettingsModal()} />
 			</footer>
 		{:else}
 			<!-- Collapsed State: Icon Buttons -->
@@ -431,15 +424,7 @@
 				<ViewMenu collapsed={true} />
 				<TunnelButton collapsed={true} onClick={() => (showTunnelModal = true)} />
 				<DbClientButton collapsed={true} onClick={() => (showDbClientModal = true)} />
-
-				<button
-					type="button"
-					class="flex items-center justify-center w-9 h-9 bg-transparent border-none rounded-lg text-slate-500 cursor-pointer transition-all duration-150 relative hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
-					onclick={() => openSettingsModal()}
-					title="Settings"
-				>
-					<Icon name="lucide:settings" class="w-5 h-5" />
-				</button>
+				<SettingButton collapsed={true} onClick={() => openSettingsModal()} />
 			</footer>
 		{/if}
 	</nav>

--- a/frontend/components/workspace/MobileNavigator.svelte
+++ b/frontend/components/workspace/MobileNavigator.svelte
@@ -10,6 +10,7 @@
 	import TunnelModal from '$frontend/components/tunnel/TunnelModal.svelte';
 	import DbClientButton from '$frontend/components/db-client/DbClientButton.svelte';
 	import DbClientModal from '$frontend/components/db-client/DbClientModal.svelte';
+	import SettingButton from '$frontend/components/settings/SettingButton.svelte';
 	import type { Project } from '$shared/types/database/schema';
 	import FolderBrowser from '$frontend/components/common/form/FolderBrowser.svelte';
 	import ProjectUserAvatars from '$frontend/components/common/display/ProjectUserAvatars.svelte';
@@ -139,7 +140,7 @@
 	<!-- Project Selector -->
 	<button
 		type="button"
-		class="flex items-center gap-2 px-3 py-2.5 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-lg text-slate-900 dark:text-slate-100 text-sm font-medium cursor-pointer transition-all duration-150 flex-1 min-w-0 active:bg-violet-500/10"
+		class="flex items-center gap-2 px-3 py-2 bg-slate-100/80 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-800 rounded-lg text-slate-900 dark:text-slate-100 text-sm font-medium cursor-pointer transition-all duration-150 flex-1 min-w-0 active:bg-violet-500/10"
 		onclick={toggleProjectMenu}
 		aria-expanded={showProjectMenu}
 		aria-haspopup="menu"
@@ -156,7 +157,7 @@
 
 	<!-- Action Buttons -->
 	<div
-		class="flex gap-1 bg-slate-100/80 dark:bg-slate-800/50 p-1 border border-slate-200 dark:border-slate-800 rounded-lg"
+		class="flex gap-1 bg-slate-100/80 dark:bg-slate-800/50 px-1 py-0.5 border border-slate-200 dark:border-slate-800 rounded-lg"
 		role="tablist"
 		aria-label="Action Buttons"
 	>
@@ -167,16 +168,7 @@
 		<DbClientButton collapsed={true} onClick={() => (showDbClientModal = true)} mobile={true} />
 
 		<!-- Settings Button -->
-		<button
-			type="button"
-			class="flex items-center justify-center w-9 h-8 bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 active:bg-violet-500/10"
-			role="tab"
-			onclick={() => openSettingsModal()}
-			aria-label="Settings"
-			title="Settings"
-		>
-			<Icon name="lucide:settings" class="w-5 h-5" />
-		</button>
+		<SettingButton collapsed={true} mobile={true} onClick={() => openSettingsModal()} />
 	</div>
 </header>
 

--- a/frontend/components/workspace/PanelHeader.svelte
+++ b/frontend/components/workspace/PanelHeader.svelte
@@ -160,13 +160,13 @@
 </script>
 
 <header
-	class="flex items-center justify-between shrink-0 {isMobile
+	class="@container flex items-center justify-between shrink-0 {isMobile
 		? 'h-11 pb-2 px-4 bg-white/90 dark:bg-slate-900/98 border-b border-slate-200 dark:border-slate-800'
 		: 'py-1 px-3.5 bg-slate-100 dark:bg-slate-800/80 border-b border-slate-200 dark:border-slate-800'}"
 >
 	<div class="flex items-center text-sm font-medium text-slate-900 dark:text-slate-100">
 		<div
-			class="flex gap-1"
+			class="flex {isMobile ? 'gap-0.5' : 'gap-1'}"
 			role="tablist"
 			aria-label="Switch panel"
 		>
@@ -184,7 +184,7 @@
 			{#each PANEL_OPTIONS as option}
 				<button
 					type="button"
-					class="flex items-center justify-center {isMobile ? 'w-10 h-9' : 'w-7 h-7'} bg-transparent border-none rounded-md cursor-pointer transition-all duration-150
+					class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-7 h-7'} bg-transparent border-none rounded-md cursor-pointer transition-all duration-150
 						{option.id === panelId
 						? 'bg-violet-500/10 dark:bg-violet-500/20 text-violet-600 dark:text-violet-400'
 						: 'text-slate-500 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100'}"
@@ -194,7 +194,7 @@
 					title={option.title}
 					onclick={() => handleSwitch(option.id)}
 				>
-					<Icon name={option.icon} class={isMobile ? 'w-5.5 h-5.5' : 'w-4 h-4'} />
+					<Icon name={option.icon} class={isMobile ? 'w-4.5 h-4.5' : 'w-4 h-4'} />
 				</button>
 			{/each}
 		</div>
@@ -240,7 +240,7 @@
 
 	<div class="flex items-center">
 		<!-- Panel-specific actions -->
-		<div class="flex items-center gap-1.5">
+		<div class="flex items-center {isMobile ? 'gap-0.5' : 'gap-1.5'}">
 			{#if panelId === 'chat'}
 				{#if sessionState.messages.length > 0 || sessionState.hasMessageHistory}
 					<ContextIndicator {isMobile} />
@@ -273,7 +273,7 @@
 				{/if}
 				<button
 					type="button"
-					class="flex items-center justify-center {isMobile ? 'w-9 h-9' : 'w-6 h-6'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
+					class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
 					onclick={onHistoryOpen}
 					title="Switch Session"
 				>
@@ -282,7 +282,7 @@
 					{#if sessionState.messages.length > 0 || sessionState.hasMessageHistory}
 					<button
 						type="button"
-						class="flex items-center justify-center {isMobile ? 'w-9 h-9' : 'w-6 h-6'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
+						class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
 						onclick={() => chatPanelRef?.panelActions?.checkpoints()}
 						title="Restore Checkpoint"
 					>
@@ -291,7 +291,7 @@
 				{/if}
 				<button
 					type="button"
-					class="flex items-center justify-center {isMobile ? 'w-9 h-9' : 'w-6 h-6'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
+					class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
 					onclick={() => chatPanelRef?.panelActions?.newChat()}
 					title="New Chat"
 				>
@@ -303,7 +303,7 @@
 					<div class="flex gap-1 bg-slate-100/80 dark:bg-slate-800/50 rounded-md">
 						<button
 							type="button"
-							class="flex items-center justify-center {isMobile ? 'w-9 h-9' : 'w-6 h-6'} bg-transparent border-none rounded text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100 disabled:opacity-40 disabled:cursor-not-allowed
+							class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100 disabled:opacity-40 disabled:cursor-not-allowed
 								{filesPanelRef?.panelActions?.getViewMode() === 'tree'
 								? 'bg-violet-500/15 dark:bg-violet-500/25 text-violet-600'
 								: ''}"
@@ -314,7 +314,7 @@
 						</button>
 						<button
 							type="button"
-							class="flex items-center justify-center {isMobile ? 'w-9 h-9' : 'w-6 h-6'} bg-transparent border-none rounded text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100 disabled:opacity-40 disabled:cursor-not-allowed
+							class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100 disabled:opacity-40 disabled:cursor-not-allowed
 								{filesPanelRef?.panelActions?.getViewMode() === 'viewer'
 								? 'bg-violet-500/15 dark:bg-violet-500/25 text-violet-600'
 								: ''}"
@@ -329,7 +329,7 @@
 			{:else if panelId === 'terminal'}
 				<button
 					type="button"
-					class="flex items-center justify-center {isMobile ? 'w-9 h-9' : 'w-6 h-6'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
+					class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
 					onclick={() => terminalPanelRef?.panelActions?.handleClear()}
 					title="Clear Terminal"
 				>
@@ -337,7 +337,7 @@
 				</button>
 				<button
 					type="button"
-					class="flex items-center justify-center {isMobile ? 'w-9 h-9' : 'w-6 h-6'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed"
+					class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed"
 					onclick={() => terminalPanelRef?.panelActions?.handleCancel()}
 					disabled={terminalPanelRef?.panelActions?.isCancelling()}
 					title="{isMobile ? 'Cancel Command (Ctrl+C)' : 'Send Ctrl+C Signal'}"
@@ -389,7 +389,7 @@
 				<div class="relative">
 					<button
 						type="button"
-						class="flex items-center justify-center {isMobile ? 'w-9 h-9' : 'w-6 h-6'} bg-transparent border-none rounded-md transition-all duration-150 {previewPanelRef?.panelActions?.getIsMcpControlled() ? 'text-slate-400 dark:text-slate-600 cursor-not-allowed opacity-50' : 'text-slate-500 cursor-pointer hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100'}"
+						class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded-md transition-all duration-150 {previewPanelRef?.panelActions?.getIsMcpControlled() ? 'text-slate-400 dark:text-slate-600 cursor-not-allowed opacity-50' : 'text-slate-500 cursor-pointer hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100'}"
 						onclick={previewPanelRef?.panelActions?.getIsMcpControlled() ? undefined : toggleDeviceDropdown}
 						disabled={previewPanelRef?.panelActions?.getIsMcpControlled()}
 						title={previewPanelRef?.panelActions?.getIsMcpControlled() ? 'Controlled by MCP agent' : `Device: ${deviceLabel}`}
@@ -477,7 +477,7 @@
 					{@const touchMode = previewPanelRef?.panelActions?.getTouchMode()}
 					<button
 						type="button"
-						class="flex items-center justify-center {isMobile ? 'w-9 h-9' : 'w-6 h-6'} bg-transparent border-none rounded-md cursor-pointer transition-all duration-150 hover:bg-violet-500/10
+						class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded-md cursor-pointer transition-all duration-150 hover:bg-violet-500/10
 							{touchMode === 'cursor' ? 'text-violet-600 dark:text-violet-400' : 'text-slate-500 hover:text-slate-900 dark:hover:text-slate-100'}"
 						onclick={() => {
 							const current = touchMode || 'scroll';
@@ -493,7 +493,7 @@
 				{@const rotation = previewPanelRef?.panelActions?.getRotation()}
 				<button
 					type="button"
-					class="flex items-center justify-center {isMobile ? 'w-9 h-9' : 'w-6 h-6'} bg-transparent border-none rounded-md transition-all duration-150 {previewPanelRef?.panelActions?.getIsMcpControlled() ? 'text-slate-400 dark:text-slate-600 cursor-not-allowed opacity-50' : 'text-slate-500 cursor-pointer hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100'}"
+					class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded-md transition-all duration-150 {previewPanelRef?.panelActions?.getIsMcpControlled() ? 'text-slate-400 dark:text-slate-600 cursor-not-allowed opacity-50' : 'text-slate-500 cursor-pointer hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100'}"
 					onclick={previewPanelRef?.panelActions?.getIsMcpControlled() ? undefined : () => previewPanelRef?.panelActions?.toggleRotation()}
 					disabled={previewPanelRef?.panelActions?.getIsMcpControlled()}
 					title={previewPanelRef?.panelActions?.getIsMcpControlled() ? 'Controlled by MCP agent' : `Orientation: ${rotation === 'portrait' ? 'Portrait' : 'Landscape'} — click to toggle`}
@@ -507,7 +507,7 @@
 					<div class="flex gap-1 bg-slate-100/80 dark:bg-slate-800/50 rounded-md">
 						<button
 							type="button"
-							class="flex items-center justify-center {isMobile ? 'w-9 h-9' : 'w-6 h-6'} bg-transparent border-none rounded text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100
+							class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100
 								{gitPanelRef?.panelActions?.getViewMode() === 'list'
 								? 'bg-violet-500/15 dark:bg-violet-500/25 text-violet-600'
 								: ''}"
@@ -518,7 +518,7 @@
 						</button>
 						<button
 							type="button"
-							class="flex items-center justify-center {isMobile ? 'w-9 h-9' : 'w-6 h-6'} bg-transparent border-none rounded text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100 disabled:opacity-40 disabled:cursor-not-allowed
+							class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100 disabled:opacity-40 disabled:cursor-not-allowed
 								{gitPanelRef?.panelActions?.getViewMode() === 'diff'
 								? 'bg-violet-500/15 dark:bg-violet-500/25 text-violet-600'
 								: ''}"
@@ -535,7 +535,7 @@
 				{#if gitPanelRef?.panelActions?.getIsRepo()}
 					<button
 						type="button"
-						class="flex items-center gap-1 {isMobile ? 'h-9 px-2' : 'h-6 px-1.5'} bg-slate-100 dark:bg-slate-800/60 border-none rounded-md text-slate-700 dark:text-slate-300 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-violet-600 dark:hover:text-violet-400"
+						class="flex items-center gap-1 {isMobile ? 'h-8 px-2' : 'h-6 px-1.5'} bg-slate-100 dark:bg-slate-800/60 border-none rounded-md text-slate-700 dark:text-slate-300 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-violet-600 dark:hover:text-violet-400"
 						onclick={() => gitPanelRef?.panelActions?.openBranches('local')}
 						title="Manage branches"
 					>


### PR DESCRIPTION
Add windowing to ChatNavigationRail so the dot list caps to the available band height instead of overflowing when a session has many user messages; paging via ellipsis markers above/below the window.

Collapse ContextIndicator to a compact ring gauge when its container narrows below 26rem (panel docked small / mobile), keeping the linear bar + % as the default wide layout.

Extract the settings button (duplicated in DesktopNavigator and MobileNavigator, collapsed/expanded/mobile variants) into a shared SettingButton component.

Align icon and control sizing (PanelHeader, TunnelButton, DbClientButton) for mobile so buttons stay consistent at h-8/w-4.5 instead of mixed h-9/w-5 sizes.