### PR TITLE
feat(update): add release history, whats-new popup, and auto-reload

### DIFF
--- a/backend/ws/system/operations.ts
+++ b/backend/ws/system/operations.ts
@@ -21,8 +21,8 @@ import { resetEnvironment } from '$backend/engine/adapters/claude/environment';
 /** In-memory flag: set after successful update, cleared on server restart */
 let pendingUpdate: { fromVersion: string; toVersion: string } | null = null;
 
-/** Read current version from package.json */
-function getCurrentVersion(): string {
+/** Read current version from package.json on disk (reflects the latest install, not necessarily what's loaded in memory) */
+function readVersionFromDisk(): string {
 	try {
 		const packagePath = join(import.meta.dir, '..', '..', '..', 'package.json');
 		const pkg = JSON.parse(readFileSync(packagePath, 'utf-8'));
@@ -31,6 +31,15 @@ function getCurrentVersion(): string {
 		return '0.0.0';
 	}
 }
+
+/**
+ * Version actually loaded into this running process, captured once at module load.
+ * If a `clopen update` CLI run (a separate process) updates package.json on disk
+ * while this server keeps running, readVersionFromDisk() will report the new
+ * version immediately even though this process is still executing the old code —
+ * runningVersion lets us detect that drift and keep flagging "restart required".
+ */
+const runningVersion = readVersionFromDisk();
 
 /** Fetch latest version from npm registry */
 async function fetchLatestVersion(): Promise<string> {
@@ -71,16 +80,23 @@ export const operationsHandler = createRouter()
 			}))
 		})
 	}, async () => {
-		const currentVersion = getCurrentVersion();
-		debug.log('server', `Checking for updates... current version: ${currentVersion}`);
+		debug.log('server', `Checking for updates... running version: ${runningVersion}`);
+
+		// If a `clopen update` CLI run (separate process) already updated package.json
+		// on disk while this server kept running, the disk version won't match what's
+		// actually loaded in memory. Treat that drift as an implicit pending restart.
+		const diskVersion = readVersionFromDisk();
+		if (pendingUpdate === null && diskVersion !== runningVersion) {
+			pendingUpdate = { fromVersion: runningVersion, toVersion: diskVersion };
+		}
 
 		const latestVersion = await fetchLatestVersion();
-		const updateAvailable = isNewerVersion(currentVersion, latestVersion);
+		const updateAvailable = isNewerVersion(runningVersion, latestVersion);
 
 		debug.log('server', `Latest version: ${latestVersion}, update available: ${updateAvailable}`);
 
 		return {
-			currentVersion,
+			currentVersion: runningVersion,
 			latestVersion,
 			updateAvailable,
 			pendingRestart: pendingUpdate !== null,
@@ -88,27 +104,27 @@ export const operationsHandler = createRouter()
 		};
 	})
 
-	// Fetch release notes from GitHub
+	// Fetch the last few releases (changelog) from GitHub
 	.http('system:get-release-notes', {
 		data: t.Object({}),
-		response: t.Object({
+		response: t.Array(t.Object({
 			tag_name: t.String(),
 			body: t.String(),
 			html_url: t.String(),
 			published_at: t.String()
-		})
+		}))
 	}, async () => {
-		const response = await fetch('https://api.github.com/repos/myrialabs/clopen/releases/latest');
+		const response = await fetch('https://api.github.com/repos/myrialabs/clopen/releases?per_page=3');
 		if (!response.ok) {
 			throw new Error(`GitHub API returned ${response.status}`);
 		}
-		const data = await response.json() as { tag_name: string; body: string; html_url: string; published_at: string };
-		return {
-			tag_name: data.tag_name,
-			body: data.body || '',
-			html_url: data.html_url,
-			published_at: data.published_at
-		};
+		const data = await response.json() as Array<{ tag_name: string; body: string; html_url: string; published_at: string }>;
+		return data.map(release => ({
+			tag_name: release.tag_name,
+			body: release.body || '',
+			html_url: release.html_url,
+			published_at: release.published_at
+		}));
 	})
 
 	// Run package update
@@ -139,7 +155,7 @@ export const operationsHandler = createRouter()
 			throw new Error(`Update failed (exit code ${exitCode}): ${output}`);
 		}
 
