### PR TITLE
fix(engine): harden one-shot structured generation across engines

### DIFF
--- a/backend/artifacts/generate.ts
+++ b/backend/artifacts/generate.ts
@@ -11,6 +11,7 @@
  */
 
 import { initializeEngine } from '$backend/engine';
+import { resolveGenerationTarget } from '$backend/engine/resolve-model';
 import { getClopenDir } from '$backend/utils/paths';
 import type { EngineType } from '$shared/types/unified';
 import { debug } from '$shared/utils/logger';
@@ -69,7 +70,8 @@ const GUIDANCE: Record<GeneratableType, string> = {
 
 export interface GenerateModel {
 	engine: EngineType;
-	providerSlug: string;
+	/** Hint only — the provider is re-derived from the engine catalog. */
+	providerSlug?: string;
 	modelId: string;
 	/** Optional cwd for the engine process; defaults to the Clopen data dir. */
 	projectPath?: string;
@@ -92,14 +94,18 @@ ${purpose.trim()}
 
 Always write the draft in English, regardless of the language of the purpose. Be specific and immediately usable.`;
 
-	debug.log('artifacts', `✨ Generating ${type} draft via ${model.engine}/${model.modelId}`);
+	// The caller's providerSlug/account can be stale (see resolve-model.ts).
+	const target = await resolveGenerationTarget(engine, model.modelId, model.providerSlug);
+	const accountId = model.accountId ?? target.accountId;
+
+	debug.log('artifacts', `✨ Generating ${type} draft via ${model.engine}/${target.providerSlug}/${target.modelId}`);
 
 	return engine.generateStructured<Record<string, unknown>>({
 		prompt,
-		providerSlug: model.providerSlug,
-		modelId: model.modelId,
+		providerSlug: target.providerSlug,
+		modelId: target.modelId,
 		schema: SCHEMAS[type],
 		projectPath: model.projectPath || getClopenDir(),
-		accountId: model.accountId
+		...(accountId != null && { accountId })
 	});
 }

--- a/backend/engine/docs/lessons-learned.md
+++ b/backend/engine/docs/lessons-learned.md
@@ -757,10 +757,32 @@ OpenCode adapter:
   Filter out `ignored`/`synthetic` parts so the SDK's own scratch text
   doesn't leak into the JSON parser. Log the part-type breakdown in the
   error message so the next failure is diagnosable.
-- **Extract JSON tolerantly.** `extractJson()` tries, in order: a
-  ` ```json ` fenced block, the first balanced `{ … }`, then the raw
-  trimmed text. Models routinely ignore the "no markdown fences"
+- **Extract JSON tolerantly.** `extractJson()` tries, in order: every
+  ` ```json ` fenced block, every top-level balanced `{ … }`, a greedy
+  first-brace-to-last-brace slice, then the raw trimmed text — parsing
+  each one twice, the second time with control characters inside string
+  literals escaped. Models routinely ignore the "no markdown fences"
   instruction; the parser should not.
+
+  Two failure modes justify the balanced scan and the repair pass, and
+  both are covered by `structured-helpers.test.ts`:
+
+  - **Trailing commentary.** A model that emits the object and then adds
+    "Let me know if you want changes!" produces JSC's
+    `Unable to parse JSON string` (its message for *valid JSON followed
+    by anything*), and the old first-`{`-to-last-`}` slice broke too
+    whenever that commentary contained a brace. Brace counting must be
+    string-aware or a `}` inside a value closes the object early.
+  - **Raw newlines in string values.** JSON forbids a literal newline
+    inside a string, but any field holding Markdown (an artifact body, a
+    commit body) attracts them — which is why artifact generation broke
+    on models that git commit generation, with its short single-line
+    fields, never tripped.
+
+  A truncated response still throws rather than half-parsing: a draft
+  missing half its body is worse than a clear failure. The error preview
+  shows both ends of the text so truncation and trailing prose are
+  distinguishable from the log alone.
 
 The native engines (Claude, Codex) skip these — Claude exposes
 `structured_output` on the `result` message and Codex's
@@ -774,6 +796,30 @@ hands its `signal` to whatever the SDK exposes (Codex
 { signal }`, Copilot `session.abort()`, Qwen `QueryOptions.abortController`).
 The contract is the same as `streamQuery`: aborting cancels the in-flight
 request, not just the await.
