### PR TITLE
fix(engine): correct cursor streaming, tools, usage, and context

### DIFF
--- a/backend/chat/stream-manager.ts
+++ b/backend/chat/stream-manager.ts
@@ -811,11 +811,11 @@ class StreamManager extends EventEmitter {
 									});
 								}
 							}
-							// Codex emits usage only once per turn (after all items
-							// streamed live), so saved assistant rows have usage:null.
-							// Backfill the turn's aggregate to every saved assistant
-							// without usage so it survives a refresh.
-							if (successResult.usage && streamState.engine === 'codex') {
+							// Codex and Cursor emit usage only once per turn (after all
+							// items streamed live), so saved assistant rows have
+							// usage:null. Backfill the turn's aggregate to every saved
+							// assistant without usage so it survives a refresh.
+							if (successResult.usage && (streamState.engine === 'codex' || streamState.engine === 'cursor')) {
 								this.backfillUsageForStream(streamState, successResult.usage, requestSender);
 							}
 						} else {

--- a/backend/engine/README.md
+++ b/backend/engine/README.md
@@ -5,7 +5,8 @@ streaming chat. The adapters today: **`claude`**
 (`@anthropic-ai/claude-agent-sdk`), **`opencode`** (`@opencode-ai/sdk`),
 **`copilot`** (`@github/copilot-sdk`), **`codex`** (`@openai/codex-sdk`),
 **`qwen`** (`@qwen-code/qwen-code`), **`pi`**
-(`@earendil-works/pi-coding-agent`), and **`cline`** (`@cline/sdk`). Every
+(`@earendil-works/pi-coding-agent`), **`cline`** (`@cline/sdk`), and
+**`cursor`** (`@cursor/sdk`). Every
 adapter follows the same shape so that the rest of the system outside this
 folder — `stream-manager`, MCP, DB, WebSocket, frontend chat, settings UI —
 stays **agnostic** to the underlying SDK.
@@ -18,6 +19,16 @@ stays **agnostic** to the underlying SDK.
 > during bring-up — read **§10.10** (checkpoint forks) and **§10.15**
 > (sub-agents) in [lessons-learned](./docs/lessons-learned.md) before adding a
 > similar engine.
+
+> **Delta-stream SDKs are another category.** `cursor` (`@cursor/sdk`) is
+> in-process with an on-disk store like `pi`, but its `run.stream()` emits each
+> text/thinking CHUNK as its own message (deltas, not snapshots), routes MCP +
+> custom tools through a single wrapper tool, streams sub-agents only via
+> `onDelta`, and reports no context-window metadata. If a new SDK is delta-based,
+> tool-wrapping, or metadata-poor, read **§10.20** in
+> [lessons-learned](./docs/lessons-learned.md) before writing the converter — and
+> capture the SDK's real runtime shapes with a throwaway script rather than
+> trusting its `.d.ts`.
 
 This guide is split into focused documents — start here for the architecture
 map, then jump to the area you need.

--- a/backend/engine/adapters/cline/agent-tool.ts
+++ b/backend/engine/adapters/cline/agent-tool.ts
@@ -35,9 +35,9 @@ const AGENT_INPUT_SCHEMA = {
 	properties: {
 		subagentType: { type: 'string', description: 'The slug of the subagent to delegate to.' },
 		prompt: { type: 'string', description: 'The self-contained task for the subagent.' },
-		description: { type: 'string', description: 'A short description of the delegated task.' },
+		description: { type: 'string', description: 'A short (3-5 word) description of the delegated task.' },
 	},
-	required: ['subagentType', 'prompt'],
+	required: ['subagentType', 'prompt', 'description'],
 } as const;
 
 export function createAgentDispatchTool(bindings: AgentDispatchBindings): AgentTool {

--- a/backend/engine/adapters/cursor/ask-question-tool.ts
+++ b/backend/engine/adapters/cursor/ask-question-tool.ts
@@ -23,6 +23,13 @@ export interface PendingAsk {
 export interface AskToolBindings {
 	register: (toolCallId: string, entry: PendingAsk) => void;
 	unregister: (toolCallId: string) => void;
+	/**
+	 * Surface the AskUserQuestion tool_use into the stream with the COMPLETE
+	 * questions. Sourced from `execute`'s args (always fully populated) rather
+	 * than the stream's `tool_call` args, which can arrive empty/partial for large
+	 * question sets — the bug behind `questions: []` in the UI.
+	 */
+	emit: (toolCallId: string, questions: AskUserQuestion[]) => void;
 }
 
 /** Format the user's answers in the shared OpenCode/Qwen/Pi/Cline wording. */
@@ -82,6 +89,8 @@ export function createAskUserQuestionTool(bindings: AskToolBindings): SDKCustomT
 					resolve('User did not answer the question.');
 					return;
 				}
+				// Emit the tool_use with the complete questions from THIS call's args.
+				bindings.emit(toolCallId, questions);
 				bindings.register(toolCallId, { questions, resolve });
 			});
 		},

