### PR TITLE
feat(db-client): improve mobile modal and add multi-column support

### DIFF
--- a/frontend/components/db-client/DbClientModal.svelte
+++ b/frontend/components/db-client/DbClientModal.svelte
@@ -608,7 +608,7 @@
 >
 	{#snippet children()}
 		{#if isMobile}
-			<header class="flex items-center justify-between py-3 px-4 border-b border-slate-200 dark:border-slate-800">
+			<header class="flex items-center justify-between py-3 px-4 bg-slate-100 dark:bg-slate-900/95 border-b border-slate-200 dark:border-slate-800">
 				<button
 					type="button"
 					class="flex items-center justify-center w-9 h-9 bg-transparent border-none rounded-lg text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
@@ -709,15 +709,13 @@
 						<!-- Mobile: two-row layout | Desktop: single row -->
 						{#if isMobile}
 							<!-- Row 1: Navigation + View selector -->
-							<div class="flex items-center gap-2 shrink-0 bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-1 min-w-0">
+							<div class="flex items-center gap-2 shrink-0 bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 py-1 px-1.5 min-w-0">
 								<div class="flex items-center gap-0.5 shrink-0">
-									<button type="button" class="flex items-center gap-1.5 px-2 h-7 rounded-md text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors" onclick={() => activeConnection && dbClientStore.navBack(activeConnection.id)} disabled={!canNavBack} title="Back" aria-label="Back">
+									<button type="button" class="flex items-center justify-center w-7 h-7 rounded-md text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors" onclick={() => activeConnection && dbClientStore.navBack(activeConnection.id)} disabled={!canNavBack} title="Back" aria-label="Back">
 										<Icon name="lucide:arrow-left" class="w-4 h-4" />
-										<span class="text-xs">Back</span>
 									</button>
-									<button type="button" class="flex items-center gap-1.5 px-2 h-7 rounded-md text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors" onclick={() => activeConnection && dbClientStore.navForward(activeConnection.id)} disabled={!canNavForward} title="Forward" aria-label="Forward">
+									<button type="button" class="flex items-center justify-center w-7 h-7 rounded-md text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors" onclick={() => activeConnection && dbClientStore.navForward(activeConnection.id)} disabled={!canNavForward} title="Forward" aria-label="Forward">
 										<Icon name="lucide:arrow-right" class="w-4 h-4" />
-										<span class="text-xs">Forward</span>
 									</button>
 								</div>
 								<div class="w-px h-4 bg-slate-200 dark:bg-slate-800 shrink-0 mx-1"></div>

--- a/frontend/components/db-client/main/StructureManager.svelte
+++ b/frontend/components/db-client/main/StructureManager.svelte
@@ -186,9 +186,8 @@
 	}
 
 	async function doAddColumn(payload: { name: string; columns: { name: string; type: string; nullable: boolean; default: string; primary: boolean; unique: boolean; autoIncrement: boolean }[] }): Promise<void> {
-		const c = payload.columns[0];
-		await dbClientStore.alterTable(connectionId, objectName, [{
-			kind: 'add-column',
+		const ops = payload.columns.map((c) => ({
+			kind: 'add-column' as const,
 			column: {
 				name: c.name,
 				type: c.type,
@@ -198,7 +197,8 @@
 				unique: c.unique,
 				autoIncrement: c.autoIncrement
 			}
-		}], { database, schema });
+		}));
+		await dbClientStore.alterTable(connectionId, objectName, ops, { database, schema });
 		dbClientStore.requestSchemaReload();
 		await load();
 	}
@@ -348,7 +348,7 @@
 			{#if isRedisDriver}
 				<section>
 					<h3 class="text-sm font-semibold text-slate-700 dark:text-slate-200 mb-2">Key details</h3>
-					<div class="border border-slate-200 dark:border-slate-800 rounded-lg overflow-hidden">
+					<div class="border border-slate-200 dark:border-slate-800 rounded-lg overflow-x-auto">
 						<dl class="divide-y divide-slate-200 dark:divide-slate-800 bg-slate-50 dark:bg-slate-800/50 text-sm">
 							<div class="flex items-center justify-between gap-4 px-4 py-2.5">
 								<dt class="text-slate-500 dark:text-slate-400">Name</dt>
@@ -369,8 +369,8 @@
 				{#if isMongoDriver}
 					<section>
 						<h3 class="text-sm font-semibold text-slate-700 dark:text-slate-200 mb-2">Sampled fields</h3>
-						<div class="border border-slate-200 dark:border-slate-800 rounded-lg overflow-hidden">
-							<table class="w-full text-sm bg-slate-50 dark:bg-slate-800/50">
+						<div class="border border-slate-200 dark:border-slate-800 rounded-lg overflow-x-auto">
+							<table class="w-full min-w-[560px] text-sm bg-slate-50 dark:bg-slate-800/50">
 								<thead class="bg-slate-200 dark:bg-slate-800">
 									<tr>
 										<th class="px-3 py-2 text-left font-semibold">Field</th>
@@ -412,8 +412,8 @@
 								</button>
 							{/if}
 						</div>
-						<div class="border border-slate-200 dark:border-slate-800 rounded-lg overflow-hidden">
-							<table class="w-full text-sm bg-slate-50 dark:bg-slate-800/50">
+						<div class="border border-slate-200 dark:border-slate-800 rounded-lg overflow-x-auto">
+							<table class="w-full min-w-[560px] text-sm bg-slate-50 dark:bg-slate-800/50">
 								<thead class="bg-slate-200 dark:bg-slate-800">
 									<tr>
 										<th class="px-3 py-2 text-left font-semibold">Name</th>
@@ -493,8 +493,8 @@
 							</button>
 						{/if}
 					</div>
-					<div class="border border-slate-200 dark:border-slate-800 rounded-lg overflow-hidden">
-						<table class="w-full text-sm bg-slate-50 dark:bg-slate-800/50">
+					<div class="border border-slate-200 dark:border-slate-800 rounded-lg overflow-x-auto">
+						<table class="w-full min-w-[560px] text-sm bg-slate-50 dark:bg-slate-800/50">
 							<thead class="bg-slate-200 dark:bg-slate-800">
 								<tr>
 									<th class="px-3 py-2 text-left font-semibold">Name</th>
@@ -545,8 +545,8 @@
 				{#if isSqlDriver}
 					<section>
 						<h3 class="text-sm font-semibold text-slate-700 dark:text-slate-200 mb-2">Relations</h3>
-						<div class="border border-slate-200 dark:border-slate-800 rounded-lg overflow-hidden">
-							<table class="w-full text-sm bg-slate-50 dark:bg-slate-800/50">
+						<div class="border border-slate-200 dark:border-slate-800 rounded-lg overflow-x-auto">
+							<table class="w-full min-w-[560px] text-sm bg-slate-50 dark:bg-slate-800/50">
 								<thead class="bg-slate-200 dark:bg-slate-800">
 									<tr>
 										<th class="px-3 py-2 text-left font-semibold">Column</th>

--- a/frontend/components/db-client/main/TableDesigner.svelte
+++ b/frontend/components/db-client/main/TableDesigner.svelte
@@ -88,31 +88,30 @@
 		}
 	}
 
+	function columnParts(c: ColumnInput): string[] {
+		const parts: string[] = [quote(c.name), c.type];
+		if (!c.nullable) parts.push('NOT NULL');
+		if (c.default) parts.push(`DEFAULT ${c.default}`);
+		if (c.unique) parts.push('UNIQUE');
+		if (c.primary) parts.push('PRIMARY KEY');
+		if (c.autoIncrement) {
+			if (driver === 'mysql') parts.push('AUTO_INCREMENT');
+			else if (driver === 'sqlite') parts.push('AUTOINCREMENT');
+		}
+		return parts;
+	}
+
 	const ddlPreview = $derived.by(() => {
 		if (isDocumentDb) return '';
 		const cols = columns.filter((c) => c.name && c.type);
+		if (cols.length === 0) return '';
 		if (isAddColumn) {
-			if (cols.length === 0) return '';
-			const c = cols[0];
-			const parts: string[] = [quote(c.name), c.type];
-			if (!c.nullable) parts.push('NOT NULL');
-			if (c.default) parts.push(`DEFAULT ${c.default}`);
-			if (c.unique) parts.push('UNIQUE');
-			return `ALTER TABLE ${quote(name || '<table>')} ADD COLUMN ${parts.join(' ')};`;
+			return cols
+				.map((c) => `ALTER TABLE ${quote(name || '<table>')} ADD COLUMN ${columnParts(c).join(' ')};`)
+				.join('\n');
 		}
-		if (!name || cols.length === 0) return '';
-		const lines = cols.map((c) => {
-			const parts: string[] = [quote(c.name), c.type];
-			if (!c.nullable) parts.push('NOT NULL');
-			if (c.default) parts.push(`DEFAULT ${c.default}`);
-			if (c.unique) parts.push('UNIQUE');
-			if (c.primary) parts.push('PRIMARY KEY');
-			if (c.autoIncrement) {
-				if (driver === 'mysql') parts.push('AUTO_INCREMENT');
-				else if (driver === 'sqlite') parts.push('AUTOINCREMENT');
-			}
-			return '  ' + parts.join(' ');
-		});
+		if (!name) return '';
+		const lines = cols.map((c) => '  ' + columnParts(c).join(' '));
 		return `CREATE TABLE ${quote(name)} (\n${lines.join(',\n')}\n);`;
 	});
 
@@ -158,80 +157,82 @@
 				<!-- Columns -->
 				<div class="space-y-2">
 					<div class="flex items-center justify-between">
-						<span class="text-sm font-semibold text-slate-700 dark:text-slate-300">
-							{isAddColumn ? 'Column' : 'Columns'}
-						</span>
-						{#if !isAddColumn}
-							<Button variant="ghost" size="sm" onclick={addColumn}>
-								<Icon name="lucide:plus" class="w-3.5 h-3.5 mr-1" /> Add column
-							</Button>
-						{/if}
+						<span class="text-sm font-semibold text-slate-700 dark:text-slate-300">Columns</span>
+						<Button variant="ghost" size="sm" onclick={addColumn}>
+							<Icon name="lucide:plus" class="w-3.5 h-3.5 mr-1" /> Add column
+						</Button>
 					</div>
 
 					<div class="space-y-2">
 						{#each columns as col, i (i)}
-							<div class="flex items-center gap-2 p-3 bg-slate-50 dark:bg-slate-800/50 rounded-lg border border-slate-200 dark:border-slate-700/60">
-								<!-- Name -->
-								<input
-									type="text"
-									placeholder="column_name"
-									class="w-32 shrink-0 px-2.5 py-1.5 text-sm bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-md focus:outline-none focus:border-violet-500"
-									bind:value={col.name}
-								/>
-								<!-- Type -->
-								<div class="relative w-36 shrink-0">
-									<input
-										type="text"
-										list="type-presets-{i}"
-										placeholder="type"
-										class="w-full px-2.5 py-1.5 text-sm bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-md focus:outline-none focus:border-violet-500"
-										bind:value={col.type}
-									/>
-									<datalist id="type-presets-{i}">
-										{#each TYPE_PRESETS[driver] as t (t)}
-											<option value={t}></option>
-										{/each}
-									</datalist>
+							<div class="space-y-3 p-3 bg-slate-50 dark:bg-slate-800/50 rounded-lg border border-slate-200 dark:border-slate-700/60">
+								<div class="flex items-center justify-between gap-2">
+									<span class="text-xs font-semibold uppercase tracking-wider text-slate-400">Column {i + 1}</span>
+									{#if columns.length > 1}
+										<button
+											type="button"
+											class="shrink-0 flex items-center justify-center w-7 h-7 rounded-md text-slate-400 hover:text-red-500 hover:bg-red-500/10 transition-colors"
+											onclick={() => removeColumn(i)}
+											aria-label="Remove column"
+										>
+											<Icon name="lucide:trash-2" class="w-3.5 h-3.5" />
+										</button>
+									{/if}
 								</div>
-								<!-- Default -->
-								<input
-									type="text"
-									placeholder="default"
-									class="w-24 shrink-0 px-2.5 py-1.5 text-sm bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-md focus:outline-none focus:border-violet-500"
-									bind:value={col.default}
-								/>
-								<!-- Flags -->
-								<div class="flex items-center gap-3 ml-1">
-									<label class="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400 cursor-pointer select-none">
-										<Checkbox bind:checked={col.nullable} ariaLabel="Nullable" />
-										<span>NULL</span>
+								<div class="grid grid-cols-2 gap-2">
+									<div>
+										<label for="td-col-name-{i}" class="text-xs font-medium text-slate-700 dark:text-slate-300">Name</label>
+										<input
+											id="td-col-name-{i}"
+											type="text"
+											placeholder="column_name"
+											class="w-full mt-1 px-2 py-1.5 text-sm bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded focus:outline-none focus:border-violet-500"
+											bind:value={col.name}
+										/>
+									</div>
+									<div>
+										<label for="td-col-type-{i}" class="text-xs font-medium text-slate-700 dark:text-slate-300">Type</label>
+										<input
+											id="td-col-type-{i}"
+											type="text"
+											list="type-presets-{i}"
+											placeholder="type"
+											class="w-full mt-1 px-2 py-1.5 text-sm bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded focus:outline-none focus:border-violet-500"
+											bind:value={col.type}
+										/>
+										<datalist id="type-presets-{i}">
+											{#each TYPE_PRESETS[driver] as t (t)}
+												<option value={t}></option>
+											{/each}
+										</datalist>
+									</div>
+								</div>
+								<div>
+									<label for="td-col-default-{i}" class="text-xs font-medium text-slate-700 dark:text-slate-300">Default</label>
+									<input
+										id="td-col-default-{i}"
+										type="text"
+										placeholder="e.g. NULL, 0, 'text'"
+										class="w-full mt-1 px-2 py-1.5 text-sm bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded focus:outline-none focus:border-violet-500"
+										bind:value={col.default}
+									/>
+								</div>
+								<div class="flex flex-wrap gap-3 text-sm">
+									<label class="inline-flex items-center gap-1.5 text-slate-500 dark:text-slate-400 cursor-pointer select-none">
+										<Checkbox bind:checked={col.nullable} ariaLabel="Nullable" /> Nullable
 									</label>
-									<label class="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400 cursor-pointer select-none">
-										<Checkbox bind:checked={col.primary} ariaLabel="Primary key" />
-										<span>PK</span>
+									<label class="inline-flex items-center gap-1.5 text-slate-500 dark:text-slate-400 cursor-pointer select-none">
+										<Checkbox bind:checked={col.primary} ariaLabel="Primary key" /> Primary key
 									</label>
-									<label class="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400 cursor-pointer select-none">
-										<Checkbox bind:checked={col.unique} ariaLabel="Unique" />
-										<span>UQ</span>
+									<label class="inline-flex items-center gap-1.5 text-slate-500 dark:text-slate-400 cursor-pointer select-none">
+										<Checkbox bind:checked={col.unique} ariaLabel="Unique" /> Unique
 									</label>
 									{#if driver === 'mysql' || driver === 'sqlite' || driver === 'postgres'}
-										<label class="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400 cursor-pointer select-none">
-											<Checkbox bind:checked={col.autoIncrement} ariaLabel="Auto-increment" />
-											<span>AI</span>
+										<label class="inline-flex items-center gap-1.5 text-slate-500 dark:text-slate-400 cursor-pointer select-none">
+											<Checkbox bind:checked={col.autoIncrement} ariaLabel="Auto-increment" /> Auto-increment
 										</label>
 									{/if}
 								</div>
-								<div class="flex-1 min-w-0"></div>
-								{#if !isAddColumn}
-									<button
-										type="button"
-										class="shrink-0 flex items-center justify-center w-7 h-7 rounded-md text-slate-400 hover:text-red-500 hover:bg-red-500/10 transition-colors"
-										onclick={() => removeColumn(i)}
-										aria-label="Remove column"
-									>
-										<Icon name="lucide:trash-2" class="w-3.5 h-3.5" />
-									</button>
-								{/if}
 							</div>
 						{:else}
 							<div class="py-3 text-center text-sm text-slate-400">No columns — click "Add column"</div>


### PR DESCRIPTION
Mobile view:
- match mobile header background to the Settings modal
- drop the Back/Forward text labels on mobile, icons only like desktop
- make Structure tab tables scroll horizontally instead of crushing columns

Add column modal:
- support adding multiple columns in one submit via a batch of add-column operations
- align the per-column layout with the Edit column modal (name/type grid, default, full-word flag labels) so both modals are consistent
- render one ALTER TABLE ... ADD COLUMN statement per column in the DDL preview via a shared clause builder