+
+**3. Never trust a caller-supplied `providerSlug`.** The adapters split
+again on whether they read it at all: Claude, Codex, Qwen, Copilot, and
+Cursor key off `modelId` alone, while OpenCode passes it as
+`model.providerID` and Pi/Cline resolve their account by it. A client
+that persists engine/provider/model as separate fields and updates only
+some of them therefore fails on exactly three engines and silently
+"works" on the other five — which is how a `commitGenerator.provider`
+stuck at its `'anthropic'` seed surfaced as `OpenCode returned empty
+response` while Claude Code was fine.
+
+The engine catalog is the only source of truth for which provider (and
+account) a model belongs to, so every `generateStructured` call site
+routes through `resolveGenerationTarget(engine, modelId, providerHint)`
+in `backend/engine/resolve-model.ts` first. It reads the registry
+(filled by `models:list`, fetching the catalog only on a miss), returns
+the catalog's provider, and throws a "pick it again in Settings →
+Models" error when the model belongs to no provider the engine offers.
+It also forwards the model's `accountId` when the catalog carries a real
+one — today every adapter reports `account.id: 0` (account is a separate
+per-chat dimension, and these routes have no account picker), so engines
+keep falling back to their active account. New engines are covered
+without touching a call site; do not reintroduce `providerSlug:
+data.providerSlug`.
 
 **Engine-not-implemented errors.** `backend/ws/git/commit-message.ts`
 guards on `engine.generateStructured` — if you add an engine that can't

--- a/backend/engine/resolve-model.ts
+++ b/backend/engine/resolve-model.ts
@@ -1,0 +1,87 @@
+/**
+ * Generation target resolution.
+ *
+ * One-shot `generateStructured` callers (git commit/branch generator, artifact
+ * authoring) take engine + provider + model as three loose strings chosen
+ * client-side. Whenever those are persisted as separate fields they can drift:
+ * a UI that updates `engine`/`modelId` but forgets `provider` leaves a provider
+ * belonging to a completely different engine.
+ *
+ * That drift is invisible on engines that ignore `providerSlug` (Claude, Codex,
+ * Qwen, Copilot, Cursor — they key off `modelId` alone) and fatal on the ones
+ * that don't: OpenCode passes it as `model.providerID` (→ "OpenCode returned
+ * empty response"), Pi and Cline look their account up by provider (→ "no
+ * account for provider X").
+ *
+ * The engine's own catalog is the only source of truth for which provider and
+ * account a model belongs to, so resolve against it and treat the caller's
+ * `providerSlug` as a hint. Keeping this in one place means a new engine is
+ * covered without touching any call site.
+ */
+
+import { getModelsByEngine, registerModels } from '$shared/constants/engines';
+import { debug } from '$shared/utils/logger';
+import type { EngineModel } from '$shared/types/unified';
+import type { AIEngine } from './types';
+
+/** Engine-verified coordinates for a one-shot generation call. */
+export interface GenerationTarget {
+	providerSlug: string;
+	modelId: string;
+	/** Account owning the model; omitted for engines with a single implicit account. */
+	accountId?: number;
+}
+
+/**
+ * Resolve `providerSlug` (and the owning account) for `modelId` from the
+ * engine's catalog. `providerHint` is the caller-supplied slug — used only when
+ * the catalog can't answer.
+ *
+ * Throws when the model belongs to no provider this engine offers, which is a
+ * far more actionable error than the engine-specific failure it would become.
+ */
+export async function resolveGenerationTarget(
+	engine: AIEngine,
+	modelId: string,
+	providerHint?: string
+): Promise<GenerationTarget> {
+	const engineType = engine.name;
+	const byId = (models: EngineModel[]) => models.find(m => m.engine.model.id === modelId);
+
+	// The registry is filled by `models:list`; only pay for a catalog fetch when
+	// this process hasn't seen the engine (or the model) yet.
+	let catalog = getModelsByEngine(engineType);
+	let match = byId(catalog);
+
+	if (!match) {
+		try {
+			catalog = await engine.getAvailableModels();
+			registerModels(engineType, catalog);
+			match = byId(catalog);
+		} catch (error) {
+			debug.warn('engine', `Catalog fetch failed for ${engineType}; using caller provider "${providerHint ?? ''}" for ${modelId}:`, error);
+			return { providerSlug: providerHint ?? '', modelId };
+		}
+	}
+
+	if (match) {
+		if (providerHint && providerHint !== match.engine.provider) {
+			debug.warn('engine', `Ignoring stale provider "${providerHint}" for ${engineType}/${modelId} — catalog says "${match.engine.provider}"`);
+		}
+		const accountId = match.engine.account.id;
+		return {
+			providerSlug: match.engine.provider,
+			modelId: match.engine.model.id,
+			...(accountId ? { accountId } : {})
+		};
+	}
+
+	// Unknown model: only trust the hint if this engine actually serves that
+	// provider, otherwise it is drift and would fail deep inside the adapter.
+	if (providerHint && catalog.some(m => m.engine.provider === providerHint)) {
+		debug.warn('engine', `Model "${modelId}" missing from ${engineType} catalog; falling back to caller provider "${providerHint}"`);
+		return { providerSlug: providerHint, modelId };
+	}
+
+	throw new Error(`Model "${modelId}" is not available for engine "${engineType}". Pick it again in Settings → Models.`);
+}