--- a/backend/engine/adapters/cursor/error-handler.ts
+++ b/backend/engine/adapters/cursor/error-handler.ts
@@ -23,6 +23,20 @@ export function handleStreamError(error: unknown): void {
 
 	const lower = error.message.toLowerCase();
 
+	// Free-tier / plan gating: the Cursor agent API is Pro-only. A free key is
+	// valid but its agent quota is limited — surface a clear, actionable message
+	// instead of the raw SDK error.
+	if (lower.includes('plan_required') || lower.includes('upgrade to pro') || lower.includes('not available for free users')) {
+		throw new Error('Cursor agent runs require a paid plan. This API key is valid but its account is on the free tier — upgrade to Cursor Pro to use this engine.');
+	}
+
+	// Transient connectivity to Cursor's backend (the SDK's connect-rpc key
+	// exchange). Seen most often with rate-limited / exhausted keys; surface a
+	// clear, retryable message rather than the raw NetworkError.
+	if (lower.includes('socket connection was closed') || lower.includes('api key exchange endpoint') || lower.includes('failed to connect')) {
+		throw new Error('Cursor could not reach its backend (connection closed). This is usually transient or a rate-limited key — retry, and verify your account has agent quota.');
+	}
+
 	if (
 		error.name === 'AuthenticationError'
 		|| lower.includes('unauthorized')

--- a/backend/engine/adapters/cursor/message-converter.ts
+++ b/backend/engine/adapters/cursor/message-converter.ts
@@ -32,9 +32,10 @@ import type {
 	SuccessResultEvent,
 	SystemInitEvent,
 	TokenUsage,
+	AskUserQuestion,
 } from '$shared/types/unified';
 import { toCanonicalToolName } from '$shared/types/unified';
-import type { SDKMessage, RunResult, TokenUsage as CursorTokenUsage, InteractionUpdate } from '@cursor/sdk';
+import type { SDKMessage, RunResult, TokenUsage as CursorTokenUsage } from '@cursor/sdk';
 import { resolveOpenCodeToolName } from '../../../mcp';
 
 // ============================================================
@@ -51,6 +52,11 @@ const CURSOR_TOOL_NAME_MAP: Record<string, string> = {
 	shell: 'Bash',
 	task: 'Agent',
 	update_todos: 'TodoWrite',
+	updatetodos: 'TodoWrite',
+	// Cursor's `create_plan` records a markdown plan; the ExitPlanMode tool
+	// component renders `input.plan`, so it's the right unified home.
+	create_plan: 'ExitPlanMode',
+	createplan: 'ExitPlanMode',
 	web_search: 'WebSearch',
 	fetch: 'WebFetch',
 };
@@ -63,26 +69,126 @@ function mapCursorToolName(rawName: string): string {
 	return toCanonicalToolName(mapped);
 }
 
+/**
+ * Cursor routes BOTH real MCP servers AND our in-process `customTools` through a
+ * single wrapper tool named `mcp`, with args `{ providerIdentifier, toolName, args }`:
+ *   - real MCP  → `{ providerIdentifier: 'clopen-mcp', toolName: 'open_new_tab', args: {…} }`
+ *   - customTool→ `{ providerIdentifier: 'custom-user-tools', toolName: 'AskUserQuestion', args: {…} }`
+ * Unwrap it so the UI renders the proper `mcp__<server>__<tool>` / `AskUserQuestion`
+ * component instead of an `Unknown:mcp` block.
+ */
+function isMcpWrapper(name: string, args: Record<string, unknown>): args is { toolName: string; args?: unknown } {
+	return name === 'mcp' && typeof args.toolName === 'string';
+}
+
+function canonicalCursorTool(name: string, args: Record<string, unknown>): string {
+	if (isMcpWrapper(name, args)) {
+		const bare = args.toolName;
+		return resolveOpenCodeToolName(bare) ?? toCanonicalToolName(bare);
+	}
+	return mapCursorToolName(name);
+}
+
+function cursorToolInput(name: string, args: Record<string, unknown>, result?: unknown): Record<string, unknown> {
+	if (isMcpWrapper(name, args)) {
+		const inner = (args.args && typeof args.args === 'object' ? args.args : {}) as Record<string, unknown>;
+		// Real MCP tools pass their args through unchanged; custom/unknown tools
+		// (e.g. AskUserQuestion) go through the per-tool normaliser.
+		return resolveOpenCodeToolName(args.toolName) ? inner : normaliseToolInput(toCanonicalToolName(args.toolName), inner, result);
+	}
+	return normaliseToolInput(mapCursorToolName(name), args, result);
+}
+
 function snakeToCamel(str: string): string {
 	return str.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
 }
 
-/** Light per-tool input normalisation into the shared canonical shape. */
-function normaliseToolInput(canonical: string, raw: Record<string, unknown>): Record<string, unknown> {
+/** Map a Cursor todo status (`inProgress`/`cancelled`/…) to the unified UI status. */
+function mapTodoStatus(status: unknown): 'pending' | 'in_progress' | 'completed' {
+	switch (status) {
+		case 'inProgress':
+		case 'in_progress':
+			return 'in_progress';
+		case 'completed':
+		case 'cancelled':
+			return 'completed';
+		default:
+			return 'pending';
+	}
+}
+
+/**
+ * Freeze a snapshot of tool args. Cursor mutates some arg objects in place across
+ * a tool's streaming lifecycle (notably the `update_todos` list, whose statuses
+ * flip to "completed" as work progresses) — persisting a live reference captures
+ * that later state, so a just-created todo renders as already done. A structural
+ * clone at emit time pins the args to the moment the tool_use is surfaced.
+ */
+function cloneArgs(raw: unknown): Record<string, unknown> {
+	if (!raw || typeof raw !== 'object') return {};
+	try {
+		return structuredClone(raw) as Record<string, unknown>;
+	} catch {
+		try {
+			return JSON.parse(JSON.stringify(raw)) as Record<string, unknown>;
+		} catch {
+			return raw as Record<string, unknown>;
+		}
+	}
+}
+
+/**
+ * Extract a unified-diff string from a Cursor tool result (`edit` success carries
+ * `value.diffString`).
+ */
+function extractDiffString(result: unknown): string | null {
+	const value = (result as { value?: { diffString?: unknown } })?.value;
+	return typeof value?.diffString === 'string' ? value.diffString : null;
+}
+
+/**
+ * Parse a unified diff into before/after text. Context lines (leading space)
+ * appear in BOTH sides; `-` lines are the old side, `+` lines the new side.
+ * File headers (`---`/`+++`) and hunk headers (`@@`) are skipped.
+ */
+function parseUnifiedDiff(diff: string): { oldString: string; newString: string } {
+	const oldLines: string[] = [];
+	const newLines: string[] = [];
+	for (const line of diff.split('\n')) {
+		if (line.startsWith('---') || line.startsWith('+++') || line.startsWith('@@')) continue;
+		if (line.startsWith('-')) oldLines.push(line.slice(1));
+		else if (line.startsWith('+')) newLines.push(line.slice(1));
+		else if (line.startsWith(' ')) { oldLines.push(line.slice(1)); newLines.push(line.slice(1)); }
+	}
+	return { oldString: oldLines.join('\n'), newString: newLines.join('\n') };
+}
+
+/**
+ * Light per-tool input normalisation into the shared canonical shape. `result`
+ * (present at tool completion) is used for tools whose ARGS don't carry the
+ * user-visible payload — Cursor's `edit` args hold only `path`; the before/after
+ * lives in the result's `diffString`.
+ */
+function normaliseToolInput(canonical: string, raw: Record<string, unknown>, result?: unknown): Record<string, unknown> {
 	switch (canonical) {
 		case 'Read':
 			return { filePath: String(raw.path ?? raw.file_path ?? raw.filePath ?? '') };
 		case 'Write':
 			return {
 				filePath: String(raw.path ?? raw.file_path ?? raw.filePath ?? ''),
-				content: String(raw.contents ?? raw.content ?? raw.text ?? ''),
+				content: String(raw.fileText ?? raw.contents ?? raw.content ?? raw.text ?? ''),
 			};
-		case 'Edit':
+		case 'Edit': {
+			const filePath = String(raw.path ?? raw.file_path ?? raw.filePath ?? '');
+			// Cursor edit args carry only `path`; recover old/new from the result diff.
+			const diff = extractDiffString(result);
+			if (diff) return { filePath, ...parseUnifiedDiff(diff) };
 			return {
-				filePath: String(raw.path ?? raw.file_path ?? raw.filePath ?? ''),
+				filePath,
 				oldString: String(raw.old_string ?? raw.oldString ?? raw.old_str ?? ''),
 				newString: String(raw.new_string ?? raw.newString ?? raw.new_str ?? ''),
 			};
+		}
 		case 'Bash':
 			return { command: String(raw.command ?? raw.cmd ?? '') };
 		case 'Grep':
@@ -91,7 +197,45 @@ function normaliseToolInput(canonical: string, raw: Record<string, unknown>): Re
 				...(raw.path != null ? { path: String(raw.path) } : {}),
 			};
 		case 'Glob':
-			return { pattern: String(raw.pattern ?? raw.glob ?? raw.query ?? '') };
+			return { pattern: String(raw.globPattern ?? raw.pattern ?? raw.glob ?? raw.query ?? '') };
+		case 'Agent': {
+			// Cursor's `task` args carry `subagentType` as an OBJECT
+			// (`{ kind: 'custom', name: 'code-reviewer' }`); the unified AgentInput
+			// wants a plain string.
+			const st = raw.subagentType;
+			let subagentType = 'general-purpose';
+			if (typeof st === 'string') subagentType = st;
+			else if (st && typeof st === 'object') {
+				const o = st as { kind?: string; name?: string };
+				subagentType = o.name || o.kind || 'general-purpose';
+			}
+			return {
+				prompt: String(raw.prompt ?? ''),
+				description: String(raw.description ?? ''),
+				subagentType,
+			};
+		}
+		case 'List':
+			return {
+				...(raw.path != null ? { path: String(raw.path) } : {}),
+				...(Array.isArray(raw.ignore) ? { ignore: raw.ignore.map(String) } : {}),
+			};
+		case 'ExitPlanMode':
+			return { plan: String(raw.plan ?? '') };
+		case 'TodoWrite': {
+			// Cursor todo statuses are `pending | inProgress | completed | cancelled`;
+			// the unified/UI shape wants `pending | in_progress | completed`.
+			const todos = (Array.isArray(raw.todos) ? raw.todos : []).map((t) => {
+				const o = (t && typeof t === 'object' ? t : {}) as Record<string, unknown>;
+				const content = String(o.content ?? '');
+				return {
+					content,
+					status: mapTodoStatus(o.status),
+					activeForm: typeof o.activeForm === 'string' ? o.activeForm : content,
+				};
+			});
+			return { todos };
+		}
 		case 'AskUserQuestion':
 			return { questions: Array.isArray(raw.questions) ? raw.questions : [] };
 		default: {
@@ -115,20 +259,42 @@ function mapUsage(raw: CursorTokenUsage | null | undefined): TokenUsage {
 	};
 }
 
-/** Extract plain text from a tool-call result payload (string / MCP content / object). */
+/** Read the text out of one Cursor/MCP content item (`{type:'text',text}`, Cursor's `{text:{text}}`, image → placeholder). */
+function contentItemText(item: unknown): string {
+	if (typeof item === 'string') return item;
+	const it = item as { type?: string; text?: unknown; image?: unknown };
+	if (it?.type === 'text' && typeof it.text === 'string') return it.text;
+	if (it?.text && typeof it.text === 'object' && typeof (it.text as { text?: unknown }).text === 'string') return (it.text as { text: string }).text;
+	if (typeof it?.text === 'string') return it.text;
+	if (it?.image) return '[image]';
+	return '';
+}
+
+/**
+ * Extract plain text from a tool-call result. Cursor wraps results as
+ * `{ status, value }`, where `value` is `{ content: [...] }` (text/image items,
+ * incl. the nested `{text:{text}}` shape), `{ text }`, or `{ diffString }` (edit).
+ * Falls back to MCP-standard `{content:[{type:'text',text}]}` and JSON.
+ */
 function extractResultText(result: unknown): string {
 	if (result == null) return '';
 	if (typeof result === 'string') return result;
-	const r = result as { content?: unknown; text?: unknown };
+	const r = result as { value?: unknown; success?: unknown; content?: unknown; text?: unknown };
+	// Cursor wraps top-level tool results as `{status,value}` and sub-agent tool
+	// results as `{success:{…}}`; unwrap either.
+	const value = (r.value ?? r.success ?? r) as { content?: unknown; text?: unknown; diffString?: unknown };
+
+	if (Array.isArray(value.content)) {
+		const joined = value.content.map(contentItemText).filter(Boolean).join('\n').trim();
+		if (joined) return joined;
+	}
+	if (typeof value.content === 'string') return value.content;
+	if (typeof value.text === 'string') return value.text;
+	if (typeof value.diffString === 'string') return value.diffString;
 	if (typeof r.text === 'string') return r.text;
 	if (Array.isArray(r.content)) {
-		return r.content
-			.map((c: unknown) => {
-				const item = c as { type?: string; text?: string };
-				return item?.type === 'text' && typeof item.text === 'string' ? item.text : '';
-			})
-			.filter(Boolean)
-			.join('\n');
+		const joined = r.content.map(contentItemText).filter(Boolean).join('\n').trim();
+		if (joined) return joined;
 	}
 	try {
 		return JSON.stringify(result);
@@ -147,63 +313,94 @@ export interface CursorConverterOptions {
 }
 
 export interface CursorMessageConverter {
-	/** Live token deltas (from `send({ onDelta })`) → transient stream_events. */
-	convertDelta(update: InteractionUpdate): EngineOutput[];
 	convert(message: SDKMessage): EngineOutput[];
 	finalize(result: RunResult): EngineOutput[];
+	/** Surface an AskUserQuestion tool_use with complete questions (from the custom tool's execute). */
+	emitAskUserQuestion(toolCallId: string, questions: AskUserQuestion[]): EngineOutput[];
+	/** Stream ONE sub-agent step live (from a `tool-call-delta.taskUpdate`) as a child of the Agent block. */
+	emitSubagentActivity(agentToolId: string, taskUpdate: unknown): EngineOutput[];
 }
 
 export function createCursorMessageConverter(options: CursorConverterOptions): CursorMessageConverter {
 	const { engine, sessionId } = options;
 	/** Tool-call ids already surfaced as a tool_use block (avoid duplicates). */
 	const emittedToolUse = new Set<string>();
+	/** Agent (task) tool ids whose sub-agent steps were streamed live via onDelta. */
+	const streamedSubagents = new Set<string>();
 	let lastUsage: TokenUsage | null = null;
 	let turns = 0;
-	// Live-typing lifecycle flags — which delta stream is currently open.
+	// ── Live-typing + accumulation state ──
+	// Cursor's `run.stream()` yields each text/thinking CHUNK as its own
+	// `assistant`/`thinking` SDKMessage (deltas, not snapshots). We stream each
+	// chunk live as a transient `stream_event` AND accumulate it into a buffer,
+	// flushing ONE consolidated `reasoning` / `assistant` message per block at a
+	// boundary (block switch, tool call, or turn end). Persisting each chunk
+	// separately was the bug behind dozens of fragmented one-word messages.
 	let textOpen = false;
 	let reasoningOpen = false;
+	let textBuffer = '';
+	let reasoningBuffer = '';
 
-	/** Emit stop events for any open live-typing stream (before a persisted message). */
-	function closeStreams(): StreamLifecycleEvent[] {
-		const out: StreamLifecycleEvent[] = [];
-		if (textOpen) { out.push({ type: 'stream_event', event: 'stop', sessionId, reasoning: false }); textOpen = false; }
+	/** Flush the accumulated reasoning buffer as ONE ReasoningMessage (+ close its live stream). */
+	function flushReasoning(): EngineOutput[] {
+		const out: EngineOutput[] = [];
 		if (reasoningOpen) { out.push({ type: 'stream_event', event: 'stop', sessionId, reasoning: true }); reasoningOpen = false; }
+		const text = reasoningBuffer.trim();
+		reasoningBuffer = '';
+		if (text) {
+			out.push({
+				type: 'reasoning',
+				createdAt: new Date().toISOString(),
+				messageId: crypto.randomUUID(),
+				sessionId,
+				parent: { messageId: null, sessionId: null, toolUseId: null },
+				engine,
+				text,
+			} as ReasoningMessage);
+		}
 		return out;
 	}
 
-	/** Translate a live `onDelta` update into transient stream_events. */
-	function convertDelta(update: InteractionUpdate): EngineOutput[] {
-		switch (update.type) {
-			case 'text-delta': {
-				const out: EngineOutput[] = [];
-				if (reasoningOpen) { out.push({ type: 'stream_event', event: 'stop', sessionId, reasoning: true }); reasoningOpen = false; }
-				if (!textOpen) { out.push({ type: 'stream_event', event: 'start', sessionId, reasoning: false } as StreamLifecycleEvent); textOpen = true; }
-				out.push({ type: 'stream_event', event: 'delta', sessionId, text: update.text || '', reasoning: false } as TextDeltaEvent);
-				return out;
-			}
-			case 'thinking-delta': {
-				const out: EngineOutput[] = [];
-				if (textOpen) { out.push({ type: 'stream_event', event: 'stop', sessionId, reasoning: false }); textOpen = false; }
-				if (!reasoningOpen) { out.push({ type: 'stream_event', event: 'start', sessionId, reasoning: true } as StreamLifecycleEvent); reasoningOpen = true; }
-				out.push({ type: 'stream_event', event: 'delta', sessionId, text: update.text || '', reasoning: true } as TextDeltaEvent);
-				return out;
-			}
-			case 'thinking-completed':
-				// Reasoning stream closed; the full ReasoningMessage arrives via `thinking`.
-				if (reasoningOpen) { reasoningOpen = false; return [{ type: 'stream_event', event: 'stop', sessionId, reasoning: true }]; }
-				return [];
-			default:
-				return [];
-		}
+	/** Flush the accumulated text buffer as ONE AssistantMessage (+ close its live stream). */
+	function flushText(): EngineOutput[] {
+		const out: EngineOutput[] = [];
+		if (textOpen) { out.push({ type: 'stream_event', event: 'stop', sessionId, reasoning: false }); textOpen = false; }
+		const text = textBuffer;
+		textBuffer = '';
+		if (text.trim()) out.push(assistantMessage({ type: 'text', text }, false));
+		return out;
 	}
 
-	function assistantMessage(block: ToolUseBlock | { type: 'text'; text: string }, isTool: boolean): AssistantMessage {
+	/** Flush both buffers (reasoning first, then text). */
+	function flushAll(): EngineOutput[] {
+		return [...flushReasoning(), ...flushText()];
+	}
+
+	/** Append a live text chunk: flush any open reasoning, stream the delta, accumulate. */
+	function appendText(chunk: string): EngineOutput[] {
+		const out: EngineOutput[] = flushReasoning();
+		if (!textOpen) { out.push({ type: 'stream_event', event: 'start', sessionId, reasoning: false } as StreamLifecycleEvent); textOpen = true; }
+		out.push({ type: 'stream_event', event: 'delta', sessionId, text: chunk, reasoning: false } as TextDeltaEvent);
+		textBuffer += chunk;
+		return out;
+	}
+
+	/** Append a live reasoning chunk: flush any open text, stream the delta, accumulate. */
+	function appendReasoning(chunk: string): EngineOutput[] {
+		const out: EngineOutput[] = flushText();
+		if (!reasoningOpen) { out.push({ type: 'stream_event', event: 'start', sessionId, reasoning: true } as StreamLifecycleEvent); reasoningOpen = true; }
+		out.push({ type: 'stream_event', event: 'delta', sessionId, text: chunk, reasoning: true } as TextDeltaEvent);
+		reasoningBuffer += chunk;
+		return out;
+	}
+
+	function assistantMessage(block: ToolUseBlock | { type: 'text'; text: string }, isTool: boolean, parentToolUseId: string | null = null): AssistantMessage {
 		return {
 			type: 'assistant',
 			createdAt: new Date().toISOString(),
 			messageId: crypto.randomUUID(),
 			sessionId,
-			parent: { messageId: null, sessionId: null, toolUseId: null },
+			parent: { messageId: null, sessionId: null, toolUseId: parentToolUseId },
 			engine,
 			content: [block],
 			stopReason: isTool ? 'tool_use' : 'end_turn',
@@ -224,19 +421,53 @@ export function createCursorMessageConverter(options: CursorConverterOptions): C
 		} as ToolUseBlock;
 	}
 
-	function toolResultMessage(toolUseId: string, content: string, isError: boolean): UserMessage {
+	function toolResultMessage(toolUseId: string, content: string, isError: boolean, parentToolUseId: string | null = null): UserMessage {
 		const block: UserContentBlock = { type: 'tool_result', toolUseId, content, isError };
 		return {
 			type: 'user',
 			createdAt: new Date().toISOString(),
 			messageId: crypto.randomUUID(),
 			sessionId,
-			parent: { messageId: null, sessionId: null, toolUseId: null },
+			parent: { messageId: null, sessionId: null, toolUseId: parentToolUseId },
 			engine,
 			sender: { id: '', name: '' },
 			content: [block],
 			synthetic: true,
 		};
+	}
+
+	/**
+	 * Cursor's `task` (Agent) tool runs the sub-agent internally and returns its
+	 * FULL transcript in `result.value.conversationSteps[]` — the parent stream
+	 * never sees the sub-agent's individual steps. We replay those steps as child
+	 * messages tagged with `parent.toolUseId = <Agent block id>` so the frontend
+	 * grouper folds them into the Agent block's `subActivities` (README §10.15).
+	 * The sub-agent's final assistant text becomes the Agent tool's result.
+	 */
+	function replaySubagent(result: unknown, agentToolId: string): { children: EngineOutput[]; finalText: string } {
+		const steps = (result as { value?: { conversationSteps?: unknown } })?.value?.conversationSteps;
+		if (!Array.isArray(steps)) return { children: [], finalText: extractResultText(result) };
+		const children: EngineOutput[] = [];
+		let finalText = '';
+		for (const step of steps as Array<Record<string, unknown>>) {
+			const asst = step.assistantMessage as { text?: unknown } | undefined;
+			if (asst && typeof asst.text === 'string' && asst.text.trim()) {
+				finalText = asst.text; // last assistant text = the sub-agent's answer (Agent result)
+				continue;
+			}
+			const tc = step.toolCall as Record<string, unknown> | undefined;
+			if (tc) {
+				const key = Object.keys(tc).find(k => k.endsWith('ToolCall'));
+				const inner = (key ? tc[key] : undefined) as { args?: unknown; result?: unknown } | undefined;
+				const toolCallId = String(tc.toolCallId ?? crypto.randomUUID());
+				const bare = key ? key.replace(/ToolCall$/, '') : 'tool';
+				const canonical = mapCursorToolName(bare);
+				const input = normaliseToolInput(canonical, (inner?.args && typeof inner.args === 'object' ? inner.args : {}) as Record<string, unknown>, inner?.result);
+				children.push(assistantMessage(toolUseBlock(toolCallId, canonical, input), true, agentToolId));
+				children.push(toolResultMessage(toolCallId, extractResultText(inner?.result), false, agentToolId));
+			}
+		}
+		return { children, finalText: finalText || extractResultText(result) };
 	}
 
 	function convert(message: SDKMessage): EngineOutput[] {
@@ -258,12 +489,16 @@ export function createCursorMessageConverter(options: CursorConverterOptions): C
 				return [];
 
 			case 'assistant': {
-				turns += 1;
-				const out: EngineOutput[] = closeStreams();
+				const out: EngineOutput[] = [];
+				let countedTurn = false;
 				for (const block of message.message.content) {
 					if (block.type === 'text') {
-						if (block.text.trim()) out.push(assistantMessage({ type: 'text', text: block.text }, false));
+						if (!countedTurn) { turns += 1; countedTurn = true; }
+						// Stream the chunk live + accumulate into ONE assistant message.
+						if (block.text) out.push(...appendText(block.text));
 					} else if (block.type === 'tool_use') {
+						// A tool call ends the current text/reasoning block — flush first.
+						out.push(...flushAll());
 						const canonical = mapCursorToolName(block.name);
 						emittedToolUse.add(block.id);
 						const input = normaliseToolInput(canonical, (block.input && typeof block.input === 'object' ? block.input : {}) as Record<string, unknown>);
@@ -273,36 +508,53 @@ export function createCursorMessageConverter(options: CursorConverterOptions): C
 				return out;
 			}
 
-			case 'thinking': {
-				const out: EngineOutput[] = closeStreams();
-				const text = (message.text ?? '').trim();
-				if (!text) return out;
-				const reasoning: ReasoningMessage = {
-					type: 'reasoning',
-					createdAt: new Date().toISOString(),
-					messageId: crypto.randomUUID(),
-					sessionId,
-					parent: { messageId: null, sessionId: null, toolUseId: null },
-					engine,
-					text,
-				};
-				out.push(reasoning);
-				return out;
-			}
+			case 'thinking':
+				// Stream the reasoning chunk live + accumulate into ONE reasoning message.
+				return message.text ? appendReasoning(message.text) : [];
 
 			case 'tool_call': {
-				const out: EngineOutput[] = closeStreams();
-				const canonical = mapCursorToolName(message.name);
+				// A tool call ends the current text/reasoning block — flush first.
+				const out: EngineOutput[] = flushAll();
+				// Freeze the args now — Cursor mutates some in place (e.g. update_todos).
+				const args = cloneArgs(message.args);
+				const canonical = canonicalCursorTool(message.name, args);
+				const terminal = message.status === 'completed' || message.status === 'error';
 
-				// Surface the tool_use block if the assistant message didn't already.
-				if (!emittedToolUse.has(message.call_id)) {
+				// `create_plan` proposes a plan FOR THE USER TO READ. Render it as normal
+				// assistant markdown (not an internal-looking tool card) so it's legible.
+				if (canonical === 'ExitPlanMode') {
+					if (terminal) {
+						const plan = String((args as { plan?: unknown }).plan ?? '');
+						if (plan.trim()) out.push(assistantMessage({ type: 'text', text: plan }, false));
+					}
+					return out;
+				}
+
+				// Surface the tool_use block ONCE. `edit` carries its before/after only
+				// in the result diff, so defer its tool_use to completion; all other
+				// tools emit on first sighting so the "running" state shows live.
+				// AskUserQuestion is emitted separately via emitAskUserQuestion() with
+				// the complete question set (stream args can arrive empty), so skip it here.
+				const deferForResult = canonical === 'Edit';
+				const skipToolUse = canonical === 'AskUserQuestion';
+				if (!emittedToolUse.has(message.call_id) && !skipToolUse && (!deferForResult || terminal)) {
 					emittedToolUse.add(message.call_id);
-					const input = normaliseToolInput(canonical, (message.args && typeof message.args === 'object' ? message.args : {}) as Record<string, unknown>);
+					const input = cursorToolInput(message.name, args, terminal ? message.result : undefined);
 					out.push(assistantMessage(toolUseBlock(message.call_id, canonical, input), true));
 				}
 
-				if (message.status === 'completed' || message.status === 'error') {
-					out.push(toolResultMessage(message.call_id, extractResultText(message.result), message.status === 'error'));
+				if (terminal) {
+					if (canonical === 'Agent') {
+						// The sub-agent's steps stream live via onDelta taskUpdates
+						// (emitSubagentActivity). Only replay from the result as a FALLBACK
+						// when nothing was streamed. Always attach its final answer as the
+						// Agent tool's result.
+						const { children, finalText } = replaySubagent(message.result, message.call_id);
+						if (!streamedSubagents.has(message.call_id)) out.push(...children);
+						out.push(toolResultMessage(message.call_id, finalText, message.status === 'error'));
+					} else {
+						out.push(toolResultMessage(message.call_id, extractResultText(message.result), message.status === 'error'));
+					}
 				}
 				return out;
 			}
@@ -317,7 +569,8 @@ export function createCursorMessageConverter(options: CursorConverterOptions): C
 	}
 
 	function finalize(result: RunResult): EngineOutput[] {
-		const out: EngineOutput[] = closeStreams();
+		// Flush any buffered reasoning/text as their consolidated messages.
+		const out: EngineOutput[] = flushAll();
 		if (result.usage) lastUsage = mapUsage(result.usage);
 		const event: SuccessResultEvent = {
 			type: 'result',
@@ -332,5 +585,31 @@ export function createCursorMessageConverter(options: CursorConverterOptions): C
 		return out;
 	}
 
-	return { convertDelta, convert, finalize };
+	function emitAskUserQuestion(toolCallId: string, questions: AskUserQuestion[]): EngineOutput[] {
+		const out: EngineOutput[] = flushAll();
+		emittedToolUse.add(toolCallId);
+		out.push(assistantMessage(toolUseBlock(toolCallId, 'AskUserQuestion', { questions: Array.isArray(questions) ? questions : [] }), true));
+		return out;
+	}
+
+	function emitSubagentActivity(agentToolId: string, taskUpdate: unknown): EngineOutput[] {
+		const tu = taskUpdate as { type?: string; callId?: string; toolCall?: { type?: string; args?: unknown; result?: unknown } };
+		// Surface completed sub-agent tool calls (they carry both args + result) as
+		// child tool_use + tool_result tagged with the Agent block id, so the
+		// frontend folds them into subActivities as they happen.
+		if (tu.type !== 'tool-call-completed' || !tu.toolCall) return [];
+		streamedSubagents.add(agentToolId);
+		const tc = tu.toolCall;
+		const innerId = String(tu.callId ?? crypto.randomUUID());
+		const args = (tc.args && typeof tc.args === 'object' ? tc.args : {}) as Record<string, unknown>;
+		const name = tc.type ?? 'tool';
+		const canonical = canonicalCursorTool(name, args);
+		const input = cursorToolInput(name, args, tc.result);
+		return [
+			assistantMessage(toolUseBlock(innerId, canonical, input), true, agentToolId),
+			toolResultMessage(innerId, extractResultText(tc.result), false, agentToolId),
+		];
+	}
+
+	return { convert, finalize, emitAskUserQuestion, emitSubagentActivity };
 }

--- a/backend/engine/adapters/cursor/models.ts
+++ b/backend/engine/adapters/cursor/models.ts
@@ -51,6 +51,8 @@ function makeModel(id: string, name: string): EngineModel {
 			model: { id, name },
 			account: { id: 0, name: '' },
 		},
+		// Cursor's models.list() does NOT report a context window; leave 0 so the
+		// UI shows "unknown" (a "?") rather than a fabricated/hardcoded max.
 		limit: { input: 0, output: 0 },
 		modalities: {
 			input: { text: true, image: true, audio: false, video: false, pdf: false },

--- a/backend/engine/adapters/cursor/stream.ts
+++ b/backend/engine/adapters/cursor/stream.ts
@@ -43,7 +43,19 @@ import { createAskUserQuestionTool, formatAnswers, type PendingAsk } from './ask
 import { createCursorMessageConverter } from './message-converter';
 import { handleStreamError } from './error-handler';
 
-/** Minimal pushable queue bridging Cursor's push callbacks + pull stream → a generator. */
+/** Strip YAML frontmatter from a subagent markdown doc, leaving the instructions. */
+function stripFrontmatter(md: string): string {
+	const match = md.match(/^---\n[\s\S]*?\n---\n?/);
+	return (match ? md.slice(match[0].length) : md).trim();
+}
+
+/**
+ * Minimal pushable queue merging Cursor's pull stream (`run.stream()`) with the
+ * push emissions of the in-process AskUserQuestion custom tool into one ordered
+ * async generator. The ask tool fires from inside the SDK's tool executor (a
+ * separate async flow from the stream loop), so a plain `for await` can't carry
+ * its emission — the queue is the merge point.
+ */
 class EventQueue<T> {
 	private buffer: T[] = [];
 	private wake: (() => void) | null = null;
@@ -68,12 +80,6 @@ class EventQueue<T> {
 			await new Promise<void>((resolve) => { this.wake = resolve; });
 		}
 	}
-}
-
-/** Strip YAML frontmatter from a subagent markdown doc, leaving the instructions. */
-function stripFrontmatter(md: string): string {
-	const match = md.match(/^---\n[\s\S]*?\n---\n?/);
-	return (match ? md.slice(match[0].length) : md).trim();
 }
 
 export class CursorEngine implements AIEngine {
@@ -136,10 +142,19 @@ export class CursorEngine implements AIEngine {
 		await syncSkills('cursor', profileId);
 		await syncEngineArtifacts('cursor', profileId);
 
+		// ── Output queue merging the pull stream with the ask tool's push emissions ──
+		const queue = new EventQueue<EngineOutput>();
+		const converterHolder: { current: ReturnType<typeof createCursorMessageConverter> | null } = { current: null };
+
 		// ── Tools: AskUserQuestion (in-process custom tool) + MCP (native config) ──
 		const askTool: SDKCustomTool = createAskUserQuestionTool({
 			register: (id, entry) => this.pendingAsks.set(id, entry),
 			unregister: (id) => this.pendingAsks.delete(id),
+			// Emit the tool_use with the COMPLETE questions from execute's args.
+			emit: (id, questions) => {
+				const c = converterHolder.current;
+				if (c) for (const out of c.emitAskUserQuestion(id, questions)) queue.push(out);
+			},
 		});
 		const customTools: Record<string, SDKCustomTool> = { AskUserQuestion: askTool };
 		const mcpServers = getCursorMcpConfig(mcpProfileFilter);
@@ -192,6 +207,7 @@ export class CursorEngine implements AIEngine {
 		const sessionId = agent.agentId;
 
 		const converter = createCursorMessageConverter({ engine: engineMeta, sessionId });
+		converterHolder.current = converter;
 
 		// Build the user turn (text + image attachments).
 		const promptText = prompt.content.filter(b => b.type === 'text').map(b => (b.type === 'text' ? b.text : '')).join('\n');
@@ -203,18 +219,24 @@ export class CursorEngine implements AIEngine {
 		}
 		const userMessage: SDKUserMessage = { text, ...(images.length ? { images } : {}) };
 
-		// Bridge Cursor's two output channels into one ordered stream:
-		//   - `onDelta` pushes live token deltas → transient stream_events (chat:partial)
-		//   - `run.stream()` yields complete SDKMessages → persisted messages
-		// Both feed the same converter (whose lifecycle flags close an open partial
-		// stream before a persisted message) and the same queue, so ordering holds.
-		const queue = new EventQueue<EngineOutput>();
+		// Cursor's `run.stream()` yields each text/thinking chunk as its own
+		// SDKMessage; the converter streams every chunk live as a transient
+		// stream_event AND accumulates it, flushing ONE consolidated reasoning /
+		// assistant message per block. The pull stream + the ask tool's push
+		// emissions are merged through the queue.
 		let onAbort: (() => void) | null = null;
 		try {
 			const run = await agent.send(userMessage, {
 				model: { id: modelId },
+				// Sub-agent (Task) steps aren't in `run.stream()` — they ride
+				// `tool-call-delta.taskUpdate` here. Stream each completed sub-agent
+				// tool call live as a child of the Agent block (parent.toolUseId).
 				onDelta: ({ update }) => {
-					for (const out of converter.convertDelta(update)) queue.push(out);
+					const u = update as { type?: string; callId?: string; taskUpdate?: unknown };
+					if (u.type === 'tool-call-delta' && u.taskUpdate && u.callId) {
+						const c = converterHolder.current;
+						if (c) for (const out of c.emitSubagentActivity(u.callId, u.taskUpdate)) queue.push(out);
+					}
 				},
 			});
 			this.activeRun = run;

--- a/backend/engine/adapters/pi/agent-tool.ts
+++ b/backend/engine/adapters/pi/agent-tool.ts
@@ -31,9 +31,9 @@ export interface AgentDispatchBindings {
 }
 
 const AGENT_PARAMS = Type.Object({
-	subagentType: Type.String(),
-	prompt: Type.String(),
-	description: Type.Optional(Type.String()),
+	subagentType: Type.String({ description: 'The slug of the subagent to delegate to.' }),
+	description: Type.String({ description: 'A short (3-5 word) description of the delegated task.' }),
+	prompt: Type.String({ description: 'The full, self-contained task/instructions for the subagent.' }),
 });
 
 export function createAgentDispatchTool(bindings: AgentDispatchBindings): ToolDefinition {

--- a/backend/engine/docs/adding-an-engine.md
+++ b/backend/engine/docs/adding-an-engine.md
@@ -13,6 +13,19 @@ blueprint for the next engine you add.
 - [ ] `shared/types/unified/message.ts`: add `'newengine'` to `MessageEngine.type`.
 - [ ] `shared/constants/engines.ts`: add an entry in `ENGINES[]`
       (`type, name, description, icon.light, icon.dark`).
+- [ ] **Exhaustive `Record<EngineType, …>` maps & unions — forgetting any is a
+      compile error, so `bun run check` after this step catches them all:**
+  - `shared/constants/engine-tools.ts`: add `'newengine'` to
+    `ENGINE_BUILTIN_TOOLS` (its built-in tool names) **and**
+    `ENGINE_TOOLS_BEST_EFFORT` (`true` unless the SDK has a real per-tool
+    permission hook).
+  - `backend/artifacts/types.ts`: add the engine's config-dir slug to
+    `ArtifactEngine` **and** `ARTIFACT_ENGINES` (usually the same as the
+    `EngineType`; `claude-code`→`claude` is the one exception).
+  - `backend/permissions/service.ts`: add the entry to `ENGINE_TYPE_TO_ARTIFACT`
+    (+ `ArtifactEngineKey`).
+  - `backend/ws/sessions/crud.ts`: add the `'newengine'` literal to the two
+    session-engine typebox unions (in addition to the Stage-4 chat/crud ones).
 - [ ] `backend/engine/adapters/newengine/models.ts`: own the catalog. Static
       engines export a `NEWENGINE_MODELS: EngineModel[]` array; dynamic
       engines export a fetcher (`fetchNewengineModels(...)`) consumed by
@@ -57,7 +70,21 @@ mandatory files; optional files use the canonical names from §2.6.
       OR `fetchNewengineModels(...): Promise<EngineModel[]>` (dynamic;
       return `[]` on failure — see §4.5).
 - [ ] `message-converter.ts` (mandatory) → pure functions SDK → `EngineOutput`.
-      Use `toCanonicalToolName()` for tool names.
+      Use `toCanonicalToolName()` for tool names. **Before writing it, capture the
+      SDK's REAL runtime shapes** — a throwaway script that runs one agent and
+      `JSON.stringify`s each stream event, tool arg, and tool result (using the
+      model the user will run). `.d.ts` types routinely mislead on: whether the
+      stream is per-chunk deltas vs snapshots, the actual tool-arg field names,
+      whether a payload lives in the args or the result, tool-name wrapping
+      (`mcp`-style), and result envelopes (`{status,value}` / images). See
+      **§10.20** for the full catalogue of these traps.
+- [ ] **Usage that arrives once per turn:** if the SDK emits a single `usage`
+      event after all messages (Codex, Cursor), assistant rows persist
+      `usage:null` — add the engine to `stream-manager.ts::backfillUsageForStream`'s
+      gate so the turn aggregate is written to every assistant row (see §10.20-I).
+- [ ] **Context window:** set `EngineModel.limit.input` to the model's real max
+      when the catalog provides it; leave `0` when it doesn't — do NOT hard-code a
+      value. The UI renders `0` as "?" via `getContextUsage(...).unknown` (§10.20-J).
 - [ ] `error-handler.ts` (mandatory) → exports `handleStreamError(error,
       ...): void` (and any helper formatters specific to the SDK's error
       payload — see `opencode/error-handler.ts::formatSessionError` for the

--- a/backend/engine/docs/lessons-learned.md
+++ b/backend/engine/docs/lessons-learned.md
@@ -960,3 +960,108 @@ still the auth-blob swap, **not** a dir per account.
   the persisted `opencode.server.{url,datadir}` so a server cached against the
   pre-move dir is re-spawned into the relocated one.
 
+---
+
+### 10.20 In-process SDK with a delta-stream, wrapped tools & no metadata (Cursor)
+
+The `cursor` adapter (`@cursor/sdk`) surfaced a whole class of gotchas that recur
+for any SDK whose stream is **delta-based**, whose tools are **wrapped/renamed**,
+and whose model catalog is **metadata-poor**. Every point below cost a round-trip
+of "user reports wrong UI → capture the real runtime shape → fix". **The meta-lesson:
+never guess an SDK's runtime shapes from its `.d.ts`; capture them live** (write a
+throwaway script that runs a real agent and `JSON.stringify`s each event/arg/result),
+using the **same model** the user runs — different models stream differently.
+
+**A. `run.stream()` yields per-chunk DELTAS, not snapshots.** Cursor emits a
+separate `assistant`/`thinking` SDKMessage for *each* text chunk. Persisting each
+as its own message produced 121 one-word rows for a "1+1=" reply and pushed the
+user message off-screen. Fix: **accumulate** chunks into ONE `reasoning` + ONE
+`assistant` message per block (buffers + flush at block-switch / tool-call /
+turn-end), while emitting each chunk live as a transient `stream_event` delta.
+Don't double-source: pick either `run.stream()` OR `onDelta`, not both, for the
+same content. (§10.4 is the sibling "buffer for usage" lesson.)
+
+**B. Tool arg field names are NOT what the `.d.ts` implies — and some payloads
+live in the RESULT, not the args.** Cursor `edit` args carry only `{path}`; the
+before/after is in the result's `value.diffString` (parse the unified diff into
+`oldString`/`newString`). `glob`→`{globPattern}`, `write`→`{fileText}` (not
+`content`). Getting these wrong = empty tool inputs in the UI. **Capture real args
+at runtime.** When the payload arrives only at completion, DEFER that tool's
+`tool_use` emission to the terminal event (like `edit`, `create_plan`).
+
+**C. MCP servers AND in-process custom tools may be delivered through ONE wrapper
+tool.** Cursor routes both through a tool literally named `mcp`, args
+`{providerIdentifier, toolName, args}` (`clopen-mcp` for real MCP,
+`custom-user-tools` for `local.customTools`). Unwrap it: `resolveOpenCodeToolName(toolName)`
+→ `mcp__server__tool` (passthrough args) for real MCP, else `toCanonicalToolName(toolName)`
++ normalise for custom (e.g. AskUserQuestion). Without unwrap everything renders
+as `Unknown:mcp`.
+
+**D. Interactive tool (AskUserQuestion) args must come from the tool's `execute`,
+not the stream.** The stream's `tool_call` args can arrive empty/partial for large
+inputs (→ `questions:[]`). The custom-tool `execute` always receives complete
+args, so emit the tool_use FROM `execute` (with the full questions) through a push
+queue that merges with `run.stream()`, and have the converter SKIP the stream's
+copy. `context.toolCallId` === the `tool_call` `call_id`, so `resolveUserAnswer`
+still matches, and the `running` event fires while `execute` blocks (dialog shows
+live, no deadlock). See §10.15 for the parent-routing half.
+
+**E. Sub-agent activity may be nowhere in `run.stream()`.** Cursor runs the
+`task` sub-agent internally: its steps ride `onDelta` `tool-call-delta` events
+whose `taskUpdate` field is the sub-agent's inner InteractionUpdate; the outer
+`callId` === the `task` `call_id` === the Agent tool_use id. Stream each
+`taskUpdate.type==='tool-call-completed'` as a child tool_use+tool_result
+(`parent.toolUseId`), and keep the full transcript in the `task` RESULT
+(`value.conversationSteps[]`) as a FALLBACK. `subagentType` can be an OBJECT
+(`{kind,name}`) — extract the string, or the UI shows "Using [object Object] agent".
+Make the synthesised Agent tool's `description` param **required** (Pi/Cline) so
+the model fills it; and in `AgentTool.svelte`, hide the description line when empty.
+
+**F. Some capabilities emit NO tool event at all.** Cursor's web search / web
+fetch run server-side — no `tool_call` in `run.stream()` or `onDelta`. They simply
+cannot be rendered as tools. Enumerate the SDK's real tool-type set before
+assuming a tool is "missing".
+
+**G. Tool RESULT shapes vary and may hide huge binaries.** Cursor wraps results as
+`{status, value:{content:[{text:{text}}]}}` (top-level) or `{success:{content}}`
+(sub-agent); images arrive as raw `Buffer` bytes. `extractResultText` must unwrap
+`value`/`success`, handle the nested `{text:{text}}` shape, and map images to a
+`[image]` placeholder (else you serialise a 500 KB PNG buffer into the row).
+
+**H. Mutable arg references corrupt persisted snapshots.** Cursor mutates some arg
+objects in place across a tool's lifecycle (notably `update_todos` — statuses flip
+to completed as work proceeds). Persisting a live reference makes a just-created
+todo render as done. **`structuredClone` the args at emit time.** Also map the
+SDK's status enum to the unified one (`inProgress`→`in_progress`, `cancelled`→
+`completed`) — a value mismatch renders in-progress as pending.
+
+**I. Usage that arrives once per turn needs backfill.** Cursor (like Codex) emits
+`usage` once after all messages, so assistant rows persist `usage:null`. Add the
+engine to `stream-manager.ts::backfillUsageForStream`'s gate so the turn's
+aggregate is written to every assistant row (survives refresh).
+
+**J. Don't fabricate a context window.** If `models.list()` reports no max context
+(`limit.input:0`), do NOT hard-code one. `getContextUsage` returns `unknown:true`
+and `ContextIndicator.svelte` shows "?" + an explanation instead of a bogus 100%.
+
+**K. A "plan" tool is a user-facing checkpoint, not internal plumbing.** Cursor's
+`create_plan` proposes a plan for the user to read, then ENDS the turn (approval
+gate, like Claude's ExitPlanMode). Render its `plan` text as a normal assistant
+markdown message, not a tool card; the user replies to continue.
+
+**L. Runtime compatibility is a first-class risk (Bun).** `@cursor/sdk` uses
+`@connectrpc/connect` over a Node transport that works under Bun with a valid
+**paid** key. A free-tier/exhausted key returns `plan_required` (403) and
+rate-limited keys surface as "socket connection closed / API key exchange
+endpoint" NetworkErrors — do NOT misread these as a Bun incompatibility. The SDK's
+fetch transport is gated behind a `globalThis.Deno` check; **faking that global is
+UNSAFE** — 45+ files (`@anthropic-ai/sdk`, `openai`, `elysia`, `mongodb`,
+`@google/genai`) platform-detect on `Deno` and would break. Map `plan_required`
+and socket errors to clear user messages in `error-handler.ts`.
+
+> **Global fixes that came out of this** (apply to ALL engines, not just Cursor):
+> the List tool renders its directory listing with `CodeBlock` (monospace), not
+> `TextMessage` (markdown); `AgentTool.svelte` hides an empty description line;
+> `ContextIndicator.svelte` handles an unknown max context. When an engine's data
+> exposes a UI bug, fix it in the shared component, not the adapter.
+

--- a/backend/engine/docs/quick-reference.md
+++ b/backend/engine/docs/quick-reference.md
@@ -11,6 +11,13 @@
 | Stateful per-stream converter               | `claude/message-converter.ts::createSdkMessageConverter`  |
 | Split one SDK message → N `EngineOutput`    | `opencode/message-converter.ts::convertAssistantMessages`, `copilot/message-converter.ts::convertAssistantMessage` |
 | Buffer until usage event arrives            | `copilot/message-converter.ts::flushPending` + `captureUsage` |
+| Accumulate per-chunk delta stream → 1 msg   | `cursor/message-converter.ts` (`appendText`/`appendReasoning`/`flushAll` — deltas, not snapshots; see §10.20-A) |
+| Unwrap a wrapper tool (MCP + custom tools)  | `cursor/message-converter.ts::canonicalCursorTool`/`cursorToolInput` (`mcp` wrapper → `mcp__server__tool` / AskUserQuestion; §10.20-C) |
+| Interactive tool args from `execute`, not stream | `cursor/ask-question-tool.ts` (`emit`) + `cursor/message-converter.ts::emitAskUserQuestion` (push queue; §10.20-D) |
+| Sub-agent streamed live via delta taskUpdate | `cursor/stream.ts` (`onDelta` `tool-call-delta.taskUpdate`) + `cursor/message-converter.ts::emitSubagentActivity`/`replaySubagent` (§10.20-E) |
+| Freeze mutable tool args before persist     | `cursor/message-converter.ts::cloneArgs` (`structuredClone`; §10.20-H) |
+| Usage backfill (once-per-turn engines)      | `backend/chat/stream-manager.ts::backfillUsageForStream` (Codex + Cursor; §10.20-I) |
+| Context window unknown → "?" not 100%       | `frontend/utils/context-manager.ts` (`unknown`) + `frontend/components/chat/widgets/ContextIndicator.svelte` (§10.20-J) |
 | Reasoning stream lifecycle                  | `opencode/stream.ts::flushReasoning`, `copilot/message-converter.ts::convertReasoningDelta` |
 | Cancel-before-RPC ordering                  | `opencode/stream.ts::cancel`, `claude/stream.ts::cancel`, `copilot/stream.ts::cancel`  |
 | Fork session (native vs. on-disk vs. in-memory) | `claude/stream.ts` (`forkSession: true`), `opencode/stream.ts` (`client.session.fork`), `copilot/stream.ts` (`client.rpc.sessions.fork`), `codex/session-fork.ts` + `qwen/session-fork.ts` (copy disk state), `pi/session-fork.ts` (`SessionManager.forkFrom`), `cline/stream.ts` (**session-less** — fresh id per turn + in-memory copy-on-branch; see §10.10) |

--- a/frontend/components/chat/tools/variants/classic/AgentTool.svelte
+++ b/frontend/components/chat/tools/variants/classic/AgentTool.svelte
@@ -53,7 +53,9 @@
 <!-- Header card -->
 <div class="bg-white dark:bg-slate-800 rounded-md border border-slate-200/60 dark:border-slate-700/60 p-3 mb-2">
 	<div class="space-y-1">
-		<InfoLine icon="lucide:search" text={description} />
+		{#if description}
+			<InfoLine icon="lucide:search" text={description} />
+		{/if}
 		<InfoLine icon="lucide:bot" text="Using {subagentType} agent" />
 	</div>
 </div>

--- a/frontend/components/chat/tools/variants/classic/ListTool.svelte
+++ b/frontend/components/chat/tools/variants/classic/ListTool.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { ToolUseBlock, ListInput } from '$shared/types/unified';
 	import { InfoLine } from './components';
-	import TextMessage from '../../../formatters/TextMessage.svelte';
+	import CodeBlock from './components/CodeBlock.svelte';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 	const input = $derived(toolInput.input as ListInput);
@@ -32,7 +32,7 @@
 </div>
 
 {#if result?.content}
-	<div class="mt-4 bg-white dark:bg-slate-800 rounded-md border border-slate-200/60 dark:border-slate-700/60 p-3">
-		<TextMessage content={typeof result.content === 'string' ? result.content : JSON.stringify(result.content)} />
+	<div class="mt-4">
+		<CodeBlock code={typeof result.content === 'string' ? result.content : JSON.stringify(result.content)} type="neutral" label="Contents" />
 	</div>
 {/if}

--- a/frontend/components/chat/widgets/ContextIndicator.svelte
+++ b/frontend/components/chat/widgets/ContextIndicator.svelte
@@ -31,7 +31,7 @@
 	);
 
 	const barColor = $derived.by(() => {
-		if (!usage) return 'bg-slate-400';
+		if (!usage || usage.unknown) return 'bg-slate-400';
 		if (usage.percentage >= 90) return 'bg-red-500';
 		if (usage.percentage >= 80) return 'bg-amber-500';
 		if (usage.percentage >= 60) return 'bg-yellow-500';
@@ -40,7 +40,7 @@
 
 	// Stroke variant of the threshold color for the compact ring gauge
 	const ringColor = $derived.by(() => {
-		if (!usage) return 'stroke-slate-400';
+		if (!usage || usage.unknown) return 'stroke-slate-400';
 		if (usage.percentage >= 90) return 'stroke-red-500';
 		if (usage.percentage >= 80) return 'stroke-amber-500';
 		if (usage.percentage >= 60) return 'stroke-yellow-500';
@@ -50,11 +50,11 @@
 	// Ring geometry — radius 8 in a 20x20 viewBox
 	const RING_CIRCUMFERENCE = 2 * Math.PI * 8;
 	const ringOffset = $derived(
-		usage ? RING_CIRCUMFERENCE * (1 - Math.min(usage.percentage, 100) / 100) : RING_CIRCUMFERENCE
+		usage && !usage.unknown ? RING_CIRCUMFERENCE * (1 - Math.min(usage.percentage, 100) / 100) : RING_CIRCUMFERENCE
 	);
 
 	const textColor = $derived.by(() => {
-		if (!usage) return 'text-slate-400';
+		if (!usage || usage.unknown) return 'text-slate-400';
 		if (usage.percentage >= 90) return 'text-red-500';
 		if (usage.percentage >= 80) return 'text-amber-500';
 		if (usage.percentage >= 60) return 'text-yellow-500';
@@ -101,7 +101,7 @@
 			type="button"
 			class="flex items-center justify-center px-2 @max-[26rem]:px-0 {isMobile ? 'h-8 @max-[26rem]:w-9' : 'h-6 @max-[26rem]:w-7'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100 group"
 			onclick={togglePopover}
-			title="Context: {formatTokens(usage.current)} / {formatTokens(usage.max)} ({Math.round(usage.percentage)}%)"
+			title={usage.unknown ? `Context: ${formatTokens(usage.current)} used / max unknown for this model` : `Context: ${formatTokens(usage.current)} / ${formatTokens(usage.max)} (${Math.round(usage.percentage)}%)`}
 		>
 			<div class="flex items-center gap-1.5">
 				<!-- Default: linear bar + %. Collapses to a ring-only when the panel/dock is narrow (container query on PanelHeader). -->
@@ -109,11 +109,11 @@
 					<div class="{isMobile ? 'w-14' : 'w-12'} h-2 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden">
 						<div
 							class="{barColor} h-full transition-all duration-500"
-							style="width: {Math.min(usage.percentage, 100)}%"
+							style="width: {usage.unknown ? 0 : Math.min(usage.percentage, 100)}%"
 						></div>
 					</div>
 					<span class="text-2xs font-medium {textColor} tabular-nums group-hover:text-slate-900 dark:group-hover:text-slate-100 transition-colors">
-						{Math.round(usage.percentage)}%
+						{usage.unknown ? '?' : `${Math.round(usage.percentage)}%`}
 					</span>
 				</div>
 
@@ -147,19 +147,31 @@
 					<span class="text-xs font-semibold text-slate-900 dark:text-slate-100">Context Window</span>
 				</div>
 
-				<!-- Progress bar (larger) -->
-				<div class="mb-3">
-					<div class="w-full h-2.5 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden">
-						<div
-							class="{barColor} h-full transition-all duration-500"
-							style="width: {Math.min(usage.percentage, 100)}%"
-						></div>
+				<!-- Progress bar (larger) — or an "unknown" note when the model has no max -->
+				{#if usage.unknown}
+					<div class="mb-3">
+						<div class="flex justify-between items-center">
+							<span class="text-2xs text-slate-500">{formatTokens(usage.current)} used</span>
+							<span class="text-2xs text-slate-500">max: <span class="font-semibold text-slate-400">?</span></span>
+						</div>
+						<p class="text-2xs text-slate-400 dark:text-slate-500 mt-1.5 leading-snug">
+							This model doesn't report a maximum context window, so usage can't be shown as a percentage.
+						</p>
 					</div>
-					<div class="flex justify-between mt-1.5">
-						<span class="text-2xs text-slate-500">{formatTokens(usage.current)} used</span>
-						<span class="text-2xs text-slate-500">{formatTokens(usage.max)} max</span>
+				{:else}
+					<div class="mb-3">
+						<div class="w-full h-2.5 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden">
+							<div
+								class="{barColor} h-full transition-all duration-500"
+								style="width: {Math.min(usage.percentage, 100)}%"
+							></div>
+						</div>
+						<div class="flex justify-between mt-1.5">
+							<span class="text-2xs text-slate-500">{formatTokens(usage.current)} used</span>
+							<span class="text-2xs text-slate-500">{formatTokens(usage.max)} max</span>
+						</div>
 					</div>
-				</div>
+				{/if}
 
 				<!-- Token breakdown -->
 				{#if lastUsage}
@@ -203,15 +215,17 @@
 					</div>
 				{/if}
 
-				<!-- Remaining -->
-				<div class="border-t border-slate-200 dark:border-slate-700 pt-2.5 mt-2.5">
-					<div class="flex justify-between items-center">
-						<span class="text-2xs font-medium text-slate-600 dark:text-slate-400">Remaining</span>
-						<span class="text-2xs font-mono font-semibold {textColor}">
-							{formatTokens(Math.max(0, usage.max - usage.current))} tokens
-						</span>
+				<!-- Remaining (only when the max is known) -->
+				{#if !usage.unknown}
+					<div class="border-t border-slate-200 dark:border-slate-700 pt-2.5 mt-2.5">
+						<div class="flex justify-between items-center">
+							<span class="text-2xs font-medium text-slate-600 dark:text-slate-400">Remaining</span>
+							<span class="text-2xs font-mono font-semibold {textColor}">
+								{formatTokens(Math.max(0, usage.max - usage.current))} tokens
+							</span>
+						</div>
 					</div>
-				</div>
+				{/if}
 			</div>
 		{/if}
 	</div>

--- a/frontend/components/settings/engines/panels/CursorPanel.svelte
+++ b/frontend/components/settings/engines/panels/CursorPanel.svelte
@@ -280,7 +280,7 @@
 											<input
 												type="text"
 												bind:value={cursorAddKey}
-												placeholder="API Key (crsr_)"
+												placeholder="key_…"
 												class="w-full px-3 py-2 text-sm rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-500/40 focus:border-violet-500"
 											/>
 										</div>

--- a/frontend/utils/context-manager.ts
+++ b/frontend/utils/context-manager.ts
@@ -16,6 +16,8 @@ export interface ContextUsage {
   max: number;
   percentage: number;
   nearLimit: boolean;
+  /** True when the model doesn't expose a max context window — usage % can't be computed. */
+  unknown: boolean;
 }
 
 /**
@@ -34,13 +36,21 @@ export function getContextUsage(messages: FrontendMessage[], contextWindow: numb
     }
   }
 
-  if (!lastUsage) {
-    return { current: 0, max: contextWindow, percentage: 0, nearLimit: false };
+  const current = lastUsage
+    ? (lastUsage.inputTokens || 0)
+      + (lastUsage.cacheCreationInputTokens || 0)
+      + (lastUsage.cacheReadInputTokens || 0)
+    : 0;
+
+  // The model didn't report a max context window (e.g. Cursor): we can show how
+  // many tokens were used, but not a percentage. Flag it so the UI renders "?".
+  if (!contextWindow || contextWindow <= 0) {
+    return { current, max: 0, percentage: 0, nearLimit: false, unknown: true };
   }
 
-  const current = (lastUsage.inputTokens || 0)
-    + (lastUsage.cacheCreationInputTokens || 0)
-    + (lastUsage.cacheReadInputTokens || 0);
+  if (!lastUsage) {
+    return { current: 0, max: contextWindow, percentage: 0, nearLimit: false, unknown: false };
+  }
 
   const percentage = Math.min(100, Math.round((current / contextWindow) * 1000) / 10);
 
@@ -48,6 +58,7 @@ export function getContextUsage(messages: FrontendMessage[], contextWindow: numb
     current,
     max: contextWindow,
     percentage,
-    nearLimit: current >= contextWindow * WARNING_THRESHOLD
+    nearLimit: current >= contextWindow * WARNING_THRESHOLD,
+    unknown: false
   };
 }


### PR DESCRIPTION
Refine the Cursor adapter (#435) after end-to-end QA surfaced a series of rendering and data bugs, plus a few shared-UI fixes the Cursor data exposed.

Cursor adapter:
- Accumulate run.stream() per-chunk deltas into one reasoning/assistant message instead of persisting each chunk (was 121 rows for "1+1=").
- Map real tool arg shapes: edit old/new from result diffString, glob globPattern, write fileText; defer content-in-result tools to completion.
- Unwrap the `mcp` wrapper tool for MCP servers and in-process custom tools (was rendering as Unknown:mcp).
- Source AskUserQuestion questions from the tool's execute (stream args can arrive empty) and emit via a push queue; skip the stream copy.
- Stream sub-agent steps live via onDelta tool-call-delta.taskUpdate, with the task-result transcript as a fallback; extract subagentType as a string.
- Render create_plan as assistant markdown (a user-facing checkpoint), not a tool card.
- structuredClone tool args to stop in-place mutation (todos flipping to done) and map the todo status enum (inProgress -> in_progress).
- Unwrap nested result envelopes and map image buffers to a placeholder.
- Map plan_required / socket-closed SDK errors to clear user messages.

Cross-cutting:
- stream-manager: backfill once-per-turn usage for Cursor (as for Codex).
- Context window: keep limit.input=0 when the model reports no max; the UI shows "?" with an explanation instead of a fabricated 100%.
- List tool renders directory contents with CodeBlock (monospace), not markdown.
- AgentTool hides an empty description line; Pi and Cline now require the Agent description param so the model fills it.

Docs: add lessons-learned §10.20 (delta-stream / wrapped-tool / metadata-poor SDK pitfalls) and update README, adding-an-engine, and quick-reference.