### PR TITLE
fix(bun): shim node:v8 isBuildingSnapshot to prevent bson import crash

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -8,7 +8,11 @@ if (typeof globalThis.Bun === 'undefined') {
 	process.exit(1);
 }
 
-// MUST be first import — cleans process.env before any other module reads it
+// MUST be first import — patches Bun's missing node:v8 isBuildingSnapshot before
+// any module (transitively mongodb/bson) loads and crashes at import time.
+import './utils/bun-compat';
+
+// Cleans process.env before any other feature module reads it.
 import { SERVER_ENV } from './utils/env';
 
 import { Elysia } from 'elysia';

--- a/backend/utils/bun-compat.ts
+++ b/backend/utils/bun-compat.ts
@@ -1,0 +1,32 @@
+/**
+ * Bun compatibility shims — applied as a side effect at process startup.
+ *
+ * `node:v8` `startupSnapshot.isBuildingSnapshot()` is not implemented in Bun
+ * (calling it throws `ERR_NOT_IMPLEMENTED`). `bson` >= 7.3.0 invokes it inside a
+ * module-level `static {}` block, so importing `mongodb` crashes the process at
+ * load time on Bun — before Clopen can even start.
+ *
+ * We cannot reliably pin the transitive `bson` for end users: they install via
+ * `bun add -g @myrialabs/clopen`, where Clopen is a dependency rather than the
+ * root package, so its `overrides`/exact pins are ignored and Bun re-resolves
+ * `mongodb`'s `bson: "^7.2.0"` to the newest (broken) version. Instead we
+ * neutralize the missing API by replacing the throwing stub with a no-op that
+ * reports "not building a snapshot" — always true for a normally-running
+ * process, so `bson` skips its snapshot branch and loads cleanly.
+ *
+ * Import this before any module that (transitively) imports `mongodb`/`bson`.
+ */
+
+if (typeof globalThis.Bun !== 'undefined') {
+	const v8 = (process as { getBuiltinModule?: (name: string) => unknown }).getBuiltinModule?.('v8') as
+		| { startupSnapshot?: { isBuildingSnapshot?: () => boolean } }
+		| undefined;
+
+	if (v8?.startupSnapshot && typeof v8.startupSnapshot.isBuildingSnapshot === 'function') {
+		try {
+			v8.startupSnapshot.isBuildingSnapshot = () => false;
+		} catch {
+			// Property is non-writable in this runtime — best effort, nothing else to do.
+		}
+	}
+}

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,6 @@
         "@opencode-ai/sdk": "1.15.12",
         "@qwen-code/sdk": "0.1.7",
         "@sinclair/typebox": "0.34.48",
-        "bson": "7.2.0",
         "bun-pty": "0.4.8",
         "dompurify": "3.4.9",
         "elysia": "1.4.27",
@@ -64,9 +63,6 @@
     "sharp",
     "puppeteer",
   ],
-  "overrides": {
-    "bson": "7.2.0",
-  },
   "packages": {
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.158", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.158", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.158", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.158", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.158", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.158", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.158", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.158", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.158" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-Rht8Ui7HBsVdBCG6SYs9b+JmJWAVoDXPD2pWNVMSFrzyAS4nizwdz3HtUnAobFumgzbT3LbpWzHdLfUDu4gM4w=="],
 

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "@opencode-ai/sdk": "1.15.12",
     "@qwen-code/sdk": "0.1.7",
     "@sinclair/typebox": "0.34.48",
-    "bson": "7.2.0",
     "bun-pty": "0.4.8",
     "dompurify": "3.4.9",
     "elysia": "1.4.27",
@@ -129,8 +128,5 @@
   "trustedDependencies": [
     "puppeteer",
     "sharp"
-  ],
-  "overrides": {
-    "bson": "7.2.0"
-  }
+  ]
 }


### PR DESCRIPTION
mongodb pulls bson >=7.3.0 on end-user global installs, whose module-level static block calls node:v8 startupSnapshot.isBuildingSnapshot(). That API is unimplemented in Bun and throws ERR_NOT_IMPLEMENTED, crashing the server at import time before Clopen can start.

Exact pins (#407) and overrides (#418) could not fix this: both are only honored from the root project, but on `bun add -g @myrialabs/clopen` Clopen is a dependency, not the root, so Bun re-resolves bson `^7.2.0` to the latest (broken) version regardless.

Neutralize the missing API in a startup shim (backend/utils/bun-compat.ts) that replaces the throwing stub with a no-op returning false — the correct answer for a normally-running process. It is imported first in backend/index.ts, before the connection-manager -> mongodb -> bson chain, so the fix is independent of dependency resolution and bson version.

Drop the now-redundant direct bson dependency and the bson override, since neither affects the global-install path the shim now covers.