--- a/backend/engine/structured-helpers.test.ts
+++ b/backend/engine/structured-helpers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test';
+
+import { extractJson } from './structured-helpers';
+
+interface Draft {
+	name: string;
+	body?: string;
+	meta?: { a: { b: number } };
+}
+
+// Every case here is a real shape a prompt-engineered engine has produced —
+// the parser is the last line of defence before a generation fails, so each
+// tolerance it grants gets a regression test.
+describe('extractJson', () => {
+	test('parses a clean object', () => {
+		const parsed = extractJson<Draft>('{"name": "X", "body": "b"}');
+		expect(parsed).toEqual({ name: 'X', body: 'b' });
+	});
+
+	test('ignores commentary appended after the object, braces and all', () => {
+		const response = `{"name": "90s Retro", "body": "# Retro"}
+
+This skill applies { retro } styling. Let me know if you want changes!`;
+		expect(extractJson<Draft>(response).name).toBe('90s Retro');
+	});
+
+	test('ignores prose before the object', () => {
+		const parsed = extractJson<Draft>('Here is the JSON:\n{"name": "X"}\nDone.');
+		expect(parsed).toEqual({ name: 'X' });
+	});
+
+	test('unwraps a fenced block followed by commentary', () => {
+		const parsed = extractJson<Draft>('```json\n{"name": "X"}\n```\n\nHope that helps!');
+		expect(parsed).toEqual({ name: 'X' });
+	});
+
+	test('repairs raw newlines and tabs inside string values', () => {
+		const response = '{"name": "X", "body": "line1\nline2\n\tindented"}';
+		expect(extractJson<Draft>(response).body).toBe('line1\nline2\n\tindented');
+	});
+
+	test('keeps braces that live inside string values', () => {
+		const response = '{"name": "X", "body": "use ${var} and }{ weird"} trailing prose';
+		expect(extractJson<Draft>(response).body).toBe('use ${var} and }{ weird');
+	});
+
+	test('handles nested objects with trailing text', () => {
+		const parsed = extractJson<Draft>('{"name": "X", "meta": {"a": {"b": 1}}} and then some prose');
+		expect(parsed).toEqual({ name: 'X', meta: { a: { b: 1 } } });
+	});
+
+	test('throws on a truncated response rather than half-parsing it', () => {
+		expect(() => extractJson('{"name": "X", "body": "unterminated…')).toThrow(/did not contain valid JSON/);
+	});
+
+	test('throws on an empty response', () => {
+		expect(() => extractJson('   ')).toThrow(/Empty response/);
+	});
+
+	test('previews both ends of a long unparseable response', () => {
+		const response = `no json here ${'x'.repeat(600)} tail-marker`;
+		expect(() => extractJson(response)).toThrow(/tail-marker/);
+	});
+});

