### PR TITLE
feat(chat): add enter key support to submit custom answers in ask tool

### DIFF
--- a/frontend/components/chat/tools/variants/classic/AskUserQuestionTool.svelte
+++ b/frontend/components/chat/tools/variants/classic/AskUserQuestionTool.svelte
@@ -316,6 +316,12 @@
 									}
 									otherActive[idx] = true;
 								}}
+								onkeydown={(e) => {
+									if (e.key === 'Enter') {
+										e.preventDefault();
+										submitAnswers();
+									}
+								}}
 							/>
 						</div>
 					</div>

--- a/frontend/components/chat/tools/variants/compact/AskUserQuestionTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/AskUserQuestionTool.svelte
@@ -216,6 +216,12 @@
 							bind:value={customInputs[idx]}
 							onclick={(e) => e.stopPropagation()}
 							onfocus={() => { if (!question.multiSelect) selections[idx] = new Set(); otherActive[idx] = true; }}
+							onkeydown={(e) => {
+								if (e.key === 'Enter') {
+									e.preventDefault();
+									submitAnswers();
+								}
+							}}
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
Users can now press Enter in the custom answer input field to submit their response instead of requiring a mouse click. This improves keyboard accessibility and provides a faster interaction flow for power users.