### PR TITLE
fix(preview): adaptive streaming to fix blur, bandwidth, and latency

### DIFF
--- a/backend/preview/browser/browser-preview-service.ts
+++ b/backend/preview/browser/browser-preview-service.ts
@@ -366,7 +366,7 @@ export class BrowserPreviewService extends EventEmitter {
 	// ============================================================================
 	// WebCodecs Streaming Methods (optimized, ~20-40ms, lower bandwidth)
 	// ============================================================================
-	async startWebCodecsStreaming(tabId: string): Promise<boolean> {
+	async startWebCodecsStreaming(tabId: string, allowVp9 = true): Promise<boolean> {
 		const tab = this.getTab(tabId);
 		if (!tab) {
 			return false;
@@ -374,7 +374,8 @@ export class BrowserPreviewService extends EventEmitter {
 		return await this.videoCapture.startStreaming(
 			tabId,
 			tab,
-			() => this.isValidTab(tabId)
+			() => this.isValidTab(tabId),
+			allowVp9
 		);
 	}
 
@@ -383,20 +384,28 @@ export class BrowserPreviewService extends EventEmitter {
 		await this.videoCapture.stopStreaming(tabId, tab ?? undefined);
 	}
 
-	async updateWebCodecsScale(tabId: string, newScale: number): Promise<boolean> {
+	async refreshWebCodecsScreencast(tabId: string): Promise<boolean> {
 		const tab = this.getTab(tabId);
 		if (!tab) {
 			return false;
 		}
-		return await this.videoCapture.updateScale(tabId, tab, newScale);
+		return await this.videoCapture.refreshScreencast(tabId, tab);
 	}
 
-	async updateWebCodecsViewport(tabId: string, width: number, height: number, newScale: number): Promise<boolean> {
+	async requestWebCodecsKeyframe(tabId: string): Promise<boolean> {
 		const tab = this.getTab(tabId);
 		if (!tab) {
 			return false;
 		}
-		return await this.videoCapture.updateViewport(tabId, tab, width, height, newScale);
+		return await this.videoCapture.requestKeyframe(tabId, tab);
+	}
+
+	async updateWebCodecsViewport(tabId: string, width: number, height: number): Promise<boolean> {
+		const tab = this.getTab(tabId);
+		if (!tab) {
+			return false;
+		}
+		return await this.videoCapture.updateViewport(tabId, tab, width, height);
 	}
 
 	async getWebCodecsOffer(tabId: string): Promise<RTCSessionDescriptionInit | null> {

--- a/backend/preview/browser/browser-video-capture.ts
+++ b/backend/preview/browser/browser-video-capture.ts
@@ -3,11 +3,15 @@
  *
  * Handles WebCodecs-based video streaming with WebRTC DataChannel transport.
  *
- * Video Architecture:
- * 1. CDP captures JPEG frames via Page.screencastFrame
+ * Video Architecture (Chrome-Remote-Desktop-style adaptive quality):
+ * 1. CDP captures JPEG frames via Page.screencastFrame at native viewport resolution
  * 2. Direct CDP Runtime.evaluate sends base64 to page (bypasses Puppeteer IPC)
- * 3. Page decodes JPEG via createImageBitmap, encodes with VP8 VideoEncoder
- * 4. Send encoded chunks via RTCDataChannel
+ * 3. Page decodes via createImageBitmap, encodes with VideoEncoder —
+ *    preferred VP9 quantizer mode (cheap during motion), VP8 bitrate fallback
+ * 4. When the page goes still, a lossless PNG screenshot is pushed through the
+ *    encoder near-losslessly (top-off) so text sharpens after motion stops
+ * 5. Send encoded chunks via reliable ordered RTCDataChannel; latency is
+ *    bounded by source-side frame dropping (bufferedAmount backpressure)
  *
  * Audio Architecture:
  * 1. AudioContext interception (handled by BrowserAudioCapture)
@@ -43,6 +47,7 @@ interface VideoStreamSession {
 	scriptInjected: boolean; // Track if persistent script was injected
 	scriptsPreInjected: boolean; // Track if scripts were pre-injected during tab creation
 	audioOnNewDocumentInjected: boolean; // Track if evaluateOnNewDocument was registered for audio
+	allowVp9: boolean; // Client decode capability (negotiated at stream start)
 	stats: {
 		videoBytesSent: number;
 		audioBytesSent: number;
@@ -52,7 +57,31 @@ interface VideoStreamSession {
 	};
 }
 
+/**
+ * Scale encoder bitrate with capture resolution to keep bits-per-pixel
+ * constant. Capture always runs at native viewport size (display fit-scale
+ * is a CSS-only concern on the frontend), so a fixed bitrate would starve
+ * larger viewports during motion.
+ * 0.045 bpp at 1280×800@24fps ≈ 1.1 Mbps (comparable to the previous fixed 1 Mbps).
+ */
+const BITS_PER_PIXEL = 0.045;
+
+function computeBitrate(width: number, height: number, framerate: number): number {
+	return Math.max(
+		DEFAULT_STREAMING_CONFIG.video.bitrate,
+		Math.round(width * height * framerate * BITS_PER_PIXEL)
+	);
+}
+
 export class BrowserVideoCapture extends EventEmitter {
+	/**
+	 * How long the screencast must be silent (no damage → no frames) before
+	 * the page is considered still and a near-lossless top-off frame is sent.
+	 * Long enough to skip inter-frame gaps of animations, short enough that
+	 * text sharpens almost immediately after scrolling stops.
+	 */
+	private static readonly TOP_OFF_DELAY_MS = 300;
+
 	private sessions = new Map<string, VideoStreamSession>();
 	private preInjectPromises = new Map<string, Promise<boolean>>();
 
@@ -78,15 +107,15 @@ export class BrowserVideoCapture extends EventEmitter {
 			const page = session.page;
 			const viewport = page.viewport()!;
 			const config = DEFAULT_STREAMING_CONFIG;
-			const scale = session.scale || 1;
 
-			const scaledWidth = Math.round(viewport.width * scale);
-			const scaledHeight = Math.round(viewport.height * scale);
-
+			// Capture at native viewport resolution. Capturing below viewport
+			// size (old behavior: viewport × display fit-scale) forced the
+			// client to upscale frames, which made the preview blurry.
 			const videoConfig: StreamingConfig['video'] = {
 				...config.video,
-				width: scaledWidth,
-				height: scaledHeight
+				width: viewport.width,
+				height: viewport.height,
+				bitrate: computeBitrate(viewport.width, viewport.height, config.video.framerate)
 			};
 
 			// Create session tracking
@@ -99,6 +128,7 @@ export class BrowserVideoCapture extends EventEmitter {
 				scriptInjected: true,
 				scriptsPreInjected: false, // Set to true only after injection completes
 				audioOnNewDocumentInjected: false,
+				allowVp9: true,
 				stats: {
 					videoBytesSent: 0,
 					audioBytesSent: 0,
@@ -184,9 +214,10 @@ export class BrowserVideoCapture extends EventEmitter {
 	async startStreaming(
 		sessionId: string,
 		session: BrowserTab,
-		isValidSession: () => boolean
+		isValidSession: () => boolean,
+		allowVp9 = true
 	): Promise<boolean> {
-		debug.log('webcodecs', `Starting streaming for session ${sessionId}`);
+		debug.log('webcodecs', `Starting streaming for session ${sessionId} (client vp9: ${allowVp9})`);
 
 		// Wait for any pending pre-injection to complete
 		const pendingPreInject = this.preInjectPromises.get(sessionId);
@@ -214,10 +245,6 @@ export class BrowserVideoCapture extends EventEmitter {
 			const viewport = page.viewport()!;
 			const config = DEFAULT_STREAMING_CONFIG;
 
-			// Get scale from session (default to 1 if not set)
-			const scale = session.scale || 1;
-			debug.log('webcodecs', `Using scale: ${scale} for session ${sessionId}`);
-
 			// Get or create session tracking
 			let videoSession = this.sessions.get(sessionId);
 			const isRestart = !!videoSession;
@@ -232,6 +259,7 @@ export class BrowserVideoCapture extends EventEmitter {
 					scriptInjected: false,
 					scriptsPreInjected: false,
 					audioOnNewDocumentInjected: false,
+					allowVp9,
 					stats: {
 						videoBytesSent: 0,
 						audioBytesSent: 0,
@@ -241,16 +269,16 @@ export class BrowserVideoCapture extends EventEmitter {
 					}
 				};
 				this.sessions.set(sessionId, videoSession);
+			} else {
+				videoSession.allowVp9 = allowVp9;
 			}
 
-			// Calculate scaled dimensions
-			const scaledWidth = Math.round(viewport.width * scale);
-			const scaledHeight = Math.round(viewport.height * scale);
-
+			// Capture at native viewport resolution (see doPreInject)
 			const videoConfig: StreamingConfig['video'] = {
 				...config.video,
-				width: scaledWidth,
-				height: scaledHeight
+				width: viewport.width,
+				height: viewport.height,
+				bitrate: computeBitrate(viewport.width, viewport.height, config.video.framerate)
 			};
 
 			// Skip script injection if already pre-injected during tab creation
@@ -263,13 +291,13 @@ export class BrowserVideoCapture extends EventEmitter {
 
 			// Single batched call: verify peer + start streaming + init audio
 			// (saves ~60ms of IPC overhead vs 4 separate page.evaluate calls)
-			const initResult = await page.evaluate(async () => {
+			const initResult = await page.evaluate(async (clientAllowsVp9) => {
 				const peer = (window as any).__webCodecsPeer;
 				if (typeof peer?.startStreaming !== 'function') {
 					return { peerExists: false, started: false, audioInitialized: false };
 				}
 
-				const started = await peer.startStreaming();
+				const started = await peer.startStreaming(clientAllowsVp9);
 				if (!started) {
 					return { peerExists: true, started: false, audioInitialized: false };
 				}
@@ -287,7 +315,7 @@ export class BrowserVideoCapture extends EventEmitter {
 				}
 
 				return { peerExists: true, started: true, audioInitialized };
-			});
+			}, allowVp9);
 
 			if (!initResult.peerExists) {
 				debug.error('webcodecs', `Peer script injected but __webCodecsPeer not available`);
@@ -335,12 +363,72 @@ export class BrowserVideoCapture extends EventEmitter {
 		const page = session.page;
 		const viewport = page.viewport()!;
 
-		// Get scale from session (default to 1 if not set)
-		const scale = session.scale || 1;
-
 		const cdp = await page.createCDPSession();
 
 		let cdpFrameCount = 0;
+
+		// Rate-limit encoding to the configured framerate. CDP screencast fires
+		// at compositor rate (up to 60fps) — encoding every frame wastes CPU on
+		// the host and bandwidth on the wire without visible benefit.
+		//
+		// Trailing edge matters: the LAST frame of a burst must always be
+		// encoded. Plain dropping left a stale frame on screen until the
+		// top-off fired (~300ms later), which felt like input lag on every
+		// click/keystroke.
+		const minFrameIntervalMs = Math.floor(1000 / config.video.framerate);
+		let lastEncodeTime = 0;
+		let pendingFrameData: string | null = null;
+		let pendingFrameTimer: ReturnType<typeof setTimeout> | null = null;
+
+		const encodeMotionFrame = (frameData: string) => {
+			lastEncodeTime = Date.now();
+			// Send frame to encoder via direct CDP (bypasses Puppeteer's
+			// ExecutionContext lookup, function serialization, Runtime.callFunctionOn
+			// overhead, and result deserialization). Base64 charset [A-Za-z0-9+/=]
+			// is safe to embed in a JS double-quoted string literal.
+			cdp.send('Runtime.evaluate', {
+				expression: `window.__webCodecsPeer?.encodeFrame("${frameData}")`,
+				awaitPromise: false,
+				returnByValue: false
+			}).catch(() => {});
+		};
+
+		// Static top-off (Chrome-Remote-Desktop-style): screencastFrame only
+		// fires on damage, so when no frame arrives for TOP_OFF_DELAY_MS the
+		// page has gone still. Capture one lossless PNG screenshot and encode
+		// it near-losslessly so the last (motion-degraded) frame doesn't stay
+		// blurry on screen. One frame per still period — idle costs nothing.
+		let topOffTimer: ReturnType<typeof setTimeout> | null = null;
+		let capturingTopOff = false;
+
+		const scheduleTopOff = () => {
+			if (topOffTimer) clearTimeout(topOffTimer);
+			topOffTimer = setTimeout(async () => {
+				topOffTimer = null;
+				const videoSession = this.sessions.get(sessionId);
+				if (!videoSession?.isActive || session.isDestroyed || capturingTopOff) return;
+
+				capturingTopOff = true;
+				const frameCountAtCapture = cdpFrameCount;
+				try {
+					const screenshot = await cdp.send('Page.captureScreenshot', { format: 'png' });
+
+					// Discard if the page moved again while capturing —
+					// new screencast frames already rescheduled the top-off
+					if (cdpFrameCount !== frameCountAtCapture) return;
+
+					cdp.send('Runtime.evaluate', {
+						expression: `window.__webCodecsPeer?.encodeFrame("${screenshot.data}", true)`,
+						awaitPromise: false,
+						returnByValue: false
+					}).catch(() => {});
+				} catch {
+					// Page may be navigating/closing — top-off is best-effort
+				} finally {
+					capturingTopOff = false;
+				}
+			}, BrowserVideoCapture.TOP_OFF_DELAY_MS);
+		};
 
 		cdp.on('Page.screencastFrame', async (event: any) => {
 			cdpFrameCount++;
@@ -359,31 +447,60 @@ export class BrowserVideoCapture extends EventEmitter {
 			// ACK immediately
 			cdp.send('Page.screencastFrameAck', { sessionId: event.sessionId }).catch(() => {});
 
-			// Send frame to encoder via direct CDP (bypasses Puppeteer's
-			// ExecutionContext lookup, function serialization, Runtime.callFunctionOn
-			// overhead, and result deserialization). Base64 charset [A-Za-z0-9+/=]
-			// is safe to embed in a JS double-quoted string literal.
-			cdp.send('Runtime.evaluate', {
-				expression: `window.__webCodecsPeer?.encodeFrame("${event.data}")`,
-				awaitPromise: false,
-				returnByValue: false
-			}).catch(() => {});
+			const now = Date.now();
+			const elapsed = now - lastEncodeTime;
+
+			if (elapsed < minFrameIntervalMs) {
+				// Too soon — hold the LATEST frame and encode it when the slot
+				// opens (trailing edge). Newer frames overwrite the pending one.
+				pendingFrameData = event.data;
+				if (!pendingFrameTimer) {
+					pendingFrameTimer = setTimeout(() => {
+						pendingFrameTimer = null;
+						if (!pendingFrameData) return;
+						const frameData = pendingFrameData;
+						pendingFrameData = null;
+
+						const vs = this.sessions.get(sessionId);
+						if (!vs?.isActive || session.isDestroyed) return;
+
+						encodeMotionFrame(frameData);
+						scheduleTopOff();
+					}, minFrameIntervalMs - elapsed);
+				}
+				scheduleTopOff();
+				return;
+			}
+
+			// This frame supersedes any pending trailing frame
+			pendingFrameData = null;
+
+			encodeMotionFrame(event.data);
+			scheduleTopOff();
 		});
 
-		// Start screencast with scaled dimensions
-		const scaledWidth = Math.round(viewport.width * scale);
-		const scaledHeight = Math.round(viewport.height * scale);
-
+		// Start screencast at native viewport resolution
 		await cdp.send('Page.startScreencast', {
 			format: 'jpeg',
 			quality: config.video.screenshotQuality,
-			maxWidth: scaledWidth,
-			maxHeight: scaledHeight,
+			maxWidth: viewport.width,
+			maxHeight: viewport.height,
 			everyNthFrame: 1
 		});
 
-		debug.log('webcodecs', `CDP screencast started with scaled dimensions: ${scaledWidth}x${scaledHeight} (scale: ${scale})`);
+		debug.log('webcodecs', `CDP screencast started at ${viewport.width}x${viewport.height}`);
 		(session as any).__webCodecsCdp = cdp;
+		(session as any).__webCodecsTopOffCancel = () => {
+			if (topOffTimer) {
+				clearTimeout(topOffTimer);
+				topOffTimer = null;
+			}
+			if (pendingFrameTimer) {
+				clearTimeout(pendingFrameTimer);
+				pendingFrameTimer = null;
+			}
+			pendingFrameData = null;
+		};
 	}
 
 	/**
@@ -488,9 +605,9 @@ export class BrowserVideoCapture extends EventEmitter {
 	}
 
 	/**
-	 * Update viewport and scale without reconnection (hot-swap)
+	 * Update viewport without reconnection (hot-swap)
 	 */
-	async updateViewport(sessionId: string, session: BrowserTab, width: number, height: number, newScale: number): Promise<boolean> {
+	async updateViewport(sessionId: string, session: BrowserTab, width: number, height: number): Promise<boolean> {
 		const videoSession = this.sessions.get(sessionId);
 		if (!videoSession?.isActive || !session.page || session.page.isClosed()) {
 			debug.warn('webcodecs', `Cannot update viewport: session not active`);
@@ -501,21 +618,18 @@ export class BrowserVideoCapture extends EventEmitter {
 			const page = session.page;
 			const config = DEFAULT_STREAMING_CONFIG;
 
-			// Calculate scaled dimensions
-			const scaledWidth = Math.round(width * newScale);
-			const scaledHeight = Math.round(height * newScale);
-
-			debug.log('webcodecs', `🔄 Hot-swapping viewport to ${width}x${height} (scaled: ${scaledWidth}x${scaledHeight}, scale: ${newScale})`);
+			debug.log('webcodecs', `🔄 Hot-swapping viewport to ${width}x${height}`);
 
 			// Step 1: Update viewport via CDP (without page reload)
 			await page.setViewport({ width, height });
 
-			// Step 2: Reconfigure VideoEncoder with scaled dimensions
-			const reconfigured = await page.evaluate((dimensions) => {
+			// Step 2: Reconfigure VideoEncoder with new dimensions and bitrate
+			const bitrate = computeBitrate(width, height, config.video.framerate);
+			const reconfigured = await page.evaluate((params) => {
 				const peer = (window as any).__webCodecsPeer;
 				if (!peer || !peer.reconfigureEncoder) return false;
-				return peer.reconfigureEncoder(dimensions.width, dimensions.height);
-			}, { width: scaledWidth, height: scaledHeight });
+				return peer.reconfigureEncoder(params.width, params.height, params.bitrate);
+			}, { width, height, bitrate });
 
 			if (!reconfigured) {
 				debug.error('webcodecs', `Failed to reconfigure encoder`);
@@ -529,12 +643,12 @@ export class BrowserVideoCapture extends EventEmitter {
 				await cdp.send('Page.startScreencast', {
 					format: 'jpeg',
 					quality: config.video.screenshotQuality,
-					maxWidth: scaledWidth,
-					maxHeight: scaledHeight,
+					maxWidth: width,
+					maxHeight: height,
 					everyNthFrame: 1
 				});
 
-				debug.log('webcodecs', `✅ Viewport hot-swapped successfully to ${width}x${height} (scale: ${newScale})`);
+				debug.log('webcodecs', `✅ Viewport hot-swapped successfully to ${width}x${height}`);
 			}
 
 			return true;
@@ -545,12 +659,15 @@ export class BrowserVideoCapture extends EventEmitter {
 	}
 
 	/**
-	 * Update scale without reconnection (hot-swap)
+	 * Restart the CDP screencast at native viewport resolution.
+	 * Used as a refresh/recovery path when the frontend detects a stuck stream
+	 * (sent as a scale-update action). Display fit-scale no longer affects
+	 * capture resolution, so no encoder reconfiguration is needed.
 	 */
-	async updateScale(sessionId: string, session: BrowserTab, newScale: number): Promise<boolean> {
+	async refreshScreencast(sessionId: string, session: BrowserTab): Promise<boolean> {
 		const videoSession = this.sessions.get(sessionId);
 		if (!videoSession?.isActive || !session.page || session.page.isClosed()) {
-			debug.warn('webcodecs', `Cannot update scale: session not active`);
+			debug.warn('webcodecs', `Cannot refresh screencast: session not active`);
 			return false;
 		}
 
@@ -559,45 +676,59 @@ export class BrowserVideoCapture extends EventEmitter {
 			const viewport = page.viewport()!;
 			const config = DEFAULT_STREAMING_CONFIG;
 
-			// Calculate new scaled dimensions
-			const scaledWidth = Math.round(viewport.width * newScale);
-			const scaledHeight = Math.round(viewport.height * newScale);
-
-			debug.log('webcodecs', `🔄 Hot-swapping resolution to ${scaledWidth}x${scaledHeight} (scale: ${newScale})`);
-
-			// Step 1: Reconfigure VideoEncoder in headless browser
-			const reconfigured = await page.evaluate((dimensions) => {
-				const peer = (window as any).__webCodecsPeer;
-				if (!peer || !peer.reconfigureEncoder) return false;
-				return peer.reconfigureEncoder(dimensions.width, dimensions.height);
-			}, { width: scaledWidth, height: scaledHeight });
-
-			if (!reconfigured) {
-				debug.error('webcodecs', `Failed to reconfigure encoder`);
-				return false;
-			}
-
-			// Step 2: Restart CDP screencast with new dimensions
 			const cdp = (session as any).__webCodecsCdp;
 			if (cdp) {
-				// Stop current screencast
 				await cdp.send('Page.stopScreencast').catch(() => {});
-
-				// Start with new dimensions
 				await cdp.send('Page.startScreencast', {
 					format: 'jpeg',
 					quality: config.video.screenshotQuality,
-					maxWidth: scaledWidth,
-					maxHeight: scaledHeight,
+					maxWidth: viewport.width,
+					maxHeight: viewport.height,
 					everyNthFrame: 1
 				});
 
-				debug.log('webcodecs', `✅ Scale hot-swapped successfully to ${scaledWidth}x${scaledHeight}`);
+				debug.log('webcodecs', `✅ Screencast refreshed at ${viewport.width}x${viewport.height}`);
 			}
 
 			return true;
 		} catch (error) {
-			debug.error('webcodecs', `Failed to update scale:`, error);
+			debug.error('webcodecs', `Failed to refresh screencast:`, error);
+			return false;
+		}
+	}
+
+	/**
+	 * Client-driven keyframe request (PLI equivalent).
+	 * Forces the next encoded frame to be a keyframe AND immediately pushes a
+	 * high-quality screenshot through the encoder — so it works even on still
+	 * pages where no screencast frames are flowing. Called when the frontend
+	 * decoder errors or joins mid-stream and needs a sync point.
+	 */
+	async requestKeyframe(sessionId: string, session: BrowserTab): Promise<boolean> {
+		const videoSession = this.sessions.get(sessionId);
+		if (!videoSession?.isActive || !session.page || session.page.isClosed()) {
+			return false;
+		}
+
+		try {
+			await session.page.evaluate(() => {
+				(window as any).__webCodecsPeer?.forceKeyframe();
+			});
+
+			const cdp = (session as any).__webCodecsCdp;
+			if (cdp) {
+				const screenshot = await cdp.send('Page.captureScreenshot', { format: 'png' });
+				cdp.send('Runtime.evaluate', {
+					expression: `window.__webCodecsPeer?.encodeFrame("${screenshot.data}", true)`,
+					awaitPromise: false,
+					returnByValue: false
+				}).catch(() => {});
+			}
+
+			debug.log('webcodecs', `Keyframe requested for ${sessionId}`);
+			return true;
+		} catch (error) {
+			debug.warn('webcodecs', `Failed to request keyframe:`, error);
 			return false;
 		}
 	}
@@ -617,18 +748,15 @@ export class BrowserVideoCapture extends EventEmitter {
 			const page = session.page;
 			const viewport = page.viewport()!;
 			const config = DEFAULT_STREAMING_CONFIG;
-			const scale = session.scale || 1;
 
 			debug.log('webcodecs', `🔄 Handling navigation for ${sessionId} - re-injecting peer script and restarting screencast`);
 
-			// Calculate scaled dimensions
-			const scaledWidth = Math.round(viewport.width * scale);
-			const scaledHeight = Math.round(viewport.height * scale);
-
+			// Capture at native viewport resolution (see doPreInject)
 			const videoConfig: StreamingConfig['video'] = {
 				...config.video,
-				width: scaledWidth,
-				height: scaledHeight
+				width: viewport.width,
+				height: viewport.height,
+				bitrate: computeBitrate(viewport.width, viewport.height, config.video.framerate)
 			};
 
 			// Re-inject video encoder and audio capture scripts to new page context
@@ -636,13 +764,13 @@ export class BrowserVideoCapture extends EventEmitter {
 			await page.evaluate(audioCaptureScript, config.audio);
 
 			// Single batched call: verify peer + start streaming + init audio
-			const initResult = await page.evaluate(async () => {
+			const initResult = await page.evaluate(async (clientAllowsVp9) => {
 				const peer = (window as any).__webCodecsPeer;
 				if (typeof peer?.startStreaming !== 'function') {
 					return { peerExists: false, started: false, audioInitialized: false };
 				}
 
-				const started = await peer.startStreaming();
+				const started = await peer.startStreaming(clientAllowsVp9);
 				if (!started) {
 					return { peerExists: true, started: false, audioInitialized: false };
 				}
@@ -659,7 +787,7 @@ export class BrowserVideoCapture extends EventEmitter {
 				}
 
 				return { peerExists: true, started: true, audioInitialized };
-			});
+			}, videoSession.allowVp9);
 
 			if (!initResult.peerExists) {
 				debug.error('webcodecs', `Peer script re-injection failed - peer not available`);
@@ -687,12 +815,12 @@ export class BrowserVideoCapture extends EventEmitter {
 				await cdp.send('Page.startScreencast', {
 					format: 'jpeg',
 					quality: config.video.screenshotQuality,
-					maxWidth: scaledWidth,
-					maxHeight: scaledHeight,
+					maxWidth: viewport.width,
+					maxHeight: viewport.height,
 					everyNthFrame: 1
 				});
 
-				debug.log('webcodecs', `✅ Navigation handled - screencast restarted at ${scaledWidth}x${scaledHeight}`);
+				debug.log('webcodecs', `✅ Navigation handled - screencast restarted at ${viewport.width}x${viewport.height}`);
 			}
 
 			// Emit event to notify frontend that streaming is ready
@@ -718,6 +846,10 @@ export class BrowserVideoCapture extends EventEmitter {
 
 		if (session?.page && !session.page.isClosed()) {
 			try {
+				// Cancel any pending top-off capture
+				(session as any).__webCodecsTopOffCancel?.();
+				(session as any).__webCodecsTopOffCancel = null;
+
 				// Stop audio + peer in one IPC round-trip
 				await session.page.evaluate(() => {
 					(window as any).__audioEncoder?.stop();

--- a/backend/preview/browser/scripts/video-stream.ts
+++ b/backend/preview/browser/scripts/video-stream.ts
@@ -29,6 +29,31 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 	let videoFrameCount = 0;
 	let audioFrameCount = 0;
 	let lastKeyframeTime = 0;
+	let forceNextKeyframe = false;
+	let motionSeq = 0; // Increments per motion frame — used to detect staleness of deferred top-offs
+	let topOffRetryTimer: any = null;
+
+	// Codec selection: prefer VP9 in quantizer mode (per-frame quality control,
+	// Chrome-Remote-Desktop-style), fall back to VP8 with fixed bitrate.
+	// codecId is embedded in every video packet so the client picks the right decoder.
+	// vp9Allowed comes from the CLIENT (decode capability, negotiated at stream
+	// start) — the headless browser can encode VP9, but the viewer must decode it.
+	let codecId = 0; // 0 = vp8, 1 = vp9
+	let usingQuantizer = false;
+	let vp9Allowed = true;
+
+	// Source-side backpressure threshold: when the DataChannel can't drain
+	// (slow network), skip encoding motion frames instead of queueing them.
+	// Kept SMALL (≈ 2-3 motion frames) on purpose: anything queued here is
+	// display latency. Quality adapts to congestion via the quantizer ladder
+	// (see currentMotionQuantizer) long before frames get skipped, so the
+	// stream degrades to coarser-but-current rather than sharp-but-stale.
+	const MAX_BUFFERED_BYTES = 64 * 1024;
+
+	// Frames larger than this are split into fragments (packet type 2) to stay
+	// well under the SCTP max-message-size (~256KB on common WebRTC stacks).
+	// Mostly hit by near-lossless top-off keyframes of complex pages.
+	const FRAGMENT_SIZE = 64 * 1024;
 
 	// Cursor tracking
 	let lastCursor = 'default';
@@ -93,22 +118,53 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		lastCursor = 'default';
 	}
 
-	// Detect supported video codec
-	async function detectVideoCodec() {
-		const codecConfig: VideoEncoderConfig = {
+	// Build encoder config for the currently selected codec mode
+	function buildEncoderConfig(width: number, height: number, bitrate?: number): VideoEncoderConfig {
+		if (usingQuantizer) {
+			// Quantizer mode: no bitrate — quality is controlled per-frame in encode()
+			return {
+				codec: 'vp09.00.10.08',
+				width,
+				height,
+				framerate: config.framerate,
+				bitrateMode: 'quantizer',
+				hardwareAcceleration: config.hardwareAcceleration,
+				latencyMode: config.latencyMode
+			} as VideoEncoderConfig;
+		}
+
+		return {
 			codec: config.codec,
-			width: config.width,
-			height: config.height,
-			bitrate: config.bitrate,
+			width,
+			height,
+			bitrate: bitrate || config.bitrate,
 			framerate: config.framerate,
 			hardwareAcceleration: config.hardwareAcceleration,
 			latencyMode: config.latencyMode
 		};
+	}
 
+	// Detect supported video codec — prefer VP9 quantizer mode, fall back to VP8
+	async function detectVideoCodec() {
+		if (vp9Allowed) {
+			usingQuantizer = true;
+			codecId = 1;
+			const vp9Config = buildEncoderConfig(config.width, config.height);
+			try {
+				const support = await VideoEncoder.isConfigSupported(vp9Config);
+				if (support.supported) {
+					return vp9Config;
+				}
+			} catch (e) {}
+		}
+
+		usingQuantizer = false;
+		codecId = 0;
+		const vp8Config = buildEncoderConfig(config.width, config.height);
 		try {
-			const support = await VideoEncoder.isConfigSupported(codecConfig);
+			const support = await VideoEncoder.isConfigSupported(vp8Config);
 			if (support.supported) {
-				return codecConfig;
+				return vp8Config;
 			}
 		} catch (e) {}
 
@@ -150,17 +206,21 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 
 		peerConnection.oniceconnectionstatechange = () => {};
 
-		// Create DataChannel for encoded chunks
+		// Create DataChannel for encoded chunks.
+		// Reliable + ordered: VP8/VP9 delta chains require in-order, lossless
+		// delivery — a single lost/reordered chunk corrupts decoding until the
+		// next keyframe (smearing/ghosting). Latency is bounded by source-side
+		// frame dropping instead (see MAX_BUFFERED_BYTES backpressure).
 		dataChannel = peerConnection.createDataChannel('media', {
-			ordered: false, // Allow out-of-order delivery for lower latency
-			maxRetransmits: 0 // No retransmits = lower latency
+			ordered: true
 		});
 
 		dataChannel.binaryType = 'arraybuffer';
 
 		dataChannel.onopen = () => {
-			// Force keyframe when DataChannel opens (previous keyframes may have been lost)
-			lastKeyframeTime = 0;
+			// Force keyframe when DataChannel opens — the decoder on the other
+			// side needs a sync point (keyframes are on-demand only)
+			forceNextKeyframe = true;
 		};
 
 		dataChannel.onclose = () => {};
@@ -191,30 +251,62 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 	function handleEncodedVideoChunk(chunk: EncodedVideoChunk, metadata: any) {
 		if (!dataChannel || dataChannel.readyState !== 'open') return;
 
-		// Send chunk via DataChannel
-		// Format: [type(1)][timestamp(8)][keyframe(1)][size(4)][data]
 		const isKeyframe = chunk.type === 'key' ? 1 : 0;
 		const timestamp = chunk.timestamp;
 		const data = new Uint8Array(chunk.byteLength);
 		chunk.copyTo(data);
 
-		const packet = new ArrayBuffer(1 + 8 + 1 + 4 + data.byteLength);
-		const view = new DataView(packet);
-		const packetData = new Uint8Array(packet);
-
-		// Type: 0 = video
-		view.setUint8(0, 0);
-		// Timestamp (microseconds)
-		view.setBigUint64(1, BigInt(timestamp), true);
-		// Keyframe flag
-		view.setUint8(9, isKeyframe);
-		// Data size
-		view.setUint32(10, data.byteLength, true);
-		// Copy data
-		packetData.set(data, 14);
-
 		try {
-			dataChannel.send(packet);
+			if (data.byteLength <= FRAGMENT_SIZE) {
+				// Single packet
+				// Format: [type=0(1)][timestamp(8)][keyframe(1)][codec(1)][size(4)][data]
+				const packet = new ArrayBuffer(1 + 8 + 1 + 1 + 4 + data.byteLength);
+				const view = new DataView(packet);
+				const packetData = new Uint8Array(packet);
+
+				// Type: 0 = video
+				view.setUint8(0, 0);
+				// Timestamp (microseconds)
+				view.setBigUint64(1, BigInt(timestamp), true);
+				// Keyframe flag
+				view.setUint8(9, isKeyframe);
+				// Codec: 0 = vp8, 1 = vp9 (lets the client pick the right decoder)
+				view.setUint8(10, codecId);
+				// Data size
+				view.setUint32(11, data.byteLength, true);
+				// Copy data
+				packetData.set(data, 15);
+
+				dataChannel.send(packet);
+			} else {
+				// Large frame (e.g. near-lossless top-off keyframe) — fragment.
+				// The channel is reliable + ordered, so fragments arrive in order
+				// and the client simply reassembles by index.
+				// Format: [type=2(1)][timestamp(8)][keyframe(1)][codec(1)][fragIndex(2)][fragCount(2)][size(4)][data]
+				const fragCount = Math.ceil(data.byteLength / FRAGMENT_SIZE);
+
+				for (let i = 0; i < fragCount; i++) {
+					const start = i * FRAGMENT_SIZE;
+					const fragData = data.subarray(start, Math.min(start + FRAGMENT_SIZE, data.byteLength));
+
+					const packet = new ArrayBuffer(1 + 8 + 1 + 1 + 2 + 2 + 4 + fragData.byteLength);
+					const view = new DataView(packet);
+					const packetData = new Uint8Array(packet);
+
+					// Type: 2 = video fragment
+					view.setUint8(0, 2);
+					view.setBigUint64(1, BigInt(timestamp), true);
+					view.setUint8(9, isKeyframe);
+					view.setUint8(10, codecId);
+					view.setUint16(11, i, true);
+					view.setUint16(13, fragCount, true);
+					view.setUint32(15, fragData.byteLength, true);
+					packetData.set(fragData, 19);
+
+					dataChannel.send(packet);
+				}
+			}
+
 			videoFrameCount++;
 		} catch (e) {}
 	}
@@ -222,6 +314,10 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 	// Send audio chunk (called from AudioContext interception)
 	function sendAudioChunk(timestamp: number, data: Uint8Array) {
 		if (!dataChannel || dataChannel.readyState !== 'open') return;
+
+		// Backpressure: drop audio when the channel is congested — the client's
+		// playback scheduler handles gaps cleanly, and stale audio is worthless
+		if (dataChannel.bufferedAmount > MAX_BUFFERED_BYTES) return;
 
 		// Format: [type(1)][timestamp(8)][size(4)][data]
 		const packet = new ArrayBuffer(1 + 8 + 4 + data.byteLength);
@@ -243,11 +339,50 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		} catch (e) {}
 	}
 
-	// Encode video frame from JPEG data
-	async function encodeFrame(imageData: string) {
+	// Congestion-adaptive motion quantizer: when the DataChannel is backing up
+	// (slow network), spend fewer bits per frame instead of stalling. The
+	// still-page top-off restores full quality once motion stops, so temporary
+	// coarseness during congestion is invisible in the end result.
+	function currentMotionQuantizer(): number {
+		const buffered = dataChannel ? dataChannel.bufferedAmount : 0;
+		if (buffered > MAX_BUFFERED_BYTES / 2) return Math.min(60, config.motionQuantizer + 16);
+		if (buffered > MAX_BUFFERED_BYTES / 4) return Math.min(60, config.motionQuantizer + 8);
+		return config.motionQuantizer;
+	}
+
+	// Encode video frame from image data.
+	// Motion frames arrive as JPEG (CDP screencast); top-off frames arrive as
+	// lossless PNG (Page.captureScreenshot) when the page goes still, and are
+	// encoded near-losslessly so the last motion-degraded frame doesn't stick.
+	async function encodeFrame(imageData: string, isTopOff?: boolean) {
 		if (!videoEncoder || !isCapturing) return;
 
 		try {
+			// Source-side backpressure: if the network can't drain the channel,
+			// skip motion frames BEFORE decoding/encoding. Dropping input frames
+			// is safe (the encoder just references the last encoded frame);
+			// dropping encoded chunks would corrupt the delta chain.
+			if (!isTopOff) {
+				motionSeq++;
+				if (dataChannel && dataChannel.bufferedAmount > MAX_BUFFERED_BYTES) {
+					return;
+				}
+			} else if (dataChannel && dataChannel.bufferedAmount > MAX_BUFFERED_BYTES) {
+				// Channel congested — dumping a large near-lossless frame on it
+				// now would spike latency. Defer briefly; abandon if new motion
+				// arrives (the backend captures a fresh top-off after the next
+				// still period anyway).
+				const seqAtCapture = motionSeq;
+				if (topOffRetryTimer) clearTimeout(topOffRetryTimer);
+				topOffRetryTimer = setTimeout(() => {
+					topOffRetryTimer = null;
+					if (motionSeq === seqAtCapture && isCapturing) {
+						encodeFrame(imageData, true);
+					}
+				}, 250);
+				return;
+			}
+
 			// Direct base64 decode (avoids fetch() + data URL parsing overhead)
 			const binaryStr = atob(imageData);
 			const len = binaryStr.length;
@@ -256,9 +391,9 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 				bytes[i] = binaryStr.charCodeAt(i);
 			}
 
-			// Decode JPEG via createImageBitmap (avoids per-frame ImageDecoder
+			// Decode via createImageBitmap (avoids per-frame ImageDecoder
 			// constructor/destructor overhead)
-			const blob = new Blob([bytes], { type: 'image/jpeg' });
+			const blob = new Blob([bytes], { type: isTopOff ? 'image/png' : 'image/jpeg' });
 			const bitmap = await createImageBitmap(blob);
 
 			// Get aligned timestamp in microseconds
@@ -270,16 +405,30 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 				alpha: 'discard'
 			});
 
-			// Check if keyframe needed
+			// Keyframes are on-demand only (stream start, reconnect, reconfigure,
+			// client request) — the channel is reliable so no periodic keyframes
+			// are needed. keyframeInterval > 0 re-enables a periodic timer.
 			const now = Date.now();
-			const needsKeyframe = (now - lastKeyframeTime) > (config.keyframeInterval * 1000);
+			const needsKeyframe = forceNextKeyframe ||
+				(config.keyframeInterval > 0 && (now - lastKeyframeTime) > (config.keyframeInterval * 1000));
 
 			if (needsKeyframe) {
 				lastKeyframeTime = now;
+				forceNextKeyframe = false;
 			}
 
-			// Encode frame
-			videoEncoder.encode(frame, { keyFrame: needsKeyframe });
+			// Encode frame — in quantizer mode, quality is chosen per frame:
+			// cheap during motion (raised further under congestion),
+			// near-lossless for still-page top-off refreshes
+			if (usingQuantizer) {
+				const quantizer = isTopOff ? config.topOffQuantizer : currentMotionQuantizer();
+				videoEncoder.encode(frame, {
+					keyFrame: needsKeyframe,
+					vp9: { quantizer }
+				} as VideoEncoderEncodeOptions);
+			} else {
+				videoEncoder.encode(frame, { keyFrame: needsKeyframe });
+			}
 			videoFrameCount++;
 
 			// Close immediately to prevent memory leaks
@@ -288,17 +437,26 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		} catch (error) {}
 	}
 
+	// Force the next encoded frame to be a keyframe (client-driven sync point,
+	// PLI equivalent — used when the client decoder errors or joins mid-stream)
+	function forceKeyframe() {
+		forceNextKeyframe = true;
+	}
+
 	// Start streaming
-	async function startStreaming() {
+	// allowVp9: client decode capability negotiated at stream start
+	async function startStreaming(allowVp9?: boolean) {
 		if (isCapturing) return true;
+
+		vp9Allowed = allowVp9 !== false;
 
 		try {
 			await initPeerConnection();
 			await initVideoEncoder();
 
 			isCapturing = true;
-			// Set to 0 to force first frame as keyframe (required for decoder init)
-			lastKeyframeTime = 0;
+			// Force first frame as keyframe (required for decoder init)
+			forceNextKeyframe = true;
 
 			// Start tracking cursor changes
 			startCursorTracking();
@@ -313,6 +471,12 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 	// Stop streaming
 	function stopStreaming() {
 		isCapturing = false;
+
+		// Cancel any deferred top-off retry
+		if (topOffRetryTimer) {
+			clearTimeout(topOffRetryTimer);
+			topOffRetryTimer = null;
+		}
 
 		// Stop cursor tracking
 		stopCursorTracking();
@@ -391,7 +555,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 	}
 
 	// Reconfigure video encoder with new dimensions (hot-swap)
-	async function reconfigureEncoder(newWidth: number, newHeight: number) {
+	async function reconfigureEncoder(newWidth: number, newHeight: number, newBitrate?: number) {
 		if (!videoEncoder || !isCapturing) {
 			return false;
 		}
@@ -400,16 +564,8 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 			// Flush pending frames
 			await videoEncoder.flush();
 
-			// Create new codec config with updated dimensions
-			const newCodecConfig: VideoEncoderConfig = {
-				codec: config.codec,
-				width: newWidth,
-				height: newHeight,
-				bitrate: config.bitrate,
-				framerate: config.framerate,
-				hardwareAcceleration: config.hardwareAcceleration,
-				latencyMode: config.latencyMode
-			};
+			// Create new codec config with updated dimensions (keeps current codec mode)
+			const newCodecConfig = buildEncoderConfig(newWidth, newHeight, newBitrate);
 
 			// Check if new config is supported
 			const support = await VideoEncoder.isConfigSupported(newCodecConfig);
@@ -423,9 +579,12 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 			// Update config reference
 			config.width = newWidth;
 			config.height = newHeight;
+			if (newBitrate) {
+				config.bitrate = newBitrate;
+			}
 
-			// Reset keyframe timer to force keyframe after reconfigure
-			lastKeyframeTime = 0;
+			// Force keyframe after reconfigure (decoder needs a sync point at the new dimensions)
+			forceNextKeyframe = true;
 
 			return true;
 		} catch (error) {
@@ -445,7 +604,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 				videoFramesEncoded: videoFrameCount,
 				audioFramesEncoded: audioFrameCount,
 				connectionState: peerConnection.connectionState,
-				videoCodec: config.codec,
+				videoCodec: usingQuantizer ? 'vp9' : config.codec,
 				audioCodec: 'opus' as const
 			};
 
@@ -469,6 +628,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		handleAnswer,
 		addIceCandidate,
 		encodeFrame,
+		forceKeyframe,
 		sendAudioChunk,
 		getStats,
 		reconfigureEncoder,

--- a/backend/preview/browser/types.ts
+++ b/backend/preview/browser/types.ts
@@ -65,7 +65,7 @@ export interface BrowserTab {
 	lastUniqueFrameTime?: number;
 	stableFrameStartTime?: number;
 	lastCursorInfo?: { x: number; y: number; cursor: string };
-	scale?: number; // Frontend canvas scale factor (for bandwidth optimization)
+	scale?: number; // Frontend display fit-scale (CSS-only; does NOT affect capture resolution)
 
 	// Interaction tracking
 	lastInteractionTime?: number;
@@ -207,15 +207,17 @@ export interface BrowserScreenshotFrame {
  */
 export interface StreamingConfig {
 	video: {
-		codec: string;
+		codec: string; // Fallback codec (VP8, fixed-bitrate mode) when VP9 quantizer mode is unsupported
         width: number;
         height: number;
-        framerate: number;
+        framerate: number; // Max encode fps — screencast frames above this rate are dropped at the source
         bitrate: number;
-        keyframeInterval: number;
+        keyframeInterval: number; // Seconds between periodic keyframes; 0 = on-demand only (start/reconnect/client request)
         screenshotQuality: number;
         hardwareAcceleration: 'no-preference' | 'prefer-hardware' | 'prefer-software';
         latencyMode: 'quality' | 'realtime';
+        motionQuantizer: number; // VP9 per-frame quantizer (0-63) while the page is moving — cheap, allowed to be soft
+        topOffQuantizer: number; // VP9 quantizer for still-page refresh frames — near-lossless so text stays crisp
 	};
 	audio: {
 		codec: string
@@ -229,11 +231,19 @@ export interface StreamingConfig {
 /**
  * Default streaming configuration
  *
- * Optimized for visual quality with reduced resource usage:
- * - Software encoding (hardwareAcceleration: 'no-preference')
- * - JPEG quality 65: slightly lower than before but still preserves thin borders/text
- * - VP8 at 1.0Mbps: ~17% reduction from 1.2Mbps, sharp edges preserved by VP8 codec
- * - keyframeInterval 5s: less frequent large keyframes, saves bandwidth on static pages
+ * Chrome-Remote-Desktop-style adaptive quality:
+ * - Preferred: VP9 in quantizer mode — motion frames encoded cheaply
+ *   (motionQuantizer, raised further under congestion), and when the page
+ *   goes still a near-lossless refresh frame is sent (topOffQuantizer) so
+ *   text stays crisp. Idle pages cost ~0 bandwidth (CDP screencast only
+ *   fires on damage).
+ * - Fallback: VP8 at a resolution-scaled bitrate (see computeBitrate).
+ * - Keyframes on demand only (keyframeInterval 0) — the DataChannel is
+ *   reliable, and the client requests a keyframe on decoder errors.
+ * - Encode rate capped at `framerate` — screencast can fire at compositor
+ *   rate (up to 60fps); excess frames are dropped at the source.
+ * - JPEG quality 75 for motion source frames (encoder quantizer controls
+ *   output size, so higher source quality no longer inflates bandwidth)
  * - Opus for audio (efficient and widely supported)
  */
 export const DEFAULT_STREAMING_CONFIG: StreamingConfig = {
@@ -243,10 +253,12 @@ export const DEFAULT_STREAMING_CONFIG: StreamingConfig = {
 		height: 0,
 		framerate: 24,
 		bitrate: 1_000_000,
-		keyframeInterval: 5,
-		screenshotQuality: 65,
+		keyframeInterval: 0,
+		screenshotQuality: 75,
 		hardwareAcceleration: 'no-preference',
-		latencyMode: 'realtime'
+		latencyMode: 'realtime',
+		motionQuantizer: 40,
+		topOffQuantizer: 10
 	},
 	audio: {
 		codec: 'opus',

--- a/backend/ws/preview/browser/interact.ts
+++ b/backend/ws/preview/browser/interact.ts
@@ -445,16 +445,18 @@ export const interactPreviewHandler = createRouter()
 						break;
 
 					case 'scale-update':
-						// Handle scale update from frontend (hot-swap, no reconnection)
+						// Display fit-scale changed on the frontend (CSS-only concern).
+						// Capture stays at native viewport resolution — restart the
+						// screencast as a refresh so a stuck stream recovers (the
+						// frontend also uses this action as its refresh path).
 						if (action.scale && action.scale > 0 && action.scale <= 1) {
 							session.scale = action.scale;
-							debug.log('preview', `📐 Scale updated for tab ${tabId}: ${action.scale}`);
+							debug.log('preview', `📐 Scale updated for tab ${tabId}: ${action.scale} (display-only), refreshing screencast`);
 
-							// Hot-swap resolution without reconnection
-							const updated = await previewService.updateWebCodecsScale(session.id, action.scale);
+							const updated = await previewService.refreshWebCodecsScreencast(session.id);
 							if (!updated) {
-								debug.warn('preview', `⚠️ Hot-swap failed, falling back to restart`);
-								// Fallback: restart if hot-swap fails
+								debug.warn('preview', `⚠️ Screencast refresh failed, falling back to restart`);
+								// Fallback: restart if refresh fails
 								await previewService.stopWebCodecsStreaming(session.id);
 								await previewService.startWebCodecsStreaming(session.id);
 							}
@@ -468,10 +470,10 @@ export const interactPreviewHandler = createRouter()
 							if (action.deviceSize) session.deviceSize = action.deviceSize as any;
 							if (action.rotation) session.rotation = action.rotation as any;
 
-							debug.log('preview', `📱 Viewport updated for tab ${tabId}: ${action.width}x${action.height} (scale: ${action.scale})`);
+							debug.log('preview', `📱 Viewport updated for tab ${tabId}: ${action.width}x${action.height}`);
 
 							// Hot-swap viewport without reconnection
-							const updated = await previewService.updateWebCodecsViewport(session.id, action.width, action.height, action.scale);
+							const updated = await previewService.updateWebCodecsViewport(session.id, action.width, action.height);
 							if (!updated) {
 								debug.warn('preview', `⚠️ Viewport hot-swap failed`);
 							}

--- a/backend/ws/preview/browser/webcodecs.ts
+++ b/backend/ws/preview/browser/webcodecs.ts
@@ -17,7 +17,10 @@ export const streamPreviewHandler = createRouter()
 		'preview:browser-stream-start',
 		{
 			data: t.Object({
-				tabId: t.Optional(t.String())
+				tabId: t.Optional(t.String()),
+				// Client VP9 decode capability — encoder prefers VP9 quantizer
+				// mode but must fall back to VP8 if the viewer can't decode it
+				vp9: t.Optional(t.Boolean())
 			}),
 			response: t.Object({
 				success: t.Boolean(),
@@ -41,7 +44,7 @@ export const streamPreviewHandler = createRouter()
 			}
 
 			// Start WebCodecs streaming
-			const started = await previewService.startWebCodecsStreaming(sessionId);
+			const started = await previewService.startWebCodecsStreaming(sessionId, data.vp9 !== false);
 
 			if (!started) {
 				throw new Error('Failed to start WebCodecs streaming');
@@ -143,6 +146,27 @@ export const streamPreviewHandler = createRouter()
 
 			const { candidate } = data;
 			const success = await previewService.addWebCodecsIceCandidate(tab.id, candidate as RTCIceCandidateInit);
+
+			return { success };
+		}
+	)
+
+	// Client-driven keyframe request (PLI equivalent) — sent when the client
+	// decoder errors or joins mid-stream and needs a sync point
+	.http(
+		'preview:browser-stream-keyframe',
+		{
+			data: t.Object({
+				tabId: t.Optional(t.String())
+			}),
+			response: t.Object({
+				success: t.Boolean()
+			})
+		},
+		async ({ data, conn }) => {
+			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
+
+			const success = await previewService.requestWebCodecsKeyframe(tab.id);
 
 			return { success };
 		}

--- a/frontend/services/preview/browser/browser-webcodecs.service.ts
+++ b/frontend/services/preview/browser/browser-webcodecs.service.ts
@@ -85,6 +85,13 @@ export class BrowserWebCodecsService {
 	// Codec configuration
 	private videoCodecConfig: VideoDecoderConfig | null = null;
 	private audioCodecConfig: AudioDecoderConfig | null = null;
+	private activeCodecId = -1; // Codec of the current decoder (0 = vp8, 1 = vp9)
+	private lastKeyframeRequestTime = 0; // Throttle for requestKeyframe (PLI equivalent)
+
+	// Reassembly of fragmented video frames (packet type 2 — large frames,
+	// e.g. near-lossless top-off keyframes, split to fit SCTP message limits)
+	private fragmentBuffer: Uint8Array[] | null = null;
+	private fragmentTimestamp = 0;
 
 	// Stats tracking
 	private stats: BrowserWebCodecsStreamStats = {
@@ -133,6 +140,12 @@ export class BrowserWebCodecsService {
 	private onError: ((error: Error) => void) | null = null;
 	private onStats: ((stats: BrowserWebCodecsStreamStats) => void) | null = null;
 	private onCursorChange: ((cursor: string) => void) | null = null;
+
+	// Grace period for transient ICE 'disconnected' states. On flaky networks
+	// (mobile, tunnels) ICE regularly drops and recovers by itself within a few
+	// seconds — tearing down immediately caused an endless loading/reconnect loop.
+	private disconnectGraceTimer: ReturnType<typeof setTimeout> | null = null;
+	private static readonly DISCONNECT_GRACE_MS = 5000;
 
 	// Navigation state - when true, DataChannel close is expected and recovery is suppressed
 	private isNavigating = false;
@@ -247,11 +260,21 @@ export class BrowserWebCodecsService {
 			// Setup WebSocket listeners
 			this.setupEventListeners();
 
+			// Detect VP9 decode capability — the encoder prefers VP9 quantizer
+			// mode (adaptive quality) but must fall back to VP8 if we can't decode it
+			let vp9Supported = false;
+			try {
+				const support = await VideoDecoder.isConfigSupported({ codec: 'vp09.00.10.08' });
+				vp9Supported = support.supported === true;
+			} catch {
+				vp9Supported = false;
+			}
+
 			// Request server to start streaming and get offer
 			// Send explicit tabId to ensure backend targets the correct tab
 			// even if user switches tabs during the async negotiation
-			debug.log('webcodecs', `[DIAG] Sending preview:browser-stream-start for session: ${sessionId}`);
-			const response = await ws.http('preview:browser-stream-start', { tabId: sessionId }, 30000);
+			debug.log('webcodecs', `[DIAG] Sending preview:browser-stream-start for session: ${sessionId} (vp9: ${vp9Supported})`);
+			const response = await ws.http('preview:browser-stream-start', { tabId: sessionId, vp9: vp9Supported }, 30000);
 			debug.log('webcodecs', `[DIAG] preview:browser-stream-start response: success=${response.success}, hasOffer=${!!response.offer}, message=${response.message}`);
 
 			if (!response.success) {
@@ -423,6 +446,7 @@ export class BrowserWebCodecsService {
 			this.stats.connectionState = state as RTCPeerConnectionState;
 
 			if (state === 'connected') {
+				this.clearDisconnectGrace();
 				this.isConnected = true;
 				this.stats.isConnected = true;
 				this.startStatsCollection();
@@ -432,6 +456,7 @@ export class BrowserWebCodecsService {
 				}
 			} else if (state === 'failed') {
 				debug.error('webcodecs', 'Connection FAILED');
+				this.clearDisconnectGrace();
 				this.isConnected = false;
 				this.stats.isConnected = false;
 				this.stopStatsCollection();
@@ -442,7 +467,14 @@ export class BrowserWebCodecsService {
 				if (this.onConnectionFailed) {
 					this.onConnectionFailed();
 				}
-			} else if (state === 'disconnected' || state === 'closed') {
+			} else if (state === 'disconnected') {
+				// Transient on flaky networks (mobile/tunnel) — ICE usually
+				// recovers on its own within seconds. Don't tear down yet;
+				// only treat as failure if the grace period expires without
+				// returning to 'connected' (prevents the loading/reconnect loop).
+				this.scheduleDisconnectGrace();
+			} else if (state === 'closed') {
+				this.clearDisconnectGrace();
 				this.isConnected = false;
 				this.stats.isConnected = false;
 				this.stopStatsCollection();
@@ -506,16 +538,17 @@ export class BrowserWebCodecsService {
 
 			if (type === 0) {
 				// Video packet
-				// Format: [type(1)][timestamp(8)][keyframe(1)][size(4)][data]
+				// Format: [type(1)][timestamp(8)][keyframe(1)][codec(1)][size(4)][data]
 				const timestamp = Number(view.getBigUint64(1, true));
 				const isKeyframe = view.getUint8(9) === 1;
-				const size = view.getUint32(10, true);
-				const chunkData = new Uint8Array(data, 14, size);
+				const codecId = view.getUint8(10); // 0 = vp8, 1 = vp9
+				const size = view.getUint32(11, true);
+				const chunkData = new Uint8Array(data, 15, size);
 
 				this.stats.videoBytesReceived += size;
 				this.stats.videoFramesReceived++;
 
-				this.handleVideoChunk(chunkData, timestamp, isKeyframe);
+				this.handleVideoChunk(chunkData, timestamp, isKeyframe, codecId);
 			} else if (type === 1) {
 				// Audio packet
 				// Format: [type(1)][timestamp(8)][size(4)][data]
@@ -527,6 +560,42 @@ export class BrowserWebCodecsService {
 				this.stats.audioFramesReceived++;
 
 				this.handleAudioChunk(chunkData, timestamp);
+			} else if (type === 2) {
+				// Fragmented video packet (large frames, e.g. top-off keyframes)
+				// Format: [type(1)][timestamp(8)][keyframe(1)][codec(1)][fragIndex(2)][fragCount(2)][size(4)][data]
+				const timestamp = Number(view.getBigUint64(1, true));
+				const isKeyframe = view.getUint8(9) === 1;
+				const codecId = view.getUint8(10);
+				const fragIndex = view.getUint16(11, true);
+				const fragCount = view.getUint16(13, true);
+				const size = view.getUint32(15, true);
+				const fragData = new Uint8Array(data, 19, size);
+
+				this.stats.videoBytesReceived += size;
+
+				// New timestamp invalidates any incomplete fragment set.
+				// The channel is reliable + ordered, so this shouldn't happen —
+				// it's a safety net against desync after reconnects.
+				if (!this.fragmentBuffer || this.fragmentTimestamp !== timestamp) {
+					this.fragmentBuffer = [];
+					this.fragmentTimestamp = timestamp;
+				}
+				this.fragmentBuffer[fragIndex] = fragData;
+
+				const received = this.fragmentBuffer.filter(Boolean).length;
+				if (received === fragCount) {
+					const totalSize = this.fragmentBuffer.reduce((sum, f) => sum + f.byteLength, 0);
+					const fullData = new Uint8Array(totalSize);
+					let offset = 0;
+					for (const frag of this.fragmentBuffer) {
+						fullData.set(frag, offset);
+						offset += frag.byteLength;
+					}
+					this.fragmentBuffer = null;
+
+					this.stats.videoFramesReceived++;
+					this.handleVideoChunk(fullData, timestamp, isKeyframe, codecId);
+				}
 			}
 		} catch (error) {
 			debug.error('webcodecs', 'DataChannel message parse error:', error);
@@ -536,14 +605,32 @@ export class BrowserWebCodecsService {
 	/**
 	 * Handle video chunk - decode and render
 	 */
-	private async handleVideoChunk(data: Uint8Array, timestamp: number, isKeyframe: boolean): Promise<void> {
+	private async handleVideoChunk(data: Uint8Array, timestamp: number, isKeyframe: boolean, codecId: number): Promise<void> {
+		// Codec changed mid-stream (e.g. navigation re-injected the encoder
+		// with different codec support) — reinit decoder on the keyframe
+		if (this.videoDecoder && isKeyframe && codecId !== this.activeCodecId) {
+			try {
+				this.videoDecoder.close();
+			} catch {}
+			this.videoDecoder = null;
+		}
+
 		// Initialize decoder on first keyframe
 		if (!this.videoDecoder && isKeyframe) {
-			await this.initVideoDecoder(data);
+			try {
+				await this.initVideoDecoder(codecId);
+			} catch {
+				// Codec unsupported or init failed — chunk is dropped below;
+				// keyframe request throttle prevents a request storm
+			}
 		}
 
 		if (!this.videoDecoder) {
+			// Delta frame without a decoder (joined mid-stream or decoder just
+			// errored) — ask the server for a sync point instead of waiting
+			// for the periodic keyframe interval
 			this.stats.videoFramesDropped++;
+			this.requestKeyframe();
 			return;
 		}
 
@@ -558,6 +645,7 @@ export class BrowserWebCodecsService {
 		} catch (error) {
 			debug.error('webcodecs', 'Video decode error:', error);
 			this.stats.videoFramesDropped++;
+			this.requestKeyframe();
 		}
 	}
 
@@ -590,12 +678,13 @@ export class BrowserWebCodecsService {
 	}
 
 	/**
-	 * Initialize VideoDecoder
+	 * Initialize VideoDecoder for the codec announced in the packet header
 	 */
-	private async initVideoDecoder(firstChunkData: Uint8Array): Promise<void> {
-		// Use VP8 codec
-		const codec = 'vp8';
-		this.stats.videoCodec = 'vp8';
+	private async initVideoDecoder(codecId: number): Promise<void> {
+		// Codec string must match the encoder in the headless browser:
+		// 0 = VP8 (fallback), 1 = VP9 profile 0 (quantizer mode)
+		const codec = codecId === 1 ? 'vp09.00.10.08' : 'vp8';
+		this.stats.videoCodec = codecId === 1 ? 'vp9' : 'vp8';
 
 		this.videoCodecConfig = {
 			codec,
@@ -617,14 +706,69 @@ export class BrowserWebCodecsService {
 					// causing handleVideoChunk's `!this.videoDecoder` check to never fire
 					// → all subsequent frames permanently dropped (stuck frames bug).
 					this.videoDecoder = null;
+					// Ask the server for a fresh sync point right away
+					this.requestKeyframe();
 				}
 			});
 
 			this.videoDecoder.configure(this.videoCodecConfig);
+			this.activeCodecId = codecId;
 			debug.log('webcodecs', 'VideoDecoder initialized:', codec);
 		} catch (error) {
 			debug.error('webcodecs', 'VideoDecoder init error:', error);
 			throw error;
+		}
+	}
+
+	/**
+	 * Start the grace timer for a transient 'disconnected' state.
+	 * If the connection doesn't return to 'connected' before the timer fires,
+	 * treat it as a real failure and trigger recovery.
+	 */
+	private scheduleDisconnectGrace(): void {
+		if (this.disconnectGraceTimer) return;
+
+		debug.warn('webcodecs', `Connection disconnected — ${BrowserWebCodecsService.DISCONNECT_GRACE_MS}ms grace period before recovery`);
+		this.disconnectGraceTimer = setTimeout(() => {
+			this.disconnectGraceTimer = null;
+
+			if (this.isCleaningUp) return;
+			if (this.peerConnection?.connectionState === 'connected') return;
+
+			debug.warn('webcodecs', 'Disconnect grace period expired — treating as connection failure');
+			this.isConnected = false;
+			this.stats.isConnected = false;
+			this.stopStatsCollection();
+			this.stopBandwidthLogging();
+			if (this.onConnectionChange) {
+				this.onConnectionChange(false);
+			}
+			if (this.onConnectionFailed) {
+				this.onConnectionFailed();
+			}
+		}, BrowserWebCodecsService.DISCONNECT_GRACE_MS);
+	}
+
+	private clearDisconnectGrace(): void {
+		if (this.disconnectGraceTimer) {
+			clearTimeout(this.disconnectGraceTimer);
+			this.disconnectGraceTimer = null;
+		}
+	}
+
+	/**
+	 * Request a keyframe from the server (PLI equivalent), throttled to 1/s.
+	 * Used when the decoder errors or delta frames arrive without a decoder —
+	 * much faster recovery than waiting for the periodic keyframe interval.
+	 */
+	private requestKeyframe(): void {
+		const now = Date.now();
+		if (now - this.lastKeyframeRequestTime < 1000) return;
+		this.lastKeyframeRequestTime = now;
+
+		if (this.sessionId) {
+			debug.log('webcodecs', 'Requesting keyframe from server');
+			ws.http('preview:browser-stream-keyframe', { tabId: this.sessionId }).catch(() => {});
 		}
 	}
 
@@ -811,8 +955,16 @@ export class BrowserWebCodecsService {
 				this.firstFrameTimestamp = this.pendingFrame.timestamp;
 			}
 
-			// Render to canvas with optimal settings
-			this.ctx.drawImage(this.pendingFrame, 0, 0, this.canvas.width, this.canvas.height);
+			// Match canvas backing store to the frame's native size and draw 1:1.
+			// Stretching frames to a differently-sized canvas caused blurry output;
+			// display fit-scaling is handled by CSS transform in the container.
+			const frameWidth = this.pendingFrame.displayWidth;
+			const frameHeight = this.pendingFrame.displayHeight;
+			if (this.canvas.width !== frameWidth || this.canvas.height !== frameHeight) {
+				this.canvas.width = frameWidth;
+				this.canvas.height = frameHeight;
+			}
+			this.ctx.drawImage(this.pendingFrame, 0, 0);
 
 			this.lastFrameTime = timestamp;
 		} catch (error) {
@@ -1196,6 +1348,7 @@ export class BrowserWebCodecsService {
 	private async cleanupLocalConnection(): Promise<void> {
 		this.isCleaningUp = true;
 
+		this.clearDisconnectGrace();
 		this.stopStatsCollection();
 		this.stopBandwidthLogging();
 
@@ -1269,6 +1422,8 @@ export class BrowserWebCodecsService {
 		this.lastFrameTime = 0;
 		this.startTime = 0;
 		this.firstFrameTimestamp = 0;
+		this.fragmentBuffer = null;
+		this.fragmentTimestamp = 0;
 
 		this.syncEstablished = false;
 		this.syncRealTimeOrigin = 0;
@@ -1289,6 +1444,7 @@ export class BrowserWebCodecsService {
 	private async cleanup(): Promise<void> {
 		this.isCleaningUp = true;
 
+		this.clearDisconnectGrace();
 		this.stopStatsCollection();
 		this.stopBandwidthLogging();
 
@@ -1397,6 +1553,8 @@ export class BrowserWebCodecsService {
 		this.lastFrameTime = 0;
 		this.startTime = 0;
 		this.firstFrameTimestamp = 0;
+		this.fragmentBuffer = null;
+		this.fragmentTimestamp = 0;
 
 		// Reset AV sync state
 		this.syncEstablished = false;
@@ -1425,6 +1583,7 @@ export class BrowserWebCodecsService {
 	private async cleanupConnection(): Promise<void> {
 		this.isCleaningUp = true;
 
+		this.clearDisconnectGrace();
 		this.stopStatsCollection();
 		this.stopBandwidthLogging();
 
@@ -1495,6 +1654,8 @@ export class BrowserWebCodecsService {
 		this.lastFrameTime = 0;
 		this.startTime = 0;
 		this.firstFrameTimestamp = 0;
+		this.fragmentBuffer = null;
+		this.fragmentTimestamp = 0;
 
 		// Reset AV sync state
 		this.syncEstablished = false;


### PR DESCRIPTION
Rework the browser preview pipeline into a Chrome-Remote-Desktop-style adaptive stream:

- Capture at native viewport resolution; display fit-scale is CSS-only. Client renders frames 1:1 (canvas backing store follows frame size), removing the upscaling that made the preview permanently blurry.
- Prefer VP9 in quantizer mode, negotiated with the client's decode support at stream start (VP8 bitrate-mode fallback): cheap per-frame quality during motion, raised further under congestion.
- Static top-off: when the screencast goes quiet for 300ms, push one lossless PNG screenshot through the encoder near-losslessly so text sharpens right after motion stops; idle pages cost ~0 bandwidth. Deferred while the channel is congested and abandoned if motion resumes, so large refreshes never add latency.
- Reliable ordered DataChannel (VP8/VP9 delta chains cannot tolerate loss/reorder); latency is bounded by source-side frame dropping with a small 64KB backpressure window instead — queued bytes are display lag, so the stream degrades to coarser-but-current, never stale.
- Fragment frames over 64KB (packet type 2) to stay under SCTP message-size limits; packet header now carries a codec byte.
- Keyframes on demand only: channel open, encoder reconfigure, or the new preview:browser-stream-keyframe request (PLI equivalent) that also works on still pages; no periodic keyframe bursts.
- Rate-limit encoding to the configured framerate at the CDP feeder with a trailing edge — the last frame of a damage burst is always encoded, keeping input feedback immediate while capping CPU and bandwidth (screencast fires at compositor rate, up to 60fps).
- Add a 5s grace period for transient ICE 'disconnected' states on flaky networks (mobile/tunnel) — fixes the endless loading/reconnect loop when the preview is accessed remotely.
- Drop audio chunks during congestion; the client's playback scheduler handles gaps cleanly.