--- a/backend/engine/structured-helpers.ts
+++ b/backend/engine/structured-helpers.ts
@@ -12,17 +12,97 @@ export function buildJsonPrompt(prompt: string, schema: Record<string, unknown>)
 	return `${prompt}
 
 IMPORTANT: You MUST respond with ONLY a valid JSON object matching this schema, no other text, no markdown fences, no commentary:
-${JSON.stringify(schema, null, 2)}`;
+${JSON.stringify(schema, null, 2)}
+
+End your response immediately after the closing brace — no explanation, no follow-up. Inside string values, escape every newline as \\n and every quote as \\".`;
+}
+
+/**
+ * Scan out every top-level `{ … }` object in `text`.
+ *
+ * Brace counting alone is not enough: a `}` inside a string value would close
+ * the object early, so this tracks string/escape state as it walks. Unbalanced
+ * tails (a truncated response) yield nothing rather than a half object.
+ */
+function balancedObjects(text: string): string[] {
+	const objects: string[] = [];
+	let depth = 0;
+	let start = -1;
+	let inString = false;
+	let escaped = false;
+
+	for (let i = 0; i < text.length; i++) {
+		const ch = text[i];
+
+		if (inString) {
+			if (escaped) escaped = false;
+			else if (ch === '\\') escaped = true;
+			else if (ch === '"') inString = false;
+			continue;
+		}
+
+		if (ch === '"') inString = true;
+		else if (ch === '{') {
+			if (depth === 0) start = i;
+			depth++;
+		} else if (ch === '}' && depth > 0) {
+			depth--;
+			if (depth === 0 && start !== -1) {
+				objects.push(text.slice(start, i + 1));
+				start = -1;
+			}
+		}
+	}
+
+	return objects;
+}
+
+/**
+ * Escape raw control characters that appear inside string literals.
+ *
+ * JSON forbids a literal newline or tab inside a string, but models emit them
+ * constantly when a field holds Markdown (an artifact body, a commit body).
+ * Characters outside strings are left alone so structure is never altered.
+ */
+function escapeControlCharsInStrings(text: string): string {
+	const ESCAPES: Record<string, string> = { '\n': '\\n', '\r': '\\r', '\t': '\\t', '\f': '\\f', '\b': '\\b' };
+	let out = '';
+	let inString = false;
+	let escaped = false;
+
+	for (const ch of text) {
+		if (inString) {
+			if (escaped) escaped = false;
+			else if (ch === '\\') escaped = true;
+			else if (ch === '"') inString = false;
+
+			if (!escaped && ch < ' ') {
+				out += ESCAPES[ch] ?? `\\u${ch.charCodeAt(0).toString(16).padStart(4, '0')}`;
+				continue;
+			}
+		} else if (ch === '"') {
+			inString = true;
+		}
+		out += ch;
+	}
+
+	return out;
 }
 
 /**
  * Extract a JSON object from a model response.
  *
- * Models routinely wrap JSON in markdown fences or prose even when asked
- * not to. This searches in order:
- *   1. ```json … ``` or ``` … ``` fenced block
- *   2. The first balanced `{ … }` substring
- *   3. The raw trimmed text
+ * Prompt-engineered engines get whatever the model felt like emitting, so this
+ * tries, in order:
+ *   1. Every ```json … ``` fenced block
+ *   2. Every top-level balanced `{ … }` object — models routinely append
+ *      commentary after the JSON, and that commentary can itself contain braces
+ *   3. First `{` … last `}` — salvages an object whose braces only look
+ *      unbalanced because of a stray brace in a string
+ *   4. The raw trimmed text
+ *
+ * Each candidate is parsed as-is first, then with control characters inside
+ * strings escaped.
  *
  * Throws if nothing parses.
  */
@@ -33,8 +113,11 @@ export function extractJson<T = unknown>(text: string): T {
 	}
 
 	const candidates: string[] = [];
-	const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
-	if (fenced) candidates.push(fenced[1].trim());
+	for (const fence of trimmed.matchAll(/```(?:json)?\s*([\s\S]*?)```/g)) {
+		candidates.push(fence[1].trim());
+	}
+
+	candidates.push(...balancedObjects(trimmed));
 
 	const braceStart = trimmed.indexOf('{');
 	const braceEnd = trimmed.lastIndexOf('}');
