### PR TITLE
fix(terminal): bump ptykit to 0.0.6 for IME keystroke fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@iconify-json/material-icon-theme": "1.2.55",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@monaco-editor/loader": "1.7.0",
-        "@myrialabs/ptykit": "0.0.5",
+        "@myrialabs/ptykit": "0.0.6",
         "@myrialabs/tunnelkit": "0.0.15",
         "@myrialabs/zipkit": "0.0.11",
         "@sinclair/typebox": "0.34.48",
@@ -469,7 +469,7 @@
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.9", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-RXSxsokhAF/4nWys8An8npsqOI33Ex1Hlzqjw2pZOO+GKtMAR2noGnUdsFiGwsaO/xXI+56mtjTmDA3JXJsvmA=="],
 
-    "@myrialabs/ptykit": ["@myrialabs/ptykit@0.0.5", "", { "dependencies": { "@xterm/addon-clipboard": "^0.2.0", "@xterm/addon-fit": "^0.11.0", "@xterm/addon-ligatures": "^0.10.0", "@xterm/addon-serialize": "^0.14.0", "@xterm/addon-unicode11": "^0.9.0", "@xterm/addon-web-links": "^0.12.0", "@xterm/headless": "^6.0.0", "@xterm/xterm": "^6.0.0" }, "optionalDependencies": { "bun-pty": "^0.4.10", "node-pty": "^1.1.0", "ws": "^8.21.0" }, "peerDependencies": { "svelte": "^5.0.0" }, "optionalPeers": ["svelte"] }, "sha512-t42kkMvuq9n43bWhTiWTZYukUGaX0PsgmxVbwjcCDtjT9okmLmeQOXxE4E7u9+DDgnqtvCmAnQ9tvenaah6qLQ=="],
+    "@myrialabs/ptykit": ["@myrialabs/ptykit@0.0.6", "", { "dependencies": { "@xterm/addon-clipboard": "^0.2.0", "@xterm/addon-fit": "^0.11.0", "@xterm/addon-ligatures": "^0.10.0", "@xterm/addon-serialize": "^0.14.0", "@xterm/addon-unicode11": "^0.9.0", "@xterm/addon-web-links": "^0.12.0", "@xterm/headless": "^6.0.0", "@xterm/xterm": "^6.0.0" }, "optionalDependencies": { "bun-pty": "^0.4.10", "node-pty": "^1.1.0", "ws": "^8.21.0" }, "peerDependencies": { "svelte": "^5.0.0" }, "optionalPeers": ["svelte"] }, "sha512-t2wz+l9o0ZqnSpgb/Y9bsdpmnMaarIzkmBbujLSVR3rpPB4vPa8prXCaKnRD5pR6Yp8nFMdUMKgHSIb/CTkbJQ=="],
 
     "@myrialabs/tunnelkit": ["@myrialabs/tunnelkit@0.0.15", "", { "bin": { "tunnelkit": "dist/cli.js" } }, "sha512-IxOED4DtZGTnpNy/s0VmFZyaWNFyyVJpN7symy7Dyj6Qu2/7TK8hUsB6gbyrbFrfix/+2ZgwnlIoXkGmYvfAMA=="],
 

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@iconify-json/material-icon-theme": "1.2.55",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@monaco-editor/loader": "1.7.0",
-    "@myrialabs/ptykit": "0.0.5",
+    "@myrialabs/ptykit": "0.0.6",
     "@myrialabs/tunnelkit": "0.0.15",
     "@myrialabs/zipkit": "0.0.11",
     "@sinclair/typebox": "0.34.48",


### PR DESCRIPTION
PtyKit 0.0.6 patches xterm's keyCode=229 input path so IME and Windows physical-keyboard text-suggestion keystrokes are no longer dropped — fixes terminal input collapsing into spaces after the first word on affected devices (xtermjs/xterm.js#5887).