### PR TITLE
feat(command-palette): add spotlight-style search with FTS5-backed session lookup

### DIFF
--- a/backend/database/migrations/064_create_messages_fts.ts
+++ b/backend/database/migrations/064_create_messages_fts.ts
@@ -1,0 +1,71 @@
+import type { DatabaseConnection } from '$shared/types/database/connection';
+import { debug } from '$shared/utils/logger';
+
+export const description = 'Create messages_fts (FTS5) index for fast global session content search with snippets';
+
+/**
+ * Minimal inline text extraction, mirroring extractMessageText from
+ * backend/snapshot/helpers.ts. Duplicated (not imported) so this migration
+ * stays runnable standalone and isn't coupled to app code that may change
+ * later — the same convention 029_migrate_messages_to_unified.ts uses.
+ */
+function extractSearchableText(msg: Record<string, unknown>): string {
+	if (msg.type === 'reasoning') return (msg.text as string) || '';
+	if (msg.type === 'compact_boundary') return '';
+	const content = msg.content;
+	if (!Array.isArray(content)) return '';
+	return (content as Record<string, unknown>[])
+		.filter(b => b.type === 'text' && b.text)
+		.map(b => b.text as string)
+		.join('\n');
+}
+
+export const up = (db: DatabaseConnection): void => {
+	debug.log('migration', 'Creating messages_fts virtual table...');
+
+	// project_id/session_id are UNINDEXED (used only to filter/join) — only
+	// `text` participates in the FTS index. Kept as our own standalone table
+	// (not `content=messages`) since indexed text is derived from JSON, not a
+	// plain column.
+	db.exec(`
+		CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+			message_id UNINDEXED,
+			session_id UNINDEXED,
+			project_id UNINDEXED,
+			text
+		)
+	`);
+
+	debug.log('migration', 'Backfilling messages_fts from existing messages...');
+
+	const rows = db.prepare(`
+		SELECT m.id, m.session_id, m.data, cs.project_id
+		FROM messages m
+		INNER JOIN chat_sessions cs ON cs.id = m.session_id
+	`).all() as { id: string; session_id: string; data: string; project_id: string }[];
+
+	const insert = db.prepare(`
+		INSERT INTO messages_fts (message_id, session_id, project_id, text)
+		VALUES (?, ?, ?, ?)
+	`);
+
+	let indexed = 0;
+	for (const row of rows) {
+		try {
+			const msg = JSON.parse(row.data) as Record<string, unknown>;
+			const text = extractSearchableText(msg).trim();
+			if (!text) continue;
+			insert.run(row.id, row.session_id, row.project_id, text);
+			indexed++;
+		} catch {
+			// Skip unparsable rows — same tolerance as other backfills in this file set.
+		}
+	}
+
+	debug.log('migration', `messages_fts backfilled: ${indexed}/${rows.length} messages indexed`);
+};
+
+export const down = (db: DatabaseConnection): void => {
+	debug.log('migration', 'Dropping messages_fts virtual table...');
+	db.exec(`DROP TABLE IF EXISTS messages_fts`);
+};

--- a/backend/database/migrations/index.ts
+++ b/backend/database/migrations/index.ts
@@ -62,6 +62,7 @@ import * as migration060 from './060_create_device_codes_table';
 import * as migration061 from './061_add_session_device_metadata';
 import * as migration062 from './062_add_session_source';
 import * as migration063 from './063_add_invite_project_ids';
+import * as migration064 from './064_create_messages_fts';
 
 // Export all migrations in order
 export const migrations = [
@@ -442,6 +443,12 @@ export const migrations = [
 		description: migration063.description,
 		up: migration063.up,
 		down: migration063.down
+	},
+	{
+		id: '064',
+		description: migration064.description,
+		up: migration064.up,
+		down: migration064.down
 	}
 ];
 

--- a/backend/database/queries/message-queries.ts
+++ b/backend/database/queries/message-queries.ts
@@ -9,6 +9,37 @@ function parseMessage(row: DatabaseMessage): UnifiedMessage {
 	return JSON.parse(row.data) as UnifiedMessage;
 }
 