@@ -46,14 +129,23 @@ export function extractJson<T = unknown>(text: string): T {
 
 	let lastError: unknown;
 	for (const candidate of candidates) {
-		try {
-			return JSON.parse(candidate) as T;
-		} catch (err) {
-			lastError = err;
+		const repaired = escapeControlCharsInStrings(candidate);
+		for (const variant of repaired === candidate ? [candidate] : [candidate, repaired]) {
+			try {
+				return JSON.parse(variant) as T;
+			} catch (err) {
+				lastError = err;
+			}
 		}
 	}
+
+	// Show both ends: a truncated response and a response with trailing prose
+	// fail identically from the head alone.
+	const preview = trimmed.length > 400
+		? `${trimmed.slice(0, 200)}… [${trimmed.length} chars] …${trimmed.slice(-200)}`
+		: trimmed;
 	throw new Error(
-		`Response did not contain valid JSON: ${trimmed.slice(0, 200)}${trimmed.length > 200 ? '…' : ''}` +
+		`Response did not contain valid JSON: ${preview}` +
 			(lastError instanceof Error ? ` (${lastError.message})` : '')
 	);
 }

--- a/backend/ws/artifacts/generate.ts
+++ b/backend/ws/artifacts/generate.ts
@@ -27,7 +27,8 @@ export const artifactGenerateHandler = createRouter()
 			]),
 			purpose: t.String(),
 			engine: t.String(),
-			providerSlug: t.String(),
+			/** Hint only — the provider is re-derived from the engine catalog. */
+			providerSlug: t.Optional(t.String()),
 			modelId: t.String(),
 			projectId: t.Optional(t.String())
 		}),

--- a/backend/ws/git/branch-name.ts
+++ b/backend/ws/git/branch-name.ts
@@ -8,6 +8,7 @@ import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { execGit } from '../../git/git-executor';
 import { initializeEngine } from '../../engine';