-		const fromVersion = getCurrentVersion();
+		const fromVersion = runningVersion;
 
 		// Re-fetch to confirm new version
 		const newVersion = await fetchLatestVersion();

--- a/bin/clopen.ts
+++ b/bin/clopen.ts
@@ -282,7 +282,7 @@ async function runUpdate() {
 	}
 
 	console.log(`✓ Updated to v${latestVersion}`);
-	console.log('\n  Restart clopen to apply the update.');
+	console.log(`\n  Update installed. Restart Clopen however you normally run it to apply v${latestVersion}.`);
 }
 
 async function recoverAdminToken() {

--- a/frontend/App.svelte
+++ b/frontend/App.svelte
@@ -5,6 +5,7 @@
 	import ConnectionBanner from '$frontend/components/common/feedback/ConnectionBanner.svelte';
 	import UpdateBanner from '$frontend/components/common/feedback/UpdateBanner.svelte';
 	import RestartRequiredDialog from '$frontend/components/common/feedback/RestartRequiredDialog.svelte';
+	import WhatsNewDialog from '$frontend/components/common/feedback/WhatsNewDialog.svelte';
 	import LoadingScreen from '$frontend/components/common/feedback/LoadingScreen.svelte';
 	import SetupPage from '$frontend/components/auth/SetupPage.svelte';
 	import LoginPage from '$frontend/components/auth/LoginPage.svelte';
@@ -101,4 +102,5 @@
 	</div>
 
 	<RestartRequiredDialog />
+	<WhatsNewDialog />
 {/if}

--- a/frontend/components/common/feedback/ReleaseNotesList.svelte
+++ b/frontend/components/common/feedback/ReleaseNotesList.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+	import Markdown from '../display/Markdown.svelte';
+	import Icon from '../display/Icon.svelte';
+
+	interface ReleaseNote {
+		tag_name: string;
+		body: string;
+		html_url: string;
+		published_at: string;
+	}
+
+	interface Props {
+		releases: ReleaseNote[];
+		/** How many releases (from the top) start expanded. The rest collapse into an accordion. Default 1. */
+		defaultExpandedCount?: number;
+	}
+
+	const { releases, defaultExpandedCount = 1 }: Props = $props();
+
+	let expanded = $state(new Set<string>());
+
+	// Seed which entries start expanded whenever the release list itself changes
+	// (new fetch, different version list) — not on every unrelated re-render.
+	$effect(() => {
+		expanded = new Set(releases.slice(0, defaultExpandedCount).map(r => r.tag_name));
+	});
+
+	function toggle(tag_name: string) {
+		if (expanded.has(tag_name)) {
+			expanded.delete(tag_name);
+		} else {
+			expanded.add(tag_name);
+		}
+		expanded = new Set(expanded);
+	}
+
+	function formatDate(published_at: string): string {
+		return new Date(published_at).toLocaleDateString(undefined, {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric'
+		});
+	}
+</script>
+
+<div class="flex flex-col divide-y divide-slate-200 dark:divide-slate-700">
+	{#each releases as release (release.tag_name)}
+		<div class="py-3 first:pt-0 last:pb-0">
+			<button
+				type="button"
+				onclick={() => toggle(release.tag_name)}
+				aria-expanded={expanded.has(release.tag_name)}
+				class="flex items-center justify-between gap-2 w-full text-left cursor-pointer"
+			>
+				<div class="flex items-center gap-2">
+					<span class="text-sm font-semibold text-slate-900 dark:text-slate-100">{release.tag_name}</span>
+					<span class="text-xs text-slate-500 dark:text-slate-500">{formatDate(release.published_at)}</span>
+				</div>
+				<Icon
+					name={expanded.has(release.tag_name) ? 'lucide:chevron-up' : 'lucide:chevron-down'}
+					class="w-4 h-4 text-slate-500 shrink-0"
+				/>
+			</button>
+
+			{#if expanded.has(release.tag_name)}
+				<div class="mt-2 release-notes-body">
+					<Markdown variant="compact" content={release.body} />
+					<div class="mt-2">
+						<a
+							href={release.html_url}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="inline-flex items-center gap-1.5 text-sm font-semibold text-violet-600 dark:text-violet-400 hover:underline"
+						>
+							<Icon name="lucide:external-link" class="w-4 h-4" />
+							View on GitHub
+						</a>
+					</div>
+				</div>
+			{/if}
+		</div>
+	{/each}
+</div>
+
+<style>
+	/* Bump the shared "compact" markdown size up a notch for release notes specifically —
+	   scoped here so it doesn't affect the other compact-variant consumer (McpSettings).
+	   Headings (e.g. GitHub's auto-generated "## What's Changed") inherit the same size
+	   as the body/list text instead of getting their own larger size — a release note's
+	   section label shouldn't look bigger than the entries listed under it. */
+	.release-notes-body :global(.markdown-compact) {
+		font-size: 0.875rem;
+		line-height: 1.65;
+	}
+	.release-notes-body :global(.markdown-compact code) {
+		font-size: 0.8125rem;
+	}
+	.release-notes-body :global(.markdown-compact h1),
+	.release-notes-body :global(.markdown-compact h2),
+	.release-notes-body :global(.markdown-compact h3) {
+		font-size: inherit !important;
+	}
+</style>

--- a/frontend/components/common/feedback/RestartRequiredDialog.svelte
+++ b/frontend/components/common/feedback/RestartRequiredDialog.svelte
@@ -1,11 +1,23 @@
 <script lang="ts">
 	import Dialog from '../overlay/Dialog.svelte';
 	import Icon from '../display/Icon.svelte';
+	import ReleaseNotesList from './ReleaseNotesList.svelte';
 	import { updateState, hideRestartModal } from '$frontend/stores/ui/update.svelte';
 
 	function handleClose() {
 		hideRestartModal();
 	}
+
+	// Show the changelog entry matching the version that was just installed, if we have it.
+	// Wrapped in a single-item array here (rather than inline in the template) so the
+	// reference stays stable across unrelated re-renders — ReleaseNotesList reseeds its
+	// expand/collapse state whenever the `releases` array reference changes.
+	const installedReleaseNote = $derived(
+		updateState.releaseNotes?.find(
+			release => release.tag_name.replace(/^v/, '') === updateState.latestVersion
+		) ?? null
+	);
+	const installedReleaseNoteList = $derived(installedReleaseNote ? [installedReleaseNote] : []);
 </script>
 
 <Dialog
@@ -15,6 +27,7 @@
 	type="success"
 	confirmText="Got it"
 	showCancel={false}
+	maxWidth="max-w-lg"
 >
 	<div class="flex items-start space-x-4">
 		<div class="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700/50 rounded-xl p-3">
@@ -22,32 +35,41 @@
 		</div>
 
 		<div class="flex-1 space-y-3">
-			<h3 class="text-lg font-semibold text-green-900 dark:text-green-100">
+			<h2 class="text-lg font-semibold text-green-900 dark:text-green-100">
 				Updated to v{updateState.latestVersion}
-			</h3>
+			</h2>
 
-			<p class="text-sm text-slate-600 dark:text-slate-400">
+			<p class="text-base text-slate-600 dark:text-slate-400">
 				To apply the update, restart the server:
 			</p>
 
-			<ol class="text-sm text-slate-700 dark:text-slate-300 space-y-2.5 list-none pl-0">
+			<ol class="text-base text-slate-700 dark:text-slate-300 space-y-2.5 list-none pl-0">
 				<li class="flex items-start gap-2.5">
-					<span class="flex items-center justify-center w-5 h-5 rounded-full bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400 text-xs font-bold shrink-0 mt-0.5">1</span>
-					<span>Go to the terminal where you ran <code class="px-1.5 py-0.5 bg-slate-100 dark:bg-slate-800 rounded text-xs font-mono">clopen</code> <span class="text-slate-500 dark:text-slate-500">(not the terminal inside Clopen)</span></span>
+					<span class="flex items-center justify-center w-5 h-5 rounded-full bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400 text-sm font-bold shrink-0 mt-0.5">1</span>
+					<span>Go to the terminal where you ran <code class="px-1.5 py-0.5 bg-slate-100 dark:bg-slate-800 rounded text-sm font-mono">clopen</code> <span class="text-slate-500 dark:text-slate-500">(not the terminal inside Clopen)</span></span>
 				</li>
 				<li class="flex items-start gap-2.5">
-					<span class="flex items-center justify-center w-5 h-5 rounded-full bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400 text-xs font-bold shrink-0 mt-0.5">2</span>
-					<span>Press <kbd class="px-1.5 py-0.5 bg-slate-100 dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded text-xs font-mono">Ctrl+C</kbd> to stop the server</span>
+					<span class="flex items-center justify-center w-5 h-5 rounded-full bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400 text-sm font-bold shrink-0 mt-0.5">2</span>
+					<span>Press <kbd class="px-1.5 py-0.5 bg-slate-100 dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded text-sm font-mono">Ctrl+C</kbd> to stop the server</span>
 				</li>
 				<li class="flex items-start gap-2.5">
-					<span class="flex items-center justify-center w-5 h-5 rounded-full bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400 text-xs font-bold shrink-0 mt-0.5">3</span>
-					<span>Run <code class="px-1.5 py-0.5 bg-slate-100 dark:bg-slate-800 rounded text-xs font-mono">clopen</code> again</span>
+					<span class="flex items-center justify-center w-5 h-5 rounded-full bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400 text-sm font-bold shrink-0 mt-0.5">3</span>
+					<span>Run <code class="px-1.5 py-0.5 bg-slate-100 dark:bg-slate-800 rounded text-sm font-mono">clopen</code> again</span>
 				</li>
 				<li class="flex items-start gap-2.5">
-					<span class="flex items-center justify-center w-5 h-5 rounded-full bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400 text-xs font-bold shrink-0 mt-0.5">4</span>
+					<span class="flex items-center justify-center w-5 h-5 rounded-full bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400 text-sm font-bold shrink-0 mt-0.5">4</span>
 					<span>Refresh this browser tab</span>
 				</li>
 			</ol>
+
+			{#if installedReleaseNote}
+				<div class="pt-3 mt-1 border-t border-slate-200 dark:border-slate-700">
+					<div class="text-sm font-semibold text-slate-500 dark:text-slate-400 mb-2">What's new</div>
+					<div class="px-3 py-3 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-700 rounded-lg max-h-64 overflow-y-auto">
+						<ReleaseNotesList releases={installedReleaseNoteList} defaultExpandedCount={0} />
+					</div>
+				</div>
+			{/if}
 		</div>
 	</div>
 </Dialog>

--- a/frontend/components/common/feedback/WhatsNewDialog.svelte
+++ b/frontend/components/common/feedback/WhatsNewDialog.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import Dialog from '../overlay/Dialog.svelte';
+	import Icon from '../display/Icon.svelte';
+	import ReleaseNotesList from './ReleaseNotesList.svelte';
+	import { updateState, runUpdate, dismissWhatsNew } from '$frontend/stores/ui/update.svelte';
+
+	function handleClose() {
+		dismissWhatsNew();
+	}
+
+	function handleUpdateNow() {
+		dismissWhatsNew();
+		runUpdate();
+	}
+</script>
+
+<Dialog
+	bind:isOpen={updateState.showWhatsNewModal}
+	onClose={handleClose}
+	title="What's new in v{updateState.latestVersion}"
+	type="info"
+	showCancel={false}
+	maxWidth="max-w-lg"
+>
+	<div class="flex items-center gap-3">
+		<div class="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-violet-500/15 text-violet-500">
+			<Icon name="lucide:sparkles" class="w-5 h-5" />
+		</div>
+		<h2 class="text-lg font-semibold text-slate-900 dark:text-slate-100">
+			v{updateState.latestVersion} is available
+		</h2>
+	</div>
+
+	<div class="mt-4 max-h-[50vh] overflow-y-auto pr-1">
+		{#if updateState.releaseNotesLoading}
+			<div class="flex items-center gap-2 text-sm text-slate-500">
+				<div class="w-4 h-4 border-2 border-slate-500/30 border-t-slate-500 rounded-full animate-spin"></div>
+				Loading release notes...
+			</div>
+		{:else if updateState.releaseNotes}
+			<ReleaseNotesList releases={updateState.releaseNotes} />
+		{:else if updateState.releaseNotesError}
+			<p class="text-sm text-red-600 dark:text-red-400">Could not load release notes. Check your connection.</p>
+		{/if}
+	</div>
+
+	<div class="flex justify-end gap-3 pt-4 mt-2 border-t border-slate-200 dark:border-slate-700">
+		<button
+			type="button"
+			onclick={handleClose}
+			class="px-6 py-2.5 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-all duration-200 font-semibold"
+		>
+			Maybe later
+		</button>
+		<button
+			type="button"
+			onclick={handleUpdateNow}
+			class="px-6 py-2.5 bg-violet-600 hover:bg-violet-700 text-white rounded-lg transition-all duration-200 font-semibold"
+		>
+			Update now
+		</button>
+	</div>
+</Dialog>

--- a/frontend/components/common/overlay/Dialog.svelte
+++ b/frontend/components/common/overlay/Dialog.svelte
@@ -23,6 +23,8 @@
 		onConfirm?: (value?: string) => void;
 		extraText?: string;
 		onExtra?: () => void;
+		/** Tailwind max-width class for the dialog box. Default 'max-w-md'; use a wider class for content-heavy dialogs (lists, changelogs). */
+		maxWidth?: string;
 		children?: import('svelte').Snippet;
 	}
 
@@ -43,6 +45,7 @@
 		onConfirm,
 		extraText,
 		onExtra,
+		maxWidth = 'max-w-md',
 		children
 	}: Props = $props();
 
@@ -199,7 +202,7 @@
 		out:fade={{ duration: 150, easing: cubicOut }}
 	>
 		<div
-			class="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl max-w-md w-full p-6 space-y-4 shadow-xl max-h-[calc(100dvh-2rem)] overflow-y-auto wrap-anywhere"
+			class="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl {maxWidth} w-full p-6 space-y-4 shadow-xl max-h-[calc(100dvh-2rem)] overflow-y-auto wrap-anywhere"
 			role="document"
 			onclick={(e) => e.stopPropagation()}
 			onkeydown={(e) => e.stopPropagation()}

--- a/frontend/components/settings/general/UpdateSettings.svelte
+++ b/frontend/components/settings/general/UpdateSettings.svelte
@@ -1,27 +1,15 @@
 <script lang="ts">
-	import { marked } from 'marked';
-	import DOMPurify from 'dompurify';
 	import { systemSettings, updateSystemSettings } from '$frontend/stores/features/settings.svelte';
-	import { updateState, checkForUpdate, runUpdate, showRestartModal, fetchReleaseNotes } from '$frontend/stores/ui/update.svelte';
+	import { updateState, checkForUpdate, runUpdate, showRestartModal, fetchReleaseNotes, refetchReleaseNotes } from '$frontend/stores/ui/update.svelte';
 	import Icon from '../../common/display/Icon.svelte';
-	import Markdown from '../../common/display/Markdown.svelte';
+	import ReleaseNotesList from '../../common/feedback/ReleaseNotesList.svelte';
 
 	let showReleaseNotes = $state(false);
 
-	const releaseDate = $derived(
-		updateState.releaseNotes?.published_at
-			? new Date(updateState.releaseNotes.published_at).toLocaleDateString(undefined, {
-					year: 'numeric',
-					month: 'short',
-					day: 'numeric'
-				})
-			: ''
-	);
-
 	const releaseSubtitle = $derived(
-		updateState.releaseNotes
-			? [updateState.releaseNotes.tag_name, releaseDate].filter(Boolean).join(' · ')
-			: "What's new in the latest version"
+		updateState.releaseNotes?.length
+			? `Last ${updateState.releaseNotes.length} versions`
+			: "What's new in recent versions"
 	);
 
 	function toggleAutoUpdate() {
@@ -38,13 +26,11 @@
 
 	function handleToggleReleaseNotes() {
 		showReleaseNotes = !showReleaseNotes;
-		if (showReleaseNotes && !updateState.releaseNotes && !updateState.releaseNotesLoading) {
-			fetchReleaseNotes();
-		}
+		if (showReleaseNotes) fetchReleaseNotes();
 	}
 
 	function handleRetryReleaseNotes() {
-		fetchReleaseNotes();
+		refetchReleaseNotes();
 	}
 </script>
 
@@ -165,18 +151,7 @@
 							Loading release notes...
 						</div>
 					{:else if updateState.releaseNotes}
-						<Markdown variant="compact" content={updateState.releaseNotes.body} />
-						<div class="mt-3">
-							<a
-								href={updateState.releaseNotes.html_url}
-								target="_blank"
-								rel="noopener noreferrer"
-								class="inline-flex items-center gap-1.5 text-xs font-semibold text-violet-600 dark:text-violet-400 hover:underline"
-							>
-								<Icon name="lucide:external-link" class="w-3.5 h-3.5" />
-								View on GitHub
-							</a>
-						</div>
+						<ReleaseNotesList releases={updateState.releaseNotes} />
 					{:else if updateState.releaseNotesError}
 						<div class="flex items-center justify-between gap-3">
 							<div class="flex items-center gap-2 min-w-0">

--- a/frontend/stores/features/settings.svelte.ts
+++ b/frontend/stores/features/settings.svelte.ts
@@ -62,7 +62,8 @@ const defaultSystemSettings: SystemSettings = {
 	autoUpdate: false,
 	sessionLifetimeDays: 30,
 	maxFileSizeMB: 500,
-	publicBaseUrl: ''
+	publicBaseUrl: '',
+	lastSeenReleaseNotesVersion: ''
 };
 
 // Create and export reactive settings state directly (starts with defaults)

--- a/frontend/stores/ui/update.svelte.ts
+++ b/frontend/stores/ui/update.svelte.ts
@@ -3,8 +3,8 @@
  * Tracks npm package update availability and auto-update state
  */
 
-import ws from '$frontend/utils/ws';
-import { systemSettings } from '$frontend/stores/features/settings.svelte';
+import ws, { onWsReconnect } from '$frontend/utils/ws';
+import { systemSettings, updateSystemSettings } from '$frontend/stores/features/settings.svelte';
 import { debug } from '$shared/utils/logger';
 
 interface ReleaseNotes {
@@ -28,9 +28,10 @@ interface UpdateState {
 	pendingRestart: boolean;
 	pendingVersions: { from: string; to: string } | null;
 	showRestartModal: boolean;
-	releaseNotes: ReleaseNotes | null;
+	releaseNotes: ReleaseNotes[] | null;
 	releaseNotesLoading: boolean;
 	releaseNotesError: string | null;
+	showWhatsNewModal: boolean;
 }
 
 export const updateState = $state<UpdateState>({
@@ -49,7 +50,8 @@ export const updateState = $state<UpdateState>({
 	showRestartModal: false,
 	releaseNotes: null,
 	releaseNotesLoading: false,
-	releaseNotesError: null
+	releaseNotesError: null,
+	showWhatsNewModal: false
 });
 
 let checkInterval: ReturnType<typeof setInterval> | null = null;
@@ -75,12 +77,23 @@ export async function checkForUpdate(): Promise<void> {
 			updateState.updateSuccess = true;
 			updateState.latestVersion = result.pendingUpdate.toVersion;
 			updateState.showRestartModal = true;
+			fetchReleaseNotes();
 		}
 
 		// Auto-update if enabled and update is available (skip if already pending restart)
 		if (result.updateAvailable && systemSettings.autoUpdate && !result.pendingRestart) {
 			debug.log('server', 'Auto-update enabled, starting update...');
 			await runUpdate();
+		} else if (
+			result.updateAvailable &&
+			!result.pendingRestart &&
+			systemSettings.lastSeenReleaseNotesVersion !== result.latestVersion
+		) {
+			// Manual-update users get a "what's new" preview before they decide to update.
+			// Auto-update users skip this (the update is about to happen anyway) and instead
+			// see the changelog folded into the post-update restart dialog.
+			await fetchReleaseNotes();
+			updateState.showWhatsNewModal = true;
 		}
 	} catch (err) {
 		updateState.error = err instanceof Error ? err.message : 'Failed to check for updates';
@@ -109,6 +122,7 @@ export async function runUpdate(): Promise<void> {
 		updateState.pendingVersions = { from: updateState.currentVersion, to: result.newVersion };
 		updateState.latestVersion = result.newVersion;
 		updateState.showRestartModal = true;
+		fetchReleaseNotes();
 
 		debug.log('server', 'Update completed successfully');
 	} catch (err) {
@@ -120,20 +134,32 @@ export async function runUpdate(): Promise<void> {
 	}
 }
 
-/** Fetch latest release notes from GitHub */
+/** Fetch the last few release notes (changelog) from GitHub */
 export async function fetchReleaseNotes(): Promise<void> {
-	if (updateState.releaseNotesLoading) return;
+	if (updateState.releaseNotesLoading || updateState.releaseNotes) return;
 	updateState.releaseNotesLoading = true;
 	updateState.releaseNotesError = null;
 	try {
 		const data = await ws.http('system:get-release-notes', {});
-		updateState.releaseNotes = data as ReleaseNotes;
+		updateState.releaseNotes = data as ReleaseNotes[];
 	} catch (err) {
 		updateState.releaseNotesError = err instanceof Error ? err.message : 'Failed to load release notes';
 		debug.error('server', 'Failed to fetch release notes:', err);
 	} finally {
 		updateState.releaseNotesLoading = false;
 	}
+}
+
+/** Force-refresh release notes (used by the retry button, ignores the cache guard) */
+export async function refetchReleaseNotes(): Promise<void> {
+	updateState.releaseNotes = null;
+	await fetchReleaseNotes();
+}
+
+/** Dismiss the "what's new" preview dialog, remembering this version so it won't repeat */
+export function dismissWhatsNew(): void {
+	updateState.showWhatsNewModal = false;
+	updateSystemSettings({ lastSeenReleaseNotesVersion: updateState.latestVersion });
 }
 
 /** Dismiss the update banner (not allowed when restart is pending) */
@@ -162,6 +188,27 @@ ws.on('system:update-completed', (payload) => {
 	updateState.latestVersion = payload.toVersion;
 	updateState.showRestartModal = true;
 	updateState.dismissed = false;
+	fetchReleaseNotes();
+});
+
+// After a WS reconnect (e.g. the server process was restarted to apply an update),
+// verify the server is still running the version this tab last observed. A mismatch
+// means the reconnect happened against new code — the loaded JS/CSS bundle is stale,
+// so reload instead of leaving the user on an old frontend talking to a new backend.
+// Version numbers only change on a real update (not on `bun --watch` dev restarts),
+// so this won't fire on every backend hot-reload during development.
+onWsReconnect(() => {
+	if (!updateState.currentVersion) return;
+	ws.http('system:check-update', {})
+		.then(result => {
+			if (result.currentVersion !== updateState.currentVersion) {
+				debug.log('server', `Server version changed after reconnect (${updateState.currentVersion} -> ${result.currentVersion}), reloading`);
+				window.location.reload();
+			}
+		})
+		.catch(err => {
+			debug.error('server', 'Version check after reconnect failed:', err);
+		});
 });
 
 /** Start periodic update checks (every 30 minutes) */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myrialabs/clopen",
-  "version": "0.4.17",
+  "version": "0.4.15",
   "description": "All-in-one web workspace for AI coding agents — Claude Code, OpenCode, Codex, Copilot, Qwen Code, Pi, Cline, and Cursor — with chat, terminal, git, browser preview, database client, checkpoints, and real-time collaboration",
   "author": "Myria Labs",
   "license": "MIT",

--- a/shared/types/stores/settings.ts
+++ b/shared/types/stores/settings.ts
@@ -97,4 +97,6 @@ export interface SystemSettings {
 	 * the current origin or a Cloudflare quick tunnel. Default: '' (unset).
 	 */
 	publicBaseUrl?: string;
+	/** Latest version the "What's New" preview dialog has been dismissed for. Default: '' (never dismissed). */
+	lastSeenReleaseNotesVersion?: string;
 }


### PR DESCRIPTION
Show the last 3 releases (not just latest), add a whats-new preview dialog before updating and a changelog recap after, auto-reload the browser when the server version changes post-restart, and fix a CLI/web desync where an externally-updated server stopped showing "restart required".