+/**
+ * Extract combined plain text from a message for the messages_fts index.
+ * Kept local (not imported from snapshot/helpers.ts) to avoid a circular
+ * import — helpers.ts imports messageQueries from this module's barrel.
+ */
+function extractSearchableText(msg: UnifiedMessage): string {
+	if (msg.type === 'reasoning') return msg.text;
+	if (msg.type === 'compact_boundary') return '';
+	return msg.content
+		.filter((block): block is { type: 'text'; text: string } => block.type === 'text' && !!block.text)
+		.map(block => block.text)
+		.join('\n');
+}
+
+/** Keep the messages_fts mirror in sync with a message's current text content. */
+function syncMessageFts(id: string, sessionId: string, msg: UnifiedMessage): void {
+	const db = getDatabase();
+	db.prepare('DELETE FROM messages_fts WHERE message_id = ?').run(id);
+
+	const text = extractSearchableText(msg).trim();
+	if (!text) return;
+
+	const session = db.prepare('SELECT project_id FROM chat_sessions WHERE id = ?').get(sessionId) as { project_id: string } | null;
+	if (!session) return;
+
+	db.prepare(`
+		INSERT INTO messages_fts (message_id, session_id, project_id, text)
+		VALUES (?, ?, ?, ?)
+	`).run(id, sessionId, session.project_id, text);
+}
+
 export const messageQueries = {
 	/**
 	 * Get visible messages for a session (git-like: from HEAD to root)
@@ -131,6 +162,8 @@ export const messageQueries = {
 			parentMessageId
 		);
 
+		syncMessageFts(id, messageData.session_id, msg);
+
 		return {
 			id,
 			session_id: messageData.session_id,
@@ -145,19 +178,30 @@ export const messageQueries = {
 	delete(id: string): void {
 		const db = getDatabase();
 		db.prepare('DELETE FROM messages WHERE id = ?').run(id);
+		db.prepare('DELETE FROM messages_fts WHERE message_id = ?').run(id);
 	},
 
 	deleteBySessionId(sessionId: string): void {
 		const db = getDatabase();
 		db.prepare('DELETE FROM messages WHERE session_id = ?').run(sessionId);
+		db.prepare('DELETE FROM messages_fts WHERE session_id = ?').run(sessionId);
 	},
 
 	deleteAfterTimestamp(sessionId: string, timestamp: string): void {
 		const db = getDatabase();
+		const ids = db.prepare(`
+			SELECT id FROM messages WHERE session_id = ? AND created_at >= ?
+		`).all(sessionId, timestamp) as { id: string }[];
+
 		db.prepare(`
 			DELETE FROM messages
 			WHERE session_id = ? AND created_at >= ?
 		`).run(sessionId, timestamp);
+
+		if (ids.length > 0) {
+			const placeholders = ids.map(() => '?').join(',');
+			db.prepare(`DELETE FROM messages_fts WHERE message_id IN (${placeholders})`).run(...ids.map(r => r.id));
+		}
 	},
 
 	/**

--- a/backend/database/queries/session-queries.ts
+++ b/backend/database/queries/session-queries.ts
@@ -2,6 +2,13 @@ import { getDatabase } from '../index';
 import type { ChatSession, Branch, DatabaseMessage } from '$shared/types/database/schema';
 import { loadMessage } from '$shared/utils/message-formatter';
 import { extractMessageText } from '../../snapshot/helpers';
+import { debug } from '$shared/utils/logger';
+
+/** ChatSession plus an optional FTS snippet, set only for message-content matches. */
+export interface SessionSearchResult extends ChatSession {
+	/** Snippet with char(1)/char(2) markers wrapping the matched text. */
+	matchSnippet?: string;
+}
 
 export const sessionQueries = {
 	getAll(): ChatSession[] {
@@ -233,20 +240,116 @@ export const sessionQueries = {
 	},
 
 	/**
-	 * Search sessions by message content.
-	 * Returns session IDs that have matching messages.
+	 * Search sessions by message content within a single project, via the
+	 * messages_fts index (fast index lookup, not a raw LIKE table scan).
+	 * Returns one result per matching session with a highlighted snippet
+	 * showing where the match occurred, ordered by relevance. Backs the
+	 * History/Sessions modal's deep search.
 	 */
-	searchByMessageContent(projectId: string, query: string, limit: number = 20): string[] {
+	searchByMessageContent(projectId: string, query: string, limit: number = 20): { sessionId: string; snippet: string }[] {
 		const db = getDatabase();
-		const rows = db.prepare(`
-			SELECT DISTINCT m.session_id
-			FROM messages m
-			INNER JOIN chat_sessions cs ON cs.id = m.session_id
-			WHERE cs.project_id = ?
-			  AND m.data LIKE ?
+		const ftsQuery = this.buildFtsQuery(query);
+		if (!ftsQuery) return [];
+
+		try {
+			const rows = db.prepare(`
+				SELECT fts.session_id AS session_id,
+				       snippet(messages_fts, 3, char(1), char(2), '…', 12) AS snippet
+				FROM messages_fts fts
+				WHERE fts.project_id = ? AND fts.text MATCH ?
+				ORDER BY rank
+				LIMIT ?
+			`).all(projectId, ftsQuery, limit * 3) as { session_id: string; snippet: string }[];
+
+			// Keep only the best (first, since ordered by rank) match per session.
+			const seen = new Set<string>();
+			const results: { sessionId: string; snippet: string }[] = [];
+			for (const row of rows) {
+				if (seen.has(row.session_id)) continue;
+				seen.add(row.session_id);
+				results.push({ sessionId: row.session_id, snippet: row.snippet });
+				if (results.length >= limit) break;
+			}
+			return results;
+		} catch (err) {
+			debug.warn('database', 'FTS content search failed for project scope:', err);
+			return [];
+		}
+	},
+
+	/**
+	 * Turn free-typed text into a safe FTS5 MATCH query: strip everything but
+	 * letters/digits per word and treat each as a quoted prefix term (implicit
+	 * AND between terms). Avoids FTS5 syntax injection from raw user input and
+	 * gives "type as you go" prefix matching.
+	 */
+	buildFtsQuery(raw: string): string | null {
+		const terms = raw
+			.split(/\s+/)
+			.map(t => t.replace(/[^\p{L}\p{N}]/gu, ''))
+			.filter(t => t.length > 0);
+		if (terms.length === 0) return null;
+		return terms.map(t => `"${t}"*`).join(' ');
+	},
+
+	/**
+	 * Search sessions across every project the user has access to.
+	 * Two passes, merged: cheap metadata match (title/head_title/head_summary)
+	 * plus an FTS5 index lookup over message content — the latter also returns
+	 * a highlighted snippet (wrapped in ... markers) showing where
+	 * the match occurred. Backs the global Command Palette session search.
+	 */
+	searchGlobal(userId: string, query: string, limit: number = 20): SessionSearchResult[] {
+		const db = getDatabase();
+		const trimmed = query.trim();
+		if (!trimmed) return [];
+
+		const results = new Map<string, SessionSearchResult>();
+
+		// Pass 1: metadata match — cheap, exact substring, no snippet needed.
+		const like = `%${trimmed}%`;
+		const metaRows = db.prepare(`
+			SELECT * FROM chat_sessions cs
+			WHERE cs.project_id IN (SELECT project_id FROM user_projects WHERE user_id = ?)
+			  AND (cs.title LIKE ? OR cs.head_title LIKE ? OR cs.head_summary LIKE ?)
+			ORDER BY COALESCE(cs.last_message_at, cs.started_at) DESC
 			LIMIT ?
-		`).all(projectId, `%${query}%`, limit) as { session_id: string }[];
-		return rows.map(r => r.session_id);
+		`).all(userId, like, like, like, limit) as ChatSession[];
+		for (const row of metaRows) {
+			results.set(row.id, row);
+		}
+
+		// Pass 2: message content match via FTS5 — fast index lookup with snippet.
+		const ftsQuery = this.buildFtsQuery(trimmed);
+		if (ftsQuery) {
+			try {
+				const contentRows = db.prepare(`
+					SELECT cs.*, snippet(messages_fts, 3, char(1), char(2), '…', 12) AS match_snippet
+					FROM messages_fts fts
+					INNER JOIN chat_sessions cs ON cs.id = fts.session_id
+					WHERE fts.project_id IN (SELECT project_id FROM user_projects WHERE user_id = ?)
+					  AND fts.text MATCH ?
+					ORDER BY rank
+					LIMIT ?
+				`).all(userId, ftsQuery, limit * 2) as (ChatSession & { match_snippet: string })[];
+
+				for (const row of contentRows) {
+					if (results.has(row.id)) continue;
+					const { match_snippet, ...session } = row;
+					results.set(row.id, { ...session, matchSnippet: match_snippet });
+				}
+			} catch (err) {
+				debug.warn('database', 'FTS content search failed, falling back to metadata-only results:', err);
+			}
+		}
+
+		return Array.from(results.values())
+			.sort((a, b) => {
+				const aTime = a.last_message_at || a.started_at;
+				const bTime = b.last_message_at || b.started_at;
+				return new Date(bTime).getTime() - new Date(aTime).getTime();
+			})
+			.slice(0, limit);
 	},
 
 	end(id: string): void {
@@ -286,6 +389,7 @@ export const sessionQueries = {
 		db.prepare('DELETE FROM message_snapshots WHERE session_id = ?').run(id);
 		db.prepare('DELETE FROM session_relationships WHERE parent_session_id = ? OR child_session_id = ?').run(id, id);
 		db.prepare('DELETE FROM messages WHERE session_id = ?').run(id);
+		db.prepare('DELETE FROM messages_fts WHERE session_id = ?').run(id);
 		db.prepare('DELETE FROM user_unread_sessions WHERE session_id = ?').run(id);
 		// Clear current_session_id references in user_projects
 		db.prepare('UPDATE user_projects SET current_session_id = NULL WHERE current_session_id = ?').run(id);
@@ -313,6 +417,7 @@ export const sessionQueries = {
 			   OR child_session_id IN (SELECT id FROM chat_sessions WHERE project_id = ?)
 		`).run(projectId, projectId);
 		db.prepare('DELETE FROM messages WHERE session_id IN (SELECT id FROM chat_sessions WHERE project_id = ?)').run(projectId);
+		db.prepare('DELETE FROM messages_fts WHERE project_id = ?').run(projectId);
 		db.prepare('DELETE FROM user_unread_sessions WHERE project_id = ?').run(projectId);
 		// Clear current_session_id references in user_projects for this project
 		db.prepare('UPDATE user_projects SET current_session_id = NULL WHERE project_id = ?').run(projectId);

--- a/backend/ws/sessions/crud.ts
+++ b/backend/ws/sessions/crud.ts
@@ -50,6 +50,12 @@ const sessionSchema = t.Object({
 	last_message_at: t.Optional(t.String()),
 });
 
+/** sessionSchema plus a highlighted match snippet — global (cross-project) search only. */
+const sessionSearchResultSchema = t.Object({
+	...sessionSchema.properties,
+	matchSnippet: t.Optional(t.String())
+});
+
 /** Convert ChatSession DB row → response (null → undefined for Elysia optional fields) */
 function serializeSession(session: ChatSession) {
 	return {
@@ -416,16 +422,35 @@ export const crudHandler = createRouter()
 		debug.log('session', `[unread] Marked ALL sessions as READ for user ${userId} in project ${data.projectId}`);
 	})
 
-	// Search sessions by message content (deep search)
+	// Search sessions by message content within the current project (deep search)
 	.http('sessions:search', {
 		data: t.Object({
 			query: t.String({ minLength: 1 })
 		}),
 		response: t.Object({
-			sessionIds: t.Array(t.String())
+			results: t.Array(t.Object({
+				sessionId: t.String(),
+				snippet: t.String()
+			}))
 		})
 	}, async ({ data, conn }) => {
 		const { projectId } = requireCurrentProjectAccess(conn);
-		const sessionIds = sessionQueries.searchByMessageContent(projectId, data.query);
-		return { sessionIds };
+		const results = sessionQueries.searchByMessageContent(projectId, data.query);
+		return { results };
+	})
+
+	// Search sessions across every project the user has access to (Command Palette)
+	.http('sessions:search-global', {
+		data: t.Object({
+			query: t.String({ minLength: 1 })
+		}),
+		response: t.Object({
+			sessions: t.Array(sessionSearchResultSchema)
+		})
+	}, async ({ data, conn }) => {
+		const userId = ws.getUserId(conn);
+		const results = sessionQueries.searchGlobal(userId, data.query);
+		return {
+			sessions: results.map(r => ({ ...serializeSession(r), matchSnippet: r.matchSnippet }))
+		};
 	});

--- a/frontend/components/common/overlay/CommandPalette.svelte
+++ b/frontend/components/common/overlay/CommandPalette.svelte
@@ -1,0 +1,435 @@
+<script lang="ts">
+	import { fade, scale } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
+	import { portal } from '$frontend/utils/portal';
+	import { isMac } from '$frontend/utils/platform';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import {
+		commandPaletteState,
+		closeCommandPalette,
+		toggleCommandPalette
+	} from '$frontend/stores/ui/command-palette.svelte';
+	import { projectState, searchProjects, setCurrentProject } from '$frontend/stores/core/projects.svelte';
+	import { setCurrentSession } from '$frontend/stores/core/sessions.svelte';
+	import { authStore } from '$frontend/stores/features/auth.svelte';
+	import { openSettingsModal, settingsSections } from '$frontend/stores/ui/settings-modal.svelte';
+	import { getCommandActions } from '$frontend/config/command-registry';
+	import ws from '$frontend/utils/ws';
+	import { debug } from '$shared/utils/logger';
+	import { parseSnippet } from '$frontend/utils/fts-snippet';
+	import type { ChatSession, Project } from '$shared/types/database/schema';
+	import type { IconName } from '$shared/types/ui/icons';
+
+	/** ChatSession plus a highlighted match snippet — set only for content matches. */
+	type SessionSearchResult = ChatSession & { matchSnippet?: string };
+
+	type ResultKind = 'project' | 'action' | 'setting' | 'session';
+
+	/** One icon+text chip in a PaletteItem's meta row (e.g. project, last active, message count). */
+	interface PaletteItemMeta {
+		icon: IconName;
+		text: string;
+	}
+
+	interface PaletteItem {
+		kind: ResultKind;
+		id: string;
+		label: string;
+		description?: string;
+		/** Trailing meta chips (project, last active, message count) — sessions only. */
+		meta?: PaletteItemMeta[];
+		/** Raw FTS snippet with sentinel markers around the matched text. */
+		snippet?: string;
+		icon: IconName;
+		run: () => void | Promise<void>;
+	}
+
+	/** Mirrors HistoryView.svelte's getRelativeTime — kept local since it's a small, one-off formatter. */
+	function getRelativeTime(dateString: string): string {
+		const diffMs = Date.now() - new Date(dateString).getTime();
+		const diffMins = Math.floor(diffMs / 1000 / 60);
+		const diffHours = Math.floor(diffMins / 60);
+		const diffDays = Math.floor(diffHours / 24);
+
+		if (diffMins < 1) return 'Just now';
+		if (diffMins < 60) return `${diffMins}m ago`;
+		if (diffHours < 24) return `${diffHours}h ago`;
+		if (diffDays < 7) return `${diffDays}d ago`;
+		if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
+		if (diffDays < 365) return `${Math.floor(diffDays / 30)}mo ago`;
+		return `${Math.floor(diffDays / 365)}y ago`;
+	}
+
+	let query = $state('');
+	let selectedIndex = $state(0);
+	let inputEl = $state<HTMLInputElement>();
+	let resultsEl = $state<HTMLElement>();
+	let sessionResults = $state<SessionSearchResult[]>([]);
+	let sessionsLoading = $state(false);
+	let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+	const modifierLabel = isMac() ? '⌘' : 'Ctrl+';
+
+	// Reset transient state every time the palette opens, and focus the input.
+	$effect(() => {
+		if (commandPaletteState.isOpen) {
+			query = '';
+			selectedIndex = 0;
+			sessionResults = [];
+			queueMicrotask(() => inputEl?.focus());
+		}
+	});
+
+	function triggerSessionSearch(q: string) {
+		clearTimeout(searchDebounceTimer);
+		if (q.trim().length < 2) {
+			sessionResults = [];
+			sessionsLoading = false;
+			return;
+		}
+		sessionsLoading = true;
+		searchDebounceTimer = setTimeout(async () => {
+			try {
+				const result = await ws.http('sessions:search-global', { query: q.trim() });
+				sessionResults = result.sessions;
+			} catch (err) {
+				debug.error('session', 'Global session search failed:', err);
+				sessionResults = [];
+			} finally {
+				sessionsLoading = false;
+			}
+		}, 150);
+	}
+
+	$effect(() => {
+		if (commandPaletteState.isOpen) triggerSessionSearch(query);
+	});
+
+	const matchedProjects = $derived.by(() => {
+		const trimmed = query.trim();
+		const base = trimmed
+			? searchProjects(trimmed)
+			: projectState.recentProjects.length
+				? projectState.recentProjects
+				: projectState.projects;
+		return base.slice(0, 6);
+	});
+
+	const matchedActions = $derived.by(() => {
+		const trimmed = query.trim().toLowerCase();
+		const all = getCommandActions();
+		if (!trimmed) return all;
+		return all.filter(
+			(a) =>
+				a.label.toLowerCase().includes(trimmed) ||
+				a.description.toLowerCase().includes(trimmed) ||
+				(a.keywords ?? []).some((k) => k.includes(trimmed))
+		);
+	});
+
+	const matchedSettings = $derived.by(() => {
+		const trimmed = query.trim().toLowerCase();
+		if (!trimmed) return [];
+		const visible = settingsSections.filter((s) => !s.adminOnly || authStore.isAdmin);
+		return visible.filter(
+			(s) =>
+				s.label.toLowerCase().includes(trimmed) ||
+				s.description.toLowerCase().includes(trimmed)
+		);
+	});
+
+	async function selectProject(project: Project) {
+		closeCommandPalette();
+		await setCurrentProject(project);
+	}
+
+	async function selectSession(session: SessionSearchResult) {
+		closeCommandPalette();
+		const project = projectState.projects.find((p) => p.id === session.project_id);
+		if (project && project.id !== projectState.currentProject?.id) {
+			await setCurrentProject(project);
+		}
+		await setCurrentSession(session);
+	}
+
+	// Flat, ordered list — drives both keyboard navigation and grouping below.
+	const items = $derived.by(() => {
+		const list: PaletteItem[] = [];
+
+		for (const p of matchedProjects) {
+			list.push({
+				kind: 'project',
+				id: `project-${p.id}`,
+				label: p.name,
+				description: p.path,
+				icon: 'lucide:folder',
+				run: () => selectProject(p)
+			});
+		}
+
+		for (const a of matchedActions) {
+			list.push({
+				kind: 'action',
+				id: `action-${a.id}`,
+				label: a.label,
+				description: a.description,
+				icon: a.icon,
+				run: a.run
+			});
+		}
+
+		for (const s of matchedSettings) {
+			list.push({
+				kind: 'setting',
+				id: `setting-${s.id}`,
+				label: s.label,
+				description: s.description,
+				icon: s.icon,
+				run: () => openSettingsModal(s.id)
+			});
+		}
+
+		for (const session of sessionResults) {
+			const project = projectState.projects.find((p) => p.id === session.project_id);
+			const lastActive = session.last_message_at || session.ended_at || session.started_at;
+			const meta: PaletteItemMeta[] = [];
+			if (project?.name) meta.push({ icon: 'lucide:folder', text: project.name });
+			if (lastActive) meta.push({ icon: 'lucide:clock', text: getRelativeTime(lastActive) });
+			if (session.message_count != null) {
+				meta.push({ icon: 'lucide:message-circle', text: `${session.message_count} msgs` });
+			}
+			list.push({
+				kind: 'session',
+				id: `session-${session.id}`,
+				label: session.title || session.head_title || 'Untitled session',
+				description: session.matchSnippet ? undefined : session.head_summary || undefined,
+				snippet: session.matchSnippet,
+				meta,
+				icon: 'lucide:message-square',
+				run: () => selectSession(session)
+			});
+		}
+
+		return list;
+	});
+
+	const indexedItems = $derived(items.map((item, index) => ({ ...item, index })));
+
+	const groups = $derived.by(() => {
+		const all = [
+			{ label: 'Projects', items: indexedItems.filter((i) => i.kind === 'project') },
+			{ label: 'Actions', items: indexedItems.filter((i) => i.kind === 'action') },
+			{ label: 'Settings', items: indexedItems.filter((i) => i.kind === 'setting') },
+			{ label: 'Sessions', items: indexedItems.filter((i) => i.kind === 'session') }
+		];
+		return all.filter((g) => g.items.length > 0);
+	});
+
+	// Keep the selection valid as the result set shrinks/grows while typing.
+	$effect(() => {
+		if (selectedIndex >= items.length) selectedIndex = Math.max(0, items.length - 1);
+	});
+
+	async function activate(item: PaletteItem) {
+		await item.run();
+		if (item.kind === 'action' || item.kind === 'setting') {
+			closeCommandPalette();
+		}
+	}
+
+	/**
+	 * Keep the highlighted row visible as arrow-key navigation moves past the
+	 * fold. Only scrolls when the row is actually out of view — anchoring to
+	 * the edge it's crossing (bottom when it overflows below, top when it
+	 * overflows above) — instead of unconditionally calling scrollIntoView
+	 * on every key press. Doing it unconditionally caused a jump on
+	 * alternating Down/Up presses: the row would still be fully visible, but
+	 * the previous direction's edge anchor would yank it back to the
+	 * opposite edge anyway.
+	 */
+	function scrollSelectedIntoView() {
+		requestAnimationFrame(() => {
+			const el = resultsEl?.querySelector(`[data-index="${selectedIndex}"]`) as HTMLElement | null;
+			if (!resultsEl || !el) return;
+			const containerRect = resultsEl.getBoundingClientRect();
+			const elRect = el.getBoundingClientRect();
+			if (elRect.bottom > containerRect.bottom) {
+				el.scrollIntoView({ block: 'end' });
+			} else if (elRect.top < containerRect.top) {
+				el.scrollIntoView({ block: 'start' });
+			}
+		});
+	}
+
+	/** Don't steal Ctrl/Cmd+K from the terminal — readline binds it to kill-line. */
+	function isTerminalFocused(): boolean {
+		const active = document.activeElement as HTMLElement | null;
+		return !!active?.closest('.xterm');
+	}
+
+	// Registered on the capture phase (see onkeydowncapture below) so the
+	// shortcut still reaches us even when focus is inside another modal —
+	// Modal.svelte's content wrapper calls stopPropagation() on keydown during
+	// the bubble phase, which would otherwise block a normal bubble listener.
+	// When we do act on a key, we also stopPropagation() so it doesn't leak
+	// through to whatever modal is open underneath the palette.
+	function handleGlobalKeydown(event: KeyboardEvent) {
+		const modifierPressed = isMac() ? event.metaKey : event.ctrlKey;
+
+		if (!commandPaletteState.isOpen) {
+			if (modifierPressed && event.key.toLowerCase() === 'k' && !isTerminalFocused()) {
+				event.preventDefault();
+				event.stopPropagation();
+				toggleCommandPalette();
+			}
+			return;
+		}
+
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			event.stopPropagation();
+			closeCommandPalette();
+			return;
+		}
+
+		if (event.key === 'ArrowDown') {
+			event.preventDefault();
+			event.stopPropagation();
+			if (items.length > 0) {
+				selectedIndex = (selectedIndex + 1) % items.length;
+				scrollSelectedIntoView();
+			}
+			return;
+		}
+
+		if (event.key === 'ArrowUp') {
+			event.preventDefault();
+			event.stopPropagation();
+			if (items.length > 0) {
+				selectedIndex = (selectedIndex - 1 + items.length) % items.length;
+				scrollSelectedIntoView();
+			}
+			return;
+		}
+
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			event.stopPropagation();
+			const item = items[selectedIndex];
+			if (item) activate(item);
+			return;
+		}
+
+		if (modifierPressed && event.key.toLowerCase() === 'k') {
+			event.preventDefault();
+			event.stopPropagation();
+			closeCommandPalette();
+		}
+	}
+
+	function handleBackdropClick(event: MouseEvent) {
+		if (event.target === event.currentTarget) closeCommandPalette();
+	}
+</script>
+
+<svelte:window onkeydowncapture={handleGlobalKeydown} />
+
+{#if commandPaletteState.isOpen}
+	<div
+		use:portal
+		class="fixed inset-0 z-[200] bg-black/50 dark:bg-slate-950/70 backdrop-blur-sm flex items-start justify-center pt-[12vh] px-4"
+		role="dialog"
+		aria-modal="true"
+		aria-label="Command palette"
+		onclick={handleBackdropClick}
+		in:fade={{ duration: 150, easing: cubicOut }}
+		out:fade={{ duration: 100, easing: cubicOut }}
+	>
+		<div
+			class="w-full max-w-xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[70vh]"
+			in:scale={{ duration: 150, easing: cubicOut, start: 0.97 }}
+			out:scale={{ duration: 100, easing: cubicOut, start: 0.97 }}
+		>
+			<!-- Search Input -->
+			<div class="flex items-center gap-3 px-4 py-3.5 border-b border-slate-200 dark:border-slate-800 shrink-0">
+				<Icon name="lucide:search" class="w-4.5 h-4.5 text-slate-400 dark:text-slate-500 shrink-0" />
+				<input
+					bind:this={inputEl}
+					bind:value={query}
+					type="text"
+					placeholder="Search projects, actions, settings, sessions..."
+					class="flex-1 bg-transparent border-none outline-none text-slate-900 dark:text-slate-100 text-sm placeholder:text-slate-400 dark:placeholder:text-slate-500"
+				/>
+				{#if sessionsLoading}
+					<div class="w-3.5 h-3.5 border-2 border-slate-300 border-t-violet-500 rounded-full animate-spin shrink-0"></div>
+				{/if}
+				<kbd class="text-3xs font-mono text-slate-400 dark:text-slate-500 border border-slate-200 dark:border-slate-700 rounded px-1.5 py-0.5 shrink-0">Esc</kbd>
+			</div>
+
+			<!-- Results -->
+			<div bind:this={resultsEl} class="flex-1 overflow-y-auto py-2">
+				{#if items.length === 0}
+					<div class="flex flex-col items-center gap-2 py-10 text-slate-500 dark:text-slate-500 text-sm">
+						<Icon name="lucide:search-x" class="w-8 h-8 opacity-40" />
+						<p>No results found</p>
+					</div>
+				{:else}
+					{#each groups as group (group.label)}
+						<div class="px-4 py-1 text-3xs font-semibold text-slate-500 dark:text-slate-500 uppercase tracking-wider mt-1.5 first:mt-0">
+							{group.label}
+						</div>
+						{#each group.items as item (item.id)}
+							<button
+								type="button"
+								data-index={item.index}
+								class="flex items-center gap-3 w-[calc(100%-1rem)] mx-2 px-2.5 py-2 rounded-lg text-left bg-transparent border-none cursor-pointer transition-colors duration-100
+									{item.index === selectedIndex
+									? 'bg-violet-500/10 text-slate-900 dark:text-slate-100'
+									: 'text-slate-700 dark:text-slate-300 hover:bg-slate-100/80 dark:hover:bg-slate-800/80'}"
+								onmouseenter={() => (selectedIndex = item.index)}
+								onclick={() => activate(item)}
+							>
+								<Icon
+									name={item.icon}
+									class="w-4 h-4 shrink-0 {item.index === selectedIndex
+										? 'text-violet-600 dark:text-violet-400'
+										: 'text-slate-400 dark:text-slate-500'}"
+								/>
+								<div class="flex-1 min-w-0">
+									<span class="block text-sm font-medium truncate">{item.label}</span>
+									{#if item.snippet}
+										<p class="text-xs text-slate-400 dark:text-slate-500 truncate">
+											{#each parseSnippet(item.snippet) as part}
+												{#if part.hl}<mark class="bg-transparent text-violet-600 dark:text-violet-400 font-semibold">{part.text}</mark>{:else}{part.text}{/if}
+											{/each}
+										</p>
+									{:else if item.description}
+										<span class="block text-xs text-slate-400 dark:text-slate-500 truncate">{item.description}</span>
+									{/if}
+									{#if item.meta && item.meta.length > 0}
+										<div class="flex items-center gap-1.5 text-3xs font-medium text-slate-500 dark:text-slate-400 truncate mt-0.5">
+											{#each item.meta as m, i (m.icon + m.text)}
+												{#if i > 0}<span class="opacity-40">·</span>{/if}
+												<span class="flex items-center gap-1 truncate">
+													<Icon name={m.icon} class="w-2.5 h-2.5 shrink-0" />
+													<span class="truncate">{m.text}</span>
+												</span>
+											{/each}
+										</div>
+									{/if}
+								</div>
+							</button>
+						{/each}
+					{/each}
+				{/if}
+			</div>
+
+			<!-- Footer Hints -->
+			<div class="flex items-center gap-3 px-4 py-2 border-t border-slate-200 dark:border-slate-800 text-3xs text-slate-400 dark:text-slate-500 shrink-0">
+				<span class="flex items-center gap-1"><kbd class="border border-slate-200 dark:border-slate-700 rounded px-1">↑↓</kbd> Navigate</span>
+				<span class="flex items-center gap-1"><kbd class="border border-slate-200 dark:border-slate-700 rounded px-1">↵</kbd> Select</span>
+				<span class="ml-auto flex items-center gap-1"><kbd class="border border-slate-200 dark:border-slate-700 rounded px-1">{modifierLabel}K</kbd> Toggle</span>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/frontend/components/history/HistoryModal.svelte
+++ b/frontend/components/history/HistoryModal.svelte
@@ -14,6 +14,7 @@
 	import { userStore } from '$frontend/stores/features/user.svelte';
 	import { debug } from '$shared/utils/logger';
 	import { modelStore } from '$frontend/stores/features/models.svelte';
+	import { parseSnippet } from '$frontend/utils/fts-snippet';
 
 	interface Props {
 		isOpen: boolean;
@@ -101,11 +102,12 @@
 
 	// Search state
 	let searchQuery = $state('');
-	let deepSearchResults = $state<Set<string> | null>(null);
+	/** sessionId -> highlighted snippet, from the message-content (deep) search. */
+	let deepSearchResults = $state<Map<string, string> | null>(null);
 	let deepSearching = $state(false);
 	let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 
-	// Deep search: query backend for message-level search
+	// Deep search: query backend for message-level search (FTS5-backed, fast)
 	function triggerDeepSearch(query: string) {
 		clearTimeout(searchDebounceTimer);
 		if (!query.trim()) {
@@ -117,14 +119,14 @@
 		searchDebounceTimer = setTimeout(async () => {
 			try {
 				const result = await ws.http('sessions:search', { query: query.trim() });
-				deepSearchResults = new Set(result.sessionIds);
+				deepSearchResults = new Map(result.results.map(r => [r.sessionId, r.snippet]));
 			} catch (err) {
 				debug.error('session', 'Deep search failed:', err);
 				deepSearchResults = null;
 			} finally {
 				deepSearching = false;
 			}
-		}, 300);
+		}, 150);
 	}
 
 	// Trigger deep search when query changes
@@ -521,6 +523,7 @@
 					{@const modelName = getSessionModel(session)}
 					{@const title = session.title || session.head_title || 'New Conversation'}
 					{@const summary = session.head_summary || 'No messages yet'}
+					{@const deepSnippet = deepSearchResults?.get(session.id)}
 					{@const userCount = session.user_count ?? 0}
 					<div
 						class="flex items-center gap-2 w-full p-3 bg-transparent border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-slate-100 text-sm text-left transition-all duration-150
@@ -594,6 +597,12 @@
 										Processing...
 									</p>
 								{/if}
+							{:else if deepSnippet}
+								<p class="text-xs text-slate-400 dark:text-slate-500 truncate mt-0.5">
+									{#each parseSnippet(deepSnippet) as part}
+										{#if part.hl}<mark class="bg-transparent text-violet-600 dark:text-violet-400 font-semibold">{part.text}</mark>{:else}{part.text}{/if}
+									{/each}
+								</p>
 							{:else}
 								<p class="text-xs text-slate-400 dark:text-slate-500 truncate mt-0.5">
 									{summary}

--- a/frontend/components/history/HistoryView.svelte
+++ b/frontend/components/history/HistoryView.svelte
@@ -14,6 +14,7 @@
 	import TimelineModal from '../checkpoint/TimelineModal.svelte';
 	import { presenceState } from '$frontend/stores/core/presence.svelte';
 	import { debug } from '$shared/utils/logger';
+	import { parseSnippet } from '$frontend/utils/fts-snippet';
 
 	// Check if a session has an active stream
 	function isSessionStreaming(chatSessionId: string): boolean {
@@ -68,8 +69,8 @@
 	let showTimelineModal = $state(false);
 	let timelineSession = $state<ChatSession | null>(null);
 
-	// Deep search state
-	let deepSearchResults = $state<Set<string> | null>(null);
+	// Deep search state — sessionId -> highlighted snippet
+	let deepSearchResults = $state<Map<string, string> | null>(null);
 	let deepSearching = $state(false);
 	let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -84,14 +85,14 @@
 		searchDebounceTimer = setTimeout(async () => {
 			try {
 				const result = await ws.http('sessions:search', { query: query.trim() });
-				deepSearchResults = new Set(result.sessionIds);
+				deepSearchResults = new Map(result.results.map(r => [r.sessionId, r.snippet]));
 			} catch (err) {
 				debug.error('session', 'Deep search failed:', err);
 				deepSearchResults = null;
 			} finally {
 				deepSearching = false;
 			}
-		}, 300);
+		}, 150);
 	}
 
 	$effect(() => {
@@ -389,6 +390,7 @@
 					{#each filteredSessions as session (session.id)}
 						{@const title = session.title || session.head_title || 'New Conversation'}
 						{@const summary = session.head_summary || 'No messages yet'}
+						{@const deepSnippet = deepSearchResults?.get(session.id)}
 						{@const userCount = session.user_count ?? 0}
 						{@const messageCount = session.message_count ?? 0}
 						<div class="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg p-6 transition-all duration-200">
@@ -438,7 +440,13 @@
 
 									<!-- Summary -->
 									<p class="text-sm text-slate-600 dark:text-slate-400 line-clamp-2">
-										{summary}
+										{#if deepSnippet}
+											{#each parseSnippet(deepSnippet) as part}
+												{#if part.hl}<mark class="bg-transparent text-violet-600 dark:text-violet-400 font-semibold">{part.text}</mark>{:else}{part.text}{/if}
+											{/each}
+										{:else}
+											{summary}
+										{/if}
 									</p>
 
 								</div>

--- a/frontend/components/workspace/DesktopNavigator.svelte
+++ b/frontend/components/workspace/DesktopNavigator.svelte
@@ -21,26 +21,36 @@
 	import Dialog from '$frontend/components/common/overlay/Dialog.svelte';
 	import ViewMenu from '$frontend/components/workspace/ViewMenu.svelte';
 	import ToolsMenu from '$frontend/components/workspace/ToolsMenu.svelte';
+	import QuickSearchButton from '$frontend/components/workspace/QuickSearchButton.svelte';
 	import TunnelModal from '$frontend/components/tunnel/TunnelModal.svelte';
 	import RemoteAccessPanel from '$frontend/components/remote-access/RemoteAccessPanel.svelte';
 	import DbClientModal from '$frontend/components/db-client/DbClientModal.svelte';
 	import SettingButton from '$frontend/components/settings/SettingButton.svelte';
 	import ProjectUserAvatars from '$frontend/components/common/display/ProjectUserAvatars.svelte';
 	import ws from '$frontend/utils/ws';
+	import {
+		quickPanelsState,
+		openNewProjectDialog,
+		closeNewProjectDialog,
+		openRemoteAccessDialog,
+		closeRemoteAccessDialog,
+		openTunnelDialog,
+		closeTunnelDialog,
+		openDbClientDialog,
+		closeDbClientDialog
+	} from '$frontend/stores/ui/quick-panels.svelte';
 
 	// State
-	let showFolderBrowser = $state(false);
 	let showDeleteDialog = $state(false);
 	let projectToDelete = $state<Project | null>(null);
 	let searchQuery = $state('');
-	let showTunnelModal = $state(false);
-	let showRemoteAccessModal = $state(false);
-	let showDbClientModal = $state(false);
 	let hoveredProject = $state<Project | null>(null);
 	let tooltipY = $state(0);
 	let tooltipX = $state(0);
 	let draggedProjectId = $state<string | null>(null);
 	let dragOverProjectId = $state<string | null>(null);
+	let expandedListEl = $state<HTMLElement>();
+	let collapsedListEl = $state<HTMLElement>();
 
 	// Derived
 	const isCollapsed = $derived(workspaceState.navigatorCollapsed);
@@ -58,6 +68,19 @@
 		);
 	});
 
+	// Auto-scroll the active project into view — covers both clicking it directly
+	// and switching to it from elsewhere (e.g. the Command Palette).
+	$effect(() => {
+		const id = currentProjectId;
+		const collapsed = isCollapsed;
+		if (!id) return;
+		requestAnimationFrame(() => {
+			const container = collapsed ? collapsedListEl : expandedListEl;
+			const el = container?.querySelector(`[data-project-id="${CSS.escape(id)}"]`);
+			el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+		});
+	});
+
 	// Select project
 	async function selectProject(project: Project) {
 		await setCurrentProject(project);
@@ -69,7 +92,7 @@
 	// Create project from folder
 	async function createProjectFromFolder(folderPath: string, folderName: string) {
 		try {
-			showFolderBrowser = false;
+			closeNewProjectDialog();
 
 			// Check if already exists
 			const existing = projectState.projects.find((p) => p.path === folderPath);
@@ -120,11 +143,6 @@
 	}
 
 	// Status color for project indicator — uses shared helper from presence store
-
-	// Close folder browser
-	function closeFolderBrowser() {
-		showFolderBrowser = false;
-	}
 
 	// Close delete dialog
 	function closeDeleteDialog() {
@@ -269,7 +287,7 @@
 						<button
 							type="button"
 							class="flex items-center justify-center w-6 h-6 bg-transparent border-none rounded-md text-slate-600 dark:text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/20 hover:text-violet-600"
-							onclick={() => (showFolderBrowser = true)}
+							onclick={openNewProjectDialog}
 							aria-label="Add project"
 							title="Add project"
 						>
@@ -278,9 +296,10 @@
 					{/if}
 				</div>
 
-				<div class="flex-1 overflow-y-auto flex flex-col">
+				<div class="flex-1 overflow-y-auto flex flex-col" bind:this={expandedListEl}>
 					{#each filteredProjects() as project (project.id)}
 						<div
+							data-project-id={project.id}
 							class="flex items-center gap-2.5 py-2.5 px-3 bg-transparent border-none rounded-lg text-slate-600 dark:text-slate-400 text-sm text-left cursor-pointer transition-all duration-150 relative group
 								hover:bg-violet-500/10
 								{draggedProjectId === project.id ? 'opacity-50' : ''}
@@ -347,7 +366,7 @@
 								<button
 									type="button"
 									class="py-2 px-4 bg-violet-500/10 dark:bg-violet-500/15 border border-violet-500/20 dark:border-violet-500/30 rounded-lg text-violet-600 text-xs font-medium cursor-pointer transition-all duration-150 hover:bg-violet-500/20 dark:hover:bg-violet-500/25"
-									onclick={() => (showFolderBrowser = true)}
+									onclick={openNewProjectDialog}
 								>
 									Add your first project
 								</button>
@@ -363,10 +382,11 @@
 			<!-- Footer Actions -->
 			<footer class="flex flex-col p-3 border-t border-slate-200 dark:border-slate-800" in:fade={{ duration: 150 }}>
 				<ToolsMenu
-					onRemoteAccess={() => (showRemoteAccessModal = true)}
-					onPublicTunnel={() => (showTunnelModal = true)}
-					onDbClient={() => (showDbClientModal = true)}
+					onRemoteAccess={openRemoteAccessDialog}
+					onPublicTunnel={openTunnelDialog}
+					onDbClient={openDbClientDialog}
 				/>
+				<QuickSearchButton />
 				<SettingButton onClick={() => openSettingsModal()} />
 				<ViewMenu />
 			</footer>
@@ -377,7 +397,7 @@
 					<button
 						type="button"
 						class="flex items-center justify-center w-9 h-9 bg-transparent border-none rounded-lg text-slate-500 cursor-pointer transition-all duration-150 relative hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
-						onclick={() => (showFolderBrowser = true)}
+						onclick={openNewProjectDialog}
 						title="Add Project"
 					>
 						<Icon name="lucide:folder-plus" class="w-5 h-5" />
@@ -387,12 +407,13 @@
 				</div>
 			{/if}
 
-			<div class="flex-1 flex flex-col items-center gap-2 px-2 pb-4 min-h-0 overflow-y-auto">
+			<div class="flex-1 flex flex-col items-center gap-2 px-2 pb-4 min-h-0 overflow-y-auto" bind:this={collapsedListEl}>
 				{#each projectState.projects as project (project.id)}
 					{@const projectStatus = presenceState.statuses.get(project.id ?? '')}
 					{@const activeUserCount = (projectStatus?.activeUsers || []).length}
 					<button
 						type="button"
+						data-project-id={project.id}
 						class="flex items-center justify-center w-9 h-9 shrink-0 border-none rounded-lg cursor-pointer transition-all duration-150 relative font-semibold text-sm
 							{draggedProjectId === project.id ? 'opacity-50' : ''}
 							{dragOverProjectId === project.id ? 'ring-1 ring-inset ring-violet-400/60' : ''}
@@ -427,10 +448,11 @@
 			<footer class="flex flex-col gap-2 py-3 px-2 border-t border-slate-200 dark:border-slate-800">
 				<ToolsMenu
 					collapsed={true}
-					onRemoteAccess={() => (showRemoteAccessModal = true)}
-					onPublicTunnel={() => (showTunnelModal = true)}
-					onDbClient={() => (showDbClientModal = true)}
+					onRemoteAccess={openRemoteAccessDialog}
+					onPublicTunnel={openTunnelDialog}
+					onDbClient={openDbClientDialog}
 				/>
+				<QuickSearchButton collapsed={true} />
 				<SettingButton collapsed={true} onClick={() => openSettingsModal()} />
 				<ViewMenu collapsed={true} />
 			</footer>
@@ -451,8 +473,8 @@
 
 <!-- Folder Browser (includes its own Modal) -->
 <FolderBrowser
-	bind:isOpen={showFolderBrowser}
-	onClose={closeFolderBrowser}
+	bind:isOpen={quickPanelsState.newProjectOpen}
+	onClose={closeNewProjectDialog}
 	onSelect={createProjectFromFolder}
 />
 
@@ -511,10 +533,10 @@
 </Dialog>
 
 <!-- Remote Access Modal -->
-<RemoteAccessPanel bind:isOpen={showRemoteAccessModal} onClose={() => (showRemoteAccessModal = false)} />
+<RemoteAccessPanel bind:isOpen={quickPanelsState.remoteAccessOpen} onClose={closeRemoteAccessDialog} />
 
 <!-- Tunnel Modal -->
-<TunnelModal bind:isOpen={showTunnelModal} onClose={() => (showTunnelModal = false)} />
+<TunnelModal bind:isOpen={quickPanelsState.tunnelOpen} onClose={closeTunnelDialog} />
 
 <!-- DB Client Modal -->
-<DbClientModal bind:isOpen={showDbClientModal} onClose={() => (showDbClientModal = false)} />
+<DbClientModal bind:isOpen={quickPanelsState.dbClientOpen} onClose={closeDbClientDialog} />

--- a/frontend/components/workspace/MobileNavigator.svelte
+++ b/frontend/components/workspace/MobileNavigator.svelte
@@ -17,15 +17,21 @@
 	import { authStore } from '$frontend/stores/features/auth.svelte';
 	import ws from '$frontend/utils/ws';
 	import { debug } from '$shared/utils/logger';
-
-	// Modal states
-	let showTunnelModal = $state(false);
-	let showRemoteAccessModal = $state(false);
-	let showDbClientModal = $state(false);
+	import {
+		quickPanelsState,
+		openNewProjectDialog,
+		closeNewProjectDialog,
+		openRemoteAccessDialog,
+		closeRemoteAccessDialog,
+		openTunnelDialog,
+		closeTunnelDialog,
+		openDbClientDialog,
+		closeDbClientDialog
+	} from '$frontend/stores/ui/quick-panels.svelte';
+	import { openCommandPalette } from '$frontend/stores/ui/command-palette.svelte';
 
 	// Project dropdown state
 	let showProjectMenu = $state(false);
-	let showFolderBrowser = $state(false);
 	let showDeleteDialog = $state(false);
 	let projectToDelete = $state<Project | null>(null);
 	let searchQuery = $state('');
@@ -59,11 +65,7 @@
 
 	function openAddProject() {
 		showProjectMenu = false;
-		showFolderBrowser = true;
-	}
-
-	function closeFolderBrowser() {
-		showFolderBrowser = false;
+		openNewProjectDialog();
 	}
 
 	function closeProjectMenu() {
@@ -109,7 +111,7 @@
 
 	async function createProjectFromFolder(folderPath: string, folderName: string) {
 		try {
-			showFolderBrowser = false;
+			closeNewProjectDialog();
 
 			const projects = await ws.http('projects:list', {});
 
@@ -166,10 +168,21 @@
 		<ToolsMenu
 			collapsed={true}
 			mobile={true}
-			onRemoteAccess={() => (showRemoteAccessModal = true)}
-			onPublicTunnel={() => (showTunnelModal = true)}
-			onDbClient={() => (showDbClientModal = true)}
+			onRemoteAccess={openRemoteAccessDialog}
+			onPublicTunnel={openTunnelDialog}
+			onDbClient={openDbClientDialog}
 		/>
+
+		<!-- Quick Search Button -->
+		<button
+			type="button"
+			class="flex items-center justify-center w-9 h-8 bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 active:bg-violet-500/10"
+			onclick={openCommandPalette}
+			aria-label="Quick search"
+			title="Quick search"
+		>
+			<Icon name="lucide:search" class="w-4.5 h-4.5" />
+		</button>
 
 		<!-- Settings Button -->
 		<SettingButton collapsed={true} mobile={true} onClick={() => openSettingsModal()} />
@@ -335,8 +348,8 @@
 
 <!-- Folder Browser -->
 <FolderBrowser
-	bind:isOpen={showFolderBrowser}
-	onClose={closeFolderBrowser}
+	bind:isOpen={quickPanelsState.newProjectOpen}
+	onClose={closeNewProjectDialog}
 	onSelect={createProjectFromFolder}
 />
 
@@ -395,9 +408,9 @@
 </Dialog>
 
 <!-- Tunnel Modal -->
-<RemoteAccessPanel bind:isOpen={showRemoteAccessModal} onClose={() => (showRemoteAccessModal = false)} />
+<RemoteAccessPanel bind:isOpen={quickPanelsState.remoteAccessOpen} onClose={closeRemoteAccessDialog} />
 
-<TunnelModal bind:isOpen={showTunnelModal} onClose={() => (showTunnelModal = false)} />
+<TunnelModal bind:isOpen={quickPanelsState.tunnelOpen} onClose={closeTunnelDialog} />
 
 <!-- DB Client Modal -->
-<DbClientModal bind:isOpen={showDbClientModal} onClose={() => (showDbClientModal = false)} />
+<DbClientModal bind:isOpen={quickPanelsState.dbClientOpen} onClose={closeDbClientDialog} />

--- a/frontend/components/workspace/ModalProvider.svelte
+++ b/frontend/components/workspace/ModalProvider.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import Alert from '$frontend/components/common/feedback/Alert.svelte';
 	import Dialog from '$frontend/components/common/overlay/Dialog.svelte';
+	import CommandPalette from '$frontend/components/common/overlay/CommandPalette.svelte';
 	import { dialogStore, closeAlert, closeConfirm } from '$frontend/stores/ui/dialog.svelte';
 
 	const alertState = $derived(dialogStore.alert);
 	const confirmState = $derived(dialogStore.confirm);
 </script>
+
+<CommandPalette />
 
 <Alert
 	isOpen={alertState.isOpen}

--- a/frontend/components/workspace/QuickSearchButton.svelte
+++ b/frontend/components/workspace/QuickSearchButton.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { openCommandPalette } from '$frontend/stores/ui/command-palette.svelte';
+	import { isMac } from '$frontend/utils/platform';
+
+	interface Props {
+		collapsed?: boolean;
+	}
+
+	const { collapsed = false }: Props = $props();
+
+	const modifierLabel = isMac() ? '⌘' : 'Ctrl+';
+</script>
+
+{#if collapsed}
+	<!-- Collapsed: Icon Only -->
+	<button
+		type="button"
+		class="flex items-center justify-center w-9 h-9 bg-transparent border-none rounded-lg text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
+		onclick={openCommandPalette}
+		aria-label="Quick search"
+		title="Quick search ({modifierLabel}K)"
+	>
+		<Icon name="lucide:search" class="w-5 h-5" />
+	</button>
+{:else}
+	<!-- Expanded: Full Width -->
+	<button
+		type="button"
+		class="flex items-center gap-2.5 w-full py-2.5 px-3 bg-transparent border-none rounded-lg text-slate-500 text-sm cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
+		onclick={openCommandPalette}
+	>
+		<Icon name="lucide:search" class="w-4 h-4" />
+		<span class="flex-1 text-left">Quick Search</span>
+		<kbd class="text-3xs font-mono text-slate-400 dark:text-slate-500 border border-slate-200 dark:border-slate-700 rounded px-1.5 py-0.5">{modifierLabel}K</kbd>
+	</button>
+{/if}

--- a/frontend/components/workspace/ToolsMenu.svelte
+++ b/frontend/components/workspace/ToolsMenu.svelte
@@ -87,11 +87,11 @@
 				: 'w-9 h-9 rounded-lg hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100'}
 				{isOpen ? 'bg-violet-500/10 text-slate-900 dark:text-slate-100' : ''}"
 			onclick={toggleMenu}
-			aria-label="Tools"
+			aria-label="More Tools"
 			aria-expanded={isOpen}
-			title="Tools"
+			title="More Tools"
 		>
-			<Icon name="lucide:ellipsis" class="{mobile ? 'w-4.5 h-4.5' : 'w-5 h-5'}" />
+			<Icon name="lucide:wrench" class="{mobile ? 'w-4.5 h-4.5' : 'w-5 h-5'}" />
 			{#if hasActivity}
 				<span
 					class="absolute top-0.5 right-0.5 w-2 h-2 rounded-full bg-green-500 border-2 border-slate-50 dark:border-slate-900/95"
@@ -105,18 +105,18 @@
 			class="flex items-center gap-2.5 w-full py-2.5 px-3 bg-transparent border-none rounded-lg text-slate-500 text-sm cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100
 				{isOpen ? 'bg-violet-500/10 text-slate-900 dark:text-slate-100' : ''}"
 			onclick={toggleMenu}
-			aria-label="Tools"
+			aria-label="More Tools"
 			aria-expanded={isOpen}
 		>
 			<div class="relative">
-				<Icon name="lucide:ellipsis" class="w-4 h-4" />
+				<Icon name="lucide:wrench" class="w-4 h-4" />
 				{#if hasActivity}
 					<span
 						class="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full border-2 border-slate-50 dark:border-slate-900/95"
 					></span>
 				{/if}
 			</div>
-			<span class="flex-1 text-left">Tools</span>
+			<span class="flex-1 text-left">More Tools</span>
 		</button>
 	{/if}
 
@@ -127,7 +127,7 @@
 		>
 			<div class="py-1.5">
 				<div class="px-3 py-1.5 text-xs font-semibold text-slate-600 dark:text-slate-500 uppercase tracking-wider">
-					Tools
+					More Tools
 				</div>
 				{#each items as item (item.label)}
 					<button

--- a/frontend/config/command-registry.ts
+++ b/frontend/config/command-registry.ts
@@ -1,0 +1,118 @@
+/**
+ * Command Palette action registry — SSOT for the palette's "Actions" category.
+ * Add a new command here and it automatically shows up in the Command Palette.
+ */
+
+import type { IconName } from '$shared/types/ui/icons';
+import { authStore } from '$frontend/stores/features/auth.svelte';
+import { projectState } from '$frontend/stores/core/projects.svelte';
+import { createNewChatSession, setCurrentSession } from '$frontend/stores/core/sessions.svelte';
+import { toggleNavigator } from '$frontend/stores/ui/workspace.svelte';
+import { openSettingsModal } from '$frontend/stores/ui/settings-modal.svelte';
+import {
+	openNewProjectDialog,
+	openRemoteAccessDialog,
+	openTunnelDialog,
+	openDbClientDialog
+} from '$frontend/stores/ui/quick-panels.svelte';
+import { addNotification } from '$frontend/stores/ui/notification.svelte';
+
+export interface CommandAction {
+	id: string;
+	label: string;
+	description: string;
+	icon: IconName;
+	keywords?: string[];
+	run: () => void | Promise<void>;
+}
+
+async function runNewChatSession() {
+	const project = projectState.currentProject;
+	if (!project) return;
+
+	const session = await createNewChatSession(project.id);
+	if (session) {
+		await setCurrentSession(session);
+	} else {
+		addNotification({
+			type: 'error',
+			title: 'Failed to Create Session',
+			message: 'Could not create a new chat session',
+			duration: 5000
+		});
+	}
+}
+
+/** Actions visible right now — gated by admin role and current project context. */
+export function getCommandActions(): CommandAction[] {
+	const actions: CommandAction[] = [];
+
+	if (authStore.isAdmin) {
+		actions.push({
+			id: 'new-project',
+			label: 'New Project',
+			description: 'Add a project from a folder on disk',
+			icon: 'lucide:folder-plus',
+			keywords: ['add', 'create', 'open', 'folder'],
+			run: openNewProjectDialog
+		});
+	}
+
+	if (projectState.currentProject) {
+		actions.push({
+			id: 'new-chat-session',
+			label: 'New Chat Session',
+			description: `Start a fresh session in ${projectState.currentProject.name}`,
+			icon: 'lucide:message-square-plus',
+			keywords: ['chat', 'session', 'new'],
+			run: runNewChatSession
+		});
+	}
+
+	actions.push({
+		id: 'toggle-sidebar',
+		label: 'Toggle Sidebar',
+		description: 'Collapse or expand the project navigator',
+		icon: 'lucide:panel-left-close',
+		keywords: ['navigator', 'collapse', 'expand', 'sidebar'],
+		run: toggleNavigator
+	});
+
+	actions.push({
+		id: 'remote-access',
+		label: 'Remote Access',
+		description: 'Share a link to reach this Clopen',
+		icon: 'lucide:radio',
+		keywords: ['share', 'device', 'invite', 'link'],
+		run: openRemoteAccessDialog
+	});
+
+	actions.push({
+		id: 'public-tunnel',
+		label: 'Public Tunnel',
+		description: 'Expose a local port via Cloudflare',
+		icon: 'lucide:cloud-upload',
+		keywords: ['cloudflare', 'expose', 'port'],
+		run: openTunnelDialog
+	});
+
+	actions.push({
+		id: 'db-client',
+		label: 'DB Client',
+		description: 'Connect to a database',
+		icon: 'lucide:database',
+		keywords: ['sql', 'database', 'query'],
+		run: openDbClientDialog
+	});
+
+	actions.push({
+		id: 'open-settings',
+		label: 'Open Settings',
+		description: 'Assistant, engines, appearance, and more',
+		icon: 'lucide:settings',
+		keywords: ['preferences', 'config'],
+		run: () => openSettingsModal()
+	});
+
+	return actions;
+}

--- a/frontend/stores/ui/command-palette.svelte.ts
+++ b/frontend/stores/ui/command-palette.svelte.ts
@@ -1,0 +1,26 @@
+/**
+ * Command Palette Store
+ * Global Spotlight-style palette (Projects, Actions, Settings, Sessions).
+ * Only tracks open/closed state — query and selection are transient UI state
+ * owned by CommandPalette.svelte and reset every time it opens.
+ */
+
+interface CommandPaletteState {
+	isOpen: boolean;
+}
+
+export const commandPaletteState = $state<CommandPaletteState>({
+	isOpen: false
+});
+
+export function openCommandPalette() {
+	commandPaletteState.isOpen = true;
+}
+
+export function closeCommandPalette() {
+	commandPaletteState.isOpen = false;
+}
+
+export function toggleCommandPalette() {
+	commandPaletteState.isOpen = !commandPaletteState.isOpen;
+}

--- a/frontend/stores/ui/quick-panels.svelte.ts
+++ b/frontend/stores/ui/quick-panels.svelte.ts
@@ -1,0 +1,53 @@
+/**
+ * Quick Panels Store
+ * SSOT for the open/closed state of top-level panels that can be triggered
+ * from more than one entry point (sidebar footer buttons, Command Palette).
+ * Data/logic for each panel still lives in its own feature store — this only
+ * tracks whether the modal is visible.
+ */
+
+interface QuickPanelsState {
+	newProjectOpen: boolean;
+	remoteAccessOpen: boolean;
+	tunnelOpen: boolean;
+	dbClientOpen: boolean;
+}
+
+export const quickPanelsState = $state<QuickPanelsState>({
+	newProjectOpen: false,
+	remoteAccessOpen: false,
+	tunnelOpen: false,
+	dbClientOpen: false
+});
+
+export function openNewProjectDialog() {
+	quickPanelsState.newProjectOpen = true;
+}
+
+export function closeNewProjectDialog() {
+	quickPanelsState.newProjectOpen = false;
+}
+
+export function openRemoteAccessDialog() {
+	quickPanelsState.remoteAccessOpen = true;
+}
+
+export function closeRemoteAccessDialog() {
+	quickPanelsState.remoteAccessOpen = false;
+}
+
+export function openTunnelDialog() {
+	quickPanelsState.tunnelOpen = true;
+}
+
+export function closeTunnelDialog() {
+	quickPanelsState.tunnelOpen = false;
+}
+
+export function openDbClientDialog() {
+	quickPanelsState.dbClientOpen = true;
+}
+
+export function closeDbClientDialog() {
+	quickPanelsState.dbClientOpen = false;
+}

--- a/frontend/utils/fts-snippet.ts
+++ b/frontend/utils/fts-snippet.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared parser for FTS5 snippet() output.
+ * Backend wraps matches in char(1)/char(2) sentinels (see session-queries.ts
+ * searchGlobal / searchByMessageContent) — this splits them into plain/
+ * highlighted segments so callers can render safely (no {@html}, since the
+ * snippet is user-authored chat content).
+ */
+
+const SNIPPET_MATCH_START = String.fromCharCode(1);
+const SNIPPET_MATCH_END = String.fromCharCode(2);
+
+export interface SnippetPart {
+	text: string;
+	hl: boolean;
+}
+
+export function parseSnippet(snippet: string): SnippetPart[] {
+	const parts: SnippetPart[] = [];
+	let cursor = 0;
+	while (cursor < snippet.length) {
+		const start = snippet.indexOf(SNIPPET_MATCH_START, cursor);
+		if (start === -1) {
+			parts.push({ text: snippet.slice(cursor), hl: false });
+			break;
+		}
+		if (start > cursor) parts.push({ text: snippet.slice(cursor, start), hl: false });
+
+		const end = snippet.indexOf(SNIPPET_MATCH_END, start + 1);
+		if (end === -1) {
+			parts.push({ text: snippet.slice(start + 1), hl: true });
+			break;
+		}
+		parts.push({ text: snippet.slice(start + 1, end), hl: true });
+		cursor = end + 1;
+	}
+	return parts;
+}


### PR DESCRIPTION
Add a global Cmd/Ctrl+K palette to search and jump to projects, run quick actions, open settings pages, and find chat sessions across all accessible projects. Replace the raw LIKE scan over JSON message content with a SQLite FTS5 index (messages_fts) everywhere session content search is used — Command Palette, History modal, and the Session History page — and surface a highlighted snippet showing where each match occurred.

- Capture-phase keydown listener so the shortcut works even when another modal is focused
- Direction-aware auto-scroll (anchored to the edge being revealed) for keyboard navigation, and auto-scroll to the active project in the sidebar
- New quick-panels store as the single source of truth for New Project / Remote Access / Tunnel / DB Client modal state, shared by the sidebar, mobile navigator, and the palette's Actions
- Quick Search entry points: sidebar footer button (desktop) and search icon (mobile), both showing the shortcut hint
- Rename the sidebar "Tools" menu to "More Tools" with a clearer icon