+import { resolveGenerationTarget } from '../../engine/resolve-model';
 import type { EngineType } from '$shared/types/unified';
 import type { GeneratedBranchName } from '$shared/types/git';
 import {
@@ -131,7 +132,8 @@ export const branchNameHandler = createRouter()
 		data: t.Object({
 			projectId: t.String(),
 			engine: t.String(),
-			providerSlug: t.String(),
+			/** Hint only — the provider is re-derived from the engine catalog. */
+			providerSlug: t.Optional(t.String()),
 			modelId: t.String(),
 			branchSeparator: t.Optional(t.String()),
 			maxWords: t.Optional(t.Number()),
@@ -167,14 +169,18 @@ export const branchNameHandler = createRouter()
 		const extra = data.customPrompt?.trim();
 		const prompt = `${instructions}${extra ? `\n\nAdditional constraints:\n${extra}` : ''}\n\nGit diff:\n${rawDiff}`;
 
-		debug.log('git', `Generating branch name via ${engineType}/${data.modelId}`);
+		// The caller's providerSlug/account can be stale (see resolve-model.ts).
+		const target = await resolveGenerationTarget(engine, data.modelId, data.providerSlug);
+
+		debug.log('git', `Generating branch name via ${engineType}/${target.providerSlug}/${target.modelId}`);
 
 		const result = await engine.generateStructured<GeneratedBranchName>({
 			prompt,
-			providerSlug: data.providerSlug,
-			modelId: data.modelId,
+			providerSlug: target.providerSlug,
+			modelId: target.modelId,
 			schema: BRANCH_NAME_SCHEMA,
-			projectPath: cwd
+			projectPath: cwd,
+			...(target.accountId != null && { accountId: target.accountId })
 		});
 
 		const description = sanitizeBranchDescription(result.description, data.maxWords ?? MAX_BRANCH_DESCRIPTION_WORDS);

--- a/backend/ws/git/commit-message.ts
+++ b/backend/ws/git/commit-message.ts
@@ -8,6 +8,7 @@ import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { execGit } from '../../git/git-executor';
 import { initializeEngine } from '../../engine';
+import { resolveGenerationTarget } from '../../engine/resolve-model';
 import type { EngineType } from '$shared/types/unified';
 import type { GeneratedCommitMessage } from '$shared/types/git';
 import { debug } from '$shared/utils/logger';
@@ -62,7 +63,8 @@ export const commitMessageHandler = createRouter()
 		data: t.Object({
 			projectId: t.String(),
 			engine: t.String(),
-			providerSlug: t.String(),
+			/** Hint only — the provider is re-derived from the engine catalog. */
+			providerSlug: t.Optional(t.String()),
 			modelId: t.String(),
 			format: t.Union([t.Literal('single-line'), t.Literal('multi-line')]),
 			customPrompt: t.Optional(t.String()),
@@ -110,14 +112,18 @@ ${rawDiff}`;
 			? `${defaultPrompt}\n\nAdditional constraints:\n${extra}`
 			: defaultPrompt;
 
-		debug.log('git', `Generating commit message via ${engineType}/${data.modelId}`);
+		// The caller's providerSlug/account can be stale (see resolve-model.ts).
+		const target = await resolveGenerationTarget(engine, data.modelId, data.providerSlug);
+
+		debug.log('git', `Generating commit message via ${engineType}/${target.providerSlug}/${target.modelId}`);
 
 		const result = await engine.generateStructured<GeneratedCommitMessage>({
 			prompt,
-			providerSlug: data.providerSlug,
-			modelId: data.modelId,
+			providerSlug: target.providerSlug,
+			modelId: target.modelId,
 			schema: COMMIT_MESSAGE_SCHEMA,
-			projectPath: cwd
+			projectPath: cwd,
+			...(target.accountId != null && { accountId: target.accountId })
 		});
 
 		// Format structured output into conventional commit string

--- a/frontend/components/git/CommitForm.svelte
+++ b/frontend/components/git/CommitForm.svelte
@@ -16,6 +16,7 @@
 		setGitOp
 	} from '$frontend/stores/features/git-workspace.svelte';
 	import ws from '$frontend/utils/ws';
+	import { resolveGenerationModel } from '$frontend/utils/model-override';
 	import GitMoreMenu, { type GitMoreAction } from '$frontend/components/git/GitMoreMenu.svelte';
 
 	interface Props {
@@ -229,10 +230,9 @@
 
 		setGitOp(projectId, 'isGenerating', true, repoPath);
 		try {
-			const { useCustomModel, engine, provider, modelId, format } = settings.commitGenerator;
-			const resolvedEngine = useCustomModel ? engine : settings.selectedEngine;
-			const resolvedProvider = useCustomModel ? provider : settings.selectedProvider;
-			const resolvedModel = useCustomModel ? modelId : settings.selectedModelId;
+			const { format } = settings.commitGenerator;
+			const { engine: resolvedEngine, providerSlug: resolvedProvider, modelId: resolvedModel } =
+				resolveGenerationModel(settings.commitGenerator);
 			const extra = buildCommitExtra();
 			const result = await ws.http('git:generate-commit-message', {
 				projectId,
@@ -266,10 +266,9 @@
 
 		setGitOp(projectId, 'isGeneratingBranch', true, repoPath);
 		try {
-			const { useCustomModel, engine, provider, modelId, branchSeparator, branchConfig } = settings.commitGenerator;
-			const resolvedEngine = useCustomModel ? engine : settings.selectedEngine;
-			const resolvedProvider = useCustomModel ? provider : settings.selectedProvider;
-			const resolvedModel = useCustomModel ? modelId : settings.selectedModelId;
+			const { branchSeparator, branchConfig } = settings.commitGenerator;
+			const { engine: resolvedEngine, providerSlug: resolvedProvider, modelId: resolvedModel } =
+				resolveGenerationModel(settings.commitGenerator);
 			const extra = buildBranchExtra();
 			const result = await ws.http('git:generate-branch-name', {
 				projectId,

--- a/frontend/components/settings/model/ArtifactsSettings.svelte
+++ b/frontend/components/settings/model/ArtifactsSettings.svelte
@@ -3,6 +3,7 @@
 	import { modelStore } from '$frontend/stores/features/models.svelte';
 	import { ENGINES } from '$shared/constants/engines';
 	import type { EngineType } from '$shared/types/unified';
+	import { modelFieldsOf } from '$frontend/utils/model-override';
 	import EngineModelPicker from './EngineModelPicker.svelte';
 
 	// Model used to generate Skills, Commands, Subagents, and Instructions from a purpose.
@@ -29,31 +30,22 @@
 	}
 
 	function handleArtifactsEngineChange(engineType: EngineType) {
-		const base = baseArtifactGen();
 		const models = modelStore.getByEngine(engineType);
-		const defaultModel = models[0];
 		updateSettings({
-			artifactGenerator: {
-				...base,
-				engine: engineType,
-				modelId: defaultModel?.engine.model.id || '',
-				modelName: defaultModel?.engine.model.name || ''
-			}
+			artifactGenerator: { ...baseArtifactGen(), engine: engineType, ...modelFieldsOf(models[0]) }
 		});
 		modelStore.fetchModels(engineType).then(fetched => {
 			if (fetched.length > 0) {
 				updateSettings({
-					artifactGenerator: { ...baseArtifactGen(), engine: engineType, modelId: fetched[0].engine.model.id, modelName: fetched[0].engine.model.name }
+					artifactGenerator: { ...baseArtifactGen(), engine: engineType, ...modelFieldsOf(fetched[0]) }
 				});
 			}
 		});
 	}
 
 	function handleArtifactsModelChange(modelId: string) {
-		const base = baseArtifactGen();
-		const model = modelStore.getById(modelId);
 		updateSettings({
-			artifactGenerator: { ...base, modelId, modelName: model?.engine.model.name || modelId }
+			artifactGenerator: { ...baseArtifactGen(), ...modelFieldsOf(modelStore.getById(modelId), modelId) }
 		});
 	}
 </script>

--- a/frontend/components/settings/model/GitSettings.svelte
+++ b/frontend/components/settings/model/GitSettings.svelte
@@ -8,6 +8,7 @@
 	import type { CommitMessageFormat } from '$shared/types/git';
 	import type { CommitMessageConfig, BranchNameConfig } from '$shared/types/stores/settings';
 	import type { IconName } from '$shared/types/ui/icons';
+	import { modelFieldsOf } from '$frontend/utils/model-override';
 	import EngineModelPicker from './EngineModelPicker.svelte';
 
 	let showModelConfig = $state(false);
@@ -70,29 +71,22 @@
 
 	function handleCommitEngineChange(engineType: EngineType) {
 		const models = modelStore.getByEngine(engineType);
-		const defaultModel = models[0];
 		updateSettings({
-			commitGenerator: {
-				...commitGen,
-				engine: engineType,
-				modelId: defaultModel?.engine.model.id || '',
-				modelName: defaultModel?.engine.model.name || ''
-			}
+			commitGenerator: { ...commitGen, engine: engineType, ...modelFieldsOf(models[0]) }
 		});
 
 		modelStore.fetchModels(engineType).then(fetched => {
 			if (fetched.length > 0) {
 				updateSettings({
-					commitGenerator: { ...settings.commitGenerator, modelId: fetched[0].engine.model.id, modelName: fetched[0].engine.model.name }
+					commitGenerator: { ...settings.commitGenerator, ...modelFieldsOf(fetched[0]) }
 				});
 			}
 		});
 	}
 
 	function handleCommitModelChange(modelId: string) {
-		const model = modelStore.getById(modelId);
 		updateSettings({
-			commitGenerator: { ...commitGen, modelId, modelName: model?.engine.model.name || modelId }
+			commitGenerator: { ...commitGen, ...modelFieldsOf(modelStore.getById(modelId), modelId) }
 		});
 	}
 

--- a/frontend/utils/artifact-generate.ts
+++ b/frontend/utils/artifact-generate.ts
@@ -7,6 +7,7 @@
 import ws from '$frontend/utils/ws';
 import { settings } from '$frontend/stores/features/settings.svelte';
 import { projectState } from '$frontend/stores/core/projects.svelte';
+import { resolveGenerationModel } from '$frontend/utils/model-override';
 
 export type GeneratableArtifactType = 'skill' | 'command' | 'subagent' | 'instruction';
 
@@ -15,11 +16,7 @@ export async function generateArtifactDraft(
 	artifactType: GeneratableArtifactType,
 	purpose: string
 ): Promise<Record<string, unknown>> {
-	const gen = settings.artifactGenerator;
-	const useCustom = !!gen?.useCustomModel;
-	const engine = useCustom ? gen!.engine : settings.selectedEngine;
-	const providerSlug = useCustom ? gen!.provider : settings.selectedProvider;
-	const modelId = useCustom ? gen!.modelId : settings.selectedModelId;
+	const { engine, providerSlug, modelId } = resolveGenerationModel(settings.artifactGenerator);
 
 	if (!modelId) throw new Error('No model configured. Pick one in Settings → Models.');
 

--- a/frontend/utils/model-override.ts
+++ b/frontend/utils/model-override.ts
@@ -1,0 +1,62 @@
+/**
+ * Resolves which engine/model an AI-assist feature runs on: the feature's own
+ * override (Settings → Models → Git / Artifacts) when enabled, otherwise the
+ * assistant model.
+ *
+ * One helper for every caller so a new feature can't reinvent — and get wrong —
+ * the three fields that must travel together. `providerSlug` is a hint only:
+ * the backend re-derives it from the engine catalog (see
+ * `backend/engine/resolve-model.ts`), so a stored provider that fell out of
+ * sync with `modelId` can't break generation.
+ */
+
+import { settings } from '$frontend/stores/features/settings.svelte';
+import type { EngineModel, EngineType } from '$shared/types/unified';
+
+/** The model-override shape shared by `commitGenerator` and `artifactGenerator`. */
+export interface ModelOverride {
+	useCustomModel: boolean;
+	engine: EngineType;
+	provider: string;
+	modelId: string;
+}
+
+export interface ResolvedGenerationModel {
+	engine: EngineType;
+	providerSlug: string;
+	modelId: string;
+}
+
+/**
+ * The persisted model fields of an override, derived from one catalog entry.
+ * Spread this when saving so `provider`, `modelId`, and `modelName` can never
+ * be written apart — a provider left behind by a model change is exactly the
+ * drift that used to break OpenCode/Pi/Cline generation.
+ */
+export function modelFieldsOf(model: EngineModel | undefined, fallbackId = ''): {
+	provider: string;
+	modelId: string;
+	modelName: string;
+} {
+	return {
+		provider: model?.engine.provider ?? '',
+		modelId: model?.engine.model.id ?? fallbackId,
+		modelName: model?.engine.model.name ?? fallbackId
+	};
+}
+
+/** Resolve an override (or the assistant model when it's off/absent). */
+export function resolveGenerationModel(override?: ModelOverride | null): ResolvedGenerationModel {
+	if (override?.useCustomModel) {
+		return {
+			engine: override.engine,
+			providerSlug: override.provider,
+			modelId: override.modelId
+		};
+	}
+	return {
+		engine: settings.selectedEngine,
+		providerSlug: settings.selectedProvider,
+		modelId: settings.selectedModelId
+	};
+}

--- a/shared/types/stores/settings.ts
+++ b/shared/types/stores/settings.ts
@@ -19,6 +19,11 @@ export interface CommitGeneratorSettings {
 	/** When false, uses the chat model (selectedEngine/selectedModel). When true, uses custom engine/model below. */
 	useCustomModel: boolean;
 	engine: EngineType;
+	/**
+	 * Provider of `modelId`. Write it with `modelFieldsOf()` so it can never lag
+	 * behind a model change — the backend re-derives it anyway
+	 * (`backend/engine/resolve-model.ts`), but a stale value here is misleading.
+	 */
 	provider: string;
 	modelId: string;
 	modelName: string;
@@ -37,6 +42,7 @@ export interface CommitGeneratorSettings {
 export interface ArtifactGeneratorSettings {
 	useCustomModel: boolean;
 	engine: EngineType;
+	/** See `CommitGeneratorSettings.provider` — write via `modelFieldsOf()`. */
 	provider: string;
 	modelId: string;
 	modelName: string;


### PR DESCRIPTION
Two independent faults made AI commit, branch, and artifact generation fail on OpenCode, Pi, and Cline while looking fine on Claude Code.

Settings persist engine, provider, and model as separate fields, but the Git and Artifacts pickers only ever wrote engine/model — leaving provider pinned to its 'anthropic' seed. Engines that ignore the slug (Claude, Codex, Qwen, Copilot, Cursor) masked the drift; OpenCode passes it as model.providerID and Pi/Cline resolve their account by it, so those three broke. The backend now derives provider from the engine's own catalog and treats the client value as a hint, which also heals configs already saved wrong. Frontend writes the fields together via modelFieldsOf so they cannot drift apart again.

Artifact drafts then failed to parse: models emit the JSON object and keep talking, and the old first-brace-to-last-brace slice swallowed any commentary containing a brace. extractJson now scans string-aware for balanced objects and escapes raw control characters inside strings — Markdown bodies attract the literal newlines JSON forbids. Git commit generation never tripped this because its fields are short one-liners.