### PR TITLE
fix(preview): keep streaming smooth on low-spec hosts and viewers

### DIFF
--- a/backend/preview/browser/browser-pool.ts
+++ b/backend/preview/browser/browser-pool.ts
@@ -15,6 +15,7 @@
  * - Direct launch() ensures puppeteer-extra wraps ALL page creation correctly.
  */
 
+import { existsSync } from 'fs';
 import type { Browser, BrowserContext, Page } from 'puppeteer';
 import { debug } from '$shared/utils/logger';
 import puppeteer from 'puppeteer-extra';
@@ -45,15 +46,88 @@ const DEFAULT_CONFIG: PoolConfig = {
 };
 
 /**
- * Chrome launch arguments for stealth (matches test-cf.ts exactly)
+ * Chrome launch arguments.
+ *
+ * Three groups, kept separate because they answer different questions:
+ * stealth (Cloudflare bypass — matches test-cf.ts), capture (what the preview
+ * pipeline needs from the renderer), and host adaptation (what a headless VPS
+ * needs that a desktop doesn't).
  */
-const CHROME_ARGS = [
-	'--no-sandbox',
-	'--disable-blink-features=AutomationControlled',
-	'--window-size=1366,768',
-	'--autoplay-policy=no-user-gesture-required',
-	'--disable-features=AudioServiceOutOfProcess,WebRtcHideLocalIpsWithMdns'
-];
+function buildChromeArgs(): string[] {
+	// Chrome only honours the last `--disable-features`, so every entry has to
+	// live in one combined flag.
+	const disabledFeatures = [
+		'AudioServiceOutOfProcess',
+		'WebRtcHideLocalIpsWithMdns',
+		// Occlusion detection throttles renderers Chrome thinks nobody is
+		// looking at — which is every headless tab, including the one we are
+		// actively streaming.
+		'CalculateNativeWinOcclusion'
+	];
+
+	const args = [
+		'--no-sandbox',
+		'--disable-blink-features=AutomationControlled',
+		'--window-size=1366,768',
+		'--autoplay-policy=no-user-gesture-required',
+
+		// In-page capture (getDisplayMedia({preferCurrentTab})) — lets the
+		// encoder read compositor frames directly instead of round-tripping
+		// JPEG through CDP. Without this the call would wait on a picker that
+		// can never be answered in headless.
+		'--auto-accept-this-tab-capture',
+
+		// A headless tab is never "visible" or "focused", and Chrome
+		// aggressively de-prioritises renderers in that state — timers get
+		// clamped and compositing stalls, which reads as a frozen preview.
+		'--disable-background-timer-throttling',
+		'--disable-backgrounding-occluded-windows',
+		'--disable-renderer-backgrounding',
+
+		// Containers and small VPS instances often ship a 64MB /dev/shm;
+		// exceeding it crashes the renderer mid-stream.
+		'--disable-dev-shm-usage',
+
+		'--no-first-run',
+		'--no-default-browser-check',
+		'--disable-hang-monitor',
+		'--metrics-recording-only',
+		'--force-color-profile=srgb'
+	];
+
+	if (shouldDisableGpu()) {
+		// Without a real GPU, Chrome falls back to SwiftShader — a software
+		// GL implementation whose setup and per-frame cost exceed plain CPU
+		// rasterisation for the 2D content a preview shows.
+		args.push('--disable-gpu', '--disable-software-rasterizer');
+	}
+
+	args.push(`--disable-features=${disabledFeatures.join(',')}`);
+
+	return args;
+}
+
+/**
+ * Whether this host benefits from skipping GPU compositing entirely.
+ *
+ * `auto` only disables it on Linux hosts with no render node, i.e. headless
+ * servers — a Linux desktop keeps its GPU so WebGL previews still work.
+ */
+function shouldDisableGpu(): boolean {
+	const override = (process.env.CLOPEN_PREVIEW_GPU || '').trim().toLowerCase();
+	if (override === 'off') return true;
+	if (override === 'on') return false;
+
+	if (process.platform !== 'linux') return false;
+
+	try {
+		return !existsSync('/dev/dri');
+	} catch {
+		return true;
+	}
+}
+
+const CHROME_ARGS = buildChromeArgs();
 
 class BrowserPool {
 	private browser: Browser | null = null;

--- a/backend/preview/browser/browser-preview-service.ts
+++ b/backend/preview/browser/browser-preview-service.ts
@@ -20,7 +20,10 @@ import type {
 	BrowserDialogResponse,
 	BrowserSelectResponse,
 	BrowserContextMenuResponse,
-	BrowserContextMenuInfo
+	BrowserContextMenuInfo,
+	ClientCodecSupport,
+	ClientDisplayMetrics,
+	ClientStreamFeedback
 } from './types';
 
 /**
@@ -366,7 +369,10 @@ export class BrowserPreviewService extends EventEmitter {
 	// ============================================================================
 	// WebCodecs Streaming Methods (optimized, ~20-40ms, lower bandwidth)
 	// ============================================================================
-	async startWebCodecsStreaming(tabId: string, allowVp9 = true): Promise<boolean> {
+	async startWebCodecsStreaming(
+		tabId: string,
+		options?: { codecSupport?: ClientCodecSupport; display?: ClientDisplayMetrics }
+	): Promise<boolean> {
 		const tab = this.getTab(tabId);
 		if (!tab) {
 			return false;
@@ -375,8 +381,36 @@ export class BrowserPreviewService extends EventEmitter {
 			tabId,
 			tab,
 			() => this.isValidTab(tabId),
-			allowVp9
+			options
 		);
+	}
+
+	/**
+	 * Viewer display metrics (fit-scale + pixel density) — drives capture
+	 * resolution so we never encode more pixels than the viewer can show.
+	 */
+	applyWebCodecsDisplayMetrics(tabId: string, metrics: ClientDisplayMetrics): boolean {
+		const tab = this.getTab(tabId);
+		if (!tab) {
+			return false;
+		}
+		this.videoCapture.applyDisplayMetrics(tabId, tab, metrics);
+		return true;
+	}
+
+	/** Viewer decoder health — closes the adaptation loop back to the source. */
+	applyWebCodecsClientFeedback(tabId: string, feedback: ClientStreamFeedback): boolean {
+		this.videoCapture.applyClientFeedback(tabId, feedback);
+		return true;
+	}
+
+	/** Suspend capture while nobody is looking at the preview. */
+	async setWebCodecsPaused(tabId: string, paused: boolean): Promise<boolean> {
+		const tab = this.getTab(tabId);
+		if (!tab) {
+			return false;
+		}
+		return await this.videoCapture.setPaused(tabId, tab, paused);
 	}
 
 	async stopWebCodecsStreaming(tabId: string): Promise<void> {

--- a/backend/preview/browser/browser-video-capture.ts
+++ b/backend/preview/browser/browser-video-capture.ts
@@ -4,14 +4,18 @@
  * Handles WebCodecs-based video streaming with WebRTC DataChannel transport.
  *
  * Video Architecture (Chrome-Remote-Desktop-style adaptive quality):
- * 1. CDP captures JPEG frames via Page.screencastFrame at native viewport resolution
- * 2. Direct CDP Runtime.evaluate sends base64 to page (bypasses Puppeteer IPC)
- * 3. Page decodes via createImageBitmap, encodes with VideoEncoder —
- *    preferred VP9 quantizer mode (cheap during motion), VP8 bitrate fallback
- * 4. When the page goes still, a lossless PNG screenshot is pushed through the
- *    encoder near-losslessly (top-off) so text sharpens after motion stops
- * 5. Send encoded chunks via reliable ordered RTCDataChannel; latency is
- *    bounded by source-side frame dropping (bufferedAmount backpressure)
+ * 1. Frames are captured at the resolution the viewer can actually display
+ *    (fit-scale × devicePixelRatio, capped by the host's pixel budget)
+ * 2. Capture runs either in-page (getDisplayMedia → VideoFrame, no round-trip)
+ *    or via CDP screencast, which is ack-gated so Chrome never rasters a frame
+ *    we would discard
+ * 3. The page encodes with VideoEncoder — VP9 quantizer mode, H.264 when the
+ *    viewer has hardware for it, VP8 as the universal floor
+ * 4. When the page goes still, one near-lossless refresh frame is sent so text
+ *    sharpens after motion stops
+ * 5. Encoded chunks travel over a reliable ordered RTCDataChannel; latency is
+ *    bounded by source-side frame dropping, driven by three independent
+ *    signals: network buffer, encoder queue, and the viewer's decode queue
  *
  * Audio Architecture:
  * 1. AudioContext interception (handled by BrowserAudioCapture)
@@ -20,34 +24,86 @@
  *
  * Client:
  * - Receives video + audio chunks via DataChannel
- * - Decodes with VideoDecoder + AudioDecoder
+ * - Decodes with VideoDecoder (off the main thread when the browser allows it)
  * - Renders video to canvas, plays audio with proper scheduling
- *
- * Benefits vs Canvas + WebRTC:
- * - Lower bandwidth (500-800 Kbps vs 1 Mbps)
- * - More control over codec selection
- * - Skip canvas rendering overhead
- * - DataChannel = lower latency than video track
  */
 
 import { EventEmitter } from 'events';
-import type { Page } from 'puppeteer';
-import type { BrowserTab, StreamingConfig } from './types';
-import { DEFAULT_STREAMING_CONFIG } from './types';
+import type { CDPSession, Page } from 'puppeteer';
+import type {
+	BrowserTab,
+	ClientCodecSupport,
+	ClientDisplayMetrics,
+	ClientStreamFeedback,
+	StreamingConfig
+} from './types';
+import { DEFAULT_STREAMING_CONFIG, resolveCodecCandidates } from './types';
 import { videoEncoderScript } from './scripts/video-stream';
 import { audioCaptureScript } from './scripts/audio-stream';
+import {
+	computeBitrate,
+	computeCaptureSize,
+	getHostCaptureProfile,
+	type CaptureProfile,
+	type CaptureSize
+} from './capture-profile';
 import { debug } from '$shared/utils/logger';
+
+/**
+ * Encoder health reported back from the page every couple of seconds.
+ * This is the CPU half of the backpressure story — `bufferedAmount` only ever
+ * described the network.
+ */
+interface EncoderStats {
+	captureMode: 'push' | 'native';
+	codec: string;
+	/** Mean main-thread cost per frame in the page: image decode + encode. */
+	avgFrameCostMs: number;
+	/** Peak encoder queue depth over the window, not an instantaneous sample. */
+	encodeQueueMax: number;
+	bufferedAmount: number;
+	framesAttempted: number;
+	framesSkippedEncoder: number;
+	framesSkippedNetwork: number;
+	/** Frames per second actually delivered to the viewer over the window. */
+	measuredFps: number;
+	width: number;
+	height: number;
+}
 
 interface VideoStreamSession {
 	sessionId: string;
 	isActive: boolean;
+	paused: boolean;
 	clientConnected: boolean;
 	headlessReady: boolean;
 	pendingCandidates: RTCIceCandidateInit[];
 	scriptInjected: boolean; // Track if persistent script was injected
 	scriptsPreInjected: boolean; // Track if scripts were pre-injected during tab creation
 	audioOnNewDocumentInjected: boolean; // Track if evaluateOnNewDocument was registered for audio
-	allowVp9: boolean; // Client decode capability (negotiated at stream start)
+	codecSupport: ClientCodecSupport; // Client decode capability (negotiated at stream start)
+	display: ClientDisplayMetrics; // Viewer fit-scale + pixel density
+	profile: CaptureProfile;
+	capture: CaptureSize;
+	/** Extra resolution derate applied when the fps floor isn't enough. */
+	pixelDerate: number;
+	targetFramerate: number;
+	captureMode: 'push' | 'native';
+	/** Consecutive healthy adaptation windows — gates recovery upward. */
+	healthyWindows: number;
+	/**
+	 * Consecutive saturated windows. Degrading on a single report made the
+	 * ladder a one-way ratchet: any momentary spike stepped the framerate down,
+	 * and because a degrade resets the recovery counter, one spike every few
+	 * seconds was enough to walk the stream to its floor and pin it there.
+	 */
+	saturatedWindows: number;
+	/**
+	 * The tab this session streams. Kept here so adaptation triggered from the
+	 * page (encoder stats arrive through an exposed binding, with no tab in
+	 * hand) can still reach the page to change capture geometry.
+	 */
+	tab?: BrowserTab;
 	stats: {
 		videoBytesSent: number;
 		audioBytesSent: number;
@@ -58,19 +114,329 @@ interface VideoStreamSession {
 }
 
 /**
- * Scale encoder bitrate with capture resolution to keep bits-per-pixel
- * constant. Capture always runs at native viewport size (display fit-scale
- * is a CSS-only concern on the frontend), so a fixed bitrate would starve
- * larger viewports during motion.
- * 0.045 bpp at 1280×800@24fps ≈ 1.1 Mbps (comparable to the previous fixed 1 Mbps).
+ * Framerate ladder. Discrete so the stream settles instead of oscillating;
+ * clamped per session to the host profile's [minFramerate, maxFramerate].
  */
-const BITS_PER_PIXEL = 0.045;
+const FRAMERATE_LADDER = [6, 8, 10, 12, 15, 18, 20, 24, 30];
 
-function computeBitrate(width: number, height: number, framerate: number): number {
-	return Math.max(
-		DEFAULT_STREAMING_CONFIG.video.bitrate,
-		Math.round(width * height * framerate * BITS_PER_PIXEL)
-	);
+/**
+ * Resolution derates applied only after the framerate floor is reached. Going
+ * coarser beats going slower — a sharp slideshow reads worse than a soft but
+ * fluid stream — so this is the last resort, not the first.
+ */
+const PIXEL_DERATE_LADDER = [1, 0.85, 0.7, 0.55];
+
+const DEFAULT_CODEC_SUPPORT: ClientCodecSupport = {
+	vp8: true,
+	vp9: true,
+	avc: false,
+	hardware: []
+};
+
+/**
+ * CDP screencast feeder with ack-gated flow control.
+ *
+ * `Page.screencastFrame` fires at the compositor rate (up to 60fps) and Chrome
+ * withholds the next frame until the current one is acked. Acking immediately
+ * and discarding surplus frames downstream — the previous design — meant the
+ * renderer still rastered, JPEG-encoded and base64'd every one of them, and
+ * the process still parsed them, before we threw half away. Holding the ack
+ * for one frame interval moves that throttle to the only place it actually
+ * saves work: before the frame is produced.
+ */
+class ScreencastFeeder {
+	private ackTimer: ReturnType<typeof setTimeout> | null = null;
+	private topOffTimer: ReturnType<typeof setTimeout> | null = null;
+	private peerObjectId: string | null = null;
+	private acquiringPeer = false;
+	private capturingTopOff = false;
+	private frameSeq = 0;
+	private destroyed = false;
+	private running = false;
+	private lastDispatchAt = 0;
+	private lastAckAt = 0;
+	private pendingAckId: number | null = null;
+
+	constructor(
+		private readonly cdp: CDPSession,
+		private readonly label: string,
+		private readonly getSession: () => VideoStreamSession | undefined,
+		private readonly getTab: () => BrowserTab | undefined,
+		private readonly onInvalidSession: () => void,
+		private readonly isValidSession: () => boolean
+	) {
+		this.cdp.on('Page.screencastFrame', (event: any) => this.handleFrame(event));
+	}
+
+	/** Milliseconds a frame is held before acking — i.e. the source frame budget. */
+	private get frameIntervalMs(): number {
+		const fps = this.getSession()?.targetFramerate || DEFAULT_STREAMING_CONFIG.video.framerate;
+		return Math.max(16, Math.round(1000 / fps));
+	}
+
+	async start(width: number, height: number, quality: number): Promise<void> {
+		if (this.destroyed) return;
+
+		// Acquire the encoder handle before the first frame so no frame is
+		// wasted waiting for it.
+		await this.acquirePeerHandle();
+
+		await this.cdp.send('Page.startScreencast', {
+			format: 'jpeg',
+			quality,
+			maxWidth: width,
+			maxHeight: height,
+			everyNthFrame: 1
+		});
+
+		this.running = true;
+		debug.log('webcodecs', `CDP screencast started for ${this.label} at ${width}x${height} (q${quality})`);
+	}
+
+	async restart(width: number, height: number, quality: number): Promise<void> {
+		if (this.destroyed) return;
+		this.clearTimers();
+		await this.cdp.send('Page.stopScreencast').catch(() => {});
+		this.running = false;
+		await this.start(width, height, quality);
+	}
+
+	async pause(): Promise<void> {
+		if (!this.running) return;
+		this.clearTimers();
+		this.running = false;
+		await this.cdp.send('Page.stopScreencast').catch(() => {});
+	}
+
+	/** Invalidate the cached page handle — the execution context is gone. */
+	invalidatePeerHandle(): void {
+		this.peerObjectId = null;
+	}
+
+	private async acquirePeerHandle(): Promise<void> {
+		if (this.destroyed || this.acquiringPeer || this.peerObjectId) return;
+		this.acquiringPeer = true;
+		try {
+			const result: any = await this.cdp.send('Runtime.evaluate', {
+				expression: 'window.__webCodecsPeer',
+				returnByValue: false,
+				silent: true
+			});
+			this.peerObjectId = result?.result?.objectId ?? null;
+		} catch {
+			this.peerObjectId = null;
+		} finally {
+			this.acquiringPeer = false;
+		}
+	}
+
+	/**
+	 * Hand a frame to the page encoder.
+	 *
+	 * The payload travels as a `callFunctionOn` **argument**, not interpolated
+	 * into a `Runtime.evaluate` expression. Interpolation made V8 parse and
+	 * compile a fresh source string containing the whole base64 frame on every
+	 * single frame — hundreds of kilobytes of compilation per frame, for a
+	 * call that never changes.
+	 */
+	private dispatch(data: string, isTopOff: boolean, mimeType: string): void {
+		if (this.destroyed) return;
+
+		if (!this.peerObjectId) {
+			void this.acquirePeerHandle();
+			return;
+		}
+
+		this.cdp
+			.send('Runtime.callFunctionOn', {
+				objectId: this.peerObjectId,
+				functionDeclaration: 'function(d,t,m){this.encodeFrame(d,t,m)}',
+				arguments: [{ value: data }, { value: isTopOff }, { value: mimeType }],
+				returnByValue: false,
+				awaitPromise: false,
+				silent: true
+			} as any)
+			.catch(() => {
+				// Stale handle (navigation) — the next frame re-acquires it.
+				this.peerObjectId = null;
+			});
+	}
+
+	private ack(cdpSessionId: number): void {
+		this.cdp.send('Page.screencastFrameAck', { sessionId: cdpSessionId }).catch(() => {});
+	}
+
+	private handleFrame(event: any): void {
+		this.frameSeq++;
+
+		// Every frame must be acknowledged exactly once — Chrome counts frames
+		// in flight and stops producing once that count sticks. If a previous
+		// ack is still held, release it now rather than replacing it.
+		this.flushPendingAck();
+
+		const session = this.getSession();
+		const tab = this.getTab();
+
+		// Ack immediately when we're not consuming — never leave the screencast
+		// waiting on an ack that will not come, or it stalls permanently.
+		if (this.destroyed || !session?.isActive || session.paused || tab?.isDestroyed) {
+			this.ack(event.sessionId);
+			return;
+		}
+
+		if (!this.isValidSession()) {
+			this.ack(event.sessionId);
+			this.onInvalidSession();
+			return;
+		}
+
+		// Native capture drives the encoder itself; the screencast should
+		// already be stopped, but ack defensively so nothing wedges.
+		if (session.captureMode === 'native') {
+			this.ack(event.sessionId);
+			return;
+		}
+
+		const now = Date.now();
+		const interval = this.frameIntervalMs;
+
+		try {
+			// Belt-and-braces rate limit against a source that isn't honouring
+			// ack flow control. The margin is loose on purpose: under working
+			// flow control frames already arrive one interval apart, and
+			// dropping one costs a *whole* extra interval (the next frame is
+			// only produced after our ack), which reads as judder.
+			if (this.lastDispatchAt > 0 && now - this.lastDispatchAt < interval * 0.6) {
+				return;
+			}
+
+			this.lastDispatchAt = now;
+			this.dispatch(event.data, false, 'image/jpeg');
+			this.scheduleTopOff();
+		} finally {
+			// Self-calibrating hold. The period the viewer actually sees is
+			// `hold + however long the source takes to produce and deliver the
+			// next frame`, so holding a full interval on top of that undershoots
+			// the target framerate — measurably, and visibly as stutter. Measure
+			// the pipeline (last ack → this frame) and hold only the remainder.
+			const pipelineMs = this.lastAckAt > 0 ? Math.max(0, now - this.lastAckAt) : 0;
+			const hold = Math.max(0, interval - pipelineMs);
+
+			this.pendingAckId = event.sessionId;
+			this.ackTimer = setTimeout(() => {
+				this.ackTimer = null;
+				this.sendPendingAck();
+			}, hold);
+		}
+	}
+
+	private flushPendingAck(): void {
+		if (!this.ackTimer) return;
+		clearTimeout(this.ackTimer);
+		this.ackTimer = null;
+		this.sendPendingAck();
+	}
+
+	private sendPendingAck(): void {
+		if (this.pendingAckId === null) return;
+		const id = this.pendingAckId;
+		this.pendingAckId = null;
+		this.lastAckAt = Date.now();
+		this.ack(id);
+	}
+
+	/**
+	 * Static top-off: screencastFrame only fires on damage, so when no frame
+	 * arrives for TOP_OFF_DELAY_MS the page has gone still. Capture one
+	 * high-quality screenshot and encode it near-losslessly so the last
+	 * (motion-degraded) frame doesn't stay soft on screen. One frame per still
+	 * period — idle costs nothing.
+	 */
+	scheduleTopOff(): void {
+		if (this.destroyed) return;
+		if (this.topOffTimer) clearTimeout(this.topOffTimer);
+
+		// The delay has to clear the gap between two motion frames, or a slow
+		// stream looks "still" between every frame and pays for a screenshot
+		// plus a near-lossless keyframe in the middle of actual motion.
+		const delay = Math.max(BrowserVideoCapture.TOP_OFF_DELAY_MS, this.frameIntervalMs * 2);
+
+		this.topOffTimer = setTimeout(async () => {
+			this.topOffTimer = null;
+
+			const session = this.getSession();
+			const tab = this.getTab();
+			if (!session?.isActive || session.paused || tab?.isDestroyed || this.capturingTopOff) return;
+			if (session.captureMode === 'native') return; // handled in-page from the retained frame
+
+			this.capturingTopOff = true;
+			const seqAtCapture = this.frameSeq;
+
+			try {
+				const profile = session.profile;
+				const viewport = tab?.page?.viewport();
+				const params: Record<string, unknown> = {
+					format: profile.topOffFormat,
+					captureBeyondViewport: false,
+					optimizeForSpeed: true
+				};
+
+				if (profile.topOffFormat === 'jpeg') {
+					params.quality = profile.topOffQuality;
+				}
+
+				// The refresh frame must arrive at the encoder's geometry, so
+				// it is captured through the same scale as the screencast.
+				if (viewport && session.capture.scale < 0.999) {
+					params.clip = {
+						x: 0,
+						y: 0,
+						width: viewport.width,
+						height: viewport.height,
+						scale: session.capture.scale
+					};
+				}
+
+				const screenshot: any = await this.cdp.send('Page.captureScreenshot', params as any);
+
+				// Discard if the page moved again while capturing — new
+				// screencast frames already rescheduled the top-off.
+				if (this.frameSeq !== seqAtCapture || this.destroyed) return;
+
+				this.dispatch(
+					screenshot.data,
+					true,
+					profile.topOffFormat === 'jpeg' ? 'image/jpeg' : 'image/png'
+				);
+			} catch {
+				// Page may be navigating/closing — top-off is best-effort
+			} finally {
+				this.capturingTopOff = false;
+			}
+		}, delay);
+	}
+
+	private clearTimers(): void {
+		// Release the held frame before dropping the timer. The screencast is
+		// about to be stopped either way, but leaving Chrome's in-flight count
+		// non-zero would wedge the next start.
+		this.flushPendingAck();
+		this.lastDispatchAt = 0;
+		this.lastAckAt = 0;
+
+		if (this.topOffTimer) {
+			clearTimeout(this.topOffTimer);
+			this.topOffTimer = null;
+		}
+	}
+
+	async destroy(): Promise<void> {
+		this.destroyed = true;
+		this.running = false;
+		this.clearTimers();
+		await this.cdp.send('Page.stopScreencast').catch(() => {});
+		await this.cdp.detach().catch(() => {});
+	}
 }
 
 export class BrowserVideoCapture extends EventEmitter {
@@ -80,14 +446,106 @@ export class BrowserVideoCapture extends EventEmitter {
 	 * Long enough to skip inter-frame gaps of animations, short enough that
 	 * text sharpens almost immediately after scrolling stops.
 	 */
-	private static readonly TOP_OFF_DELAY_MS = 300;
+	static readonly TOP_OFF_DELAY_MS = 300;
+
+	/** Debounce for viewer resize storms before touching the encoder. */
+	private static readonly DISPLAY_METRICS_DEBOUNCE_MS = 250;
 
 	private sessions = new Map<string, VideoStreamSession>();
+	private feeders = new Map<string, ScreencastFeeder>();
 	private preInjectPromises = new Map<string, Promise<boolean>>();
+	private displayMetricsTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 	constructor() {
 		super();
 	}
+
+	// ------------------------------------------------------------------
+	// Session configuration
+	// ------------------------------------------------------------------
+
+	/**
+	 * Build the per-session video config: capture geometry from the viewer's
+	 * display metrics, quality ceilings from the host profile, and the codec
+	 * order from the viewer's decode capabilities.
+	 */
+	private buildVideoConfig(
+		videoSession: VideoStreamSession,
+		viewport: { width: number; height: number }
+	): StreamingConfig['video'] {
+		const profile = videoSession.profile;
+
+		const derated = {
+			...profile,
+			maxPixels: Math.round(profile.maxPixels * videoSession.pixelDerate)
+		};
+
+		videoSession.capture = computeCaptureSize(
+			viewport.width,
+			viewport.height,
+			videoSession.display.scale,
+			videoSession.display.dpr,
+			derated
+		);
+
+		const { width, height } = videoSession.capture;
+
+		return {
+			...DEFAULT_STREAMING_CONFIG.video,
+			width,
+			height,
+			framerate: videoSession.targetFramerate,
+			minFramerate: profile.minFramerate,
+			bitrate: computeBitrate(width, height, videoSession.targetFramerate),
+			screenshotQuality: profile.screenshotQuality,
+			motionQuantizer: profile.motionQuantizer,
+			topOffQuantizer: profile.topOffQuantizer,
+			codecCandidates: resolveCodecCandidates(videoSession.codecSupport),
+			nativeCapture: isNativeCaptureEnabled()
+		};
+	}
+
+	private buildAudioConfig(videoSession: VideoStreamSession): StreamingConfig['audio'] {
+		return {
+			...DEFAULT_STREAMING_CONFIG.audio,
+			bitrate: videoSession.profile.audioBitrate
+		};
+	}
+
+	private createSessionState(sessionId: string): VideoStreamSession {
+		const profile = getHostCaptureProfile();
+		return {
+			sessionId,
+			isActive: false,
+			paused: false,
+			clientConnected: false,
+			headlessReady: false,
+			pendingCandidates: [],
+			scriptInjected: false,
+			scriptsPreInjected: false,
+			audioOnNewDocumentInjected: false,
+			codecSupport: { ...DEFAULT_CODEC_SUPPORT },
+			display: {},
+			profile,
+			capture: { width: 0, height: 0, scale: 1 },
+			pixelDerate: 1,
+			targetFramerate: profile.maxFramerate,
+			captureMode: 'push',
+			healthyWindows: 0,
+			saturatedWindows: 0,
+			stats: {
+				videoBytesSent: 0,
+				audioBytesSent: 0,
+				videoFramesEncoded: 0,
+				audioFramesEncoded: 0,
+				connectionState: 'new'
+			}
+		};
+	}
+
+	// ------------------------------------------------------------------
+	// Script injection
+	// ------------------------------------------------------------------
 
 	/**
 	 * Pre-inject WebCodecs scripts during tab creation.
@@ -106,40 +564,12 @@ export class BrowserVideoCapture extends EventEmitter {
 		try {
 			const page = session.page;
 			const viewport = page.viewport()!;
-			const config = DEFAULT_STREAMING_CONFIG;
 
-			// Capture at native viewport resolution. Capturing below viewport
-			// size (old behavior: viewport × display fit-scale) forced the
-			// client to upscale frames, which made the preview blurry.
-			const videoConfig: StreamingConfig['video'] = {
-				...config.video,
-				width: viewport.width,
-				height: viewport.height,
-				bitrate: computeBitrate(viewport.width, viewport.height, config.video.framerate)
-			};
-
-			// Create session tracking
-			const videoSession: VideoStreamSession = {
-				sessionId,
-				isActive: false,
-				clientConnected: false,
-				headlessReady: false,
-				pendingCandidates: [],
-				scriptInjected: true,
-				scriptsPreInjected: false, // Set to true only after injection completes
-				audioOnNewDocumentInjected: false,
-				allowVp9: true,
-				stats: {
-					videoBytesSent: 0,
-					audioBytesSent: 0,
-					videoFramesEncoded: 0,
-					audioFramesEncoded: 0,
-					connectionState: 'new'
-				}
-			};
+			const videoSession = this.createSessionState(sessionId);
+			videoSession.scriptInjected = true;
 			this.sessions.set(sessionId, videoSession);
 
-			await this.injectScripts(sessionId, page, videoConfig, config);
+			await this.injectScripts(sessionId, page, this.buildVideoConfig(videoSession, viewport), this.buildAudioConfig(videoSession));
 
 			// Mark as pre-injected only after successful completion
 			videoSession.scriptsPreInjected = true;
@@ -163,7 +593,7 @@ export class BrowserVideoCapture extends EventEmitter {
 		sessionId: string,
 		page: Page,
 		videoConfig: StreamingConfig['video'],
-		config: StreamingConfig
+		audioConfig: StreamingConfig['audio']
 	): Promise<void> {
 		// Check if bindings exist
 		const bindingsExist = await page.evaluate(() => {
@@ -180,9 +610,17 @@ export class BrowserVideoCapture extends EventEmitter {
 
 			await page.exposeFunction('__sendConnectionState', (state: string) => {
 				const activeSession = Array.from(this.sessions.values()).find(s => s.isActive);
-				if (activeSession) {
-					activeSession.stats.connectionState = state;
-					this.emit('connection-state', { sessionId: activeSession.sessionId, state });
+				if (!activeSession) return;
+
+				activeSession.stats.connectionState = state;
+				this.emit('connection-state', { sessionId: activeSession.sessionId, state });
+
+				// Capture sources only produce frames on damage, so a viewer
+				// that connects to an already-still page would otherwise wait
+				// for the first mouse move to see anything. Push one refresh
+				// frame as soon as the peer is up.
+				if (state === 'connected' && activeSession.tab) {
+					void this.requestKeyframe(activeSession.sessionId, activeSession.tab);
 				}
 			});
 
@@ -192,6 +630,13 @@ export class BrowserVideoCapture extends EventEmitter {
 					this.emit('cursor-change', { sessionId: activeSession.sessionId, cursor });
 				}
 			});
+
+			await page.exposeFunction('__sendEncoderStats', (stats: EncoderStats) => {
+				const activeSession = Array.from(this.sessions.values()).find(s => s.isActive);
+				if (activeSession) {
+					this.applyEncoderStats(activeSession.sessionId, stats);
+				}
+			});
 		}
 
 		// Register audio capture as a startup script — runs before page scripts on every new document load.
@@ -199,14 +644,18 @@ export class BrowserVideoCapture extends EventEmitter {
 		// The idempotency guard in audioCaptureScript prevents double-injection.
 		const session = this.sessions.get(sessionId);
 		if (session && !session.audioOnNewDocumentInjected) {
-			await page.evaluateOnNewDocument(audioCaptureScript, config.audio);
+			await page.evaluateOnNewDocument(audioCaptureScript, audioConfig);
 			session.audioOnNewDocumentInjected = true;
 		}
 
 		// Inject video encoder + audio capture scripts into the current page context
 		await page.evaluate(videoEncoderScript, videoConfig);
-		await page.evaluate(audioCaptureScript, config.audio);
+		await page.evaluate(audioCaptureScript, audioConfig);
 	}
+
+	// ------------------------------------------------------------------
+	// Stream lifecycle
+	// ------------------------------------------------------------------
 
 	/**
 	 * Start video streaming for a session
@@ -215,9 +664,12 @@ export class BrowserVideoCapture extends EventEmitter {
 		sessionId: string,
 		session: BrowserTab,
 		isValidSession: () => boolean,
-		allowVp9 = true
+		options?: {
+			codecSupport?: ClientCodecSupport;
+			display?: ClientDisplayMetrics;
+		}
 	): Promise<boolean> {
-		debug.log('webcodecs', `Starting streaming for session ${sessionId} (client vp9: ${allowVp9})`);
+		debug.log('webcodecs', `Starting streaming for session ${sessionId}`);
 
 		// Wait for any pending pre-injection to complete
 		const pendingPreInject = this.preInjectPromises.get(sessionId);
@@ -243,47 +695,32 @@ export class BrowserVideoCapture extends EventEmitter {
 		try {
 			const page = session.page;
 			const viewport = page.viewport()!;
-			const config = DEFAULT_STREAMING_CONFIG;
 
 			// Get or create session tracking
 			let videoSession = this.sessions.get(sessionId);
-			const isRestart = !!videoSession;
-
 			if (!videoSession) {
-				videoSession = {
-					sessionId,
-					isActive: false,
-					clientConnected: false,
-					headlessReady: false,
-					pendingCandidates: [],
-					scriptInjected: false,
-					scriptsPreInjected: false,
-					audioOnNewDocumentInjected: false,
-					allowVp9,
-					stats: {
-						videoBytesSent: 0,
-						audioBytesSent: 0,
-						videoFramesEncoded: 0,
-						audioFramesEncoded: 0,
-						connectionState: 'new'
-					}
-				};
+				videoSession = this.createSessionState(sessionId);
 				this.sessions.set(sessionId, videoSession);
-			} else {
-				videoSession.allowVp9 = allowVp9;
 			}
 
-			// Capture at native viewport resolution (see doPreInject)
-			const videoConfig: StreamingConfig['video'] = {
-				...config.video,
-				width: viewport.width,
-				height: viewport.height,
-				bitrate: computeBitrate(viewport.width, viewport.height, config.video.framerate)
-			};
+			videoSession.tab = session;
 
-			// Skip script injection if already pre-injected during tab creation
-			if (!videoSession.scriptsPreInjected) {
-				await this.injectScripts(sessionId, page, videoConfig, config);
+			// Viewer capabilities/metrics always come from the newest handshake
+			if (options?.codecSupport) videoSession.codecSupport = options.codecSupport;
+			if (options?.display) videoSession.display = { ...videoSession.display, ...options.display };
+			videoSession.paused = false;
+			videoSession.captureMode = 'push';
+			videoSession.healthyWindows = 0;
+
+			const videoConfig = this.buildVideoConfig(videoSession, viewport);
+			const audioConfig = this.buildAudioConfig(videoSession);
+
+			// The pre-injected script was configured before the viewer's codec
+			// support and display metrics were known, so re-inject whenever the
+			// handshake carried either.
+			const mustReinject = !videoSession.scriptsPreInjected || !!options?.codecSupport || !!options?.display;
+			if (mustReinject) {
+				await this.injectScripts(sessionId, page, videoConfig, audioConfig);
 				videoSession.scriptInjected = true;
 			} else {
 				debug.log('webcodecs', `Scripts already pre-injected for ${sessionId}, skipping injection`);
@@ -291,13 +728,13 @@ export class BrowserVideoCapture extends EventEmitter {
 
 			// Single batched call: verify peer + start streaming + init audio
 			// (saves ~60ms of IPC overhead vs 4 separate page.evaluate calls)
-			const initResult = await page.evaluate(async (clientAllowsVp9) => {
+			const initResult = await page.evaluate(async () => {
 				const peer = (window as any).__webCodecsPeer;
 				if (typeof peer?.startStreaming !== 'function') {
 					return { peerExists: false, started: false, audioInitialized: false };
 				}
 
-				const started = await peer.startStreaming(clientAllowsVp9);
+				const started = await peer.startStreaming();
 				if (!started) {
 					return { peerExists: true, started: false, audioInitialized: false };
 				}
@@ -315,7 +752,7 @@ export class BrowserVideoCapture extends EventEmitter {
 				}
 
 				return { peerExists: true, started: true, audioInitialized };
-			}, allowVp9);
+			});
 
 			if (!initResult.peerExists) {
 				debug.error('webcodecs', `Peer script injected but __webCodecsPeer not available`);
@@ -339,169 +776,429 @@ export class BrowserVideoCapture extends EventEmitter {
 
 			videoSession.headlessReady = true;
 
-			// Setup CDP screencast to feed frames to encoder
-			await this.setupFrameFeeder(sessionId, session, config, isValidSession);
+			await this.setupCapture(sessionId, session, isValidSession);
 
-			debug.log('webcodecs', `Streaming started for ${sessionId}`);
+			debug.log(
+				'webcodecs',
+				`Streaming started for ${sessionId} — ${videoSession.capture.width}x${videoSession.capture.height} ` +
+					`@${videoSession.targetFramerate}fps (${videoSession.captureMode}, ${videoSession.profile.tier})`
+			);
 			return true;
 		} catch (error) {
 			debug.error('webcodecs', `Failed to start streaming:`, error);
+			await this.destroyFeeder(sessionId);
 			this.sessions.delete(sessionId);
 			throw error;
 		}
 	}
 
 	/**
-	 * Setup CDP screencast to feed JPEG frames to VideoEncoder
+	 * Bring up a capture source for the session.
+	 *
+	 * In-page capture is tried first: it hands compositor frames straight to
+	 * the encoder, skipping a JPEG encode, a base64 hop through this process,
+	 * and a JPEG decode. It needs a secure context, so any page served over
+	 * plain http falls back to the CDP screencast — which is why the fallback
+	 * is a first-class path and not an error case.
+	 */
+	private async setupCapture(
+		sessionId: string,
+		session: BrowserTab,
+		isValidSession: () => boolean
+	): Promise<void> {
+		const videoSession = this.sessions.get(sessionId);
+		if (!videoSession) return;
+
+		if (await this.tryStartNativeCapture(sessionId, session)) {
+			videoSession.captureMode = 'native';
+			// Native capture drives the encoder itself — a leftover screencast
+			// from a previous page would fight it for the same encoder.
+			await this.destroyFeeder(sessionId);
+			debug.log('webcodecs', `Native in-page capture active for ${sessionId}`);
+			return;
+		}
+
+		videoSession.captureMode = 'push';
+		await this.setupFrameFeeder(sessionId, session, isValidSession);
+	}
+
+	private async tryStartNativeCapture(sessionId: string, session: BrowserTab): Promise<boolean> {
+		if (!isNativeCaptureEnabled()) return false;
+		if (!session.page || session.page.isClosed()) return false;
+
+		try {
+			// getDisplayMedia requires transient user activation, which only
+			// CDP's `userGesture` flag can grant to an automated page.
+			const cdp = await session.page.createCDPSession();
+			try {
+				const result: any = await cdp.send('Runtime.evaluate', {
+					expression: 'window.__webCodecsPeer && window.__webCodecsPeer.startNativeCapture()',
+					awaitPromise: true,
+					returnByValue: true,
+					userGesture: true,
+					silent: true,
+					timeout: 4000
+				} as any);
+
+				return result?.result?.value === true;
+			} finally {
+				await cdp.detach().catch(() => {});
+			}
+		} catch (error) {
+			debug.log('webcodecs', `Native capture unavailable for ${sessionId}, using screencast`);
+			return false;
+		}
+	}
+
+	/**
+	 * Setup CDP screencast to feed frames to VideoEncoder
 	 */
 	private async setupFrameFeeder(
 		sessionId: string,
 		session: BrowserTab,
-		config: StreamingConfig,
 		isValidSession: () => boolean
 	): Promise<void> {
-		const page = session.page;
-		const viewport = page.viewport()!;
+		const videoSession = this.sessions.get(sessionId);
+		if (!videoSession) return;
 
-		const cdp = await page.createCDPSession();
+		await this.destroyFeeder(sessionId);
 
-		let cdpFrameCount = 0;
+		const cdp = await session.page.createCDPSession();
+		const feeder = new ScreencastFeeder(
+			cdp,
+			sessionId,
+			() => this.sessions.get(sessionId),
+			() => session,
+			() => {
+				void this.stopStreaming(sessionId);
+			},
+			isValidSession
+		);
 
-		// Rate-limit encoding to the configured framerate. CDP screencast fires
-		// at compositor rate (up to 60fps) — encoding every frame wastes CPU on
-		// the host and bandwidth on the wire without visible benefit.
-		//
-		// Trailing edge matters: the LAST frame of a burst must always be
-		// encoded. Plain dropping left a stale frame on screen until the
-		// top-off fired (~300ms later), which felt like input lag on every
-		// click/keystroke.
-		const minFrameIntervalMs = Math.floor(1000 / config.video.framerate);
-		let lastEncodeTime = 0;
-		let pendingFrameData: string | null = null;
-		let pendingFrameTimer: ReturnType<typeof setTimeout> | null = null;
+		this.feeders.set(sessionId, feeder);
 
-		const encodeMotionFrame = (frameData: string) => {
-			lastEncodeTime = Date.now();
-			// Send frame to encoder via direct CDP (bypasses Puppeteer's
-			// ExecutionContext lookup, function serialization, Runtime.callFunctionOn
-			// overhead, and result deserialization). Base64 charset [A-Za-z0-9+/=]
-			// is safe to embed in a JS double-quoted string literal.
-			cdp.send('Runtime.evaluate', {
-				expression: `window.__webCodecsPeer?.encodeFrame("${frameData}")`,
-				awaitPromise: false,
-				returnByValue: false
-			}).catch(() => {});
-		};
-
-		// Static top-off (Chrome-Remote-Desktop-style): screencastFrame only
-		// fires on damage, so when no frame arrives for TOP_OFF_DELAY_MS the
-		// page has gone still. Capture one lossless PNG screenshot and encode
-		// it near-losslessly so the last (motion-degraded) frame doesn't stay
-		// blurry on screen. One frame per still period — idle costs nothing.
-		let topOffTimer: ReturnType<typeof setTimeout> | null = null;
-		let capturingTopOff = false;
-
-		const scheduleTopOff = () => {
-			if (topOffTimer) clearTimeout(topOffTimer);
-			topOffTimer = setTimeout(async () => {
-				topOffTimer = null;
-				const videoSession = this.sessions.get(sessionId);
-				if (!videoSession?.isActive || session.isDestroyed || capturingTopOff) return;
-
-				capturingTopOff = true;
-				const frameCountAtCapture = cdpFrameCount;
-				try {
-					const screenshot = await cdp.send('Page.captureScreenshot', { format: 'png' });
-
-					// Discard if the page moved again while capturing —
-					// new screencast frames already rescheduled the top-off
-					if (cdpFrameCount !== frameCountAtCapture) return;
-
-					cdp.send('Runtime.evaluate', {
-						expression: `window.__webCodecsPeer?.encodeFrame("${screenshot.data}", true)`,
-						awaitPromise: false,
-						returnByValue: false
-					}).catch(() => {});
-				} catch {
-					// Page may be navigating/closing — top-off is best-effort
-				} finally {
-					capturingTopOff = false;
-				}
-			}, BrowserVideoCapture.TOP_OFF_DELAY_MS);
-		};
-
-		cdp.on('Page.screencastFrame', async (event: any) => {
-			cdpFrameCount++;
-
-			const videoSession = this.sessions.get(sessionId);
-			if (!videoSession?.isActive || session.isDestroyed) {
-				cdp.send('Page.screencastFrameAck', { sessionId: event.sessionId }).catch(() => {});
-				return;
-			}
-
-			if (!isValidSession()) {
-				this.stopStreaming(sessionId);
-				return;
-			}
-
-			// ACK immediately
-			cdp.send('Page.screencastFrameAck', { sessionId: event.sessionId }).catch(() => {});
-
-			const now = Date.now();
-			const elapsed = now - lastEncodeTime;
-
-			if (elapsed < minFrameIntervalMs) {
-				// Too soon — hold the LATEST frame and encode it when the slot
-				// opens (trailing edge). Newer frames overwrite the pending one.
-				pendingFrameData = event.data;
-				if (!pendingFrameTimer) {
-					pendingFrameTimer = setTimeout(() => {
-						pendingFrameTimer = null;
-						if (!pendingFrameData) return;
-						const frameData = pendingFrameData;
-						pendingFrameData = null;
-
-						const vs = this.sessions.get(sessionId);
-						if (!vs?.isActive || session.isDestroyed) return;
-
-						encodeMotionFrame(frameData);
-						scheduleTopOff();
-					}, minFrameIntervalMs - elapsed);
-				}
-				scheduleTopOff();
-				return;
-			}
-
-			// This frame supersedes any pending trailing frame
-			pendingFrameData = null;
-
-			encodeMotionFrame(event.data);
-			scheduleTopOff();
-		});
-
-		// Start screencast at native viewport resolution
-		await cdp.send('Page.startScreencast', {
-			format: 'jpeg',
-			quality: config.video.screenshotQuality,
-			maxWidth: viewport.width,
-			maxHeight: viewport.height,
-			everyNthFrame: 1
-		});
-
-		debug.log('webcodecs', `CDP screencast started at ${viewport.width}x${viewport.height}`);
-		(session as any).__webCodecsCdp = cdp;
-		(session as any).__webCodecsTopOffCancel = () => {
-			if (topOffTimer) {
-				clearTimeout(topOffTimer);
-				topOffTimer = null;
-			}
-			if (pendingFrameTimer) {
-				clearTimeout(pendingFrameTimer);
-				pendingFrameTimer = null;
-			}
-			pendingFrameData = null;
-		};
+		await feeder.start(
+			videoSession.capture.width,
+			videoSession.capture.height,
+			videoSession.profile.screenshotQuality
+		);
 	}
+
+	private async destroyFeeder(sessionId: string): Promise<void> {
+		const feeder = this.feeders.get(sessionId);
+		if (!feeder) return;
+		this.feeders.delete(sessionId);
+		await feeder.destroy();
+	}
+
+	// ------------------------------------------------------------------
+	// Adaptive quality
+	// ------------------------------------------------------------------
+
+	private framerateLadder(profile: CaptureProfile): number[] {
+		const ladder = FRAMERATE_LADDER.filter(
+			(fps) => fps >= profile.minFramerate && fps <= profile.maxFramerate
+		);
+		return ladder.length > 0 ? ladder : [profile.maxFramerate];
+	}
+
+	/**
+	 * Fold one health report into the quality ladder.
+	 *
+	 * Framerate moves first and resolution only after the fps floor is reached,
+	 * because a soft-but-fluid stream reads far better than a sharp slideshow.
+	 * Recovery requires several consecutive healthy windows so a single quiet
+	 * moment doesn't push the stream straight back into saturation.
+	 */
+	private adaptQuality(sessionId: string, degrade: boolean): void {
+		const videoSession = this.sessions.get(sessionId);
+		if (!videoSession?.isActive) return;
+
+		const session = videoSession.tab;
+
+		const ladder = this.framerateLadder(videoSession.profile);
+		const fpsIndex = Math.max(0, ladder.indexOf(videoSession.targetFramerate));
+		const derateIndex = Math.max(0, PIXEL_DERATE_LADDER.indexOf(videoSession.pixelDerate));
+
+		let nextFps = videoSession.targetFramerate;
+		let nextDerate = videoSession.pixelDerate;
+
+		if (degrade) {
+			videoSession.healthyWindows = 0;
+			videoSession.saturatedWindows++;
+			// Only act on sustained pressure. A single window can be saturated
+			// by one heavy repaint, and reacting to that is what turned the
+			// ladder into a one-way ratchet.
+			if (videoSession.saturatedWindows < 2) return;
+			videoSession.saturatedWindows = 0;
+
+			if (fpsIndex > 0) {
+				nextFps = ladder[fpsIndex - 1];
+			} else if (derateIndex < PIXEL_DERATE_LADDER.length - 1) {
+				nextDerate = PIXEL_DERATE_LADDER[derateIndex + 1];
+			} else {
+				return; // already at the floor
+			}
+		} else {
+			videoSession.saturatedWindows = 0;
+			videoSession.healthyWindows++;
+			if (videoSession.healthyWindows < 2) return;
+			videoSession.healthyWindows = 0;
+
+			// Recover framerate before resolution. Stutter is what the eye
+			// objects to first, so smoothness is bought back before sharpness.
+			if (fpsIndex < ladder.length - 1) {
+				nextFps = ladder[fpsIndex + 1];
+			} else if (derateIndex > 0) {
+				nextDerate = PIXEL_DERATE_LADDER[derateIndex - 1];
+			} else {
+				return; // already at the ceiling
+			}
+		}
+
+		if (nextFps === videoSession.targetFramerate && nextDerate === videoSession.pixelDerate) return;
+
+		const fpsChanged = nextFps !== videoSession.targetFramerate;
+		const derateChanged = nextDerate !== videoSession.pixelDerate;
+
+		videoSession.targetFramerate = nextFps;
+		videoSession.pixelDerate = nextDerate;
+
+		debug.log(
+			'webcodecs',
+			`Quality ${degrade ? '↓' : '↑'} for ${sessionId}: ${nextFps}fps, derate ${nextDerate}`
+		);
+
+		if (fpsChanged) {
+			void this.pushTargetFramerate(sessionId, session, nextFps);
+		}
+		if (derateChanged && session) {
+			void this.applyCaptureGeometry(sessionId, session);
+		}
+	}
+
+	private async pushTargetFramerate(
+		sessionId: string,
+		session: BrowserTab | undefined,
+		fps: number
+	): Promise<void> {
+		if (!session?.page || session.page.isClosed()) return;
+		try {
+			await session.page.evaluate((value: number) => {
+				(window as any).__webCodecsPeer?.setTargetFramerate(value);
+			}, fps);
+		} catch {
+			// Page may be navigating — the next start/navigation re-applies it
+		}
+	}
+
+	/**
+	 * Recompute the capture geometry and push it through the whole chain:
+	 * the page encoder, and the screencast (or the capture track in native
+	 * mode, which `reconfigureEncoder` handles in-page).
+	 */
+	private async applyCaptureGeometry(sessionId: string, session: BrowserTab): Promise<boolean> {
+		const videoSession = this.sessions.get(sessionId);
+		if (!videoSession?.isActive || !session.page || session.page.isClosed()) return false;
+
+		const viewport = session.page.viewport();
+		if (!viewport) return false;
+
+		const previous = videoSession.capture;
+		const videoConfig = this.buildVideoConfig(videoSession, viewport);
+		const next = videoSession.capture;
+
+		// Ignore sub-3% changes — reconfiguring costs a keyframe, and a resize
+		// drag would otherwise fire dozens of them. Roll the recomputed value
+		// back so the recorded geometry keeps matching the live encoder (the
+		// top-off clip scale is read from it).
+		if (
+			previous.width > 0 &&
+			Math.abs(next.width - previous.width) / previous.width < 0.03 &&
+			Math.abs(next.height - previous.height) / previous.height < 0.03
+		) {
+			videoSession.capture = previous;
+			return true;
+		}
+
+		try {
+			const reconfigured = await session.page.evaluate(
+				(params: { width: number; height: number; bitrate: number }) => {
+					const peer = (window as any).__webCodecsPeer;
+					if (!peer?.reconfigureEncoder) return false;
+					return peer.reconfigureEncoder(params.width, params.height, params.bitrate);
+				},
+				{ width: next.width, height: next.height, bitrate: videoConfig.bitrate }
+			);
+
+			if (!reconfigured) {
+				debug.warn('webcodecs', `Encoder reconfigure rejected for ${sessionId}`);
+			}
+
+			const feeder = this.feeders.get(sessionId);
+			if (feeder && videoSession.captureMode === 'push') {
+				await feeder.restart(next.width, next.height, videoSession.profile.screenshotQuality);
+			}
+
+			debug.log(
+				'webcodecs',
+				`Capture geometry for ${sessionId}: ${next.width}x${next.height} ` +
+					`(viewport ${viewport.width}x${viewport.height}, scale ${next.scale.toFixed(2)})`
+			);
+			return true;
+		} catch (error) {
+			debug.warn('webcodecs', `Failed to apply capture geometry:`, error);
+			return false;
+		}
+	}
+
+	/**
+	 * Encoder health from the page. Saturation here means this host cannot
+	 * produce frames fast enough, which no amount of network headroom fixes.
+	 */
+	private applyEncoderStats(sessionId: string, stats: EncoderStats): void {
+		const videoSession = this.sessions.get(sessionId);
+		if (!videoSession?.isActive) return;
+
+		videoSession.captureMode = stats.captureMode || videoSession.captureMode;
+
+		// In-page capture can end on its own — the captured surface goes away
+		// on some navigations — and the page has no way to start a screencast.
+		// Detecting the drop here is what keeps the preview from freezing on
+		// its last frame.
+		if (
+			videoSession.captureMode === 'push' &&
+			!videoSession.paused &&
+			!this.feeders.has(sessionId) &&
+			videoSession.tab
+		) {
+			debug.warn('webcodecs', `Native capture ended for ${sessionId}, falling back to screencast`);
+			const tab = videoSession.tab;
+			void this.setupFrameFeeder(sessionId, tab, () => !tab.isDestroyed);
+		}
+
+		const frameBudgetMs = 1000 / Math.max(1, videoSession.targetFramerate);
+		const skipRatio =
+			stats.framesAttempted > 0 ? stats.framesSkippedEncoder / stats.framesAttempted : 0;
+
+		// Encoding is only one stage of the frame's journey; once it eats most
+		// of the budget on its own there is nothing left for capture, decode
+		// and paint, and the stream visibly stutters.
+		//
+		// All three signals are deliberately generous. A ratio rather than a
+		// raw count, a window peak rather than a spot sample, and a threshold
+		// above the queue depth that healthy asynchronous encoding produces
+		// anyway — anything tighter reports saturation on an idle host.
+		const encoderSaturated =
+			stats.avgFrameCostMs > frameBudgetMs * 0.8 ||
+			stats.encodeQueueMax >= 4 ||
+			skipRatio > 0.4;
+
+		debug.log(
+			'webcodecs',
+			`enc ${sessionId}: ${stats.codec}/${stats.captureMode} ${stats.width}x${stats.height} ` +
+				`${(stats.measuredFps ?? 0).toFixed(1)}/${videoSession.targetFramerate}fps ` +
+				`derate=${videoSession.pixelDerate} | ` +
+				`cost=${stats.avgFrameCostMs.toFixed(1)}ms/${frameBudgetMs.toFixed(0)}ms ` +
+				`qMax=${stats.encodeQueueMax} skip=${(skipRatio * 100).toFixed(0)}%` +
+				`${encoderSaturated ? ' SATURATED' : ''}`
+		);
+
+		this.adaptQuality(sessionId, encoderSaturated);
+	}
+
+	/**
+	 * Viewer-side health. A phone that cannot decode fast enough shows exactly
+	 * the same stutter with an empty network buffer and an idle encoder, so the
+	 * decode queue has to close the loop back to the source.
+	 */
+	applyClientFeedback(sessionId: string, feedback: ClientStreamFeedback): void {
+		const videoSession = this.sessions.get(sessionId);
+		if (!videoSession?.isActive) return;
+
+		// Thresholds sit well clear of healthy operation for the same reason as
+		// the encoder ones: decodeQueueSize is a spot sample and dropRatio has
+		// window-boundary skew, so tight limits fire on a stream that is fine.
+		const decoderSaturated =
+			feedback.decodeQueueSize >= 4 ||
+			feedback.dropRatio > 0.4 ||
+			feedback.decodeLatencyMs > 300;
+
+		this.adaptQuality(sessionId, decoderSaturated);
+	}
+
+	/**
+	 * Viewer display metrics changed (panel resize, device change, zoom, or a
+	 * move to a different-density screen). Debounced because a resize drag
+	 * emits a continuous stream of these.
+	 */
+	applyDisplayMetrics(sessionId: string, session: BrowserTab, metrics: ClientDisplayMetrics): void {
+		const videoSession = this.sessions.get(sessionId);
+		if (!videoSession) return;
+
+		videoSession.display = { ...videoSession.display, ...metrics };
+
+		const existing = this.displayMetricsTimers.get(sessionId);
+		if (existing) clearTimeout(existing);
+
+		this.displayMetricsTimers.set(
+			sessionId,
+			setTimeout(() => {
+				this.displayMetricsTimers.delete(sessionId);
+				void this.applyCaptureGeometry(sessionId, session);
+			}, BrowserVideoCapture.DISPLAY_METRICS_DEBOUNCE_MS)
+		);
+	}
+
+	/**
+	 * Pause capture while the viewer can't see it (panel collapsed, browser tab
+	 * hidden). An unwatched preview otherwise keeps a headless renderer and an
+	 * encoder busy for nothing — the dominant idle cost on a shared VPS.
+	 */
+	async setPaused(sessionId: string, session: BrowserTab, paused: boolean): Promise<boolean> {
+		const videoSession = this.sessions.get(sessionId);
+		if (!videoSession?.isActive) return false;
+		if (videoSession.paused === paused) return true;
+
+		videoSession.paused = paused;
+		debug.log('webcodecs', `${paused ? '⏸️ Paused' : '▶️ Resumed'} capture for ${sessionId}`);
+
+		const feeder = this.feeders.get(sessionId);
+
+		if (paused) {
+			if (videoSession.captureMode === 'native') {
+				await session.page
+					?.evaluate(() => {
+						(window as any).__webCodecsPeer?.stopNativeCapture();
+					})
+					.catch(() => {});
+				videoSession.captureMode = 'push';
+			}
+			await feeder?.pause();
+			return true;
+		}
+
+		// Resuming: rebuild whichever source is available — pausing tears the
+		// native track down, so this re-probes rather than assuming the feeder
+		// is still the right source — then force a sync point so the viewer
+		// isn't left staring at the pre-pause frame.
+		if (feeder) {
+			await feeder.restart(
+				videoSession.capture.width,
+				videoSession.capture.height,
+				videoSession.profile.screenshotQuality
+			);
+		} else {
+			await this.setupCapture(sessionId, session, () => !session.isDestroyed);
+		}
+
+		await this.requestKeyframe(sessionId, session);
+		return true;
+	}
+
+	// ------------------------------------------------------------------
+	// Signaling
+	// ------------------------------------------------------------------
 
 	/**
 	 * Create offer from headless browser
@@ -604,6 +1301,10 @@ export class BrowserVideoCapture extends EventEmitter {
 		}
 	}
 
+	// ------------------------------------------------------------------
+	// Viewport / refresh / recovery
+	// ------------------------------------------------------------------
+
 	/**
 	 * Update viewport without reconnection (hot-swap)
 	 */
@@ -615,43 +1316,17 @@ export class BrowserVideoCapture extends EventEmitter {
 		}
 
 		try {
-			const page = session.page;
-			const config = DEFAULT_STREAMING_CONFIG;
-
 			debug.log('webcodecs', `🔄 Hot-swapping viewport to ${width}x${height}`);
 
-			// Step 1: Update viewport via CDP (without page reload)
-			await page.setViewport({ width, height });
+			// The emulated viewport is what the page lays out against; capture
+			// resolution is derived from it and the viewer's display metrics.
+			await session.page.setViewport({ width, height });
 
-			// Step 2: Reconfigure VideoEncoder with new dimensions and bitrate
-			const bitrate = computeBitrate(width, height, config.video.framerate);
-			const reconfigured = await page.evaluate((params) => {
-				const peer = (window as any).__webCodecsPeer;
-				if (!peer || !peer.reconfigureEncoder) return false;
-				return peer.reconfigureEncoder(params.width, params.height, params.bitrate);
-			}, { width, height, bitrate });
+			// Force a recompute even if the derived size happens to land close
+			// to the previous one — the page content changed shape.
+			videoSession.capture = { width: 0, height: 0, scale: 1 };
 
-			if (!reconfigured) {
-				debug.error('webcodecs', `Failed to reconfigure encoder`);
-				return false;
-			}
-
-			// Step 3: Restart CDP screencast with new dimensions
-			const cdp = (session as any).__webCodecsCdp;
-			if (cdp) {
-				await cdp.send('Page.stopScreencast').catch(() => {});
-				await cdp.send('Page.startScreencast', {
-					format: 'jpeg',
-					quality: config.video.screenshotQuality,
-					maxWidth: width,
-					maxHeight: height,
-					everyNthFrame: 1
-				});
-
-				debug.log('webcodecs', `✅ Viewport hot-swapped successfully to ${width}x${height}`);
-			}
-
-			return true;
+			return await this.applyCaptureGeometry(sessionId, session);
 		} catch (error) {
 			debug.error('webcodecs', `Failed to update viewport:`, error);
 			return false;
@@ -659,10 +1334,8 @@ export class BrowserVideoCapture extends EventEmitter {
 	}
 
 	/**
-	 * Restart the CDP screencast at native viewport resolution.
-	 * Used as a refresh/recovery path when the frontend detects a stuck stream
-	 * (sent as a scale-update action). Display fit-scale no longer affects
-	 * capture resolution, so no encoder reconfiguration is needed.
+	 * Restart capture at the current geometry.
+	 * Used as a refresh/recovery path when the frontend detects a stuck stream.
 	 */
 	async refreshScreencast(sessionId: string, session: BrowserTab): Promise<boolean> {
 		const videoSession = this.sessions.get(sessionId);
@@ -672,24 +1345,17 @@ export class BrowserVideoCapture extends EventEmitter {
 		}
 
 		try {
-			const page = session.page;
-			const viewport = page.viewport()!;
-			const config = DEFAULT_STREAMING_CONFIG;
-
-			const cdp = (session as any).__webCodecsCdp;
-			if (cdp) {
-				await cdp.send('Page.stopScreencast').catch(() => {});
-				await cdp.send('Page.startScreencast', {
-					format: 'jpeg',
-					quality: config.video.screenshotQuality,
-					maxWidth: viewport.width,
-					maxHeight: viewport.height,
-					everyNthFrame: 1
-				});
-
-				debug.log('webcodecs', `✅ Screencast refreshed at ${viewport.width}x${viewport.height}`);
+			const feeder = this.feeders.get(sessionId);
+			if (feeder) {
+				feeder.invalidatePeerHandle();
+				await feeder.restart(
+					videoSession.capture.width,
+					videoSession.capture.height,
+					videoSession.profile.screenshotQuality
+				);
 			}
 
+			await this.requestKeyframe(sessionId, session);
 			return true;
 		} catch (error) {
 			debug.error('webcodecs', `Failed to refresh screencast:`, error);
@@ -700,9 +1366,9 @@ export class BrowserVideoCapture extends EventEmitter {
 	/**
 	 * Client-driven keyframe request (PLI equivalent).
 	 * Forces the next encoded frame to be a keyframe AND immediately pushes a
-	 * high-quality screenshot through the encoder — so it works even on still
-	 * pages where no screencast frames are flowing. Called when the frontend
-	 * decoder errors or joins mid-stream and needs a sync point.
+	 * high-quality frame through the encoder — so it works even on still pages
+	 * where no capture frames are flowing. Called when the frontend decoder
+	 * errors or joins mid-stream and needs a sync point.
 	 */
 	async requestKeyframe(sessionId: string, session: BrowserTab): Promise<boolean> {
 		const videoSession = this.sessions.get(sessionId);
@@ -711,18 +1377,14 @@ export class BrowserVideoCapture extends EventEmitter {
 		}
 
 		try {
+			// In native mode `forceKeyframe` re-encodes the retained compositor
+			// frame in-page, so no screenshot is needed at all.
 			await session.page.evaluate(() => {
 				(window as any).__webCodecsPeer?.forceKeyframe();
 			});
 
-			const cdp = (session as any).__webCodecsCdp;
-			if (cdp) {
-				const screenshot = await cdp.send('Page.captureScreenshot', { format: 'png' });
-				cdp.send('Runtime.evaluate', {
-					expression: `window.__webCodecsPeer?.encodeFrame("${screenshot.data}", true)`,
-					awaitPromise: false,
-					returnByValue: false
-				}).catch(() => {});
+			if (videoSession.captureMode === 'push') {
+				this.feeders.get(sessionId)?.scheduleTopOff();
 			}
 
 			debug.log('webcodecs', `Keyframe requested for ${sessionId}`);
@@ -734,7 +1396,7 @@ export class BrowserVideoCapture extends EventEmitter {
 	}
 
 	/**
-	 * Handle navigation - re-inject peer script and restart CDP screencast
+	 * Handle navigation - re-inject peer script and restart capture
 	 * Called after page navigation to restore video streaming without full reconnection
 	 */
 	async handleNavigation(sessionId: string, session: BrowserTab): Promise<boolean> {
@@ -747,30 +1409,24 @@ export class BrowserVideoCapture extends EventEmitter {
 		try {
 			const page = session.page;
 			const viewport = page.viewport()!;
-			const config = DEFAULT_STREAMING_CONFIG;
 
-			debug.log('webcodecs', `🔄 Handling navigation for ${sessionId} - re-injecting peer script and restarting screencast`);
+			debug.log('webcodecs', `🔄 Handling navigation for ${sessionId} - re-injecting peer script and restarting capture`);
 
-			// Capture at native viewport resolution (see doPreInject)
-			const videoConfig: StreamingConfig['video'] = {
-				...config.video,
-				width: viewport.width,
-				height: viewport.height,
-				bitrate: computeBitrate(viewport.width, viewport.height, config.video.framerate)
-			};
+			const videoConfig = this.buildVideoConfig(videoSession, viewport);
+			const audioConfig = this.buildAudioConfig(videoSession);
 
 			// Re-inject video encoder and audio capture scripts to new page context
 			await page.evaluate(videoEncoderScript, videoConfig);
-			await page.evaluate(audioCaptureScript, config.audio);
+			await page.evaluate(audioCaptureScript, audioConfig);
 
 			// Single batched call: verify peer + start streaming + init audio
-			const initResult = await page.evaluate(async (clientAllowsVp9) => {
+			const initResult = await page.evaluate(async () => {
 				const peer = (window as any).__webCodecsPeer;
 				if (typeof peer?.startStreaming !== 'function') {
 					return { peerExists: false, started: false, audioInitialized: false };
 				}
 
-				const started = await peer.startStreaming(clientAllowsVp9);
+				const started = await peer.startStreaming();
 				if (!started) {
 					return { peerExists: true, started: false, audioInitialized: false };
 				}
@@ -787,7 +1443,7 @@ export class BrowserVideoCapture extends EventEmitter {
 				}
 
 				return { peerExists: true, started: true, audioInitialized };
-			}, videoSession.allowVp9);
+			});
 
 			if (!initResult.peerExists) {
 				debug.error('webcodecs', `Peer script re-injection failed - peer not available`);
@@ -805,23 +1461,9 @@ export class BrowserVideoCapture extends EventEmitter {
 				debug.warn('webcodecs', 'Audio not available after navigation, continuing with video only');
 			}
 
-			// Restart CDP screencast
-			const cdp = (session as any).__webCodecsCdp;
-			if (cdp) {
-				// Stop current screencast
-				await cdp.send('Page.stopScreencast').catch(() => {});
-
-				// Start with current dimensions
-				await cdp.send('Page.startScreencast', {
-					format: 'jpeg',
-					quality: config.video.screenshotQuality,
-					maxWidth: viewport.width,
-					maxHeight: viewport.height,
-					everyNthFrame: 1
-				});
-
-				debug.log('webcodecs', `✅ Navigation handled - screencast restarted at ${viewport.width}x${viewport.height}`);
-			}
+			// The old page's encoder handle died with its execution context.
+			videoSession.captureMode = 'push';
+			await this.setupCapture(sessionId, session, () => !session.isDestroyed);
 
 			// Emit event to notify frontend that streaming is ready
 			this.emit('navigation-streaming-ready', { sessionId });
@@ -844,25 +1486,21 @@ export class BrowserVideoCapture extends EventEmitter {
 
 		videoSession.isActive = false;
 
+		const metricsTimer = this.displayMetricsTimers.get(sessionId);
+		if (metricsTimer) {
+			clearTimeout(metricsTimer);
+			this.displayMetricsTimers.delete(sessionId);
+		}
+
+		await this.destroyFeeder(sessionId);
+
 		if (session?.page && !session.page.isClosed()) {
 			try {
-				// Cancel any pending top-off capture
-				(session as any).__webCodecsTopOffCancel?.();
-				(session as any).__webCodecsTopOffCancel = null;
-
 				// Stop audio + peer in one IPC round-trip
 				await session.page.evaluate(() => {
 					(window as any).__audioEncoder?.stop();
 					(window as any).__webCodecsPeer?.stopStreaming();
 				}).catch(() => {});
-
-				// Stop CDP screencast
-				const cdp = (session as any).__webCodecsCdp;
-				if (cdp) {
-					await cdp.send('Page.stopScreencast').catch(() => {});
-					await cdp.detach().catch(() => {});
-					(session as any).__webCodecsCdp = null;
-				}
 			} catch (error) {
 				debug.warn('webcodecs', `Error during cleanup: ${error}`);
 			}
@@ -912,4 +1550,13 @@ export class BrowserVideoCapture extends EventEmitter {
 
 		this.sessions.clear();
 	}
+}
+
+/**
+ * In-page capture is on by default and self-disables wherever it can't work
+ * (insecure origin, missing API). The kill switch exists for hosts where the
+ * probe itself is undesirable.
+ */
+function isNativeCaptureEnabled(): boolean {
+	return (process.env.CLOPEN_PREVIEW_NATIVE_CAPTURE || '').trim().toLowerCase() !== 'off';
 }

--- a/backend/preview/browser/capture-profile.ts
+++ b/backend/preview/browser/capture-profile.ts
@@ -1,0 +1,213 @@
+/**
+ * Preview Capture Profile
+ *
+ * Single source of truth for "how much work is this host allowed to do per
+ * frame". Every expensive stage of the preview pipeline — Chrome's screencast
+ * JPEG encode, the in-page VideoEncoder, the wire, and the viewer's decoder —
+ * scales with `pixels × framerate`, so both are budgeted here instead of being
+ * hard-coded at each call site.
+ *
+ * Two independent mechanisms feed into the final capture size:
+ *
+ * 1. **Display-matched resolution** (`computeCaptureSize`). The preview is
+ *    almost always displayed smaller than the emulated viewport (a 1440×900
+ *    laptop preview shown in a half-width panel). Capturing at the full
+ *    viewport means encoding ~5× more pixels than the screen can show. We
+ *    capture at `displayScale × devicePixelRatio` instead, which is exactly
+ *    one captured pixel per physical screen pixel — sharper is impossible to
+ *    see, so this costs nothing visually. On a Retina display at 50% fit the
+ *    factor is 0.5 × 2 = 1.0 and we capture natively, exactly as before.
+ *
+ * 2. **Host budget** (`getHostCaptureProfile`). A 2-core VPS cannot software-
+ *    encode 1080p24 in realtime no matter how large the panel is, so the tier
+ *    caps total pixels, framerate, and quality. The runtime ladder in
+ *    BrowserVideoCapture adapts within these bounds.
+ */
+
+import os from 'os';
+import { debug } from '$shared/utils/logger';
+
+export type QualityTier = 'high' | 'balanced' | 'low';
+
+export interface CaptureProfile {
+	tier: QualityTier;
+	/** Hard ceiling on captured pixels per frame (width × height). */
+	maxPixels: number;
+	/** Upper bound of the adaptive framerate ladder. */
+	maxFramerate: number;
+	/** Lower bound — below this, motion stops reading as motion. */
+	minFramerate: number;
+	/** VP9 per-frame quantizer while the page is moving (higher = cheaper). */
+	motionQuantizer: number;
+	/** VP9 quantizer for the still-page refresh frame (lower = sharper). */
+	topOffQuantizer: number;
+	/** JPEG quality of CDP screencast source frames. */
+	screenshotQuality: number;
+	/**
+	 * Still-page refresh capture format. PNG is lossless but costs a full
+	 * raster + deflate pass and produces multi-megabyte base64 payloads;
+	 * JPEG at high quality is visually equivalent for UI text at a fraction
+	 * of the CPU on both ends.
+	 */
+	topOffFormat: 'png' | 'jpeg';
+	topOffQuality: number;
+	audioBitrate: number;
+}
+
+const PROFILES: Record<QualityTier, Omit<CaptureProfile, 'tier'>> = {
+	high: {
+		maxPixels: 1920 * 1080,
+		// 24 was inherited from the fixed-rate era, where every frame cost a
+		// JPEG encode and a base64 round-trip. In-page capture hands compositor
+		// frames straight to the encoder, so the headroom now goes to motion
+		// smoothness — which is the difference the eye actually notices.
+		maxFramerate: 30,
+		minFramerate: 10,
+		motionQuantizer: 38,
+		topOffQuantizer: 10,
+		screenshotQuality: 80,
+		topOffFormat: 'jpeg',
+		topOffQuality: 95,
+		audioBitrate: 128_000
+	},
+	balanced: {
+		maxPixels: 1440 * 900,
+		maxFramerate: 20,
+		minFramerate: 8,
+		motionQuantizer: 42,
+		topOffQuantizer: 14,
+		screenshotQuality: 72,
+		topOffFormat: 'jpeg',
+		topOffQuality: 92,
+		audioBitrate: 96_000
+	},
+	low: {
+		maxPixels: 1280 * 720,
+		maxFramerate: 12,
+		minFramerate: 6,
+		motionQuantizer: 48,
+		topOffQuantizer: 20,
+		screenshotQuality: 65,
+		topOffFormat: 'jpeg',
+		topOffQuality: 88,
+		audioBitrate: 64_000
+	}
+};
+
+/**
+ * Discrete capture scales. Every change reconfigures the encoder and forces a
+ * keyframe, so a continuous scale would thrash on every resize pixel. Snapping
+ * to a short ladder keeps reconfigurations rare while staying within ~15% of
+ * the ideal resolution.
+ */
+const CAPTURE_SCALE_STEPS = [0.25, 0.35, 0.5, 0.6, 0.75, 0.85, 1] as const;
+
+/** Below this the preview stops being readable regardless of panel size. */
+const MIN_CAPTURE_WIDTH = 360;
+
+let cachedProfile: CaptureProfile | null = null;
+
+function detectTier(): QualityTier {
+	const override = (process.env.CLOPEN_PREVIEW_QUALITY || '').trim().toLowerCase();
+	if (override === 'high' || override === 'balanced' || override === 'low') {
+		return override;
+	}
+
+	// os.cpus() can return an empty array in some containers — treat unknown
+	// as constrained rather than assuming a fast host.
+	const cores = os.cpus()?.length || 2;
+	const memGb = os.totalmem() / 1024 ** 3;
+
+	if (cores <= 2 || memGb < 2.5) return 'low';
+	if (cores <= 4 || memGb < 6) return 'balanced';
+	return 'high';
+}
+
+/**
+ * Host capability tier. Cached — hardware doesn't change at runtime, and the
+ * per-session ladder handles transient load.
+ */
+export function getHostCaptureProfile(): CaptureProfile {
+	if (cachedProfile) return cachedProfile;
+
+	const tier = detectTier();
+	cachedProfile = { tier, ...PROFILES[tier] };
+
+	debug.log(
+		'webcodecs',
+		`Capture profile: ${tier} (${os.cpus()?.length || '?'} cores, ` +
+			`${(os.totalmem() / 1024 ** 3).toFixed(1)} GB, ${os.platform()}) — ` +
+			`≤${(cachedProfile.maxPixels / 1e6).toFixed(2)}MP @ ${cachedProfile.maxFramerate}fps`
+	);
+
+	return cachedProfile;
+}
+
+function evenRound(value: number): number {
+	return Math.max(2, Math.round(value / 2) * 2);
+}
+
+export interface CaptureSize {
+	width: number;
+	height: number;
+	/** Effective scale relative to the emulated viewport (for CDP clip). */
+	scale: number;
+}
+
+/**
+ * Resolve the capture resolution for a viewport.
+ *
+ * `displayScale` is the CSS fit-scale the frontend applies to the preview and
+ * `devicePixelRatio` is the viewer's screen density; their product is how many
+ * physical screen pixels each viewport pixel actually occupies. Capturing above
+ * that is invisible work; capturing below it is the upscaling blur this
+ * pipeline was rewritten to remove — so the product is the target, clamped to
+ * [floor, native] and to the host's pixel budget.
+ */
+export function computeCaptureSize(
+	viewportWidth: number,
+	viewportHeight: number,
+	displayScale: number | undefined,
+	devicePixelRatio: number | undefined,
+	profile: CaptureProfile
+): CaptureSize {
+	// Unknown display metrics (first frame, headless MCP use) → capture native
+	// and let the client's first metrics report narrow it down.
+	const fit = displayScale && displayScale > 0 ? Math.min(1, displayScale) : 1;
+	const dpr = devicePixelRatio && devicePixelRatio > 0 ? Math.min(4, devicePixelRatio) : 1;
+
+	const wanted = Math.min(1, fit * dpr);
+	const step = CAPTURE_SCALE_STEPS.find((s) => s >= wanted - 0.001) ?? 1;
+
+	// Width leads and height follows the viewport's exact aspect ratio.
+	// Rounding both independently drifts the aspect, and the screencast — which
+	// always preserves the viewport ratio — then delivers frames a pixel or two
+	// away from what was asked for, on every single restart.
+	const aspect = viewportHeight / viewportWidth;
+	let width = evenRound(viewportWidth * step);
+
+	// Host budget — shrink so the frame fits the pixel ceiling.
+	if (width * (width * aspect) > profile.maxPixels) {
+		width = evenRound(Math.sqrt(profile.maxPixels / aspect));
+	}
+
+	// Readability floor, but never above the emulated viewport itself.
+	if (width < MIN_CAPTURE_WIDTH) {
+		width = evenRound(Math.min(viewportWidth, MIN_CAPTURE_WIDTH));
+	}
+
+	width = Math.min(evenRound(width), evenRound(viewportWidth));
+	const height = Math.min(evenRound(width * aspect), evenRound(viewportHeight));
+
+	return { width, height, scale: width / viewportWidth };
+}
+
+/**
+ * Bits-per-pixel target for codecs driven by bitrate rather than a per-frame
+ * quantizer (VP8 fallback, H.264). 0.045 bpp ≈ 1.1 Mbps at 1280×800@24.
+ */
+const BITS_PER_PIXEL = 0.045;
+
+export function computeBitrate(width: number, height: number, framerate: number): number {
+	return Math.max(400_000, Math.round(width * height * framerate * BITS_PER_PIXEL));
+}

--- a/backend/preview/browser/scripts/audio-stream.ts
+++ b/backend/preview/browser/scripts/audio-stream.ts
@@ -7,6 +7,12 @@
  *
  * Audio is encoded with AudioEncoder (Opus codec) and sent via DataChannel
  * to the WebCodecs peer connection.
+ *
+ * The tap is a side-chain: the page's own signal path stays untouched and a
+ * parallel branch feeds the encoder through a muted sink. `ScriptProcessor`
+ * (the only option before AudioWorklet) had to sit *inside* the signal path
+ * and re-emit what it received, which both ran the mixdown on the page's main
+ * thread and added a buffer of latency to everything the page played.
  */
 
 import type { StreamingConfig } from '../types';
@@ -75,76 +81,195 @@ export function audioCaptureScript(config: StreamingConfig['audio']) {
 		}
 	}
 
-	// Create capture nodes for an AudioContext
-	function setupCaptureForContext(ctx: AudioContext) {
-		if (captureNodes.has(ctx)) return captureNodes.get(ctx);
+	/**
+	 * Encode one interleaved-by-channel block.
+	 * `left`/`right` are separate planes; AudioData wants them concatenated
+	 * for the planar format.
+	 */
+	function encodeBlock(left: Float32Array, right: Float32Array, sampleRate: number) {
+		if (!isCapturing || !audioEncoder || audioEncoder.state !== 'configured') return;
+
+		// Skip digital silence — most pages are silent most of the time, and an
+		// Opus frame of silence still costs an encode, a packet and a decode.
+		let hasAudio = false;
+		for (let i = 0; i < left.length; i += 64) {
+			if (Math.abs(left[i]) > 0.0001 || Math.abs(right[i]) > 0.0001) {
+				hasAudio = true;
+				break;
+			}
+		}
+		if (!hasAudio) return;
 
 		try {
-			// Create a script processor to capture audio
-			const processor = ctx.createScriptProcessor(config.bufferSize, config.numberOfChannels, config.numberOfChannels);
+			const planar = new Float32Array(left.length * config.numberOfChannels);
+			planar.set(left, 0);
+			if (config.numberOfChannels > 1) {
+				planar.set(right, left.length);
+			}
+
+			// Use performance.now() directly (same as video) for proper AV sync
+			const audioData = new AudioData({
+				format: 'f32-planar',
+				sampleRate,
+				numberOfFrames: left.length,
+				numberOfChannels: config.numberOfChannels,
+				timestamp: performance.now() * 1000, // microseconds
+				data: planar
+			});
+
+			audioEncoder.encode(audioData);
+			audioData.close();
+
+			sampleCount += left.length;
+		} catch (error) {
+			// Silent fail to not interrupt audio
+		}
+	}
+
+	/**
+	 * AudioWorklet tap. Runs on the audio rendering thread, so the page's main
+	 * thread (which is also running the video encoder) never sees it.
+	 */
+	const workletSource = `
+		class ClopenTapProcessor extends AudioWorkletProcessor {
+			constructor(options) {
+				super();
+				this.blockSize = (options.processorOptions && options.processorOptions.blockSize) || 2048;
+				this.left = new Float32Array(this.blockSize);
+				this.right = new Float32Array(this.blockSize);
+				this.filled = 0;
+			}
+			process(inputs) {
+				const input = inputs[0];
+				if (!input || input.length === 0) return true;
+				const l = input[0];
+				const r = input.length > 1 ? input[1] : input[0];
+				if (!l) return true;
+				for (let i = 0; i < l.length; i++) {
+					this.left[this.filled] = l[i];
+					this.right[this.filled] = r[i];
+					this.filled++;
+					if (this.filled === this.blockSize) {
+						this.port.postMessage(
+							{ left: this.left, right: this.right },
+							[this.left.buffer, this.right.buffer]
+						);
+						this.left = new Float32Array(this.blockSize);
+						this.right = new Float32Array(this.blockSize);
+						this.filled = 0;
+					}
+				}
+				return true;
+			}
+		}
+		registerProcessor('clopen-tap', ClopenTapProcessor);
+	`;
+
+	let workletModuleUrl: string | null = null;
+
+	function getWorkletUrl(): string | null {
+		if (workletModuleUrl) return workletModuleUrl;
+		try {
+			workletModuleUrl = URL.createObjectURL(new Blob([workletSource], { type: 'text/javascript' }));
+			return workletModuleUrl;
+		} catch (e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Attach a capture tap to a context.
+	 *
+	 * Returns the node the page's audio should be routed *into*. The tap itself
+	 * terminates in a muted gain node so it never contributes to what the page
+	 * plays — the audible path is a separate direct connection.
+	 */
+	function setupCaptureForContext(ctx: AudioContext, destination: AudioNode) {
+		if (captureNodes.has(ctx)) return captureNodes.get(ctx);
+
+		let sink: GainNode;
+		try {
+			// Muted terminator: nodes only pull audio while connected to a
+			// destination, but this branch must stay inaudible.
+			sink = ctx.createGain();
+			sink.gain.value = 0;
+			sink.connect(destination);
+		} catch (e) {
+			return null;
+		}
+
+		const captureInfo: { input: AudioNode | null; sink: GainNode } = { input: null, sink };
+		captureNodes.set(ctx, captureInfo);
+
+		const url = getWorkletUrl();
+		if (url && ctx.audioWorklet) {
+			ctx.audioWorklet
+				.addModule(url)
+				.then(() => {
+					const node = new AudioWorkletNode(ctx, 'clopen-tap', {
+						numberOfInputs: 1,
+						numberOfOutputs: 1,
+						outputChannelCount: [config.numberOfChannels],
+						processorOptions: { blockSize: config.bufferSize }
+					});
+					node.port.onmessage = (event) => {
+						encodeBlock(event.data.left, event.data.right, ctx.sampleRate);
+					};
+					node.connect(sink);
+					captureInfo.input = node;
+				})
+				.catch(() => {
+					// Blob worklets are blocked by strict CSP on some pages —
+					// fall back to the legacy tap rather than losing audio.
+					captureInfo.input = createScriptProcessorTap(ctx, sink);
+				});
+		} else {
+			captureInfo.input = createScriptProcessorTap(ctx, sink);
+		}
+
+		return captureInfo;
+	}
+
+	/**
+	 * Run `connect` once the tap node exists. Bounded: if the worklet module
+	 * never loads and the fallback also failed, give up instead of polling for
+	 * the lifetime of the page.
+	 */
+	function whenTapReady(
+		captureInfo: { input: AudioNode | null },
+		connect: (input: AudioNode) => void,
+		attempt = 0
+	) {
+		if (captureInfo.input) {
+			try {
+				connect(captureInfo.input);
+			} catch (e) {}
+			return;
+		}
+		if (attempt >= 40) return; // ~2s
+		setTimeout(() => whenTapReady(captureInfo, connect, attempt + 1), 50);
+	}
+
+	function createScriptProcessorTap(ctx: AudioContext, sink: GainNode): AudioNode | null {
+		try {
+			const processor = ctx.createScriptProcessor(
+				config.bufferSize,
+				config.numberOfChannels,
+				config.numberOfChannels
+			);
 
 			processor.onaudioprocess = (event: AudioProcessingEvent) => {
-				if (!isCapturing || !audioEncoder || audioEncoder.state !== 'configured') {
-					// Pass through audio unchanged
-					for (let ch = 0; ch < event.outputBuffer.numberOfChannels; ch++) {
-						const input = event.inputBuffer.getChannelData(ch);
-						const output = event.outputBuffer.getChannelData(ch);
-						output.set(input);
-					}
-					return;
-				}
-
-				try {
-					const left = event.inputBuffer.getChannelData(0);
-					const right = event.inputBuffer.numberOfChannels > 1
-						? event.inputBuffer.getChannelData(1)
-						: left;
-
-					// Pass through to output
-					event.outputBuffer.getChannelData(0).set(left);
-					if (event.outputBuffer.numberOfChannels > 1) {
-						event.outputBuffer.getChannelData(1).set(right);
-					}
-
-					// Check if there's any audio (not silence)
-					let hasAudio = false;
-					for (let i = 0; i < left.length; i += 64) {
-						if (Math.abs(left[i]) > 0.0001 || Math.abs(right[i]) > 0.0001) {
-							hasAudio = true;
-							break;
-						}
-					}
-
-					if (!hasAudio) return;
-
-					// Use performance.now() directly (same as video) for proper AV sync
-					// Both video and audio now use the same timestamp origin
-					const timestamp = performance.now() * 1000; // microseconds
-
-					// Create AudioData with planar format
-					const audioData = new AudioData({
-						format: 'f32-planar',
-						sampleRate: ctx.sampleRate,
-						numberOfFrames: left.length,
-						numberOfChannels: config.numberOfChannels,
-						timestamp: timestamp,
-						data: new Float32Array([...left, ...right])
-					});
-
-					audioEncoder!.encode(audioData);
-					audioData.close();
-
-					sampleCount += left.length;
-				} catch (error) {
-					// Silent fail to not interrupt audio
-				}
+				if (!isCapturing) return;
+				const left = event.inputBuffer.getChannelData(0);
+				const right =
+					event.inputBuffer.numberOfChannels > 1 ? event.inputBuffer.getChannelData(1) : left;
+				// Copy: the event buffers are reused by the audio thread.
+				encodeBlock(new Float32Array(left), new Float32Array(right), ctx.sampleRate);
 			};
 
-			const captureInfo = { processor };
-			captureNodes.set(ctx, captureInfo);
-
-			return captureInfo;
-		} catch (error) {
+			processor.connect(sink);
+			return processor;
+		} catch (e) {
 			return null;
 		}
 	}
@@ -154,13 +279,14 @@ export function audioCaptureScript(config: StreamingConfig['audio']) {
 		interceptedContexts.add(ctx);
 
 		// Resume AudioContext immediately — in headless Chrome without a user gesture,
-		// AudioContext starts in 'suspended' state and onaudioprocess never fires.
+		// AudioContext starts in 'suspended' state and rendering never runs.
 		if (ctx.state === 'suspended') {
 			ctx.resume().catch(() => {});
 		}
 
 		// Store original destination
 		const originalDestination = ctx.destination;
+		(ctx as any).__originalDestination = originalDestination;
 
 		// Create a capture gain node that sits before the destination
 		let captureGain: GainNode | null = null;
@@ -168,20 +294,22 @@ export function audioCaptureScript(config: StreamingConfig['audio']) {
 			captureGain = ctx.createGain();
 			captureGain.gain.value = 1.0;
 
-			// Setup capture processor connected to this gain
-			const captureInfo = setupCaptureForContext(ctx);
-			if (captureInfo) {
-				captureGain.connect(captureInfo.processor);
-				captureInfo.processor.connect(originalDestination);
-			}
+			// Audible path — unchanged, full gain, no added latency.
 			captureGain.connect(originalDestination);
+
+			// Side-chain tap for the encoder.
+			const captureInfo = setupCaptureForContext(ctx, originalDestination);
+			if (captureInfo) {
+				// The tap node may appear asynchronously (worklet module load).
+				const gain = captureGain;
+				whenTapReady(captureInfo, (input) => gain.connect(input));
+			}
 		} catch (e) {
 			return;
 		}
 
 		// Store references
 		(ctx as any).__captureDestination = captureGain;
-		(ctx as any).__originalDestination = originalDestination;
 
 		// Override the destination getter to return our capture node
 		try {
@@ -221,8 +349,8 @@ export function audioCaptureScript(config: StreamingConfig['audio']) {
 
 		try {
 			// We need an AudioContext to capture from media element
-			const OriginalAudioContext = (window as any).__OriginalAudioContext || window.AudioContext;
-			const ctx = new OriginalAudioContext();
+			const OriginalCtor = (window as any).__OriginalAudioContext || window.AudioContext;
+			const ctx = new OriginalCtor();
 
 			// Resume context immediately — headless Chrome requires explicit resume
 			if (ctx.state === 'suspended') {
@@ -232,13 +360,12 @@ export function audioCaptureScript(config: StreamingConfig['audio']) {
 			// Create media element source
 			const source = ctx.createMediaElementSource(element);
 
-			// Create capture chain
-			const captureInfo = setupCaptureForContext(ctx);
+			// Audible path first so playback never depends on the tap.
+			source.connect(ctx.destination);
+
+			const captureInfo = setupCaptureForContext(ctx, ctx.destination);
 			if (captureInfo) {
-				source.connect(captureInfo.processor);
-				captureInfo.processor.connect(ctx.destination);
-			} else {
-				source.connect(ctx.destination);
+				whenTapReady(captureInfo, (input) => source.connect(input));
 			}
 
 			mediaElementSources.set(element, { ctx, source });

--- a/backend/preview/browser/scripts/video-stream.ts
+++ b/backend/preview/browser/scripts/video-stream.ts
@@ -6,9 +6,23 @@
  * 2. Initialize VideoEncoder for encoding frames
  * 3. Handle WebRTC signaling (offer/answer/ICE)
  * 4. Send encoded video chunks via DataChannel
+ *
+ * Two capture modes feed the encoder:
+ *
+ * - **native** — `getDisplayMedia({preferCurrentTab})` + MediaStreamTrackProcessor.
+ *   Compositor frames arrive as VideoFrame objects and go straight into the
+ *   encoder. No JPEG encode, no base64, no CDP round-trip; the still-page
+ *   refresh re-encodes the retained last frame, which is pristine.
+ *   Requires a secure context, so it is probed and silently skipped otherwise.
+ *
+ * - **push** — the backend feeds base64 JPEG frames from `Page.screencastFrame`
+ *   into `encodeFrame()`. Universal fallback; the still-page refresh comes from
+ *   a high-quality screenshot pushed by the backend.
+ *
+ * Both modes share one encoder, one adaptive quality ladder and one wire format.
  */
 
-import type { StreamingConfig } from '../types';
+import type { StreamingConfig, VideoCodecCandidate } from '../types';
 
 /**
  * Generate video encoder script that runs in the browser
@@ -33,14 +47,57 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 	let motionSeq = 0; // Increments per motion frame — used to detect staleness of deferred top-offs
 	let topOffRetryTimer: any = null;
 
-	// Codec selection: prefer VP9 in quantizer mode (per-frame quality control,
-	// Chrome-Remote-Desktop-style), fall back to VP8 with fixed bitrate.
-	// codecId is embedded in every video packet so the client picks the right decoder.
-	// vp9Allowed comes from the CLIENT (decode capability, negotiated at stream
-	// start) — the headless browser can encode VP9, but the viewer must decode it.
-	let codecId = 0; // 0 = vp8, 1 = vp9
+	// Active codec. `codecId` is embedded in every video packet so the client
+	// picks the matching decoder; `activeCodec` also decides whether quality is
+	// controlled per frame (quantizer mode) or by the configured bitrate.
+	let activeCodec: VideoCodecCandidate = config.codecCandidates?.[config.codecCandidates.length - 1] || {
+		codec: 'vp8',
+		name: 'vp8',
+		id: 0
+	};
+	let codecId = activeCodec.id;
 	let usingQuantizer = false;
-	let vp9Allowed = true;
+
+	// Encoder geometry. Kept in sync with whatever the capture source actually
+	// produces — Chrome's screencast rounds `maxWidth/maxHeight` to preserve
+	// aspect ratio, and tab-capture constraints are advisory, so the incoming
+	// frame size is the authority rather than what we asked for.
+	let encoderWidth = config.width;
+	let encoderHeight = config.height;
+	let currentBitrate = config.bitrate;
+	let reconfiguring = false;
+
+	// Adaptive framerate. The backend owns the ladder (it also sees the
+	// viewer's decode queue) and pushes the target down here so native capture
+	// can ask the compositor for fewer frames instead of discarding them.
+	let targetFramerate = config.framerate;
+
+	// Capture mode + retained frame for still-page refreshes in native mode.
+	let captureMode: 'push' | 'native' = 'push';
+	let nativeStream: MediaStream | null = null;
+	let nativeTrack: MediaStreamTrack | null = null;
+	let nativeReader: any = null;
+	let lastNativeFrame: VideoFrame | null = null;
+	let nativeIdleTimer: any = null;
+	let lastNativeEncodeTime = 0;
+
+	// Encoder cost tracking, reported back to the backend so the framerate
+	// ladder reacts to CPU saturation and not just to network congestion.
+	//
+	// The cost that matters is the whole frame path on this thread — image
+	// decode plus the encode call — not the encode call alone, which merely
+	// enqueues and always measures near zero. And the queue is tracked as a
+	// window maximum: sampling it once every couple of seconds says nothing
+	// about whether the encoder is actually falling behind.
+	let frameCostSamples = 0;
+	let frameCostTotalMs = 0;
+	let framesAttempted = 0;
+	let framesSkippedEncoder = 0;
+	let framesSkippedNetwork = 0;
+	let framesEncodedWindow = 0;
+	let encodeQueueMax = 0;
+	let statsWindowStart = 0;
+	let statsReportTimer: any = null;
 
 	// Source-side backpressure threshold: when the DataChannel can't drain
 	// (slow network), skip encoding motion frames instead of queueing them.
@@ -50,10 +107,25 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 	// stream degrades to coarser-but-current rather than sharp-but-stale.
 	const MAX_BUFFERED_BYTES = 64 * 1024;
 
+	// Same idea for CPU: anything sitting in the encoder queue is latency the
+	// viewer will see. Encoding is asynchronous, so a depth of one or two is
+	// normal even on a fast host — the threshold has to sit above that or the
+	// pipeline throws away frames it could comfortably have encoded.
+	const MAX_ENCODE_QUEUE = 3;
+
 	// Frames larger than this are split into fragments (packet type 2) to stay
 	// well under the SCTP max-message-size (~256KB on common WebRTC stacks).
 	// Mostly hit by near-lossless top-off keyframes of complex pages.
 	const FRAGMENT_SIZE = 64 * 1024;
+
+	// Frame sizes within this many pixels of the encoder are treated as the
+	// same geometry and snapped, rather than triggering a reconfiguration.
+	const SIZE_SNAP_TOLERANCE = 8;
+
+	// How long the native capture track must be quiet before the retained
+	// frame is re-encoded near-losslessly. Mirrors the backend's screencast
+	// top-off delay so both modes sharpen at the same moment.
+	const NATIVE_TOP_OFF_DELAY_MS = 300;
 
 	// Cursor tracking
 	let lastCursor = 'default';
@@ -118,55 +190,57 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		lastCursor = 'default';
 	}
 
-	// Build encoder config for the currently selected codec mode
-	function buildEncoderConfig(width: number, height: number, bitrate?: number): VideoEncoderConfig {
-		if (usingQuantizer) {
-			// Quantizer mode: no bitrate — quality is controlled per-frame in encode()
-			return {
-				codec: 'vp09.00.10.08',
-				width,
-				height,
-				framerate: config.framerate,
-				bitrateMode: 'quantizer',
-				hardwareAcceleration: config.hardwareAcceleration,
-				latencyMode: config.latencyMode
-			} as VideoEncoderConfig;
-		}
-
-		return {
-			codec: config.codec,
+	// Build encoder config for a codec candidate at the current geometry
+	function buildEncoderConfig(candidate: VideoCodecCandidate, width: number, height: number, bitrate: number): VideoEncoderConfig {
+		const base: any = {
+			codec: candidate.codec,
 			width,
 			height,
-			bitrate: bitrate || config.bitrate,
-			framerate: config.framerate,
+			framerate: targetFramerate,
 			hardwareAcceleration: config.hardwareAcceleration,
 			latencyMode: config.latencyMode
 		};
+
+		if (candidate.annexb) {
+			// Raw chunks travel without a `description`, so the stream has to
+			// be self-describing. AVCC (Chrome's default) would be undecodable.
+			base.avc = { format: 'annexb' };
+		}
+
+		if (candidate.quantizerKey) {
+			// Quantizer mode: no bitrate — quality is chosen per frame in encode()
+			base.bitrateMode = 'quantizer';
+		} else {
+			base.bitrate = bitrate;
+			base.bitrateMode = 'variable';
+		}
+
+		return base as VideoEncoderConfig;
 	}
 
-	// Detect supported video codec — prefer VP9 quantizer mode, fall back to VP8
-	async function detectVideoCodec() {
-		if (vp9Allowed) {
-			usingQuantizer = true;
-			codecId = 1;
-			const vp9Config = buildEncoderConfig(config.width, config.height);
+	/**
+	 * Pick the first codec candidate this browser can actually encode.
+	 * The list arrives pre-ordered by the backend from the viewer's decode
+	 * capabilities, so the first supported entry is also the best for the pair.
+	 */
+	async function detectVideoCodec(width: number, height: number, bitrate: number) {
+		const candidates: VideoCodecCandidate[] =
+			config.codecCandidates && config.codecCandidates.length > 0
+				? config.codecCandidates
+				: [{ codec: config.codec || 'vp8', name: 'vp8', id: 0 } as VideoCodecCandidate];
+
+		for (const candidate of candidates) {
+			const encoderConfig = buildEncoderConfig(candidate, width, height, bitrate);
 			try {
-				const support = await VideoEncoder.isConfigSupported(vp9Config);
+				const support = await VideoEncoder.isConfigSupported(encoderConfig);
 				if (support.supported) {
-					return vp9Config;
+					activeCodec = candidate;
+					codecId = candidate.id;
+					usingQuantizer = !!candidate.quantizerKey;
+					return encoderConfig;
 				}
 			} catch (e) {}
 		}
-
-		usingQuantizer = false;
-		codecId = 0;
-		const vp8Config = buildEncoderConfig(config.width, config.height);
-		try {
-			const support = await VideoEncoder.isConfigSupported(vp8Config);
-			if (support.supported) {
-				return vp8Config;
-			}
-		} catch (e) {}
 
 		return null;
 	}
@@ -207,10 +281,10 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		peerConnection.oniceconnectionstatechange = () => {};
 
 		// Create DataChannel for encoded chunks.
-		// Reliable + ordered: VP8/VP9 delta chains require in-order, lossless
-		// delivery — a single lost/reordered chunk corrupts decoding until the
-		// next keyframe (smearing/ghosting). Latency is bounded by source-side
-		// frame dropping instead (see MAX_BUFFERED_BYTES backpressure).
+		// Reliable + ordered: VP8/VP9/H.264 delta chains require in-order,
+		// lossless delivery — a single lost/reordered chunk corrupts decoding
+		// until the next keyframe (smearing/ghosting). Latency is bounded by
+		// source-side frame dropping instead (see MAX_BUFFERED_BYTES).
 		dataChannel = peerConnection.createDataChannel('media', {
 			ordered: true
 		});
@@ -232,7 +306,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 
 	// Initialize VideoEncoder
 	async function initVideoEncoder() {
-		const codecConfig = await detectVideoCodec();
+		const codecConfig = await detectVideoCodec(encoderWidth, encoderHeight, currentBitrate);
 		if (!codecConfig) {
 			throw new Error('No supported video codec');
 		}
@@ -245,6 +319,79 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		});
 
 		await videoEncoder.configure(codecConfig);
+	}
+
+	/**
+	 * Keep the encoder's geometry aligned with the frames actually arriving.
+	 *
+	 * The capture source is authoritative: CDP rounds screencast dimensions to
+	 * preserve aspect ratio and tab-capture honours constraints only
+	 * approximately, so asking for 648×406 can yield 648×405. Encoding a frame
+	 * whose size differs from the configuration throws, which would stall the
+	 * stream — reconfiguring on mismatch makes every rounding difference
+	 * self-healing instead.
+	 */
+	async function ensureEncoderSize(width: number, height: number, tolerant = false): Promise<boolean> {
+		if (!videoEncoder || width <= 0 || height <= 0) return false;
+		if (width === encoderWidth && height === encoderHeight) return true;
+
+		// A difference of a pixel or two is rounding, not a geometry change:
+		// the screencast fits the viewport inside maxWidth/maxHeight while
+		// preserving aspect ratio, and the still-page screenshot is clipped by
+		// a single scalar, so the two can land a pixel apart on the same page.
+		// Reconfiguring on that reset the encoder — and forced a keyframe plus
+		// a client canvas resize — every time motion started or stopped.
+		// Callers that pass `tolerant` snap the source instead (see snapSource).
+		if (
+			tolerant &&
+			Math.abs(width - encoderWidth) <= SIZE_SNAP_TOLERANCE &&
+			Math.abs(height - encoderHeight) <= SIZE_SNAP_TOLERANCE
+		) {
+			return true;
+		}
+
+		if (reconfiguring) return false;
+
+		reconfiguring = true;
+		try {
+			encoderWidth = width;
+			encoderHeight = height;
+			currentBitrate = Math.max(400_000, Math.round(width * height * targetFramerate * 0.045));
+
+			const encoderConfig = buildEncoderConfig(activeCodec, width, height, currentBitrate);
+			videoEncoder.configure(encoderConfig);
+			forceNextKeyframe = true;
+			return true;
+		} catch (e) {
+			return false;
+		} finally {
+			reconfiguring = false;
+		}
+	}
+
+	// Scratch surface used to snap an off-by-a-few-pixels source onto the
+	// encoder's exact geometry. Only the still-page refresh normally needs it,
+	// so this runs about once per still period, not per frame.
+	let snapCanvas: OffscreenCanvas | null = null;
+	let snapCtx: OffscreenCanvasRenderingContext2D | null = null;
+
+	function snapSource(bitmap: ImageBitmap): CanvasImageSource {
+		if (bitmap.width === encoderWidth && bitmap.height === encoderHeight) {
+			return bitmap as unknown as CanvasImageSource;
+		}
+
+		try {
+			if (!snapCanvas || snapCanvas.width !== encoderWidth || snapCanvas.height !== encoderHeight) {
+				snapCanvas = new OffscreenCanvas(encoderWidth, encoderHeight);
+				snapCtx = snapCanvas.getContext('2d', { alpha: false }) as OffscreenCanvasRenderingContext2D | null;
+			}
+			if (!snapCtx) return bitmap as unknown as CanvasImageSource;
+
+			snapCtx.drawImage(bitmap, 0, 0, encoderWidth, encoderHeight);
+			return snapCanvas as unknown as CanvasImageSource;
+		} catch (e) {
+			return bitmap as unknown as CanvasImageSource;
+		}
 	}
 
 	// Handle encoded video chunk
@@ -270,7 +417,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 				view.setBigUint64(1, BigInt(timestamp), true);
 				// Keyframe flag
 				view.setUint8(9, isKeyframe);
-				// Codec: 0 = vp8, 1 = vp9 (lets the client pick the right decoder)
+				// Codec: 0 = vp8, 1 = vp9, 2 = avc (lets the client pick the right decoder)
 				view.setUint8(10, codecId);
 				// Data size
 				view.setUint32(11, data.byteLength, true);
@@ -350,23 +497,112 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		return config.motionQuantizer;
 	}
 
-	// Encode video frame from image data.
+	/**
+	 * Whether a motion frame should be skipped before any decode/encode work.
+	 *
+	 * Two independent limits, both of which mean "the viewer is already behind":
+	 * the network can't drain the channel, or this host can't encode fast
+	 * enough. Dropping input frames is safe — the encoder simply references the
+	 * last encoded frame — whereas dropping encoded chunks would corrupt the
+	 * delta chain.
+	 */
+	function shouldSkipMotionFrame(): boolean {
+		framesAttempted++;
+
+		if (dataChannel && dataChannel.bufferedAmount > MAX_BUFFERED_BYTES) {
+			framesSkippedNetwork++;
+			return true;
+		}
+		if (videoEncoder) {
+			if (videoEncoder.encodeQueueSize > encodeQueueMax) {
+				encodeQueueMax = videoEncoder.encodeQueueSize;
+			}
+			if (videoEncoder.encodeQueueSize >= MAX_ENCODE_QUEUE) {
+				framesSkippedEncoder++;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Encode a VideoFrame with the right quality for its kind.
+	 *
+	 * In quantizer mode quality is per frame: coarse during motion (raised
+	 * further under congestion), near-lossless for the still-page refresh. In
+	 * fixed-bitrate mode (H.264, VP8) the same effect is achieved by briefly
+	 * raising the target bitrate around the refresh keyframe, since there is no
+	 * per-frame quality knob.
+	 */
+	function encodeVideoFrame(frame: VideoFrame, isTopOff: boolean) {
+		if (!videoEncoder) return;
+
+		const now = Date.now();
+		const needsKeyframe =
+			forceNextKeyframe ||
+			(isTopOff && !usingQuantizer) ||
+			(config.keyframeInterval > 0 && now - lastKeyframeTime > config.keyframeInterval * 1000);
+
+		if (needsKeyframe) {
+			lastKeyframeTime = now;
+			forceNextKeyframe = false;
+		}
+
+		if (usingQuantizer && activeCodec.quantizerKey) {
+			const quantizer = isTopOff ? config.topOffQuantizer : currentMotionQuantizer();
+			const options: any = { keyFrame: needsKeyframe };
+			options[activeCodec.quantizerKey] = { quantizer };
+			videoEncoder.encode(frame, options as VideoEncoderEncodeOptions);
+		} else {
+			// Fixed-bitrate codec. The still-page refresh is a plain keyframe:
+			// VBR already spends far more on keyframes than on deltas, and
+			// reconfiguring the encoder to bump the bitrate around it resets
+			// the codec twice per still period — on a page with any recurring
+			// damage (a blinking caret is enough) that is a reset storm.
+			videoEncoder.encode(frame, { keyFrame: needsKeyframe || isTopOff });
+		}
+
+		videoFrameCount++;
+		if (!isTopOff) framesEncodedWindow++;
+	}
+
+	/**
+	 * Decode base64 into bytes.
+	 *
+	 * `Uint8Array.fromBase64` is a single native pass; the manual loop it
+	 * replaces ran `charCodeAt` per byte, which at full-viewport resolution was
+	 * millions of calls per second on the page's main thread.
+	 */
+	function base64ToBytes(input: string): Uint8Array<ArrayBuffer> {
+		const fromBase64 = (Uint8Array as any).fromBase64;
+		if (typeof fromBase64 === 'function') {
+			try {
+				return fromBase64.call(Uint8Array, input) as Uint8Array<ArrayBuffer>;
+			} catch (e) {}
+		}
+
+		const binaryStr = atob(input);
+		const len = binaryStr.length;
+		const bytes = new Uint8Array(len);
+		for (let i = 0; i < len; i++) {
+			bytes[i] = binaryStr.charCodeAt(i);
+		}
+		return bytes;
+	}
+
+	// Encode video frame from image data (push mode).
 	// Motion frames arrive as JPEG (CDP screencast); top-off frames arrive as
-	// lossless PNG (Page.captureScreenshot) when the page goes still, and are
-	// encoded near-losslessly so the last motion-degraded frame doesn't stick.
-	async function encodeFrame(imageData: string, isTopOff?: boolean) {
+	// a high-quality screenshot when the page goes still, and are encoded
+	// near-losslessly so the last motion-degraded frame doesn't stick.
+	async function encodeFrame(imageData: string, isTopOff?: boolean, mimeType?: string) {
 		if (!videoEncoder || !isCapturing) return;
+		// Native capture owns the encoder — a stray pushed frame would fight it.
+		if (captureMode === 'native' && !isTopOff) return;
 
 		try {
-			// Source-side backpressure: if the network can't drain the channel,
-			// skip motion frames BEFORE decoding/encoding. Dropping input frames
-			// is safe (the encoder just references the last encoded frame);
-			// dropping encoded chunks would corrupt the delta chain.
 			if (!isTopOff) {
 				motionSeq++;
-				if (dataChannel && dataChannel.bufferedAmount > MAX_BUFFERED_BYTES) {
-					return;
-				}
+				if (shouldSkipMotionFrame()) return;
 			} else if (dataChannel && dataChannel.bufferedAmount > MAX_BUFFERED_BYTES) {
 				// Channel congested — dumping a large near-lossless frame on it
 				// now would spike latency. Defer briefly; abandon if new motion
@@ -377,78 +613,324 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 				topOffRetryTimer = setTimeout(() => {
 					topOffRetryTimer = null;
 					if (motionSeq === seqAtCapture && isCapturing) {
-						encodeFrame(imageData, true);
+						encodeFrame(imageData, true, mimeType);
 					}
 				}, 250);
 				return;
 			}
 
-			// Direct base64 decode (avoids fetch() + data URL parsing overhead)
-			const binaryStr = atob(imageData);
-			const len = binaryStr.length;
-			const bytes = new Uint8Array(len);
-			for (let i = 0; i < len; i++) {
-				bytes[i] = binaryStr.charCodeAt(i);
-			}
+			const costStart = performance.now();
+			const bytes = base64ToBytes(imageData);
 
 			// Decode via createImageBitmap (avoids per-frame ImageDecoder
 			// constructor/destructor overhead)
-			const blob = new Blob([bytes], { type: isTopOff ? 'image/png' : 'image/jpeg' });
+			const blob = new Blob([bytes], { type: mimeType || (isTopOff ? 'image/png' : 'image/jpeg') });
 			const bitmap = await createImageBitmap(blob);
+
+			if (!videoEncoder || !isCapturing) {
+				bitmap.close();
+				return;
+			}
+
+			// The source is authoritative for geometry (see ensureEncoderSize),
+			// but only for real changes — small rounding differences are
+			// snapped onto the current geometry instead.
+			if (!(await ensureEncoderSize(bitmap.width, bitmap.height, true))) {
+				bitmap.close();
+				return;
+			}
 
 			// Get aligned timestamp in microseconds
 			const timestamp = performance.now() * 1000;
 
-			// Create VideoFrame from ImageBitmap
-			const frame = new VideoFrame(bitmap, {
+			const frame = new VideoFrame(snapSource(bitmap), {
 				timestamp,
 				alpha: 'discard'
 			});
 
-			// Keyframes are on-demand only (stream start, reconnect, reconfigure,
-			// client request) — the channel is reliable so no periodic keyframes
-			// are needed. keyframeInterval > 0 re-enables a periodic timer.
-			const now = Date.now();
-			const needsKeyframe = forceNextKeyframe ||
-				(config.keyframeInterval > 0 && (now - lastKeyframeTime) > (config.keyframeInterval * 1000));
-
-			if (needsKeyframe) {
-				lastKeyframeTime = now;
-				forceNextKeyframe = false;
-			}
-
-			// Encode frame — in quantizer mode, quality is chosen per frame:
-			// cheap during motion (raised further under congestion),
-			// near-lossless for still-page top-off refreshes
-			if (usingQuantizer) {
-				const quantizer = isTopOff ? config.topOffQuantizer : currentMotionQuantizer();
-				videoEncoder.encode(frame, {
-					keyFrame: needsKeyframe,
-					vp9: { quantizer }
-				} as VideoEncoderEncodeOptions);
-			} else {
-				videoEncoder.encode(frame, { keyFrame: needsKeyframe });
-			}
-			videoFrameCount++;
+			encodeVideoFrame(frame, !!isTopOff);
 
 			// Close immediately to prevent memory leaks
 			frame.close();
 			bitmap.close();
+
+			if (!isTopOff) {
+				frameCostTotalMs += performance.now() - costStart;
+				frameCostSamples++;
+			}
 		} catch (error) {}
+	}
+
+	// ------------------------------------------------------------------
+	// Native capture (getDisplayMedia + MediaStreamTrackProcessor)
+	// ------------------------------------------------------------------
+
+	function retainNativeFrame(frame: VideoFrame) {
+		if (lastNativeFrame) {
+			try {
+				lastNativeFrame.close();
+			} catch (e) {}
+		}
+		try {
+			lastNativeFrame = frame.clone();
+		} catch (e) {
+			lastNativeFrame = null;
+		}
+	}
+
+	/**
+	 * Still-page refresh for native capture.
+	 *
+	 * The retained frame came straight from the compositor, so re-encoding it
+	 * near-losslessly is genuinely lossless relative to the source — no
+	 * screenshot, no JPEG round-trip, no CDP traffic. Push mode can't do this:
+	 * its retained frame would already carry JPEG artifacts.
+	 */
+	function scheduleNativeTopOff() {
+		if (nativeIdleTimer) clearTimeout(nativeIdleTimer);
+		nativeIdleTimer = setTimeout(() => {
+			nativeIdleTimer = null;
+			if (!isCapturing || !lastNativeFrame || !videoEncoder) return;
+			if (dataChannel && dataChannel.bufferedAmount > MAX_BUFFERED_BYTES) {
+				scheduleNativeTopOff();
+				return;
+			}
+			try {
+				encodeVideoFrame(lastNativeFrame, true);
+			} catch (e) {}
+		}, NATIVE_TOP_OFF_DELAY_MS);
+	}
+
+	async function readNativeFrames() {
+		if (!nativeReader) return;
+
+		while (isCapturing && nativeReader) {
+			let result: any;
+			try {
+				result = await nativeReader.read();
+			} catch (e) {
+				break;
+			}
+
+			if (result.done) break;
+
+			const frame: VideoFrame = result.value;
+			try {
+				// Secondary rate limit. The track is already constrained to
+				// `targetFramerate`, so this only exists for a source that
+				// ignores the constraint.
+				//
+				// The tolerance is essential: with the track delivering at
+				// exactly the target, frame-to-frame jitter puts gaps a hair
+				// under a full interval, and a threshold of one full interval
+				// then rejects roughly every second frame — halving the frame
+				// rate the viewer sees while every other counter still reads
+				// perfectly healthy.
+				const now = performance.now();
+				const minInterval = 1000 / Math.max(1, targetFramerate);
+				if (now - lastNativeEncodeTime < minInterval * 0.75) {
+					continue;
+				}
+
+				if (shouldSkipMotionFrame()) continue;
+
+				if (!(await ensureEncoderSize(frame.displayWidth, frame.displayHeight))) continue;
+
+				const costStart = performance.now();
+				lastNativeEncodeTime = now;
+				motionSeq++;
+				encodeVideoFrame(frame, false);
+				retainNativeFrame(frame);
+				scheduleNativeTopOff();
+
+				frameCostTotalMs += performance.now() - costStart;
+				frameCostSamples++;
+			} catch (e) {
+			} finally {
+				try {
+					frame.close();
+				} catch (e) {}
+			}
+		}
+	}
+
+	/**
+	 * Probe in-page capture. Returns false (quietly) whenever it isn't
+	 * available so the backend falls back to the CDP screencast path:
+	 * insecure origin, missing API, denied permission, or no frame in time.
+	 */
+	async function startNativeCapture(): Promise<boolean> {
+		if (!config.nativeCapture) return false;
+		if (captureMode === 'native') return true;
+		if (!isCapturing) return false;
+
+		try {
+			// getDisplayMedia is gated on a secure context, and the preview
+			// navigates to arbitrary URLs — plain-http targets simply use the
+			// fallback path.
+			if (!window.isSecureContext) return false;
+			if (!navigator.mediaDevices || typeof navigator.mediaDevices.getDisplayMedia !== 'function') return false;
+			if (typeof (window as any).MediaStreamTrackProcessor !== 'function') return false;
+
+			const withTimeout = <T,>(promise: Promise<T>, ms: number): Promise<T | null> =>
+				Promise.race([promise, new Promise<null>((resolve) => setTimeout(() => resolve(null), ms))]);
+
+			const stream = await withTimeout(
+				navigator.mediaDevices.getDisplayMedia({
+					video: {
+						frameRate: { max: Math.max(1, targetFramerate) },
+						width: { max: encoderWidth },
+						height: { max: encoderHeight }
+					},
+					audio: false,
+					// Chrome-only hints: capture this tab without a picker.
+					preferCurrentTab: true,
+					selfBrowserSurface: 'include',
+					surfaceSwitching: 'exclude',
+					systemAudio: 'exclude'
+				} as any),
+				2000
+			);
+
+			if (!stream) return false;
+
+			const track = stream.getVideoTracks()[0];
+			if (!track) {
+				stream.getTracks().forEach((t) => t.stop());
+				return false;
+			}
+
+			const processor = new (window as any).MediaStreamTrackProcessor({ track });
+			nativeStream = stream;
+			nativeTrack = track;
+			nativeReader = processor.readable.getReader();
+			captureMode = 'native';
+			forceNextKeyframe = true;
+
+			track.addEventListener('ended', () => {
+				// The surface went away (navigation, tab teardown) — drop back
+				// to push mode rather than freezing on the last frame.
+				stopNativeCapture();
+			});
+
+			readNativeFrames();
+			return true;
+		} catch (e) {
+			stopNativeCapture();
+			return false;
+		}
+	}
+
+	function stopNativeCapture() {
+		captureMode = 'push';
+
+		if (nativeIdleTimer) {
+			clearTimeout(nativeIdleTimer);
+			nativeIdleTimer = null;
+		}
+
+		if (nativeReader) {
+			try {
+				nativeReader.cancel();
+			} catch (e) {}
+			nativeReader = null;
+		}
+
+		if (nativeTrack) {
+			try {
+				nativeTrack.stop();
+			} catch (e) {}
+			nativeTrack = null;
+		}
+
+		if (nativeStream) {
+			try {
+				nativeStream.getTracks().forEach((t) => t.stop());
+			} catch (e) {}
+			nativeStream = null;
+		}
+
+		if (lastNativeFrame) {
+			try {
+				lastNativeFrame.close();
+			} catch (e) {}
+			lastNativeFrame = null;
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Adaptive controls driven by the backend
+	// ------------------------------------------------------------------
+
+	/**
+	 * Apply a new framerate target. In native mode this is pushed down to the
+	 * capture track so the compositor stops producing frames we would discard;
+	 * in push mode the backend enforces it by withholding the screencast ack.
+	 */
+	function setTargetFramerate(fps: number) {
+		const next = Math.max(1, Math.min(60, Math.round(fps)));
+		if (next === targetFramerate) return;
+		targetFramerate = next;
+
+		if (nativeTrack) {
+			try {
+				nativeTrack.applyConstraints({ frameRate: { max: next } } as MediaTrackConstraints).catch(() => {});
+			} catch (e) {}
+		}
+	}
+
+	function reportEncoderStats() {
+		const send = (window as any).__sendEncoderStats;
+		if (typeof send !== 'function') return;
+
+		const now = performance.now();
+		const windowMs = statsWindowStart > 0 ? now - statsWindowStart : 0;
+		statsWindowStart = now;
+
+		try {
+			send({
+				captureMode,
+				codec: activeCodec.name,
+				avgFrameCostMs: frameCostSamples > 0 ? frameCostTotalMs / frameCostSamples : 0,
+				encodeQueueMax,
+				bufferedAmount: dataChannel ? dataChannel.bufferedAmount : 0,
+				framesAttempted,
+				framesSkippedEncoder,
+				framesSkippedNetwork,
+				// Frames per second the viewer actually receives. Every other
+				// counter can read healthy while this quietly sits at half the
+				// target, so it is the one number worth trusting.
+				measuredFps: windowMs > 0 ? (framesEncodedWindow * 1000) / windowMs : 0,
+				width: encoderWidth,
+				height: encoderHeight
+			});
+		} catch (e) {}
+
+		frameCostSamples = 0;
+		frameCostTotalMs = 0;
+		framesAttempted = 0;
+		framesSkippedEncoder = 0;
+		framesSkippedNetwork = 0;
+		framesEncodedWindow = 0;
+		encodeQueueMax = 0;
 	}
 
 	// Force the next encoded frame to be a keyframe (client-driven sync point,
 	// PLI equivalent — used when the client decoder errors or joins mid-stream)
 	function forceKeyframe() {
 		forceNextKeyframe = true;
+		// On a still page nothing new will be encoded, so nudge the retained
+		// frame out immediately when we have one.
+		if (captureMode === 'native' && lastNativeFrame && videoEncoder) {
+			try {
+				encodeVideoFrame(lastNativeFrame, true);
+			} catch (e) {}
+		}
 	}
 
 	// Start streaming
-	// allowVp9: client decode capability negotiated at stream start
-	async function startStreaming(allowVp9?: boolean) {
+	async function startStreaming() {
 		if (isCapturing) return true;
-
-		vp9Allowed = allowVp9 !== false;
 
 		try {
 			await initPeerConnection();
@@ -460,6 +942,9 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 
 			// Start tracking cursor changes
 			startCursorTracking();
+
+			if (statsReportTimer) clearInterval(statsReportTimer);
+			statsReportTimer = setInterval(reportEncoderStats, 2000);
 
 			return true;
 		} catch (error) {
@@ -477,6 +962,13 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 			clearTimeout(topOffRetryTimer);
 			topOffRetryTimer = null;
 		}
+
+		if (statsReportTimer) {
+			clearInterval(statsReportTimer);
+			statsReportTimer = null;
+		}
+
+		stopNativeCapture();
 
 		// Stop cursor tracking
 		stopCursorTracking();
@@ -564,23 +1056,33 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 			// Flush pending frames
 			await videoEncoder.flush();
 
-			// Create new codec config with updated dimensions (keeps current codec mode)
-			const newCodecConfig = buildEncoderConfig(newWidth, newHeight, newBitrate);
+			currentBitrate = newBitrate || currentBitrate;
+			const newCodecConfig = buildEncoderConfig(activeCodec, newWidth, newHeight, currentBitrate);
 
-			// Check if new config is supported
 			const support = await VideoEncoder.isConfigSupported(newCodecConfig);
 			if (!support.supported) {
 				return false;
 			}
 
-			// Reconfigure encoder with new dimensions
-			await videoEncoder.configure(newCodecConfig);
+			videoEncoder.configure(newCodecConfig);
 
-			// Update config reference
+			encoderWidth = newWidth;
+			encoderHeight = newHeight;
 			config.width = newWidth;
 			config.height = newHeight;
-			if (newBitrate) {
-				config.bitrate = newBitrate;
+
+			// Native capture has to be told separately — its frame size comes
+			// from track constraints, not from the encoder.
+			if (nativeTrack) {
+				try {
+					nativeTrack
+						.applyConstraints({
+							width: { max: newWidth },
+							height: { max: newHeight },
+							frameRate: { max: targetFramerate }
+						} as MediaTrackConstraints)
+						.catch(() => {});
+				} catch (e) {}
 			}
 
 			// Force keyframe after reconfigure (decoder needs a sync point at the new dimensions)
@@ -604,8 +1106,9 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 				videoFramesEncoded: videoFrameCount,
 				audioFramesEncoded: audioFrameCount,
 				connectionState: peerConnection.connectionState,
-				videoCodec: usingQuantizer ? 'vp9' : config.codec,
-				audioCodec: 'opus' as const
+				videoCodec: activeCodec.name,
+				audioCodec: 'opus' as const,
+				captureMode
 			};
 
 			stats.forEach(report => {
@@ -632,6 +1135,10 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		sendAudioChunk,
 		getStats,
 		reconfigureEncoder,
+		startNativeCapture,
+		stopNativeCapture,
+		setTargetFramerate,
+		getCaptureMode: () => captureMode,
 		isActive: () => isCapturing
 	};
 }

--- a/backend/preview/browser/types.ts
+++ b/backend/preview/browser/types.ts
@@ -65,7 +65,7 @@ export interface BrowserTab {
 	lastUniqueFrameTime?: number;
 	stableFrameStartTime?: number;
 	lastCursorInfo?: { x: number; y: number; cursor: string };
-	scale?: number; // Frontend display fit-scale (CSS-only; does NOT affect capture resolution)
+	scale?: number; // Frontend display fit-scale — with the viewer's devicePixelRatio, this sets capture resolution
 
 	// Interaction tracking
 	lastInteractionTime?: number;
@@ -198,6 +198,83 @@ export interface BrowserScreenshotFrame {
 }
 
 /**
+ * Wire codec identifiers.
+ *
+ * Every video packet carries one of these so the viewer can configure the
+ * matching decoder without a side-channel. Values are part of the wire format —
+ * append only, never renumber.
+ */
+export const VIDEO_CODEC_ID = {
+	vp8: 0,
+	vp9: 1,
+	avc: 2
+} as const;
+
+export type VideoCodecName = keyof typeof VIDEO_CODEC_ID;
+
+/**
+ * A candidate the in-page encoder may use, in preference order.
+ *
+ * `quantizerKey` selects per-frame quality control (Chrome-Remote-Desktop
+ * style): cheap frames during motion, near-lossless when the page goes still.
+ * Candidates without it fall back to fixed-bitrate mode, where the still-page
+ * refresh is a forced keyframe at a temporarily raised bitrate instead.
+ */
+export interface VideoCodecCandidate {
+	/** WebCodecs codec string, identical on encoder and decoder. */
+	codec: string;
+	name: VideoCodecName;
+	id: number;
+	quantizerKey?: 'vp9';
+	/**
+	 * H.264 must be emitted as Annex-B: we ship raw chunk bytes with no
+	 * `description`, so an AVCC-formatted stream would be undecodable.
+	 */
+	annexb?: boolean;
+}
+
+/**
+ * Client decode capabilities, negotiated at stream start.
+ *
+ * The headless browser can encode far more than a given viewer can decode —
+ * an iPhone or a low-end Android has hardware H.264 but only software VP9,
+ * which is exactly the case where software decoding wrecks the frame rate.
+ */
+export interface ClientCodecSupport {
+	vp8: boolean;
+	vp9: boolean;
+	avc: boolean;
+	/** Codecs the viewer reports a hardware decoder for. */
+	hardware: VideoCodecName[];
+}
+
+/**
+ * Viewer display metrics — drives capture resolution (see computeCaptureSize).
+ */
+export interface ClientDisplayMetrics {
+	/** CSS fit-scale applied to the preview (0-1). */
+	scale?: number;
+	/** Viewer screen density. */
+	dpr?: number;
+}
+
+/**
+ * Runtime feedback from the viewer's decoder.
+ *
+ * Backpressure used to be network-only (`bufferedAmount`). A viewer that
+ * cannot decode fast enough shows the same symptom — growing latency and
+ * stutter — with an empty network buffer, so the decode queue has to travel
+ * back to the source as well.
+ */
+export interface ClientStreamFeedback {
+	decodeQueueSize: number;
+	/** Mean decode-to-render latency over the reporting window (ms). */
+	decodeLatencyMs: number;
+	/** Frames dropped before render, as a fraction of frames received. */
+	dropRatio: number;
+}
+
+/**
  * Unified Streaming Configuration
  *
  * Central configuration for WebCodecs streaming (video + audio).
@@ -207,17 +284,26 @@ export interface BrowserScreenshotFrame {
  */
 export interface StreamingConfig {
 	video: {
-		codec: string; // Fallback codec (VP8, fixed-bitrate mode) when VP9 quantizer mode is unsupported
+		codec: string; // Fallback codec (VP8, fixed-bitrate mode) when nothing better is negotiated
         width: number;
         height: number;
-        framerate: number; // Max encode fps — screencast frames above this rate are dropped at the source
+        framerate: number; // Target encode fps — the screencast is throttled to this at the source
+        minFramerate: number; // Floor of the adaptive framerate ladder
         bitrate: number;
         keyframeInterval: number; // Seconds between periodic keyframes; 0 = on-demand only (start/reconnect/client request)
         screenshotQuality: number;
         hardwareAcceleration: 'no-preference' | 'prefer-hardware' | 'prefer-software';
         latencyMode: 'quality' | 'realtime';
-        motionQuantizer: number; // VP9 per-frame quantizer (0-63) while the page is moving — cheap, allowed to be soft
-        topOffQuantizer: number; // VP9 quantizer for still-page refresh frames — near-lossless so text stays crisp
+        motionQuantizer: number; // Per-frame quantizer (0-63) while the page is moving — cheap, allowed to be soft
+        topOffQuantizer: number; // Quantizer for still-page refresh frames — near-lossless so text stays crisp
+        /** Ordered encoder candidates resolved from the viewer's capabilities. */
+        codecCandidates: VideoCodecCandidate[];
+        /**
+         * Attempt in-page capture (getDisplayMedia + MediaStreamTrackProcessor)
+         * before falling back to the CDP screencast push path. Removes a JPEG
+         * encode/decode round-trip and the base64 CDP hop per frame.
+         */
+        nativeCapture: boolean;
 	};
 	audio: {
 		codec: string
@@ -237,13 +323,17 @@ export interface StreamingConfig {
  *   goes still a near-lossless refresh frame is sent (topOffQuantizer) so
  *   text stays crisp. Idle pages cost ~0 bandwidth (CDP screencast only
  *   fires on damage).
+ * - H.264 when the viewer has a hardware decoder for it but not for VP9
+ *   (phones, tablets, low-end laptops) — fixed-bitrate mode with a bitrate
+ *   bump on the still-page refresh.
  * - Fallback: VP8 at a resolution-scaled bitrate (see computeBitrate).
  * - Keyframes on demand only (keyframeInterval 0) — the DataChannel is
  *   reliable, and the client requests a keyframe on decoder errors.
- * - Encode rate capped at `framerate` — screencast can fire at compositor
- *   rate (up to 60fps); excess frames are dropped at the source.
- * - JPEG quality 75 for motion source frames (encoder quantizer controls
- *   output size, so higher source quality no longer inflates bandwidth)
+ * - Encode rate capped at `framerate`, enforced at the source by withholding
+ *   the screencast ack so Chrome never rasters frames we would discard.
+ * - Resolution, framerate and quantizers are overridden per session from the
+ *   host capture profile and the viewer's display metrics; the values here
+ *   are only the shape and the fallback for non-streaming call sites.
  * - Opus for audio (efficient and widely supported)
  */
 export const DEFAULT_STREAMING_CONFIG: StreamingConfig = {
@@ -252,22 +342,75 @@ export const DEFAULT_STREAMING_CONFIG: StreamingConfig = {
 		width: 0,
 		height: 0,
 		framerate: 24,
+		minFramerate: 8,
 		bitrate: 1_000_000,
 		keyframeInterval: 0,
 		screenshotQuality: 75,
 		hardwareAcceleration: 'no-preference',
 		latencyMode: 'realtime',
 		motionQuantizer: 40,
-		topOffQuantizer: 10
+		topOffQuantizer: 10,
+		codecCandidates: [],
+		nativeCapture: false
 	},
 	audio: {
 		codec: 'opus',
 		sampleRate: 48_000,
-		bitrate: 128_000,
+		bitrate: 96_000,
 		numberOfChannels: 2,
 		bufferSize: 4096
 	}
 };
+
+/**
+ * Build the ordered encoder candidate list for a viewer.
+ *
+ * **VP9 wins whenever the viewer can decode it at all**, including in software.
+ * Only VP9 supports per-frame quantizer control, and that is what the whole
+ * quality model rests on: coarse frames while the page moves, a near-lossless
+ * refresh the moment it stops. A fixed-bitrate codec has no equivalent — it has
+ * to be run at a bitrate high enough for motion (wasteful) or low enough for
+ * bandwidth (blocky), and its still-page refresh is just a keyframe.
+ *
+ * H.264 is therefore reserved for viewers that cannot decode VP9 at all —
+ * typically Safari and iOS, which is also where hardware H.264 is guaranteed.
+ * Preferring it merely because the viewer *also* has hardware H.264 trades a
+ * working quality model for a decode saving the viewer usually doesn't need;
+ * viewers that genuinely can't keep up are handled by the decode-feedback
+ * ladder instead, which lowers framerate and resolution without changing codec.
+ *
+ * VP8 is the universal floor and is always appended last.
+ */
+export function resolveCodecCandidates(support: ClientCodecSupport): VideoCodecCandidate[] {
+	const vp9: VideoCodecCandidate = {
+		codec: 'vp09.00.10.08',
+		name: 'vp9',
+		id: VIDEO_CODEC_ID.vp9,
+		quantizerKey: 'vp9'
+	};
+	// Constrained Baseline @ 5.1 — a level ceiling, not a request, so one
+	// string covers every viewport we capture and both ends stay in sync
+	// without negotiating dimensions first.
+	const avc: VideoCodecCandidate = {
+		codec: 'avc1.42E033',
+		name: 'avc',
+		id: VIDEO_CODEC_ID.avc,
+		annexb: true
+	};
+	const vp8: VideoCodecCandidate = {
+		codec: 'vp8',
+		name: 'vp8',
+		id: VIDEO_CODEC_ID.vp8
+	};
+
+	const candidates: VideoCodecCandidate[] = [];
+
+	if (support.vp9) candidates.push(vp9);
+	if (support.avc) candidates.push(avc);
+	if (support.vp8 !== false) candidates.push(vp8);
+
+	return candidates.length > 0 ? candidates : [vp8];
+}
 
 /**
  * Native UI Dialog Types

--- a/backend/ws/preview/browser/interact.ts
+++ b/backend/ws/preview/browser/interact.ts
@@ -56,6 +56,7 @@ export const interactPreviewHandler = createRouter()
 				shiftKey: t.Optional(t.Boolean()),
 				clearFirst: t.Optional(t.Boolean()),
 				scale: t.Optional(t.Number()),
+				dpr: t.Optional(t.Number()),
 				width: t.Optional(t.Number()),
 				height: t.Optional(t.Number()),
 				deviceSize: t.Optional(t.String()),
@@ -445,13 +446,16 @@ export const interactPreviewHandler = createRouter()
 						break;
 
 					case 'scale-update':
-						// Display fit-scale changed on the frontend (CSS-only concern).
-						// Capture stays at native viewport resolution — restart the
-						// screencast as a refresh so a stuck stream recovers (the
-						// frontend also uses this action as its refresh path).
+						// Recovery path: the frontend sends this when the stream
+						// looks stuck. It also carries the current display
+						// metrics, which capture resolution is derived from.
 						if (action.scale && action.scale > 0 && action.scale <= 1) {
 							session.scale = action.scale;
-							debug.log('preview', `📐 Scale updated for tab ${tabId}: ${action.scale} (display-only), refreshing screencast`);
+							previewService.applyWebCodecsDisplayMetrics(session.id, {
+								scale: action.scale,
+								dpr: action.dpr
+							});
+							debug.log('preview', `📐 Scale updated for tab ${tabId}: ${action.scale}, refreshing capture`);
 
 							const updated = await previewService.refreshWebCodecsScreencast(session.id);
 							if (!updated) {
@@ -471,6 +475,14 @@ export const interactPreviewHandler = createRouter()
 							if (action.rotation) session.rotation = action.rotation as any;
 
 							debug.log('preview', `📱 Viewport updated for tab ${tabId}: ${action.width}x${action.height}`);
+
+							// The emulated viewport changed, so the derived
+							// capture size has to be recomputed from the new
+							// dimensions before the hot-swap.
+							previewService.applyWebCodecsDisplayMetrics(session.id, {
+								scale: action.scale,
+								dpr: action.dpr
+							});
 
 							// Hot-swap viewport without reconnection
 							const updated = await previewService.updateWebCodecsViewport(session.id, action.width, action.height);

--- a/backend/ws/preview/browser/webcodecs.ts
+++ b/backend/ws/preview/browser/webcodecs.ts
@@ -18,9 +18,29 @@ export const streamPreviewHandler = createRouter()
 		{
 			data: t.Object({
 				tabId: t.Optional(t.String()),
-				// Client VP9 decode capability — encoder prefers VP9 quantizer
-				// mode but must fall back to VP8 if the viewer can't decode it
-				vp9: t.Optional(t.Boolean())
+				// Legacy VP9-only capability flag — superseded by `codecs`,
+				// kept so an older client can still negotiate.
+				vp9: t.Optional(t.Boolean()),
+				// Full viewer decode capability. Which codecs the viewer can
+				// decode *in hardware* decides the encoder choice: software VP9
+				// decode is the main reason phones and low-end laptops drop
+				// frames no server-side tuning can recover.
+				codecs: t.Optional(
+					t.Object({
+						vp8: t.Boolean(),
+						vp9: t.Boolean(),
+						avc: t.Boolean(),
+						hardware: t.Array(t.String())
+					})
+				),
+				// Viewer display metrics — capture resolution is derived from
+				// these so we never encode pixels the screen cannot show.
+				display: t.Optional(
+					t.Object({
+						scale: t.Optional(t.Number()),
+						dpr: t.Optional(t.Number())
+					})
+				)
 			}),
 			response: t.Object({
 				success: t.Boolean(),
@@ -43,8 +63,20 @@ export const streamPreviewHandler = createRouter()
 				throw new Error('Preview session not found or invalid');
 			}
 
+			const codecSupport = data.codecs
+				? {
+						vp8: data.codecs.vp8,
+						vp9: data.codecs.vp9,
+						avc: data.codecs.avc,
+						hardware: data.codecs.hardware as ('vp8' | 'vp9' | 'avc')[]
+					}
+				: { vp8: true, vp9: data.vp9 !== false, avc: false, hardware: [] };
+
 			// Start WebCodecs streaming
-			const started = await previewService.startWebCodecsStreaming(sessionId, data.vp9 !== false);
+			const started = await previewService.startWebCodecsStreaming(sessionId, {
+				codecSupport,
+				display: data.display
+			});
 
 			if (!started) {
 				throw new Error('Failed to start WebCodecs streaming');
@@ -167,6 +199,87 @@ export const streamPreviewHandler = createRouter()
 			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
 
 			const success = await previewService.requestWebCodecsKeyframe(tab.id);
+
+			return { success };
+		}
+	)
+
+	// Viewer decoder health, reported periodically while connected.
+	//
+	// Backpressure used to be network-only: the source watched its own send
+	// buffer and nothing else. A viewer that cannot decode fast enough stutters
+	// identically with an empty buffer, so its decode queue has to travel back
+	// to the source for the adaptation loop to be closed.
+	.http(
+		'preview:browser-stream-feedback',
+		{
+			data: t.Object({
+				tabId: t.Optional(t.String()),
+				decodeQueueSize: t.Number(),
+				decodeLatencyMs: t.Number(),
+				dropRatio: t.Number()
+			}),
+			response: t.Object({
+				success: t.Boolean()
+			})
+		},
+		async ({ data, conn }) => {
+			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
+
+			previewService.applyWebCodecsClientFeedback(tab.id, {
+				decodeQueueSize: data.decodeQueueSize,
+				decodeLatencyMs: data.decodeLatencyMs,
+				dropRatio: data.dropRatio
+			});
+
+			return { success: true };
+		}
+	)
+
+	// Viewer display metrics changed (panel resize, device swap, moved to a
+	// different-density screen). Capture resolution follows this.
+	.http(
+		'preview:browser-stream-display',
+		{
+			data: t.Object({
+				tabId: t.Optional(t.String()),
+				scale: t.Optional(t.Number()),
+				dpr: t.Optional(t.Number())
+			}),
+			response: t.Object({
+				success: t.Boolean()
+			})
+		},
+		async ({ data, conn }) => {
+			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
+
+			const success = previewService.applyWebCodecsDisplayMetrics(tab.id, {
+				scale: data.scale,
+				dpr: data.dpr
+			});
+
+			return { success };
+		}
+	)
+
+	// Suspend/resume capture when the preview leaves or re-enters view.
+	// An unwatched preview otherwise keeps a headless renderer and an encoder
+	// busy indefinitely — the dominant idle cost on a shared host.
+	.http(
+		'preview:browser-stream-visibility',
+		{
+			data: t.Object({
+				tabId: t.Optional(t.String()),
+				visible: t.Boolean()
+			}),
+			response: t.Object({
+				success: t.Boolean()
+			})
+		},
+		async ({ data, conn }) => {
+			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
+
+			const success = await previewService.setWebCodecsPaused(tab.id, !data.visible);
 
 			return { success };
 		}

--- a/frontend/components/preview/browser/BrowserPreview.svelte
+++ b/frontend/components/preview/browser/BrowserPreview.svelte
@@ -11,7 +11,7 @@
 	import type { DeviceSize, Rotation } from '$frontend/utils/preview-constants';
 	import { debug } from '$shared/utils/logger';
 	import { createBrowserCoordinator } from './core/coordinator.svelte';
-	import { sendScaleUpdate } from './core/interactions.svelte';
+	import { sendDisplayUpdate } from './core/interactions.svelte';
 	import { projectState } from '$frontend/stores/core/projects.svelte';
 	import { appState } from '$frontend/stores/core/app.svelte';
 
@@ -282,13 +282,16 @@
 		}
 	});
 
-	// Watch scale changes and send to backend
+	// Watch scale changes and send to backend.
+	// Capture resolution follows the displayed size, so a resize needs the new
+	// metrics — but not a capture restart, which is what sendScaleUpdate does
+	// and is reserved for recovering a stuck stream.
 	let lastSentScale = 1;
 	$effect(() => {
 		const currentScale = previewDimensions?.scale || 1;
 		if (currentScale !== lastSentScale && sessionId && isStreamReady) {
 			debug.log('preview', `📐 Scale changed to ${currentScale}, sending to backend`);
-			sendScaleUpdate(currentScale);
+			sendDisplayUpdate(currentScale);
 			lastSentScale = currentScale;
 		}
 	});

--- a/frontend/components/preview/browser/components/Container.svelte
+++ b/frontend/components/preview/browser/components/Container.svelte
@@ -13,7 +13,7 @@
 		type Rotation
 	} from '$frontend/utils/preview-constants';
 	import { debug } from '$shared/utils/logger';
-	import { sendScaleUpdate } from '../core/interactions.svelte';
+	import { sendScaleUpdate, setDisplayScale } from '../core/interactions.svelte';
 
 	let {
 		projectId = '', // REQUIRED for project isolation (read-only from parent)
@@ -178,6 +178,10 @@
 		const scaleX = availableWidth > 0 ? Math.min(1, availableWidth / totalWidth) : 1;
 		const scaleY = availableHeight > 0 ? Math.min(1, availableHeight / totalHeight) : 1;
 		const scale = Math.min(scaleX, scaleY);
+
+		// Publish immediately — the streaming handshake reads this to pick a
+		// capture resolution, and it runs before any scale-change event fires.
+		setDisplayScale(scale);
 
 		previewDimensions = {
 			// Outer wrapper = full scaled footprint (body + stand accessory)

--- a/frontend/components/preview/browser/core/interactions.svelte.ts
+++ b/frontend/components/preview/browser/core/interactions.svelte.ts
@@ -30,6 +30,7 @@ export interface InteractionAction {
 	delay?: number;
 	steps?: number;
 	scale?: number;
+	dpr?: number;
 	width?: number;
 	height?: number;
 	deviceSize?: string;
@@ -38,6 +39,30 @@ export interface InteractionAction {
 
 // Store current projectId for interactions
 let currentProjectId = '';
+
+/**
+ * Last known CSS fit-scale of the preview.
+ *
+ * Capture resolution is derived from `scale × devicePixelRatio`, so the
+ * streaming service needs this value at handshake time — before any resize
+ * event would have carried it. Kept here because this module is already the
+ * single place that reports scale changes to the backend.
+ */
+let currentDisplayScale = 1;
+
+export function setDisplayScale(scale: number): void {
+	if (scale > 0 && scale <= 1) {
+		currentDisplayScale = scale;
+	}
+}
+
+export function getDisplayScale(): number {
+	return currentDisplayScale;
+}
+
+function currentDpr(): number {
+	return typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+}
 
 /**
  * Set current project ID for interactions
@@ -61,20 +86,43 @@ export function sendInteraction(action: InteractionAction): void {
 }
 
 /**
- * Send scale update to active tab
+ * Send scale update to active tab.
+ *
+ * Doubles as the stream-recovery path (the frontend re-sends the current scale
+ * when it detects a stuck stream), so it carries the display metrics too —
+ * capture resolution is derived from `scale × devicePixelRatio`.
  */
 export function sendScaleUpdate(scale: number): void {
+	setDisplayScale(scale);
 	try {
 		ws.emit('preview:browser-interact', {
 			action: {
 				type: 'scale-update',
-				scale
+				scale,
+				dpr: currentDpr()
 			}
 		});
-		debug.log('preview', `📐 Sent scale update: ${scale}`);
+		debug.log('preview', `📐 Sent scale update: ${scale} @${currentDpr()}x`);
 	} catch (error) {
 		debug.error('preview', 'Error sending scale update:', error);
 	}
+}
+
+/**
+ * Report display metrics without disturbing the stream.
+ *
+ * A resize only needs the capture resolution recomputed; `sendScaleUpdate`
+ * additionally restarts capture, which is right for recovery but wasteful on
+ * every drag frame of a panel resize.
+ */
+export function sendDisplayUpdate(scale: number): void {
+	setDisplayScale(scale);
+	ws.http('preview:browser-stream-display', {
+		scale,
+		dpr: currentDpr()
+	}).catch(() => {
+		// Best-effort: the next scale-update or reconnect carries it anyway
+	});
 }
 
 /**
@@ -91,6 +139,8 @@ export async function updateViewport(
 	// Use getViewportDimensions for consistent viewport calculation
 	const { width, height } = getViewportDimensions(deviceSize, rotation);
 
+	setDisplayScale(scale);
+
 	try {
 		ws.emit('preview:browser-interact', {
 			action: {
@@ -98,6 +148,7 @@ export async function updateViewport(
 				width,
 				height,
 				scale,
+				dpr: currentDpr(),
 				deviceSize,
 				rotation
 			}

--- a/frontend/services/preview/browser/browser-webcodecs.service.ts
+++ b/frontend/services/preview/browser/browser-webcodecs.service.ts
@@ -16,6 +16,46 @@
 
 import ws from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { getDisplayScale } from '$frontend/components/preview/browser/core/interactions.svelte';
+
+/** Wire codec ids — must match VIDEO_CODEC_ID in backend/preview/browser/types.ts. */
+const CODEC_STRINGS: Record<number, string> = {
+	0: 'vp8',
+	1: 'vp09.00.10.08',
+	2: 'avc1.42E033'
+};
+
+const CODEC_NAMES: Record<number, 'vp8' | 'vp9' | 'avc'> = {
+	0: 'vp8',
+	1: 'vp9',
+	2: 'avc'
+};
+
+export interface ClientCodecSupportPayload {
+	vp8: boolean;
+	vp9: boolean;
+	avc: boolean;
+	/** Codecs this device reports a hardware decoder for. */
+	hardware: string[];
+}
+
+/**
+ * A decoded frame, from either the decode worker or the inline decoder.
+ * `ImageBitmap` carries no timestamp or display size, so both travel alongside.
+ */
+interface RenderableFrame {
+	image: VideoFrame | ImageBitmap;
+	timestamp: number;
+	width: number;
+	height: number;
+}
+
+function closeRenderable(frame: RenderableFrame | null): void {
+	if (!frame) return;
+	try {
+		frame.image.close();
+	} catch {}
+}
 
 export interface BrowserWebCodecsStreamStats {
 	isConnected: boolean;
@@ -57,7 +97,7 @@ export class BrowserWebCodecsService {
 	private isCleaningUp = false;
 
 	// Frame rendering optimization with timestamp-based scheduling
-	private pendingFrame: VideoFrame | null = null;
+	private pendingFrame: RenderableFrame | null = null;
 	private isRenderingFrame = false;
 	private renderFrameId: number | null = null;
 	private lastFrameTime = 0;
@@ -89,9 +129,34 @@ export class BrowserWebCodecsService {
 	private lastKeyframeRequestTime = 0; // Throttle for requestKeyframe (PLI equivalent)
 
 	// Reassembly of fragmented video frames (packet type 2 — large frames,
-	// e.g. near-lossless top-off keyframes, split to fit SCTP message limits)
+	// e.g. near-lossless top-off keyframes, split to fit SCTP message limits).
+	// Only used by the inline fallback path; the worker reassembles its own.
 	private fragmentBuffer: Uint8Array[] | null = null;
 	private fragmentTimestamp = 0;
+
+	// Off-thread decode. Packet parsing and VideoDecoder run in a worker so the
+	// main thread only paints — on a low-end device, software decode competing
+	// with Svelte reactivity on one thread is what makes the preview stutter.
+	// Null whenever the worker is unavailable; the inline decoder then runs.
+	private videoWorker: Worker | null = null;
+	private workerFailed = false;
+	private workerProducedFrame = false;
+	private workerWatchdog: ReturnType<typeof setTimeout> | null = null;
+
+	// Viewer decode health, fed back to the source so it can lower framerate or
+	// resolution. Without this the source only ever sees network congestion.
+	private feedbackIntervalId: ReturnType<typeof setInterval> | null = null;
+	private lastFeedback = { decodeQueueSize: 0, decodeLatencyMs: 0, dropRatio: 0 };
+	private framesReceivedWindow = 0;
+	private framesDroppedWindow = 0;
+
+	// Capture is suspended while the preview is off-screen or the browser tab
+	// is hidden — an unwatched preview otherwise pins a headless renderer.
+	private visibilityHandler: (() => void) | null = null;
+	private visibilitySuspendTimer: ReturnType<typeof setTimeout> | null = null;
+	private isViewerVisible = true;
+	/** How long the tab must stay hidden before capture is torn down. */
+	private static readonly VISIBILITY_SUSPEND_DELAY_MS = 10_000;
 
 	// Stats tracking
 	private stats: BrowserWebCodecsStreamStats = {
@@ -190,6 +255,32 @@ export class BrowserWebCodecsService {
 		};
 		document.addEventListener('click', this.userGestureHandler, { once: false });
 		document.addEventListener('keydown', this.userGestureHandler, { once: false });
+
+		// Backgrounding the browser tab should stop the capture entirely, not
+		// just stop painting: the headless renderer and encoder on the host
+		// keep running otherwise, which is pure waste on a shared machine.
+		//
+		// Suspending is deferred, though. Tearing capture down means rebuilding
+		// it on return — re-probing the capture source and waiting for a fresh
+		// keyframe — so doing it for a two-second glance at another tab costs
+		// the user a visible stall to save nothing.
+		this.visibilityHandler = () => {
+			if (document.hidden) {
+				if (this.visibilitySuspendTimer) return;
+				this.visibilitySuspendTimer = setTimeout(() => {
+					this.visibilitySuspendTimer = null;
+					if (document.hidden) this.setViewerVisible(false);
+				}, BrowserWebCodecsService.VISIBILITY_SUSPEND_DELAY_MS);
+				return;
+			}
+
+			if (this.visibilitySuspendTimer) {
+				clearTimeout(this.visibilitySuspendTimer);
+				this.visibilitySuspendTimer = null;
+			}
+			this.setViewerVisible(true);
+		};
+		document.addEventListener('visibilitychange', this.visibilityHandler);
 	}
 
 	/**
@@ -201,6 +292,176 @@ export class BrowserWebCodecsService {
 			typeof AudioDecoder !== 'undefined' &&
 			typeof RTCPeerConnection !== 'undefined'
 		);
+	}
+
+	/**
+	 * Probe which codecs this viewer can decode, and which of those it decodes
+	 * in hardware.
+	 *
+	 * The hardware answer is the important one. A phone or a low-end laptop
+	 * decodes H.264 on dedicated silicon but VP9 on the CPU, so sending it VP9
+	 * costs frames no matter how well-tuned the source is. `prefer-hardware` is
+	 * a hint rather than a guarantee, but Chrome and Safari both reject the
+	 * probe when no hardware path exists, which is exactly the signal we want.
+	 */
+	private async detectCodecSupport(): Promise<ClientCodecSupportPayload> {
+		const support: ClientCodecSupportPayload = {
+			vp8: false,
+			vp9: false,
+			avc: false,
+			hardware: []
+		};
+
+		for (const [id, codec] of Object.entries(CODEC_STRINGS)) {
+			const name = CODEC_NAMES[Number(id)];
+
+			try {
+				const generic = await VideoDecoder.isConfigSupported({ codec, optimizeForLatency: true });
+				support[name] = generic.supported === true;
+			} catch {
+				support[name] = false;
+			}
+
+			if (!support[name]) continue;
+
+			try {
+				const hw = await VideoDecoder.isConfigSupported({
+					codec,
+					optimizeForLatency: true,
+					hardwareAcceleration: 'prefer-hardware'
+				});
+				if (hw.supported === true) support.hardware.push(name);
+			} catch {
+				// No hardware path — leave it out of the list.
+			}
+		}
+
+		debug.log(
+			'webcodecs',
+			`Decode support: vp8=${support.vp8} vp9=${support.vp9} avc=${support.avc}, hw=[${support.hardware.join(',')}]`
+		);
+
+		return support;
+	}
+
+	/**
+	 * Spin up the decode worker. Returns false when workers, module workers or
+	 * WebCodecs-in-worker aren't available, in which case the inline decoder
+	 * takes over transparently.
+	 */
+	private initVideoWorker(): boolean {
+		if (this.videoWorker) return true;
+		if (this.workerFailed) return false;
+		if (typeof Worker === 'undefined') return false;
+
+		try {
+			const worker = new Worker(new URL('./preview-video.worker.ts', import.meta.url), {
+				type: 'module'
+			});
+
+			worker.onmessage = (event: MessageEvent) => this.handleWorkerMessage(event.data);
+			worker.onerror = () => this.disableVideoWorker('worker error');
+
+			worker.postMessage({ t: 'init', preferHardware: true });
+			this.videoWorker = worker;
+			this.workerProducedFrame = false;
+			return true;
+		} catch (error) {
+			debug.warn('webcodecs', 'Decode worker unavailable:', error);
+			this.workerFailed = true;
+			return false;
+		}
+	}
+
+	private terminateVideoWorker(): void {
+		this.clearWorkerWatchdog();
+		if (!this.videoWorker) return;
+		try {
+			this.videoWorker.postMessage({ t: 'close' });
+			this.videoWorker.terminate();
+		} catch {}
+		this.videoWorker = null;
+	}
+
+	/**
+	 * Stop using the worker and decode on the main thread instead.
+	 *
+	 * The worker path can fail without raising anything: a browser that doesn't
+	 * expose WebCodecs to workers happily accepts packets and decodes nothing.
+	 * Falling back explicitly is what keeps the preview working there instead
+	 * of leaving a permanently blank canvas.
+	 */
+	private disableVideoWorker(reason: string): void {
+		if (!this.videoWorker && this.workerFailed) return;
+		debug.warn('webcodecs', `Decode worker disabled (${reason}) — decoding on the main thread`);
+		this.workerFailed = true;
+		this.terminateVideoWorker();
+		// The inline decoder starts from nothing and needs a sync point.
+		this.requestKeyframe();
+	}
+
+	/**
+	 * Watch the first handful of packets: if none of them produce a frame, the
+	 * worker is decoding into the void and we switch back to inline decode.
+	 */
+	private armWorkerWatchdog(): void {
+		if (this.workerWatchdog || this.workerProducedFrame || !this.videoWorker) return;
+
+		this.workerWatchdog = setTimeout(() => {
+			this.workerWatchdog = null;
+			if (!this.workerProducedFrame && this.videoWorker) {
+				this.disableVideoWorker('no frames decoded');
+			}
+		}, 4000);
+	}
+
+	private clearWorkerWatchdog(): void {
+		if (this.workerWatchdog) {
+			clearTimeout(this.workerWatchdog);
+			this.workerWatchdog = null;
+		}
+	}
+
+	private handleWorkerMessage(message: any): void {
+		switch (message?.t) {
+			case 'ready':
+				if (message.ok === false) {
+					this.disableVideoWorker('WebCodecs unavailable in worker');
+				}
+				break;
+
+			case 'frame':
+				this.workerProducedFrame = true;
+				this.clearWorkerWatchdog();
+				this.handleDecodedVideoFrame({
+					image: message.frame,
+					timestamp: message.timestamp,
+					width: message.width,
+					height: message.height
+				});
+				break;
+
+			case 'keyframe-request':
+				this.requestKeyframe();
+				break;
+
+			case 'codec':
+				this.stats.videoCodec = CODEC_NAMES[message.codecId] ?? 'unknown';
+				this.activeCodecId = message.codecId;
+				break;
+
+			case 'stats':
+				this.lastFeedback = {
+					decodeQueueSize: message.decodeQueueSize,
+					decodeLatencyMs: message.decodeLatencyMs,
+					dropRatio:
+						message.framesReceived > 0
+							? Math.max(0, (message.framesReceived - message.framesDecoded) / message.framesReceived)
+							: 0
+				};
+				this.sendFeedback();
+				break;
+		}
 	}
 
 	/**
@@ -260,21 +521,29 @@ export class BrowserWebCodecsService {
 			// Setup WebSocket listeners
 			this.setupEventListeners();
 
-			// Detect VP9 decode capability — the encoder prefers VP9 quantizer
-			// mode (adaptive quality) but must fall back to VP8 if we can't decode it
-			let vp9Supported = false;
-			try {
-				const support = await VideoDecoder.isConfigSupported({ codec: 'vp09.00.10.08' });
-				vp9Supported = support.supported === true;
-			} catch {
-				vp9Supported = false;
-			}
+			// Decode off the main thread when the browser allows it
+			this.initVideoWorker();
+
+			const codecs = await this.detectCodecSupport();
 
 			// Request server to start streaming and get offer
 			// Send explicit tabId to ensure backend targets the correct tab
-			// even if user switches tabs during the async negotiation
-			debug.log('webcodecs', `[DIAG] Sending preview:browser-stream-start for session: ${sessionId} (vp9: ${vp9Supported})`);
-			const response = await ws.http('preview:browser-stream-start', { tabId: sessionId, vp9: vp9Supported }, 30000);
+			// even if user switches tabs during the async negotiation.
+			// The display metrics decide capture resolution — sending them with
+			// the handshake means the very first frame already arrives at the
+			// size this screen can show, instead of a full-viewport frame that
+			// gets downscaled away.
+			debug.log('webcodecs', `[DIAG] Sending preview:browser-stream-start for session: ${sessionId}`);
+			const response = await ws.http(
+				'preview:browser-stream-start',
+				{
+					tabId: sessionId,
+					vp9: codecs.vp9,
+					codecs,
+					display: this.currentDisplayMetrics()
+				},
+				30000
+			);
 			debug.log('webcodecs', `[DIAG] preview:browser-stream-start response: success=${response.success}, hasOffer=${!!response.offer}, message=${response.message}`);
 
 			if (!response.success) {
@@ -450,6 +719,7 @@ export class BrowserWebCodecsService {
 				this.isConnected = true;
 				this.stats.isConnected = true;
 				this.startStatsCollection();
+				this.startFeedbackLoop();
 				// this.startBandwidthLogging();
 				if (this.onConnectionChange) {
 					this.onConnectionChange(true);
@@ -460,6 +730,7 @@ export class BrowserWebCodecsService {
 				this.isConnected = false;
 				this.stats.isConnected = false;
 				this.stopStatsCollection();
+				this.stopFeedbackLoop();
 				this.stopBandwidthLogging();
 				if (this.onConnectionChange) {
 					this.onConnectionChange(false);
@@ -478,6 +749,7 @@ export class BrowserWebCodecsService {
 				this.isConnected = false;
 				this.stats.isConnected = false;
 				this.stopStatsCollection();
+				this.stopFeedbackLoop();
 				this.stopBandwidthLogging();
 				if (this.onConnectionChange) {
 					this.onConnectionChange(false);
@@ -534,7 +806,20 @@ export class BrowserWebCodecsService {
 			const view = new DataView(data);
 
 			// Parse packet header
-			const type = view.getUint8(0); // 0 = video, 1 = audio
+			const type = view.getUint8(0); // 0 = video, 1 = audio, 2 = video fragment
+
+			// Video goes straight to the decode worker as a transfer — no copy,
+			// and the main thread never touches the bitstream. Audio stays here
+			// because AudioContext isn't available inside a worker.
+			if ((type === 0 || type === 2) && this.videoWorker) {
+				const size = type === 0 ? view.getUint32(11, true) : view.getUint32(15, true);
+				this.stats.videoBytesReceived += size;
+				if (type === 0) this.stats.videoFramesReceived++;
+				this.framesReceivedWindow++;
+				this.armWorkerWatchdog();
+				this.videoWorker.postMessage({ t: 'packet', buffer: data }, [data]);
+				return;
+			}
 
 			if (type === 0) {
 				// Video packet
@@ -547,6 +832,7 @@ export class BrowserWebCodecsService {
 
 				this.stats.videoBytesReceived += size;
 				this.stats.videoFramesReceived++;
+				this.framesReceivedWindow++;
 
 				this.handleVideoChunk(chunkData, timestamp, isKeyframe, codecId);
 			} else if (type === 1) {
@@ -594,6 +880,7 @@ export class BrowserWebCodecsService {
 					this.fragmentBuffer = null;
 
 					this.stats.videoFramesReceived++;
+					this.framesReceivedWindow++;
 					this.handleVideoChunk(fullData, timestamp, isKeyframe, codecId);
 				}
 			}
@@ -681,24 +968,36 @@ export class BrowserWebCodecsService {
 	 * Initialize VideoDecoder for the codec announced in the packet header
 	 */
 	private async initVideoDecoder(codecId: number): Promise<void> {
-		// Codec string must match the encoder in the headless browser:
-		// 0 = VP8 (fallback), 1 = VP9 profile 0 (quantizer mode)
-		const codec = codecId === 1 ? 'vp09.00.10.08' : 'vp8';
-		this.stats.videoCodec = codecId === 1 ? 'vp9' : 'vp8';
+		// Codec string must match the encoder in the headless browser
+		const codec = CODEC_STRINGS[codecId] ?? 'vp8';
+		this.stats.videoCodec = CODEC_NAMES[codecId] ?? 'vp8';
 
 		this.videoCodecConfig = {
 			codec,
-			optimizeForLatency: true
+			optimizeForLatency: true,
+			hardwareAcceleration: 'prefer-hardware'
 		};
 
 		try {
-			const support = await VideoDecoder.isConfigSupported(this.videoCodecConfig);
+			let support = await VideoDecoder.isConfigSupported(this.videoCodecConfig);
+			if (!support.supported) {
+				// Hardware is a preference, not a requirement — retry without it
+				// before declaring the codec unusable.
+				this.videoCodecConfig = { codec, optimizeForLatency: true };
+				support = await VideoDecoder.isConfigSupported(this.videoCodecConfig);
+			}
 			if (!support.supported) {
 				throw new Error(`Video codec ${codec} not supported`);
 			}
 
 			this.videoDecoder = new VideoDecoder({
-				output: (frame) => this.handleDecodedVideoFrame(frame),
+				output: (frame) =>
+					this.handleDecodedVideoFrame({
+						image: frame,
+						timestamp: frame.timestamp,
+						width: frame.displayWidth,
+						height: frame.displayHeight
+					}),
 				error: (e) => {
 					debug.error('webcodecs', 'VideoDecoder error:', e);
 					// Null out so next keyframe triggers reinitialization.
@@ -739,6 +1038,7 @@ export class BrowserWebCodecsService {
 			this.isConnected = false;
 			this.stats.isConnected = false;
 			this.stopStatsCollection();
+			this.stopFeedbackLoop();
 			this.stopBandwidthLogging();
 			if (this.onConnectionChange) {
 				this.onConnectionChange(false);
@@ -833,16 +1133,16 @@ export class BrowserWebCodecsService {
 	/**
 	 * Handle decoded video frame - render to canvas with timestamp-based optimization
 	 */
-	private handleDecodedVideoFrame(frame: VideoFrame): void {
+	private handleDecodedVideoFrame(frame: RenderableFrame): void {
 		if (this.isCleaningUp || !this.canvas || !this.ctx) {
-			frame.close();
+			closeRenderable(frame);
 			return;
 		}
 
 		// During SPA navigation freeze, skip rendering to hold the last frame
 		// This prevents brief white flashes during SPA page transitions
 		if (this.spaFreezeUntil > 0 && Date.now() < this.spaFreezeUntil) {
-			frame.close();
+			closeRenderable(frame);
 			return;
 		}
 		// Auto-reset freeze after it expires
@@ -853,8 +1153,8 @@ export class BrowserWebCodecsService {
 		try {
 			// Update stats
 			this.stats.videoFramesDecoded++;
-			this.stats.frameWidth = frame.displayWidth;
-			this.stats.frameHeight = frame.displayHeight;
+			this.stats.frameWidth = frame.width;
+			this.stats.frameHeight = frame.height;
 
 			// Establish AV sync reference on first video frame
 			if (!this.syncEstablished) {
@@ -893,8 +1193,9 @@ export class BrowserWebCodecsService {
 
 			// Drop old pending frame if exists (frame skipping for performance)
 			if (this.pendingFrame) {
-				this.pendingFrame.close();
+				closeRenderable(this.pendingFrame);
 				this.stats.videoFramesDropped++;
+				this.framesDroppedWindow++;
 			}
 
 			// Store frame for next render cycle
@@ -906,7 +1207,7 @@ export class BrowserWebCodecsService {
 			}
 		} catch (error) {
 			debug.error('webcodecs', 'Video frame handle error:', error);
-			frame.close();
+			closeRenderable(frame);
 		}
 	}
 
@@ -932,7 +1233,7 @@ export class BrowserWebCodecsService {
 
 		if (!this.pendingFrame || this.isCleaningUp || !this.canvas || !this.ctx) {
 			if (this.pendingFrame) {
-				this.pendingFrame.close();
+				closeRenderable(this.pendingFrame);
 				this.pendingFrame = null;
 			}
 			return;
@@ -958,20 +1259,20 @@ export class BrowserWebCodecsService {
 			// Match canvas backing store to the frame's native size and draw 1:1.
 			// Stretching frames to a differently-sized canvas caused blurry output;
 			// display fit-scaling is handled by CSS transform in the container.
-			const frameWidth = this.pendingFrame.displayWidth;
-			const frameHeight = this.pendingFrame.displayHeight;
+			const frameWidth = this.pendingFrame.width;
+			const frameHeight = this.pendingFrame.height;
 			if (this.canvas.width !== frameWidth || this.canvas.height !== frameHeight) {
 				this.canvas.width = frameWidth;
 				this.canvas.height = frameHeight;
 			}
-			this.ctx.drawImage(this.pendingFrame, 0, 0);
+			this.ctx.drawImage(this.pendingFrame.image as CanvasImageSource, 0, 0);
 
 			this.lastFrameTime = timestamp;
 		} catch (error) {
 			debug.error('webcodecs', 'Video frame render error:', error);
 		} finally {
 			// Close frame immediately to free memory
-			this.pendingFrame.close();
+			closeRenderable(this.pendingFrame);
 			this.pendingFrame = null;
 		}
 	}
@@ -1207,6 +1508,109 @@ export class BrowserWebCodecsService {
 	}
 
 	/**
+	 * Current viewer display metrics.
+	 *
+	 * The product of these two numbers is how many physical screen pixels each
+	 * emulated viewport pixel occupies — which is exactly the resolution worth
+	 * capturing. Above it is invisible work; below it is upscaling blur.
+	 */
+	private currentDisplayMetrics(): { scale: number; dpr: number } {
+		return {
+			scale: getDisplayScale(),
+			dpr: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1
+		};
+	}
+
+	/**
+	 * Report decoder health upstream so the source can back off.
+	 *
+	 * Stutter caused by a viewer that can't decode fast enough looks identical
+	 * from the outside to network congestion, but needs the opposite response:
+	 * fewer or smaller frames rather than a smaller send buffer. The source can
+	 * only tell them apart if we say which one it is.
+	 */
+	private sendFeedback(): void {
+		if (!this.sessionId || !this.isConnected) return;
+
+		// The inline decode path has no queue telemetry of its own, so derive
+		// the drop ratio from what the renderer had to throw away.
+		if (!this.videoWorker) {
+			const received = this.framesReceivedWindow;
+			this.lastFeedback = {
+				decodeQueueSize: this.videoDecoder?.decodeQueueSize ?? 0,
+				decodeLatencyMs: 0,
+				dropRatio: received > 0 ? Math.min(1, this.framesDroppedWindow / received) : 0
+			};
+		}
+
+		this.framesReceivedWindow = 0;
+		this.framesDroppedWindow = 0;
+
+		ws.http('preview:browser-stream-feedback', {
+			tabId: this.sessionId,
+			decodeQueueSize: this.lastFeedback.decodeQueueSize,
+			decodeLatencyMs: this.lastFeedback.decodeLatencyMs,
+			dropRatio: this.lastFeedback.dropRatio
+		}).catch(() => {});
+	}
+
+	private startFeedbackLoop(): void {
+		if (this.feedbackIntervalId) return;
+
+		this.feedbackIntervalId = setInterval(() => {
+			// The worker owns the decode counters, so ask it to drain them; it
+			// answers with a 'stats' message which triggers the actual send.
+			if (this.videoWorker) {
+				this.videoWorker.postMessage({ t: 'stats' });
+			} else {
+				this.sendFeedback();
+			}
+		}, 2000);
+	}
+
+	private stopFeedbackLoop(): void {
+		if (this.feedbackIntervalId) {
+			clearInterval(this.feedbackIntervalId);
+			this.feedbackIntervalId = null;
+		}
+	}
+
+	/**
+	 * Tell the source whether anyone is actually looking.
+	 *
+	 * Capture is suspended entirely while hidden, not just rendering — the
+	 * expensive half of an unwatched preview (renderer + encoder) runs on the
+	 * host, where it competes with every other session.
+	 */
+	setViewerVisible(visible: boolean): void {
+		if (this.isViewerVisible === visible) return;
+		this.isViewerVisible = visible;
+
+		if (!this.sessionId) return;
+
+		debug.log('webcodecs', `Viewer ${visible ? 'visible' : 'hidden'} — ${visible ? 'resuming' : 'suspending'} capture`);
+		ws.http('preview:browser-stream-visibility', {
+			tabId: this.sessionId,
+			visible
+		}).catch(() => {});
+	}
+
+	/**
+	 * Push new display metrics to the source (panel resize, device change, or
+	 * a move to a screen with a different pixel density).
+	 */
+	sendDisplayMetrics(): void {
+		if (!this.sessionId || !this.isConnected) return;
+
+		const metrics = this.currentDisplayMetrics();
+		ws.http('preview:browser-stream-display', {
+			tabId: this.sessionId,
+			scale: metrics.scale,
+			dpr: metrics.dpr
+		}).catch(() => {});
+	}
+
+	/**
 	 * Collect stats
 	 */
 	private async collectStats(): Promise<void> {
@@ -1317,6 +1721,10 @@ export class BrowserWebCodecsService {
 			// Setup WebSocket listeners
 			this.setupEventListeners();
 
+			// The worker survives reconnects; recreate it only if a previous
+			// failure tore it down.
+			this.initVideoWorker();
+
 			// Create peer connection
 			await this.createPeerConnection();
 
@@ -1350,6 +1758,7 @@ export class BrowserWebCodecsService {
 
 		this.clearDisconnectGrace();
 		this.stopStatsCollection();
+		this.stopFeedbackLoop();
 		this.stopBandwidthLogging();
 
 		// Cancel pending frame render
@@ -1360,7 +1769,7 @@ export class BrowserWebCodecsService {
 
 		// Close pending frame
 		if (this.pendingFrame) {
-			this.pendingFrame.close();
+			closeRenderable(this.pendingFrame);
 			this.pendingFrame = null;
 		}
 
@@ -1371,6 +1780,10 @@ export class BrowserWebCodecsService {
 			debug.warn('webcodecs', 'Error in ws cleanup:', e);
 		}
 		this.wsCleanupFunctions = [];
+
+		// Drop the worker's decoder state too, or the next stream would
+		// resume decoding against a stale delta chain.
+		this.videoWorker?.postMessage({ t: 'reset' });
 
 		// Close decoders immediately (reset + close, no flush).
 		// Flushing processes all queued frames which is slow and can fire
@@ -1446,6 +1859,7 @@ export class BrowserWebCodecsService {
 
 		this.clearDisconnectGrace();
 		this.stopStatsCollection();
+		this.stopFeedbackLoop();
 		this.stopBandwidthLogging();
 
 		// Cancel pending frame render
@@ -1456,7 +1870,7 @@ export class BrowserWebCodecsService {
 
 		// Close pending frame
 		if (this.pendingFrame) {
-			this.pendingFrame.close();
+			closeRenderable(this.pendingFrame);
 			this.pendingFrame = null;
 		}
 
@@ -1472,6 +1886,10 @@ export class BrowserWebCodecsService {
 		if (this.sessionId) {
 			ws.http('preview:browser-stream-stop', { tabId: this.sessionId }).catch(() => {});
 		}
+
+		// Drop the worker's decoder state too, or the next stream would resume
+		// decoding against a stale delta chain.
+		this.videoWorker?.postMessage({ t: 'reset' });
 
 		// Close decoders immediately (reset + close, no flush for speed)
 		if (this.videoDecoder) {
@@ -1585,6 +2003,7 @@ export class BrowserWebCodecsService {
 
 		this.clearDisconnectGrace();
 		this.stopStatsCollection();
+		this.stopFeedbackLoop();
 		this.stopBandwidthLogging();
 
 		// Cancel pending frame render
@@ -1595,7 +2014,7 @@ export class BrowserWebCodecsService {
 
 		// Close pending frame
 		if (this.pendingFrame) {
-			this.pendingFrame.close();
+			closeRenderable(this.pendingFrame);
 			this.pendingFrame = null;
 		}
 
@@ -1710,7 +2129,7 @@ export class BrowserWebCodecsService {
 			this.renderFrameId = null;
 		}
 		if (this.pendingFrame) {
-			this.pendingFrame.close();
+			closeRenderable(this.pendingFrame);
 			this.pendingFrame = null;
 		}
 	}
@@ -1785,6 +2204,8 @@ export class BrowserWebCodecsService {
 	destroy(): void {
 		this.cleanup();
 
+		this.terminateVideoWorker();
+
 		// Close AudioContext only on full destroy (not reused after this)
 		if (this.audioContext && this.audioContext.state !== 'closed') {
 			this.audioContext.close().catch(() => {});
@@ -1804,6 +2225,16 @@ export class BrowserWebCodecsService {
 			document.removeEventListener('click', this.userGestureHandler);
 			document.removeEventListener('keydown', this.userGestureHandler);
 			this.userGestureHandler = null;
+		}
+
+		if (this.visibilitySuspendTimer) {
+			clearTimeout(this.visibilitySuspendTimer);
+			this.visibilitySuspendTimer = null;
+		}
+
+		if (this.visibilityHandler) {
+			document.removeEventListener('visibilitychange', this.visibilityHandler);
+			this.visibilityHandler = null;
 		}
 	}
 }

--- a/frontend/services/preview/browser/preview-video.worker.ts
+++ b/frontend/services/preview/browser/preview-video.worker.ts
@@ -1,0 +1,297 @@
+/**
+ * Preview Video Decode Worker
+ *
+ * Packet parsing, fragment reassembly and VideoDecoder all run here instead of
+ * on the page's main thread.
+ *
+ * On a capable machine this is invisible. On a low-end device it is the
+ * difference between a smooth preview and a stuttering one: software VP9/H.264
+ * decode at 20+ fps competes directly with Svelte reactivity, the terminal and
+ * the chat view for the same thread, so whichever runs first starves the
+ * other. Off-thread, the main thread's only remaining job is `drawImage`.
+ *
+ * Decoded frames go back as transferred `VideoFrame` objects (zero copy). Some
+ * engines don't allow transferring them, so the first failure permanently
+ * switches this worker to transferring `ImageBitmap` instead — one extra GPU
+ * copy, still off the main thread.
+ */
+
+/** Wire codec ids — must match VIDEO_CODEC_ID in backend/preview/browser/types.ts. */
+const CODEC_STRINGS: Record<number, string> = {
+	0: 'vp8',
+	1: 'vp09.00.10.08',
+	2: 'avc1.42E033'
+};
+
+interface DecoderState {
+	decoder: VideoDecoder | null;
+	codecId: number;
+	preferHardware: boolean;
+}
+
+const state: DecoderState = {
+	decoder: null,
+	codecId: -1,
+	preferHardware: true
+};
+
+let fragmentBuffer: Uint8Array[] | null = null;
+let fragmentTimestamp = 0;
+let fragmentExpected = 0;
+
+/** Set once a VideoFrame transfer is rejected — falls back to ImageBitmap. */
+let canTransferFrames = true;
+
+// Rolling decode-health counters, drained by the service every report window.
+let framesReceived = 0;
+let framesDecoded = 0;
+let decodeLatencyTotal = 0;
+let decodeLatencySamples = 0;
+const pendingTimestamps = new Map<number, number>();
+
+function post(message: unknown, transfer?: Transferable[]) {
+	if (transfer && transfer.length > 0) {
+		(self as unknown as Worker).postMessage(message, transfer);
+	} else {
+		(self as unknown as Worker).postMessage(message);
+	}
+}
+
+function closeDecoder() {
+	if (state.decoder) {
+		try {
+			state.decoder.reset();
+			state.decoder.close();
+		} catch {}
+	}
+	state.decoder = null;
+	state.codecId = -1;
+	pendingTimestamps.clear();
+}
+
+async function emitFrame(frame: VideoFrame) {
+	const started = pendingTimestamps.get(frame.timestamp);
+	if (started !== undefined) {
+		pendingTimestamps.delete(frame.timestamp);
+		decodeLatencyTotal += performance.now() - started;
+		decodeLatencySamples++;
+	}
+	framesDecoded++;
+
+	// Geometry and timestamp travel alongside the frame: an ImageBitmap
+	// carries neither, and the renderer needs both for 1:1 drawing and A/V sync.
+	const meta = {
+		t: 'frame' as const,
+		timestamp: frame.timestamp,
+		width: frame.displayWidth,
+		height: frame.displayHeight
+	};
+
+	if (canTransferFrames) {
+		try {
+			post({ ...meta, frame, kind: 'videoframe' }, [frame as unknown as Transferable]);
+			return;
+		} catch {
+			// Engine refuses to transfer VideoFrame — stop trying.
+			canTransferFrames = false;
+		}
+	}
+
+	try {
+		const bitmap = await createImageBitmap(frame);
+		post({ ...meta, frame: bitmap, kind: 'imagebitmap' }, [bitmap]);
+	} catch {
+		// Nothing renderable — drop it rather than leaking the frame.
+	} finally {
+		try {
+			frame.close();
+		} catch {}
+	}
+}
+
+async function ensureDecoder(codecId: number): Promise<boolean> {
+	if (state.decoder && state.codecId === codecId) return true;
+
+	closeDecoder();
+
+	const codec = CODEC_STRINGS[codecId];
+	if (!codec) return false;
+
+	const config: VideoDecoderConfig = {
+		codec,
+		optimizeForLatency: true,
+		// A hint, not a guarantee — but on phones and low-end laptops it is
+		// what routes H.264 to the dedicated decoder instead of the CPU.
+		hardwareAcceleration: state.preferHardware ? 'prefer-hardware' : 'no-preference'
+	};
+
+	try {
+		let support = await VideoDecoder.isConfigSupported(config);
+		if (!support.supported && state.preferHardware) {
+			config.hardwareAcceleration = 'no-preference';
+			support = await VideoDecoder.isConfigSupported(config);
+		}
+		if (!support.supported) return false;
+
+		state.decoder = new VideoDecoder({
+			output: (frame) => {
+				void emitFrame(frame);
+			},
+			error: () => {
+				// Null out so the next keyframe reinitialises. Leaving a closed
+				// decoder in place would silently drop every later frame.
+				closeDecoder();
+				post({ t: 'keyframe-request' });
+			}
+		});
+
+		state.decoder.configure(config);
+		state.codecId = codecId;
+		post({ t: 'codec', codecId, codec });
+		return true;
+	} catch {
+		closeDecoder();
+		return false;
+	}
+}
+
+async function decodeChunk(data: Uint8Array, timestamp: number, isKeyframe: boolean, codecId: number) {
+	// Codec changed mid-stream (navigation re-injected the encoder, or the
+	// adaptation loop switched codecs) — swap on the keyframe.
+	if (state.decoder && isKeyframe && codecId !== state.codecId) {
+		closeDecoder();
+	}
+
+	if (!state.decoder && isKeyframe) {
+		await ensureDecoder(codecId);
+	}
+
+	if (!state.decoder) {
+		// Delta frame with no decoder (joined mid-stream, or the decoder just
+		// errored) — ask for a sync point instead of waiting one out.
+		post({ t: 'keyframe-request' });
+		return;
+	}
+
+	try {
+		pendingTimestamps.set(timestamp, performance.now());
+		state.decoder.decode(
+			new EncodedVideoChunk({
+				type: isKeyframe ? 'key' : 'delta',
+				timestamp,
+				data
+			})
+		);
+	} catch {
+		pendingTimestamps.delete(timestamp);
+		closeDecoder();
+		post({ t: 'keyframe-request' });
+	}
+}
+
+function handlePacket(buffer: ArrayBuffer) {
+	const view = new DataView(buffer);
+	const type = view.getUint8(0);
+
+	if (type === 0) {
+		// [type(1)][timestamp(8)][keyframe(1)][codec(1)][size(4)][data]
+		const timestamp = Number(view.getBigUint64(1, true));
+		const isKeyframe = view.getUint8(9) === 1;
+		const codecId = view.getUint8(10);
+		const size = view.getUint32(11, true);
+		framesReceived++;
+		void decodeChunk(new Uint8Array(buffer, 15, size), timestamp, isKeyframe, codecId);
+		return;
+	}
+
+	if (type === 2) {
+		// [type(1)][timestamp(8)][keyframe(1)][codec(1)][fragIndex(2)][fragCount(2)][size(4)][data]
+		const timestamp = Number(view.getBigUint64(1, true));
+		const isKeyframe = view.getUint8(9) === 1;
+		const codecId = view.getUint8(10);
+		const fragIndex = view.getUint16(11, true);
+		const fragCount = view.getUint16(13, true);
+		const size = view.getUint32(15, true);
+		const fragData = new Uint8Array(buffer, 19, size);
+
+		// A new timestamp invalidates any incomplete set. The channel is
+		// reliable and ordered so this shouldn't happen — it's a safety net
+		// against desync after a reconnect.
+		if (!fragmentBuffer || fragmentTimestamp !== timestamp) {
+			fragmentBuffer = [];
+			fragmentTimestamp = timestamp;
+			fragmentExpected = fragCount;
+		}
+		fragmentBuffer[fragIndex] = fragData;
+
+		let received = 0;
+		for (const frag of fragmentBuffer) if (frag) received++;
+		if (received !== fragmentExpected) return;
+
+		let total = 0;
+		for (const frag of fragmentBuffer) total += frag.byteLength;
+		const full = new Uint8Array(total);
+		let offset = 0;
+		for (const frag of fragmentBuffer) {
+			full.set(frag, offset);
+			offset += frag.byteLength;
+		}
+		fragmentBuffer = null;
+
+		framesReceived++;
+		void decodeChunk(full, timestamp, isKeyframe, codecId);
+	}
+}
+
+function drainStats() {
+	const stats = {
+		t: 'stats' as const,
+		decodeQueueSize: state.decoder?.decodeQueueSize ?? 0,
+		decodeLatencyMs: decodeLatencySamples > 0 ? decodeLatencyTotal / decodeLatencySamples : 0,
+		framesReceived,
+		framesDecoded
+	};
+
+	framesReceived = 0;
+	framesDecoded = 0;
+	decodeLatencyTotal = 0;
+	decodeLatencySamples = 0;
+
+	post(stats);
+}
+
+self.onmessage = (event: MessageEvent) => {
+	const data = event.data;
+
+	switch (data?.t) {
+		case 'packet':
+			try {
+				handlePacket(data.buffer as ArrayBuffer);
+			} catch {
+				// Malformed packet — drop it, the next keyframe resyncs.
+			}
+			break;
+
+		case 'stats':
+			drainStats();
+			break;
+
+		case 'reset':
+			closeDecoder();
+			fragmentBuffer = null;
+			fragmentTimestamp = 0;
+			break;
+
+		case 'init':
+			state.preferHardware = data.preferHardware !== false;
+			// WebCodecs is not exposed to workers everywhere. Say so up front
+			// rather than accepting packets and silently decoding nothing.
+			post({ t: 'ready', ok: typeof VideoDecoder !== 'undefined' });
+			break;
+
+		case 'close':
+			closeDecoder();
+			self.close();
+			break;
+	}
+};


### PR DESCRIPTION
## Summary

Browser preview was unusable on low-spec machines and on VPS hosts: heavy,
stuttering, and far more expensive than the picture warranted. This reworks
the capture pipeline so the cost tracks what the viewer can actually see and
what both ends can actually do.

## Why

Three structural problems, none of which a fast dev machine ever exposed:

1. **Capture ignored the display size.** Frames were always captured at the
   full emulated viewport, but the preview is almost always shown smaller —
   a 1440x900 laptop preview in a half-width panel on a non-Retina screen was
   encoding ~5x more pixels than the screen could resolve.
2. **Throttling ran at the wrong end.** The screencast fires at compositor
   rate and every frame was rastered, JPEG-encoded, base64'd and parsed
   before the surplus was discarded downstream. The payload was also
   interpolated into a `Runtime.evaluate` expression, so V8 compiled a fresh
   multi-hundred-KB source string per frame.
3. **Adaptation only ever watched the network.** A saturated encoder or a
   viewer that cannot decode fast enough produces identical stutter with an
   empty send buffer, and nothing in the pipeline could see either.

## Changes

- Capture at `fitScale x devicePixelRatio`, clamped to the host's pixel
  budget. On Retina at 50% fit this resolves to native, so high-DPI viewers
  are unchanged by construction; the saving lands on DPR-1 screens.
- Pace the source by withholding the screencast ack, so Chrome never rasters
  a frame that would be discarded. The hold is self-calibrating against the
  measured produce-and-deliver time.
- Pass frame payloads as a `Runtime.callFunctionOn` argument instead of
  interpolating them into evaluated source.
- Add in-page capture via `getDisplayMedia` + `MediaStreamTrackProcessor`,
  removing the JPEG round-trip entirely. Requires a secure context, so the
  screencast path stays a first-class fallback.
- Adapt on three signals — network buffer, encoder queue, and the viewer's
  decode queue — degrading framerate first and resolution only at the floor,
  with sustained-pressure gating in both directions.
- Choose the codec from the viewer's decode support: VP9 quantizer mode
  wherever VP9 decodes, H.264 (Annex-B) for viewers without it.
- Move client decode into a worker with transferred buffers, with an explicit
  fallback for engines that do not expose WebCodecs to workers.
- Replace the ScriptProcessor audio tap with a muted AudioWorklet side-chain.
  This also fixes page audio being summed twice with ~85ms of comb delay.
- Suspend capture for previews nobody is watching, after a delay so brief tab
  switches do not pay for a teardown.
- Tune Chrome launch flags for headless and container hosts.

## Notes

- Escape hatches: `CLOPEN_PREVIEW_QUALITY`, `CLOPEN_PREVIEW_NATIVE_CAPTURE`,
  `CLOPEN_PREVIEW_GPU`.