### PR TITLE
fix(preview): rebuild the browser panel into a real browsing surface

### DIFF
--- a/backend/mcp/internal/servers/browser-automation/browser.ts
+++ b/backend/mcp/internal/servers/browser-automation/browser.ts
@@ -94,10 +94,16 @@ export async function getActiveTabSession(projectId?: string) {
 /**
  * List all open tabs in the browser preview.
  * Shows MCP control status so AI can avoid conflicts.
+ *
+ * NOTE: every tool handler is invoked as `handler(args)` with an object, even
+ * when the tool declares no schema (`args` is then `{}`). A positional
+ * `projectId: string` parameter here would receive that object, sail past the
+ * falsy check in `getService()`, and mint a brand-new empty service keyed by it
+ * — which is why this tool used to report "no tabs" no matter what was open.
  */
-export async function listTabsHandler(projectId?: string) {
+export async function listTabsHandler(args: { projectId?: string } = {}) {
 	try {
-		const previewService = getPreviewService(projectId);
+		const previewService = getPreviewService(args.projectId);
 		const tabs = previewService.getAllTabs();
 		const chatSessionId = projectContextService.getCurrentChatSessionId();
 
@@ -119,7 +125,11 @@ export async function listTabsHandler(projectId?: string) {
 					: ' (MCP: another session)';
 			}
 
-			return `${index + 1}. ${tab.isActive ? '* ' : '  '}[${tab.id}] ${tab.title || 'Untitled'}${status}\n   URL: ${tab.url || '(empty)'}`;
+			return [
+				`${index + 1}. ${tab.isActive ? '* ' : '  '}[${tab.id}] ${tab.title || 'Untitled'}${status}`,
+				`   URL: ${tab.url || '(empty)'}`,
+				`   Viewport: ${tab.deviceSize} (${tab.rotation})${tab.isLoading ? ' — loading' : ''}`
+			].join('\n');
 		}).join('\n\n');
 
 		return {

--- a/backend/preview/browser/browser-console-manager.ts
+++ b/backend/preview/browser/browser-console-manager.ts
@@ -1,88 +1,259 @@
 import { EventEmitter } from 'events';
 import type { Page, ConsoleMessage as PuppeteerConsoleMessage, HTTPResponse } from 'puppeteer';
-import type { BrowserConsoleMessage, BrowserTab } from './types';
+import type { BrowserConsoleMessage, BrowserConsoleValue, BrowserTab } from './types';
 
 import { debug } from '$shared/utils/logger';
+
+/** Ring-buffer bounds for a tab's console history. */
+const MAX_LOGS = 1000;
+const TRIM_TO = 500;
+
+/**
+ * Flatten a page value into something renderable.
+ *
+ * Runs inside the page (serialized by `JSHandle.evaluate`), so it has to be
+ * self-contained. Depth and breadth are capped because a single logged object
+ * graph can otherwise be unbounded, and the panel only ever shows two levels
+ * before the user expands further.
+ */
+function serializeConsoleValue(value: unknown, maxDepth = 2, maxEntries = 100): BrowserConsoleValue {
+	const seen = new WeakSet<object>();
+
+	function shortString(text: string, limit = 200): string {
+		return text.length > limit ? `${text.slice(0, limit)}…` : text;
+	}
+
+	function walk(input: unknown, depth: number): BrowserConsoleValue {
+		if (input === null) return { type: 'null', preview: 'null' };
+
+		const raw = typeof input;
+
+		if (raw === 'undefined') return { type: 'undefined', preview: 'undefined' };
+		if (raw === 'string') return { type: 'string', preview: shortString(input as string, 1000) };
+		if (raw === 'number') return { type: 'number', preview: String(input) };
+		if (raw === 'boolean') return { type: 'boolean', preview: String(input) };
+		if (raw === 'bigint') return { type: 'bigint', preview: `${String(input)}n` };
+		if (raw === 'symbol') return { type: 'symbol', preview: String(input) };
+		if (raw === 'function') {
+			const fn = input as { name?: string };
+			return { type: 'function', preview: `ƒ ${fn.name || '(anonymous)'}()` };
+		}
+
+		const obj = input as object;
+		if (seen.has(obj)) return { type: 'object', preview: '[Circular]' };
+		seen.add(obj);
+
+		if (obj instanceof Error) {
+			return { type: 'error', preview: obj.stack || `${obj.name}: ${obj.message}` };
+		}
+		if (typeof Node !== 'undefined' && obj instanceof Node) {
+			const el = obj as Element;
+			if (el.tagName) {
+				const attrs = el.id ? `#${el.id}` : el.className ? `.${String(el.className).split(/\s+/)[0]}` : '';
+				return { type: 'node', preview: `<${el.tagName.toLowerCase()}${attrs}>` };
+			}
+			return { type: 'node', preview: obj.nodeName };
+		}
+		if (obj instanceof Date) return { type: 'date', preview: obj.toISOString() };
+		if (obj instanceof RegExp) return { type: 'regexp', preview: String(obj) };
+
+		if (obj instanceof Map || obj instanceof Set) {
+			const isMap = obj instanceof Map;
+			const size = obj.size;
+			const result: BrowserConsoleValue = {
+				type: isMap ? 'map' : 'set',
+				preview: `${isMap ? 'Map' : 'Set'}(${size})`
+			};
+			if (depth < maxDepth) {
+				const entries: BrowserConsoleValue['entries'] = [];
+				let index = 0;
+				for (const item of obj as Iterable<unknown>) {
+					if (index >= maxEntries) {
+						result.truncated = true;
+						break;
+					}
+					if (isMap) {
+						const [key, val] = item as [unknown, unknown];
+						entries.push({ key: String(key), value: walk(val, depth + 1) });
+					} else {
+						entries.push({ key: String(index), value: walk(item, depth + 1) });
+					}
+					index += 1;
+				}
+				result.entries = entries;
+			}
+			return result;
+		}
+
+		if (Array.isArray(obj)) {
+			const result: BrowserConsoleValue = { type: 'array', preview: `Array(${obj.length})` };
+			if (depth < maxDepth) {
+				const limit = Math.min(obj.length, maxEntries);
+				result.entries = [];
+				for (let i = 0; i < limit; i += 1) {
+					result.entries.push({ key: String(i), value: walk(obj[i], depth + 1) });
+				}
+				result.truncated = obj.length > limit;
+			}
+			return result;
+		}
+
+		const ctor = (obj as { constructor?: { name?: string } }).constructor?.name;
+		const label = ctor && ctor !== 'Object' ? ctor : 'Object';
+		const result: BrowserConsoleValue = { type: 'object', preview: label };
+
+		if (depth < maxDepth) {
+			let keys: string[] = [];
+			try {
+				keys = Object.keys(obj);
+			} catch {
+				keys = [];
+			}
+			const limit = Math.min(keys.length, maxEntries);
+			result.entries = [];
+			for (let i = 0; i < limit; i += 1) {
+				const key = keys[i];
+				try {
+					result.entries.push({ key, value: walk((obj as Record<string, unknown>)[key], depth + 1) });
+				} catch {
+					result.entries.push({ key, value: { type: 'object', preview: '[unreadable]' } });
+				}
+			}
+			result.truncated = keys.length > limit;
+			if (keys.length > 0 && label === 'Object') {
+				result.preview = `{${keys.slice(0, 3).join(', ')}${keys.length > 3 ? ', …' : ''}}`;
+			}
+		}
+
+		return result;
+	}
+
+	return walk(value, 0);
+}
+
+/**
+ * Collapse Chrome's console levels onto the four the panel filters by.
+ *
+ * Puppeteer reports every variant `console.*` can produce (`dir`, `table`,
+ * `assert`, `count`, `verbose`, group markers…); left unmapped these fall
+ * outside every filter and the message becomes invisible.
+ */
+function normalizeConsoleType(type: string): BrowserConsoleMessage['type'] {
+	switch (type) {
+		case 'error':
+		case 'assert':
+			return 'error';
+		case 'warn':
+			return 'warn';
+		case 'info':
+			return 'info';
+		case 'debug':
+		case 'verbose':
+			return 'debug';
+		case 'trace':
+			return 'trace';
+		case 'clear':
+			return 'clear';
+		default:
+			return 'log';
+	}
+}
+
 export class BrowserConsoleManager extends EventEmitter {
 	constructor() {
 		super();
 	}
 
-	async setupConsoleLogging(sessionId: string, page: Page, session: BrowserTab) {
+	/**
+	 * Append a message to the tab's buffer, collapsing an identical repeat into
+	 * a counter the way DevTools does — a page logging inside a rAF loop would
+	 * otherwise flood the panel and evict everything useful.
+	 */
+	private record(session: BrowserTab, message: BrowserConsoleMessage): void {
+		const previous = session.consoleLogs[session.consoleLogs.length - 1];
 
+		if (
+			previous &&
+			previous.type === message.type &&
+			previous.text === message.text &&
+			previous.location?.url === message.location?.url &&
+			previous.location?.lineNumber === message.location?.lineNumber
+		) {
+			previous.count = (previous.count ?? 1) + 1;
+			previous.timestamp = message.timestamp;
+			this.emit('console-message', { sessionId: session.id, message: previous });
+			return;
+		}
+
+		session.consoleLogs.push(message);
+		if (session.consoleLogs.length > MAX_LOGS) {
+			session.consoleLogs = session.consoleLogs.slice(-TRIM_TO);
+		}
+
+		this.emit('console-message', { sessionId: session.id, message });
+	}
+
+	private static makeId(prefix: string): string {
+		return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+	}
+
+	async setupConsoleLogging(sessionId: string, page: Page, session: BrowserTab) {
 		// Clear any existing console logs for this session
 		session.consoleLogs = [];
 
 		// Listen to ALL console events from the page
 		page.on('console', async (consoleMessage: PuppeteerConsoleMessage) => {
-			// Always log to server console for debugging
 			if (!session.consoleEnabled) {
 				return;
 			}
 
 			try {
-				const messageId = `console-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 				const text = consoleMessage.text();
-				const type = consoleMessage.type() as BrowserConsoleMessage['type'];
+				const type = normalizeConsoleType(consoleMessage.type());
 
 				// Get location information (Puppeteer uses location() method)
 				const location = consoleMessage.location();
-				const messageLocation = location ? {
-					url: location.url || '',
-					lineNumber: location.lineNumber || 0,
-					columnNumber: location.columnNumber || 0
-				} : undefined;
+				const messageLocation = location
+					? {
+							url: location.url || '',
+							lineNumber: location.lineNumber || 0,
+							columnNumber: location.columnNumber || 0
+						}
+					: undefined;
 
-				// Extract arguments with improved error handling
-				let args: any[] = [];
+				// Structured argument previews. Serializing in the page keeps DOM
+				// nodes, class instances and circular graphs renderable — all of
+				// which make `jsonValue()` throw and used to be dropped entirely.
+				let values: BrowserConsoleValue[] = [];
 				try {
-					const messageArgs = consoleMessage.args();
-					if (messageArgs && messageArgs.length > 0) {
-						args = await Promise.all(
-							messageArgs.map(async (arg) => {
-								try {
-									// Try to get JSON value first
-									const jsonValue = await arg.jsonValue();
-									return jsonValue;
-								} catch {
-									try {
-										// Fallback to string representation
-										return arg.toString();
-									} catch {
-										// Final fallback
-										return '[Unable to serialize]';
-									}
-								}
-							})
+					const args = consoleMessage.args();
+					if (args.length > 0) {
+						values = await Promise.all(
+							args.map((arg) =>
+								arg
+									.evaluate(serializeConsoleValue as never)
+									.catch(() => ({ type: 'object', preview: '[unserializable]' }) as BrowserConsoleValue)
+							)
 						);
 					}
 				} catch (error) {
 					debug.warn('preview', 'Could not extract console message args:', error);
-					args = [];
 				}
 
-				const consoleLog: BrowserConsoleMessage = {
-					id: messageId,
+				const stack = consoleMessage.stackTrace();
+
+				this.record(session, {
+					id: BrowserConsoleManager.makeId('console'),
 					type,
 					text,
-					args,
+					values,
 					location: messageLocation,
+					stackTrace:
+						stack.length > 0
+							? stack.map((frame) => `  at ${frame.url}:${frame.lineNumber}:${frame.columnNumber}`).join('\n')
+							: undefined,
 					timestamp: Date.now()
-				};
-
-				// Add to session logs (with limit to prevent memory issues)
-				session.consoleLogs.push(consoleLog);
-				if (session.consoleLogs.length > 1000) {
-					session.consoleLogs = session.consoleLogs.slice(-500); // Keep last 500 logs
-				}
-
-				// Emit console message event for real-time streaming
-				this.emit('console-message', {
-					sessionId: session.id,
-					message: consoleLog
 				});
-
-
 			} catch (error) {
 				debug.error('preview', '❌ Error processing console message:', error);
 			}
@@ -96,73 +267,60 @@ export class BrowserConsoleManager extends EventEmitter {
 
 			try {
 				const error = err as Error;
-				const messageId = `error-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-				const consoleLog: BrowserConsoleMessage = {
-					id: messageId,
+				this.record(session, {
+					id: BrowserConsoleManager.makeId('error'),
 					type: 'error',
 					text: `Uncaught ${error.message || String(err)}`,
 					stackTrace: error.stack,
 					timestamp: Date.now()
-				};
-
-				session.consoleLogs.push(consoleLog);
-				if (session.consoleLogs.length > 1000) {
-					session.consoleLogs = session.consoleLogs.slice(-500);
-				}
-
-				this.emit('console-message', {
-					sessionId: session.id,
-					message: consoleLog
 				});
-
-
-			} catch (err) {
-				debug.error('preview', '❌ Error processing page error:', err);
+			} catch (err2) {
+				debug.error('preview', '❌ Error processing page error:', err2);
 			}
 		});
 
 		// Listen to response failures (network errors)
 		page.on('response', (response: HTTPResponse) => {
 			if (!session.consoleEnabled) return;
+			if (response.ok() || response.status() < 400) return;
 
-			if (!response.ok() && response.status() >= 400) {
-
-				
-				try {
-					const messageId = `network-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-					const consoleLog: BrowserConsoleMessage = {
-						id: messageId,
-						type: 'error',
-						text: `Network error: ${response.status()} ${response.statusText()} - ${response.url()}`,
-						location: {
-							url: response.url(),
-							lineNumber: 0,
-							columnNumber: 0
-						},
-						timestamp: Date.now()
-					};
-
-					session.consoleLogs.push(consoleLog);
-					if (session.consoleLogs.length > 1000) {
-						session.consoleLogs = session.consoleLogs.slice(-500);
-					}
-
-					this.emit('console-message', {
-						sessionId: session.id,
-						message: consoleLog
-					});
-
-
-				} catch (err) {
-					debug.error('preview', '❌ Error processing network error:', err);
-				}
+			try {
+				this.record(session, {
+					id: BrowserConsoleManager.makeId('network'),
+					type: 'error',
+					text: `${response.status()} ${response.statusText()} — ${response.url()}`,
+					status: response.status(),
+					location: {
+						url: response.url(),
+						lineNumber: 0,
+						columnNumber: 0
+					},
+					timestamp: Date.now()
+				});
+			} catch (err) {
+				debug.error('preview', '❌ Error processing network error:', err);
 			}
 		});
 
-		// Console monitoring is handled automatically by Puppeteer's console event listener
-		// No additional injection needed
+		// Requests that never got a response at all (DNS failure, refused
+		// connection, blocked by an extension) never fire `response`, so they
+		// would otherwise be invisible in the panel.
+		page.on('requestfailed', (request) => {
+			if (!session.consoleEnabled) return;
 
-
+			try {
+				const failure = request.failure();
+				this.record(session, {
+					id: BrowserConsoleManager.makeId('network'),
+					type: 'error',
+					text: `${failure?.errorText || 'Request failed'} — ${request.url()}`,
+					location: { url: request.url(), lineNumber: 0, columnNumber: 0 },
+					timestamp: Date.now()
+				});
+			} catch (err) {
+				debug.error('preview', '❌ Error processing request failure:', err);
+			}
+		});
 	}
 
 	getConsoleLogs(session: BrowserTab): BrowserConsoleMessage[] {
@@ -173,23 +331,12 @@ export class BrowserConsoleManager extends EventEmitter {
 		if (!session) return false;
 
 		session.consoleLogs = [];
-		
-		// Add a clear message to console logs
-		const clearMessage: BrowserConsoleMessage = {
-			id: `clear-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-			type: 'clear',
-			text: 'Console was cleared',
-			timestamp: Date.now()
-		};
-
-		session.consoleLogs.push(clearMessage);
 
 		// Emit clear event
 		this.emit('console-clear', {
 			sessionId: session.id,
 			timestamp: Date.now()
 		});
-
 
 		return true;
 	}
@@ -202,59 +349,66 @@ export class BrowserConsoleManager extends EventEmitter {
 		return true;
 	}
 
-	async executeConsoleCommand(session: BrowserTab, command: string): Promise<any> {
+	/**
+	 * Evaluate a REPL entry in the page and record both the input and its result.
+	 *
+	 * Expressions and statements are both accepted: the expression form is tried
+	 * first so `{a: 1}` reads as an object rather than a block, and the statement
+	 * form catches everything the parser rejects (`let x = 1`, `for (…)`).
+	 */
+	async executeConsoleCommand(session: BrowserTab, command: string): Promise<BrowserConsoleValue> {
 		if (!session) throw new Error('Session not found');
 
+		this.record(session, {
+			id: BrowserConsoleManager.makeId('input'),
+			type: 'input',
+			text: command,
+			timestamp: Date.now()
+		});
+
 		try {
+			const outcome = await session.page.evaluate(
+				async (source: string, serializerSource: string) => {
+					const serialize = new Function(`return (${serializerSource})`)() as (
+						value: unknown
+					) => BrowserConsoleValue;
 
-			
-			// Execute the command in the browser context
-			const result = await session.page.evaluate((cmd: string) => {
-				// Create a safe evaluation context
-				try {
-					// Use Function constructor for safer evaluation than eval
-					const func = new Function('return ' + cmd);
-					return func();
-				} catch (error) {
-					return { error: error instanceof Error ? error.message : String(error) };
-				}
-			}, command);
+					let value: unknown;
+					try {
+						value = await (0, eval)(`(${source})`);
+					} catch (expressionError) {
+						if (!(expressionError instanceof SyntaxError)) {
+							return { failed: true, value: serialize(expressionError) };
+						}
+						try {
+							value = await (0, eval)(source);
+						} catch (statementError) {
+							return { failed: true, value: serialize(statementError) };
+						}
+					}
+					return { failed: false, value: serialize(value) };
+				},
+				command,
+				serializeConsoleValue.toString()
+			);
 
-			// Log the command execution as a console message
-			const commandMessage: BrowserConsoleMessage = {
-				id: `command-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-				type: 'log',
-				text: `> ${command}`,
-				args: [result],
+			this.record(session, {
+				id: BrowserConsoleManager.makeId('result'),
+				type: outcome.failed ? 'error' : 'result',
+				text: outcome.value.preview,
+				values: [outcome.value],
 				timestamp: Date.now()
-			};
-
-			session.consoleLogs.push(commandMessage);
-
-			// Emit the command result
-			this.emit('console-message', {
-				sessionId: session.id,
-				message: commandMessage
 			});
 
-			return result;
+			return outcome.value;
 		} catch (error) {
-			debug.error('preview', 'Error executing console command:', error);
-			
-			// Log the error as a console message
-			const errorMessage: BrowserConsoleMessage = {
-				id: `command-error-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+			const message = error instanceof Error ? error.message : String(error);
+
+			this.record(session, {
+				id: BrowserConsoleManager.makeId('result'),
 				type: 'error',
-				text: `Error executing command: ${command}`,
-				args: [error instanceof Error ? error.message : String(error)],
+				text: message,
 				timestamp: Date.now()
-			};
-
-			session.consoleLogs.push(errorMessage);
-
-			this.emit('console-message', {
-				sessionId: session.id,
-				message: errorMessage
 			});
 
 			throw error;

--- a/backend/preview/browser/browser-dialog-handler.ts
+++ b/backend/preview/browser/browser-dialog-handler.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import type { Page, Dialog } from 'puppeteer';
-import type { BrowserTab, BrowserDialogEvent, BrowserDialogResponse, BrowserPrintEvent } from './types';
+import type { BrowserDialogResponse } from './types';
 import { debug } from '$shared/utils/logger';
 import { nanoid } from 'nanoid';
 
@@ -12,9 +12,20 @@ import { nanoid } from 'nanoid';
  *
  * Also intercepts window.print() calls and emits print events.
  */
+/**
+ * How long a dialog waits for the viewer before it is dismissed on its own.
+ *
+ * A JS dialog blocks the renderer, so an unanswered one freezes the page —
+ * including the video stream. That is the correct behaviour while someone is
+ * looking at the prompt, and a hang once nobody is (panel closed, browser tab
+ * gone), which is what this bound exists for.
+ */
+const DIALOG_RESPONSE_TIMEOUT_MS = 120_000;
+
 export class BrowserDialogHandler extends EventEmitter {
-	// Store pending dialogs waiting for response
-	private pendingDialogs = new Map<string, Dialog>();
+	// Store pending dialogs waiting for response, tagged with the tab that raised
+	// them so closing one tab cannot dismiss another tab's prompt.
+	private pendingDialogs = new Map<string, { sessionId: string; dialog: Dialog; timeout: NodeJS.Timeout }>();
 
 	constructor() {
 		super();
@@ -39,7 +50,7 @@ export class BrowserDialogHandler extends EventEmitter {
 	/**
 	 * Setup dialog event listeners - can be called AFTER navigation
 	 */
-	async setupDialogHandling(sessionId: string, page: Page, session: BrowserTab) {
+	async setupDialogHandling(sessionId: string, page: Page) {
 		debug.log('preview', `🎭 Setting up dialog event listeners for session: ${sessionId}`);
 
 		// Intercept Puppeteer dialog events
@@ -61,8 +72,18 @@ export class BrowserDialogHandler extends EventEmitter {
 
 		debug.log('preview', `🎭 Dialog detected - Type: ${dialogType}, Session: ${sessionId}`);
 
-		// Store pending dialog for later response
-		this.pendingDialogs.set(dialogId, dialog);
+		// Store pending dialog for later response, with a deadline so an
+		// unattended page cannot stay blocked indefinitely.
+		const timeout = setTimeout(() => {
+			this.pendingDialogs.delete(dialogId);
+			debug.warn('preview', `⏱️ Dialog ${dialogId} unanswered, auto-dismissing`);
+			// beforeunload is the one dialog where dismissing is the safe default
+			// in both directions: it cancels the navigation rather than losing work.
+			dialog.dismiss().catch(() => {});
+			this.emit('dialog-closed', { sessionId, dialogId, timestamp: Date.now() });
+		}, DIALOG_RESPONSE_TIMEOUT_MS);
+
+		this.pendingDialogs.set(dialogId, { sessionId, dialog, timeout });
 
 		// Emit dialog event to frontend (sessionId will be converted to tabId by previewService)
 		const dialogEvent: any = {
@@ -87,12 +108,15 @@ export class BrowserDialogHandler extends EventEmitter {
 
 		debug.log('preview', `🔍 Responding to dialog - dialogId: ${dialogId}, accept: ${accept}, pending dialogs: ${this.pendingDialogs.size}`);
 
-		const dialog = this.pendingDialogs.get(dialogId);
-		if (!dialog) {
+		const entry = this.pendingDialogs.get(dialogId);
+		if (!entry) {
 			debug.warn('preview', `⚠️ Dialog not found in pendingDialogs: ${dialogId}`);
 			debug.warn('preview', `   Available dialog IDs: ${Array.from(this.pendingDialogs.keys()).join(', ') || '(none)'}`);
 			return false;
 		}
+
+		const { dialog } = entry;
+		clearTimeout(entry.timeout);
 
 		debug.log('preview', `✅ Dialog found in pendingDialogs - Type: ${dialog.type()}, Message: "${dialog.message()}"`);
 
@@ -118,10 +142,15 @@ export class BrowserDialogHandler extends EventEmitter {
 			// Remove from pending dialogs
 			this.pendingDialogs.delete(dialogId);
 			debug.log('preview', `🗑️ Removed dialog from pendingDialogs - remaining: ${this.pendingDialogs.size}`);
+			// The page has one dialog and it is now answered, but every viewer of
+			// this tab was shown a copy of it. Telling them all it is settled is
+			// what stops the other devices holding a prompt that no longer exists.
+			this.emit('dialog-closed', { sessionId: entry.sessionId, dialogId, timestamp: Date.now() });
 			return true;
 		} catch (error) {
 			debug.error('preview', `💥 Error responding to dialog ${dialogId}:`, error);
 			this.pendingDialogs.delete(dialogId);
+			this.emit('dialog-closed', { sessionId: entry.sessionId, dialogId, timestamp: Date.now() });
 			return false;
 		}
 	}
@@ -181,15 +210,14 @@ export class BrowserDialogHandler extends EventEmitter {
 	 * Clear pending dialogs for a session
 	 */
 	clearSessionDialogs(sessionId: string) {
-		// Find and dismiss all dialogs for this session
 		const dialogsToRemove: string[] = [];
 
-		for (const [dialogId, dialog] of this.pendingDialogs.entries()) {
-			// Check if dialog belongs to this session (we store sessionId in the dialogId via Map)
-			// Since we don't have direct sessionId mapping, we'll clear all pending dialogs
-			// This is safe as each session has its own page instance
+		for (const [dialogId, entry] of this.pendingDialogs.entries()) {
+			if (entry.sessionId !== sessionId) continue;
+
+			clearTimeout(entry.timeout);
 			try {
-				dialog.dismiss().catch(() => {});
+				entry.dialog.dismiss().catch(() => {});
 			} catch (error) {
 				// Dialog might already be closed
 			}
@@ -208,9 +236,10 @@ export class BrowserDialogHandler extends EventEmitter {
 	clearAllDialogs() {
 		const count = this.pendingDialogs.size;
 
-		for (const [dialogId, dialog] of this.pendingDialogs.entries()) {
+		for (const entry of this.pendingDialogs.values()) {
+			clearTimeout(entry.timeout);
 			try {
-				dialog.dismiss().catch(() => {});
+				entry.dialog.dismiss().catch(() => {});
 			} catch (error) {
 				// Dialog might already be closed
 			}

--- a/backend/preview/browser/browser-host-bridge.ts
+++ b/backend/preview/browser/browser-host-bridge.ts
@@ -1,0 +1,464 @@
+/**
+ * Browser Host Bridge
+ *
+ * Owns everything the headless browser cannot answer for itself and the
+ * *viewer's* browser can: geolocation, camera/microphone, clipboard,
+ * notifications, file pickers and downloads.
+ *
+ * Two directions meet here:
+ * - **Page → viewer.** An injected shim (see `scripts/host-bridge.ts`) turns a
+ *   `navigator.*` call into a request; this class parks it, emits it, and
+ *   resolves the page's promise once the frontend answers.
+ * - **Chrome → viewer.** File choosers and downloads are intercepted over CDP,
+ *   which needs no injection because Chrome surfaces them as protocol events.
+ *
+ * Requests are keyed by an id rather than by tab so a slow decision on one tab
+ * never blocks another, and every one carries a deadline — a page that asks for
+ * a camera while nobody is watching the panel must eventually fail rather than
+ * hang the renderer forever.
+ */
+
+import { EventEmitter } from 'events';
+import { randomUUID } from 'crypto';
+import { mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import type { CDPSession, Page } from 'puppeteer';
+import { debug } from '$shared/utils/logger';
+import { getClopenDir } from '$backend/utils/paths';
+
+/** Capability requests the injected shim can raise. */
+export type HostRequestKind =
+	| 'geolocation'
+	| 'media-request'
+	| 'media-stop'
+	| 'media-devices'
+	| 'clipboard-read'
+	| 'clipboard-write'
+	| 'notification-permission'
+	| 'notification-show'
+	| 'speech-start'
+	| 'speech-stop'
+	| 'file-pick';
+
+export interface HostRequestEvent {
+	tabId: string;
+	requestId: string;
+	kind: HostRequestKind;
+	payload: unknown;
+	timestamp: number;
+}
+
+export interface HostDownloadEvent {
+	tabId: string;
+	downloadId: string;
+	filename: string;
+	url: string;
+	/** base64 payload, present only once the download completed. */
+	data?: string;
+	state: 'started' | 'completed' | 'failed';
+	totalBytes?: number;
+	error?: string;
+	timestamp: number;
+}
+
+export interface HostResponse {
+	ok: boolean;
+	result?: unknown;
+	error?: { name?: string; message?: string; code?: number };
+}
+
+/** A file handed back by the viewer for an intercepted file chooser. */
+export interface HostPickedFile {
+	name: string;
+	/** base64, without the data-URL prefix. */
+	data: string;
+}
+
+interface PendingRequest {
+	tabId: string;
+	kind: HostRequestKind;
+	resolve: (response: HostResponse) => void;
+	timeout: NodeJS.Timeout;
+}
+
+interface TabBridge {
+	bindingName: string;
+	cdp?: CDPSession;
+	transferDir: string;
+}
+
+/**
+ * How long the page waits before a capability request gives up.
+ *
+ * Media gets longer than the rest: the viewer has to answer their own browser's
+ * camera prompt, and a hurried timeout there reads as a broken feature.
+ */
+const REQUEST_TIMEOUT_MS: Record<HostRequestKind, number> = {
+	'geolocation': 60_000,
+	'media-request': 120_000,
+	'media-stop': 5_000,
+	'media-devices': 15_000,
+	'clipboard-read': 30_000,
+	'clipboard-write': 15_000,
+	'notification-permission': 60_000,
+	'notification-show': 15_000,
+	// Only the handshake is timed; results stream back as events afterwards.
+	'speech-start': 120_000,
+	'speech-stop': 5_000,
+	'file-pick': 300_000
+};
+
+/**
+ * Ceiling for a completed download relayed to the viewer over the WebSocket.
+ * Above this the base64 round-trip costs more than the download is worth, so
+ * the viewer is told to fetch it directly instead.
+ */
+const MAX_RELAYED_DOWNLOAD_BYTES = 32 * 1024 * 1024;
+
+export class BrowserHostBridge extends EventEmitter {
+	private tabs = new Map<string, TabBridge>();
+	private pending = new Map<string, PendingRequest>();
+
+	/** Downloads seen per tab, so progress events can find their metadata. */
+	private downloads = new Map<string, { tabId: string; filename: string; url: string }>();
+
+	/**
+	 * Install the bridge for a tab. Must run before the first navigation so the
+	 * shim is in place by the time page scripts execute.
+	 */
+	async setup(tabId: string, page: Page): Promise<void> {
+		if (this.tabs.has(tabId)) return;
+
+		// Randomised per tab: a fixed global name is a one-line detection rule
+		// for the same bot-detection scripts these APIs tend to sit behind.
+		const bindingName = `__h${randomUUID().replace(/-/g, '').slice(0, 16)}`;
+		const transferDir = join(getClopenDir(), 'preview', 'transfer', tabId.replace(/[^\w.-]/g, '_'));
+
+		this.tabs.set(tabId, { bindingName, transferDir });
+
+		try {
+			await page.exposeFunction(bindingName, (raw: string) => this.handlePageRequest(tabId, raw));
+
+			const { hostBridgeScript } = await import('./scripts/host-bridge');
+			await page.evaluateOnNewDocument(hostBridgeScript, bindingName);
+
+			debug.log('preview', `🌉 Host bridge installed for tab ${tabId}`);
+		} catch (error) {
+			debug.warn('preview', `⚠️ Host bridge injection failed for tab ${tabId}:`, error);
+		}
+
+		await this.setupCdpInterception(tabId, page, transferDir);
+	}
+
+	/**
+	 * File choosers and downloads come straight off the protocol, so they work
+	 * even when script injection was rejected above.
+	 */
+	private async setupCdpInterception(tabId: string, page: Page, transferDir: string): Promise<void> {
+		try {
+			const cdp = await page.createCDPSession();
+			const entry = this.tabs.get(tabId);
+			if (entry) entry.cdp = cdp;
+
+			// `Page.enable` is not optional here: without it the Page domain emits
+			// nothing, so `Page.fileChooserOpened` never arrived and file inputs
+			// appeared to be ignored entirely.
+			await cdp.send('Page.enable');
+			await cdp.send('DOM.enable').catch(() => {});
+			await cdp.send('Page.setInterceptFileChooserDialog', { enabled: true });
+
+			// Covers the main frame and every same-process iframe. A chooser raised
+			// inside a cross-origin (out-of-process) iframe is dispatched on that
+			// frame's own target, which Puppeteer does not surface as a Target —
+			// those stay un-intercepted.
+			cdp.on('Page.fileChooserOpened', (params: { mode: string; backendNodeId?: number }) => {
+				void this.handleFileChooser(tabId, cdp, params);
+			});
+
+			await mkdir(transferDir, { recursive: true });
+			await cdp.send('Browser.setDownloadBehavior', {
+				behavior: 'allowAndName',
+				downloadPath: transferDir,
+				eventsEnabled: true
+			});
+
+			cdp.on('Browser.downloadWillBegin', (params: { guid: string; url: string; suggestedFilename: string }) => {
+				this.downloads.set(params.guid, {
+					tabId,
+					filename: params.suggestedFilename || 'download',
+					url: params.url
+				});
+				this.emit('download', {
+					tabId,
+					downloadId: params.guid,
+					filename: params.suggestedFilename || 'download',
+					url: params.url,
+					state: 'started',
+					timestamp: Date.now()
+				} satisfies HostDownloadEvent);
+			});
+
+			cdp.on(
+				'Browser.downloadProgress',
+				(params: { guid: string; state: string; totalBytes?: number; receivedBytes?: number }) => {
+					if (params.state === 'inProgress') return;
+					void this.finalizeDownload(params.guid, params.state, transferDir, params.totalBytes);
+				}
+			);
+		} catch (error) {
+			debug.warn('preview', `⚠️ Host bridge CDP interception failed for tab ${tabId}:`, error);
+		}
+	}
+
+	/**
+	 * Park a request from the page and hand it to whoever is watching the panel.
+	 * The returned promise is what the page's `await` is blocked on, so it always
+	 * settles — a rejection here would surface as an unhandled error in the page.
+	 */
+	private handlePageRequest(tabId: string, raw: string): Promise<string> {
+		let parsed: { kind: HostRequestKind; payload?: unknown };
+		try {
+			parsed = JSON.parse(raw);
+		} catch {
+			return Promise.resolve(
+				JSON.stringify({ ok: false, error: { name: 'DataError', message: 'Malformed bridge request' } })
+			);
+		}
+
+		return this.request(tabId, parsed.kind, parsed.payload).then((response) => JSON.stringify(response));
+	}
+
+	/**
+	 * Emit a request and wait for the frontend's answer.
+	 */
+	request(tabId: string, kind: HostRequestKind, payload: unknown): Promise<HostResponse> {
+		const requestId = randomUUID();
+
+		return new Promise<HostResponse>((resolve) => {
+			const timeout = setTimeout(() => {
+				this.pending.delete(requestId);
+				this.emit('request-settled', { tabId, requestId });
+				resolve({
+					ok: false,
+					error: { name: 'NotAllowedError', message: 'No response from the preview host', code: 1 }
+				});
+			}, REQUEST_TIMEOUT_MS[kind] ?? 60_000);
+
+			this.pending.set(requestId, { tabId, kind, resolve, timeout });
+
+			this.emit('request', {
+				tabId,
+				requestId,
+				kind,
+				payload,
+				timestamp: Date.now()
+			} satisfies HostRequestEvent);
+		});
+	}
+
+	/**
+	 * Push an event down to the page.
+	 *
+	 * The request/response channel cannot carry a stream, and speech recognition
+	 * is one — results keep arriving until the page stops listening. The top
+	 * frame receives this and rebroadcasts to its children.
+	 */
+	async dispatchEvent(page: Page, tabId: string, kind: string, payload: unknown): Promise<void> {
+		const entry = this.tabs.get(tabId);
+		if (!entry) return;
+
+		try {
+			await page.evaluate(
+				(hook: string, raw: string) => {
+					const deliver = (window as unknown as Record<string, ((value: string) => void) | undefined>)[hook];
+					if (typeof deliver === 'function') deliver(raw);
+				},
+				`${entry.bindingName}E`,
+				JSON.stringify({ kind, payload })
+			);
+		} catch {
+			// Page navigated away mid-stream; the session ends with it.
+		}
+	}
+
+	/**
+	 * Deliver the viewer's answer. Unknown ids are ignored — they belong to
+	 * requests that already timed out or to a tab that has since closed.
+	 */
+	respond(requestId: string, response: HostResponse): boolean {
+		const pending = this.pending.get(requestId);
+		if (!pending) return false;
+
+		clearTimeout(pending.timeout);
+		this.pending.delete(requestId);
+		// The page asked once, but the prompt was raised on every device watching
+		// this tab. Whoever answered first answered for all of them, so the rest
+		// are told to take their copy down.
+		this.emit('request-settled', { tabId: pending.tabId, requestId });
+		pending.resolve(response);
+		return true;
+	}
+
+	// ── File chooser ────────────────────────────────────────────────────────
+
+	/**
+	 * Chrome cannot open a file picker in headless mode, so the viewer's browser
+	 * opens a real one and the bytes are written to a scratch dir the renderer
+	 * can read. Cancelling still has to answer the protocol, otherwise the input
+	 * stays wedged open for the life of the page.
+	 */
+	private async handleFileChooser(
+		tabId: string,
+		cdp: CDPSession,
+		params: { mode: string; backendNodeId?: number }
+	): Promise<void> {
+		const backendNodeId = params.backendNodeId;
+		if (!backendNodeId) return;
+
+		const entry = this.tabs.get(tabId);
+		const transferDir = entry?.transferDir;
+		let paths: string[] = [];
+
+		try {
+			const response = await this.request(tabId, 'file-pick', {
+				multiple: params.mode === 'selectMultiple'
+			});
+
+			if (response.ok && transferDir) {
+				const files = (response.result as { files?: HostPickedFile[] })?.files ?? [];
+				paths = await this.writePickedFiles(transferDir, files);
+			}
+		} catch (error) {
+			debug.warn('preview', `⚠️ File chooser relay failed for tab ${tabId}:`, error);
+		}
+
+		try {
+			await cdp.send('DOM.setFileInputFiles', { files: paths, backendNodeId });
+		} catch (error) {
+			debug.warn('preview', `⚠️ Failed to hand files to the page for tab ${tabId}:`, error);
+		}
+	}
+
+	private async writePickedFiles(transferDir: string, files: HostPickedFile[]): Promise<string[]> {
+		if (files.length === 0) return [];
+
+		const uploadDir = join(transferDir, 'upload', randomUUID());
+		await mkdir(uploadDir, { recursive: true });
+
+		const paths: string[] = [];
+		for (const file of files) {
+			// Names come from the viewer's filesystem — keep the basename only so
+			// a crafted "../" cannot escape the scratch directory.
+			const safeName = (file.name || 'file').split(/[\\/]/).pop() || 'file';
+			const target = join(uploadDir, safeName);
+			await writeFile(target, Buffer.from(file.data, 'base64'));
+			paths.push(target);
+		}
+		return paths;
+	}
+
+	// ── Downloads ───────────────────────────────────────────────────────────
+
+	/**
+	 * Relay a finished download to the viewer, then drop the server-side copy —
+	 * the file belongs on the machine the person is sitting at, not on the host.
+	 */
+	private async finalizeDownload(
+		guid: string,
+		state: string,
+		transferDir: string,
+		totalBytes?: number
+	): Promise<void> {
+		const meta = this.downloads.get(guid);
+		this.downloads.delete(guid);
+		if (!meta) return;
+
+		const filePath = join(transferDir, guid);
+
+		if (state !== 'completed') {
+			await rm(filePath, { force: true }).catch(() => {});
+			this.emit('download', {
+				tabId: meta.tabId,
+				downloadId: guid,
+				filename: meta.filename,
+				url: meta.url,
+				state: 'failed',
+				error: 'Download was cancelled',
+				timestamp: Date.now()
+			} satisfies HostDownloadEvent);
+			return;
+		}
+
+		try {
+			const bytes = await readFile(filePath);
+
+			if (bytes.byteLength > MAX_RELAYED_DOWNLOAD_BYTES) {
+				this.emit('download', {
+					tabId: meta.tabId,
+					downloadId: guid,
+					filename: meta.filename,
+					url: meta.url,
+					state: 'failed',
+					totalBytes: bytes.byteLength,
+					error: `File is too large to transfer (${Math.round(bytes.byteLength / 1024 / 1024)}MB). Open the link in your own browser instead.`,
+					timestamp: Date.now()
+				} satisfies HostDownloadEvent);
+				return;
+			}
+
+			this.emit('download', {
+				tabId: meta.tabId,
+				downloadId: guid,
+				filename: meta.filename,
+				url: meta.url,
+				state: 'completed',
+				totalBytes: totalBytes ?? bytes.byteLength,
+				data: bytes.toString('base64'),
+				timestamp: Date.now()
+			} satisfies HostDownloadEvent);
+		} catch (error) {
+			this.emit('download', {
+				tabId: meta.tabId,
+				downloadId: guid,
+				filename: meta.filename,
+				url: meta.url,
+				state: 'failed',
+				error: error instanceof Error ? error.message : 'Failed to read the downloaded file',
+				timestamp: Date.now()
+			} satisfies HostDownloadEvent);
+		} finally {
+			await rm(filePath, { force: true }).catch(() => {});
+		}
+	}
+
+	// ── Lifecycle ───────────────────────────────────────────────────────────
+
+	/**
+	 * Release a tab: settle anything it left pending so the renderer's promises
+	 * do not dangle, then drop the scratch directory.
+	 */
+	async teardown(tabId: string): Promise<void> {
+		for (const [requestId, pending] of this.pending) {
+			if (pending.tabId !== tabId) continue;
+			clearTimeout(pending.timeout);
+			this.pending.delete(requestId);
+			this.emit('request-settled', { tabId, requestId });
+			pending.resolve({ ok: false, error: { name: 'AbortError', message: 'Tab closed' } });
+		}
+
+		const entry = this.tabs.get(tabId);
+		this.tabs.delete(tabId);
+		if (!entry) return;
+
+		if (entry.cdp) {
+			await entry.cdp.detach().catch(() => {});
+		}
+		await rm(entry.transferDir, { recursive: true, force: true }).catch(() => {});
+	}
+
+	async cleanup(): Promise<void> {
+		const tabIds = Array.from(this.tabs.keys());
+		await Promise.all(tabIds.map((tabId) => this.teardown(tabId)));
+		this.downloads.clear();
+	}
+}

--- a/backend/preview/browser/browser-native-ui-handler.ts
+++ b/backend/preview/browser/browser-native-ui-handler.ts
@@ -1,15 +1,40 @@
 import { EventEmitter } from 'events';
-import type { Page } from 'puppeteer';
+import type { Frame, Page } from 'puppeteer';
 import type {
 	BrowserTab,
 	BrowserSelectInfo,
 	BrowserSelectResponse,
 	BrowserContextMenuInfo,
 	BrowserContextMenuResponse,
-	BrowserContextMenuItem
+	BrowserContextMenuItem,
+	BrowserNativePickerInfo
 } from './types';
+import { resolveFrameTarget } from './frame-targeting';
 import { debug } from '$shared/utils/logger';
 import { nanoid } from 'nanoid';
+
+/**
+ * Read the current text selection from wherever it actually lives.
+ *
+ * A selection inside an iframe is invisible to the top document, so asking only
+ * the main frame returns an empty string for exactly the pages most likely to
+ * be embedding content. `cut` additionally deletes it in the frame that owns it.
+ */
+async function readSelection(page: Page, deleteAfter = false): Promise<string> {
+	for (const frame of page.frames()) {
+		try {
+			const text = await frame.evaluate((remove: boolean) => {
+				const selected = window.getSelection()?.toString() ?? '';
+				if (selected && remove) document.execCommand('delete');
+				return selected;
+			}, deleteAfter);
+			if (text) return text;
+		} catch {
+			// Detached or cross-origin mid-navigation; keep looking.
+		}
+	}
+	return '';
+}
 
 /**
  * Browser Native UI Handler
@@ -34,7 +59,12 @@ export class BrowserNativeUIHandler extends EventEmitter {
 			// Generate unique select ID
 			const selectId = nanoid(10);
 
-			const selectData = await page.evaluate((params) => {
+			// Resolve which frame owns the point first. Evaluating against the main
+			// frame would find the `<iframe>` element rather than the select inside
+			// it, which is why selects in embedded pages never opened.
+			const target = await resolveFrameTarget(page, x, y);
+
+			const selectData = await target.frame.evaluate((params) => {
 				const { x, y, selectId } = params;
 				const element = document.elementFromPoint(x, y);
 
@@ -50,17 +80,51 @@ export class BrowserNativeUIHandler extends EventEmitter {
 
 				if (!selectElement) return null;
 
+				// A `size > 1` or `multiple` select renders as an inline list box that
+				// the page already paints — it has no popup to stand in for, and
+				// intercepting its clicks would break selection outright.
+				if (selectElement.multiple || selectElement.size > 1) return null;
+				if (selectElement.disabled) return null;
+
 				// IMPORTANT: Mark this select element with unique ID for later reference
 				selectElement.setAttribute('data-puppeteer-select-id', selectId);
 
-				// Extract select options
-				const options = Array.from(selectElement.options).map((opt, index) => ({
-					index,
-					value: opt.value || '',
-					text: opt.textContent || '',
-					selected: opt.selected,
-					disabled: opt.disabled
-				}));
+				// Walk the children rather than `.options`, so `<optgroup>` labels and
+				// grouping survive instead of being flattened into a single list.
+				const options: Array<{
+					index: number;
+					value: string;
+					text: string;
+					selected: boolean;
+					disabled?: boolean;
+					group?: string;
+					groupDisabled?: boolean;
+				}> = [];
+
+				const pushOption = (option: HTMLOptionElement, group?: HTMLOptGroupElement) => {
+					options.push({
+						index: option.index,
+						value: option.value || '',
+						text: option.label || option.textContent || '',
+						selected: option.selected,
+						// An option inside a disabled group is unusable even when the
+						// option itself carries no disabled attribute.
+						disabled: option.disabled || !!group?.disabled,
+						group: group?.label || undefined,
+						groupDisabled: group?.disabled || undefined
+					});
+				};
+
+				for (const child of Array.from(selectElement.children)) {
+					if (child.tagName === 'OPTGROUP') {
+						const group = child as HTMLOptGroupElement;
+						for (const option of Array.from(group.children)) {
+							if (option.tagName === 'OPTION') pushOption(option as HTMLOptionElement, group);
+						}
+					} else if (child.tagName === 'OPTION') {
+						pushOption(child as HTMLOptionElement);
+					}
+				}
 
 				// Get bounding box
 				const rect = selectElement.getBoundingClientRect();
@@ -76,15 +140,26 @@ export class BrowserNativeUIHandler extends EventEmitter {
 					selectedIndex: selectElement.selectedIndex,
 					boundingBox
 				};
-			}, { x, y, selectId });
+			}, { x: target.x, y: target.y, selectId });
 
 			if (!selectData) return null;
+
+			// The box came back in the owning frame's coordinates; shift it back
+			// into page space so the overlay lands over the real element.
+			const offsetX = x - target.x;
+			const offsetY = y - target.y;
+
 			const selectInfo: any = {
 				sessionId, // Internal use only, converted to tabId at previewService layer
 				selectId,
 				x,
 				y,
-				boundingBox: selectData.boundingBox,
+				boundingBox: {
+					x: selectData.boundingBox.x + offsetX,
+					y: selectData.boundingBox.y + offsetY,
+					width: selectData.boundingBox.width,
+					height: selectData.boundingBox.height
+				},
 				options: selectData.options,
 				selectedIndex: selectData.selectedIndex,
 				timestamp: Date.now()
@@ -99,23 +174,139 @@ export class BrowserNativeUIHandler extends EventEmitter {
 	}
 
 	/**
+	 * Detect a native input whose picker Chrome renders outside the page — a
+	 * colour swatch or a date field. Those popups are drawn by the browser
+	 * process and never reach the screencast, so the viewer has to supply one.
+	 */
+	async checkForNativePicker(
+		sessionId: string,
+		page: Page,
+		x: number,
+		y: number
+	): Promise<BrowserNativePickerInfo | null> {
+		try {
+			const pickerId = nanoid(10);
+			const target = await resolveFrameTarget(page, x, y);
+
+			const data = await target.frame.evaluate((params) => {
+				const { x, y, pickerId } = params;
+				const element = document.elementFromPoint(x, y);
+				if (!element || element.tagName !== 'INPUT') return null;
+
+				const input = element as HTMLInputElement;
+				const type = (input.type || '').toLowerCase();
+				const PICKER_TYPES = ['color', 'date', 'datetime-local', 'month', 'time', 'week'];
+				if (!PICKER_TYPES.includes(type)) return null;
+				if (input.disabled || input.readOnly) return null;
+
+				input.setAttribute('data-clopen-picker-id', pickerId);
+
+				const rect = input.getBoundingClientRect();
+				return {
+					inputType: type,
+					value: input.value,
+					min: input.min || undefined,
+					max: input.max || undefined,
+					step: input.step || undefined,
+					boundingBox: { x: rect.left, y: rect.top, width: rect.width, height: rect.height }
+				};
+			}, { x: target.x, y: target.y, pickerId });
+
+			if (!data) return null;
+
+			const offsetX = x - target.x;
+			const offsetY = y - target.y;
+
+			return {
+				sessionId,
+				pickerId,
+				inputType: data.inputType as BrowserNativePickerInfo['inputType'],
+				value: data.value,
+				min: data.min,
+				max: data.max,
+				step: data.step,
+				boundingBox: {
+					x: data.boundingBox.x + offsetX,
+					y: data.boundingBox.y + offsetY,
+					width: data.boundingBox.width,
+					height: data.boundingBox.height
+				},
+				timestamp: Date.now()
+				// sessionId is converted to tabId at the previewService layer, the
+				// same handoff the select and context-menu payloads use.
+			} as unknown as BrowserNativePickerInfo;
+		} catch (error) {
+			debug.error('preview', 'Error checking for native picker:', error);
+			return null;
+		}
+	}
+
+	/**
+	 * Write a value chosen in the viewer's own picker back into the page.
+	 */
+	async handleNativePickerResponse(page: Page, pickerId: string, value: string): Promise<boolean> {
+		for (const frame of page.frames()) {
+			try {
+				const applied = await frame.evaluate(
+					(params) => {
+						const input = document.querySelector(
+							`input[data-clopen-picker-id="${params.pickerId}"]`
+						) as HTMLInputElement | null;
+						if (!input) return false;
+
+						input.value = params.value;
+						input.dispatchEvent(new Event('input', { bubbles: true }));
+						input.dispatchEvent(new Event('change', { bubbles: true }));
+						input.removeAttribute('data-clopen-picker-id');
+						return true;
+					},
+					{ pickerId, value }
+				);
+				if (applied) return true;
+			} catch {
+				// Frame went away or is cross-origin mid-navigation; keep looking.
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Handle select option selection from frontend
 	 */
 	async handleSelectResponse(page: Page, response: BrowserSelectResponse): Promise<boolean> {
 		const { selectId, selectedIndex } = response;
 
+		// The marked select may live in any frame, and only the frame that owns it
+		// can see the marker — so every frame is asked until one claims it.
+		for (const frame of page.frames()) {
+			try {
+				const applied = await this.applySelectResponse(frame, selectId, selectedIndex);
+				if (applied) return true;
+			} catch {
+				// Detached or cross-origin mid-navigation; try the next frame.
+			}
+		}
+
+		debug.warn('preview', `⚠️ Select element ${selectId} not found in any frame`);
+		return false;
+	}
+
+	private async applySelectResponse(
+		frame: Frame,
+		selectId: string,
+		selectedIndex: number
+	): Promise<boolean> {
 		try {
 			// Update the select value in the page
-			const result = await page.evaluate((params) => {
+			const result = await frame.evaluate((params) => {
 				const { selectId, index } = params;
 
 				// Find the select element by the unique ID we set earlier
 				const selectElement = document.querySelector(`select[data-puppeteer-select-id="${selectId}"]`) as HTMLSelectElement;
 
-				if (!selectElement) {
-					console.error(`Select element with ID ${selectId} not found`);
-					return false;
-				}
+				// Absent here just means the select lives in a different frame —
+				// the caller keeps asking, so this must stay quiet.
+				if (!selectElement) return false;
 
 				if (index < 0 || index >= selectElement.options.length) {
 					console.error(`Invalid option index: ${index}`);
@@ -141,8 +332,6 @@ export class BrowserNativeUIHandler extends EventEmitter {
 
 			if (result) {
 				debug.log('preview', `✅ Select option updated to index: ${selectedIndex}`);
-			} else {
-				debug.warn('preview', `⚠️ Failed to update select option to index: ${selectedIndex}`);
 			}
 
 			return result;
@@ -155,9 +344,20 @@ export class BrowserNativeUIHandler extends EventEmitter {
 	/**
 	 * Check element at coordinates and build context menu
 	 */
-	async checkForContextMenu(sessionId: string, page: Page, x: number, y: number): Promise<BrowserContextMenuInfo | null> {
+	async checkForContextMenu(
+		sessionId: string,
+		page: Page,
+		x: number,
+		y: number,
+		navigation?: { canGoBack: boolean; canGoForward: boolean }
+	): Promise<BrowserContextMenuInfo | null> {
 		try {
-			const contextData = await page.evaluate((coordinates) => {
+			// Same reason as the select path: inside an iframe the main frame only
+			// ever reports the `<iframe>` element, so the menu came back describing
+			// the frame rather than whatever was actually right-clicked.
+			const target = await resolveFrameTarget(page, x, y);
+
+			const contextData = await target.frame.evaluate((coordinates) => {
 				const { x, y } = coordinates;
 				const element = document.elementFromPoint(x, y);
 
@@ -165,28 +365,23 @@ export class BrowserNativeUIHandler extends EventEmitter {
 
 				// Get element information
 				const tagName = element.tagName;
-				const isLink = element.tagName === 'A' || element.closest('a') !== null;
+				const anchor = (element.tagName === 'A' ? element : element.closest('a')) as HTMLAnchorElement | null;
+				const isLink = !!anchor;
 				const isImage = element.tagName === 'IMG';
 				const isInput = element.tagName === 'INPUT' || element.tagName === 'TEXTAREA';
+				// contenteditable regions accept the same edit commands as a real
+				// input, and every rich-text editor on the web is built on them.
+				const isEditable = isInput || (element as HTMLElement).isContentEditable;
+
+				const mediaElement = (
+					element.tagName === 'VIDEO' || element.tagName === 'AUDIO' ? element : null
+				) as HTMLMediaElement | null;
 
 				// Check for text selection
 				const selection = window.getSelection();
-				const isTextSelected = selection ? selection.toString().length > 0 : false;
+				const selectedText = selection ? selection.toString() : '';
+				const isTextSelected = selectedText.length > 0;
 
-				// Get link URL if it's a link
-				let linkUrl: string | undefined;
-				if (isLink) {
-					const linkElement = element.tagName === 'A' ? element as HTMLAnchorElement : element.closest('a') as HTMLAnchorElement;
-					linkUrl = linkElement?.href;
-				}
-
-				// Get image URL if it's an image
-				let imageUrl: string | undefined;
-				if (isImage) {
-					imageUrl = (element as HTMLImageElement).src;
-				}
-
-				// Get input type
 				let inputType: string | undefined;
 				if (isInput && element.tagName === 'INPUT') {
 					inputType = (element as HTMLInputElement).type;
@@ -197,17 +392,25 @@ export class BrowserNativeUIHandler extends EventEmitter {
 					isLink,
 					isImage,
 					isInput,
+					isEditable,
 					isTextSelected,
-					linkUrl,
-					imageUrl,
-					inputType
+					// Long selections are only ever used for a "search for…" label,
+					// so there is no reason to ship the whole thing over the wire.
+					selectedText: selectedText.slice(0, 200),
+					linkUrl: anchor?.href,
+					linkText: anchor?.textContent?.trim().slice(0, 120),
+					imageUrl: isImage ? (element as HTMLImageElement).src : undefined,
+					mediaUrl: mediaElement?.currentSrc || mediaElement?.src,
+					mediaType: mediaElement ? mediaElement.tagName.toLowerCase() : undefined,
+					inputType,
+					pageUrl: location.href
 				};
-			}, { x, y });
+			}, { x: target.x, y: target.y });
 
 			if (!contextData) return null;
 
 			// Build context menu items based on element type
-			const items = this.buildContextMenuItems(contextData);
+			const items = this.buildContextMenuItems(contextData, navigation);
 
 			const menuId = nanoid(10);
 			const menuInfo: any = {
@@ -215,6 +418,11 @@ export class BrowserNativeUIHandler extends EventEmitter {
 				menuId,
 				x,
 				y,
+				// Kept so actions that re-hit-test (paste, media controls) can go
+				// straight back to the same element instead of re-resolving.
+				frameX: target.x,
+				frameY: target.y,
+				frameUrl: target.frame.url(),
 				items,
 				elementInfo: contextData,
 				timestamp: Date.now()
@@ -231,54 +439,116 @@ export class BrowserNativeUIHandler extends EventEmitter {
 	/**
 	 * Build context menu items based on element type
 	 */
-	private buildContextMenuItems(elementInfo: any): BrowserContextMenuItem[] {
+	private buildContextMenuItems(
+		elementInfo: {
+			isLink?: boolean;
+			isImage?: boolean;
+			isEditable?: boolean;
+			isTextSelected?: boolean;
+			selectedText?: string;
+			linkUrl?: string;
+			imageUrl?: string;
+			mediaUrl?: string;
+			mediaType?: string;
+		},
+		navigation?: { canGoBack: boolean; canGoForward: boolean }
+	): BrowserContextMenuItem[] {
 		const items: BrowserContextMenuItem[] = [];
+		let separatorSeq = 0;
 
-		// Back / Forward
-		items.push(
-			{ id: 'back', label: 'Back', enabled: true },
-			{ id: 'forward', label: 'Forward', enabled: true },
-			{ id: 'reload', label: 'Reload', enabled: true },
-			{ id: 'separator-1', label: '', enabled: false, type: 'separator' }
-		);
+		/** Append a divider, but never two in a row and never a leading one. */
+		const divider = () => {
+			const last = items[items.length - 1];
+			if (!last || last.type === 'separator') return;
+			separatorSeq += 1;
+			items.push({ id: `separator-${separatorSeq}`, label: '', enabled: false, type: 'separator' });
+		};
 
-		// Link-specific actions
+		// Context-specific actions come first, exactly as a browser orders them:
+		// what you right-clicked on matters more than what the page can do.
 		if (elementInfo.isLink && elementInfo.linkUrl) {
 			items.push(
-				{ id: 'open-link-new-tab', label: 'Open Link in New Tab', enabled: true },
-				{ id: 'copy-link', label: 'Copy Link Address', enabled: true },
-				{ id: 'separator-2', label: '', enabled: false, type: 'separator' }
+				{ id: 'open-link-new-tab', label: 'Open Link in New Tab', enabled: true, icon: 'lucide:external-link' },
+				{ id: 'open-link-host', label: 'Open Link in Your Browser', enabled: true, icon: 'lucide:app-window' },
+				{ id: 'copy-link', label: 'Copy Link Address', enabled: true, icon: 'lucide:link' }
 			);
+			divider();
 		}
 
-		// Image-specific actions
 		if (elementInfo.isImage && elementInfo.imageUrl) {
 			items.push(
-				{ id: 'open-image-new-tab', label: 'Open Image in New Tab', enabled: true },
-				{ id: 'save-image', label: 'Save Image As...', enabled: true },
-				{ id: 'copy-image', label: 'Copy Image', enabled: true },
-				{ id: 'copy-image-address', label: 'Copy Image Address', enabled: true },
-				{ id: 'separator-3', label: '', enabled: false, type: 'separator' }
+				{ id: 'open-image-new-tab', label: 'Open Image in New Tab', enabled: true, icon: 'lucide:image' },
+				{ id: 'save-image', label: 'Save Image As…', enabled: true, icon: 'lucide:download' },
+				{ id: 'copy-image', label: 'Copy Image', enabled: true, icon: 'lucide:copy' },
+				{ id: 'copy-image-address', label: 'Copy Image Address', enabled: true, icon: 'lucide:link' }
 			);
+			divider();
 		}
 
-		// Text selection actions
-		if (elementInfo.isTextSelected) {
+		if (elementInfo.mediaUrl) {
 			items.push(
-				{ id: 'copy', label: 'Copy', enabled: true },
-				{ id: 'separator-4', label: '', enabled: false, type: 'separator' }
+				{ id: 'media-play-pause', label: 'Play / Pause', enabled: true, icon: 'lucide:play' },
+				{ id: 'media-mute', label: 'Mute / Unmute', enabled: true, icon: 'lucide:volume-2' },
+				{ id: 'media-loop', label: 'Loop', enabled: true, icon: 'lucide:repeat' },
+				{
+					id: 'open-media-new-tab',
+					label: `Open ${elementInfo.mediaType === 'audio' ? 'Audio' : 'Video'} in New Tab`,
+					enabled: true,
+					icon: 'lucide:external-link'
+				}
 			);
+			divider();
 		}
 
-		// Input-specific actions
-		if (elementInfo.isInput) {
+		if (elementInfo.isEditable) {
 			items.push(
-				{ id: 'cut', label: 'Cut', enabled: true },
-				{ id: 'copy', label: 'Copy', enabled: elementInfo.isTextSelected },
-				{ id: 'paste', label: 'Paste', enabled: true },
-				{ id: 'separator-5', label: '', enabled: false, type: 'separator' }
+				{ id: 'undo', label: 'Undo', enabled: true, icon: 'lucide:undo-2' },
+				{ id: 'redo', label: 'Redo', enabled: true, icon: 'lucide:redo-2' }
 			);
+			divider();
+			items.push(
+				{ id: 'cut', label: 'Cut', enabled: !!elementInfo.isTextSelected, icon: 'lucide:scissors' },
+				{ id: 'copy', label: 'Copy', enabled: !!elementInfo.isTextSelected, icon: 'lucide:copy' },
+				{ id: 'paste', label: 'Paste', enabled: true, icon: 'lucide:clipboard' },
+				{ id: 'paste-plain', label: 'Paste as Plain Text', enabled: true, icon: 'lucide:clipboard-type' },
+				{ id: 'delete', label: 'Delete', enabled: !!elementInfo.isTextSelected, icon: 'lucide:eraser' },
+				{ id: 'select-all', label: 'Select All', enabled: true, icon: 'lucide:text-select' }
+			);
+			divider();
+		} else if (elementInfo.isTextSelected) {
+			const snippet = (elementInfo.selectedText || '').replace(/\s+/g, ' ').trim();
+			const label = snippet.length > 24 ? `${snippet.slice(0, 24)}…` : snippet;
+			items.push(
+				{ id: 'copy', label: 'Copy', enabled: true, icon: 'lucide:copy' },
+				{
+					id: 'search-selection',
+					label: label ? `Search for “${label}”` : 'Search for selection',
+					enabled: true,
+					icon: 'lucide:search'
+				}
+			);
+			divider();
 		}
+
+		// Page-level navigation last, and only enabled where it can actually go
+		// somewhere — an always-enabled Back that does nothing is worse than none.
+		items.push(
+			{ id: 'back', label: 'Back', enabled: navigation?.canGoBack ?? false, icon: 'lucide:arrow-left' },
+			{ id: 'forward', label: 'Forward', enabled: navigation?.canGoForward ?? false, icon: 'lucide:arrow-right' },
+			{ id: 'reload', label: 'Reload', enabled: true, icon: 'lucide:refresh-cw' }
+		);
+		divider();
+
+		if (!elementInfo.isEditable) {
+			items.push({ id: 'select-all', label: 'Select All', enabled: true, icon: 'lucide:text-select' });
+		}
+		items.push(
+			{ id: 'copy-page-url', label: 'Copy Page Address', enabled: true, icon: 'lucide:link-2' },
+			{ id: 'open-page-host', label: 'Open Page in Your Browser', enabled: true, icon: 'lucide:app-window' },
+			{ id: 'print', label: 'Print…', enabled: true, icon: 'lucide:printer' }
+		);
+		divider();
+		items.push({ id: 'inspect', label: 'Inspect', enabled: true, icon: 'lucide:code' });
 
 		return items;
 	}
@@ -339,7 +609,9 @@ export class BrowserNativeUIHandler extends EventEmitter {
 		try {
 			debug.log('preview', `📋 Pasting text to element at (${x}, ${y})`);
 
-			await page.evaluate((params) => {
+			const target = await resolveFrameTarget(page, x, y);
+
+			await target.frame.evaluate((params) => {
 				const { x, y, text } = params;
 				const element = document.elementFromPoint(x, y) as HTMLElement;
 
@@ -370,7 +642,7 @@ export class BrowserNativeUIHandler extends EventEmitter {
 						document.execCommand('insertText', false, text);
 					}
 				}
-			}, { x, y, text });
+			}, { x: target.x, y: target.y, text });
 
 			debug.log('preview', `✅ Pasted ${text.length} characters successfully`);
 		} catch (error) {
@@ -439,24 +711,126 @@ export class BrowserNativeUIHandler extends EventEmitter {
 					break;
 
 				case 'copy':
-					await page.evaluate(() => {
-						document.execCommand('copy');
-					});
+					// Read the selection out of the page and hand it to the viewer's
+					// clipboard: `execCommand('copy')` would only fill the headless
+					// browser's, which nothing the user can paste into ever reads.
+					{
+						const selected = await readSelection(page);
+						if (selected) {
+							this.emit('copy-to-clipboard', { text: selected });
+						}
+					}
 					break;
 
 				case 'cut':
-					await page.evaluate(() => {
-						document.execCommand('cut');
-					});
+					{
+						const selected = await readSelection(page, true);
+						if (selected) {
+							this.emit('copy-to-clipboard', { text: selected });
+						}
+					}
 					break;
 
 				case 'paste':
+				case 'paste-plain':
 					// Paste clipboard content to the page
 					if (clipboardText !== undefined) {
 						await this.pasteTextToPage(page, menuInfo.x, menuInfo.y, clipboardText);
 					} else {
 						debug.warn('preview', '⚠️ No clipboard text provided for paste action');
 					}
+					break;
+
+				case 'undo':
+					await page.evaluate(() => document.execCommand('undo'));
+					break;
+
+				case 'redo':
+					await page.evaluate(() => document.execCommand('redo'));
+					break;
+
+				case 'delete':
+					await page.evaluate(() => document.execCommand('delete'));
+					break;
+
+				case 'select-all': {
+					// Inside a field select just that field, otherwise the document —
+					// the same split Chrome makes.
+					const selectAllTarget = await resolveFrameTarget(page, menuInfo.x, menuInfo.y);
+					await selectAllTarget.frame.evaluate(() => {
+						const active = document.activeElement as HTMLInputElement | HTMLTextAreaElement | null;
+						if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA')) {
+							active.select();
+						} else {
+							document.execCommand('selectAll');
+						}
+					});
+					break;
+				}
+
+				case 'search-selection':
+					{
+						const selected = await readSelection(page);
+						if (selected.trim()) {
+							this.emit('open-url-new-tab', {
+								url: `https://www.google.com/search?q=${encodeURIComponent(selected.trim())}`
+							});
+						}
+					}
+					break;
+
+				case 'copy-page-url':
+					this.emit('copy-to-clipboard', { text: page.url() });
+					break;
+
+				case 'open-page-host':
+					this.emit('open-url-host-browser', { url: page.url() });
+					break;
+
+				case 'open-link-host':
+					if (menuInfo.elementInfo.linkUrl) {
+						this.emit('open-url-host-browser', { url: menuInfo.elementInfo.linkUrl });
+					}
+					break;
+
+				case 'open-media-new-tab':
+					if (menuInfo.elementInfo.mediaUrl) {
+						this.emit('open-url-new-tab', { url: menuInfo.elementInfo.mediaUrl });
+					}
+					break;
+
+				case 'media-play-pause':
+				case 'media-mute':
+				case 'media-loop': {
+					const mediaTarget = await resolveFrameTarget(page, menuInfo.x, menuInfo.y);
+					await mediaTarget.frame.evaluate(
+						(params: { x: number; y: number; action: string }) => {
+							const element = document.elementFromPoint(params.x, params.y);
+							const media = (element?.tagName === 'VIDEO' || element?.tagName === 'AUDIO'
+								? element
+								: element?.closest('video, audio')) as HTMLMediaElement | null;
+							if (!media) return;
+
+							if (params.action === 'media-play-pause') {
+								if (media.paused) void media.play();
+								else media.pause();
+							} else if (params.action === 'media-mute') {
+								media.muted = !media.muted;
+							} else {
+								media.loop = !media.loop;
+							}
+						},
+						{ x: mediaTarget.x, y: mediaTarget.y, action: itemId }
+					);
+					break;
+				}
+
+				case 'print':
+					this.emit('print-page', { timestamp: Date.now() });
+					break;
+
+				case 'inspect':
+					this.emit('open-inspector', { timestamp: Date.now() });
 					break;
 
 				case 'copy-link':

--- a/backend/preview/browser/browser-navigation-tracker.ts
+++ b/backend/preview/browser/browser-navigation-tracker.ts
@@ -261,6 +261,62 @@ export class BrowserNavigationTracker extends EventEmitter {
 	}
 
 	/**
+	 * Reuse the tab's tracking CDP session, creating one if setup failed or ran
+	 * before this call. History reads happen on every navigation, so attaching a
+	 * fresh session each time would be wasteful.
+	 */
+	private async getCdpSession(sessionId: string, page: Page): Promise<CDPSession> {
+		const existing = this.cdpSessions.get(sessionId);
+		if (existing) return existing;
+
+		const cdp = await page.createCDPSession();
+		this.cdpSessions.set(sessionId, cdp);
+		return cdp;
+	}
+
+	/**
+	 * Read the tab's real navigation history from CDP.
+	 *
+	 * `window.history.length` cannot answer "can I go forward?" and over-counts
+	 * for SPAs; `Page.getNavigationHistory` returns the actual entry list plus
+	 * the current index, which is what a real browser's buttons read.
+	 */
+	async getNavigationHistory(
+		sessionId: string,
+		page: Page
+	): Promise<{ currentIndex: number; entries: Array<{ id: number; url: string; title: string }> } | null> {
+		try {
+			const cdp = await this.getCdpSession(sessionId, page);
+			const history = await cdp.send('Page.getNavigationHistory');
+			return {
+				currentIndex: history.currentIndex,
+				entries: history.entries.map((entry) => ({
+					id: entry.id,
+					url: entry.url,
+					title: entry.title || entry.url
+				}))
+			};
+		} catch (error) {
+			debug.warn('preview', `⚠️ Failed to read navigation history for ${sessionId}:`, error);
+			return null;
+		}
+	}
+
+	/**
+	 * Jump to a specific history entry by CDP entry id.
+	 */
+	async navigateToHistoryEntry(sessionId: string, page: Page, entryId: number): Promise<boolean> {
+		try {
+			const cdp = await this.getCdpSession(sessionId, page);
+			await cdp.send('Page.navigateToHistoryEntry', { entryId });
+			return true;
+		} catch (error) {
+			debug.warn('preview', `⚠️ Failed to navigate to history entry ${entryId} for ${sessionId}:`, error);
+			return false;
+		}
+	}
+
+	/**
 	 * Cleanup CDP session for a tab
 	 */
 	async cleanupSession(sessionId: string) {

--- a/backend/preview/browser/browser-preview-service.ts
+++ b/backend/preview/browser/browser-preview-service.ts
@@ -7,6 +7,7 @@ import { BrowserNavigationTracker } from './browser-navigation-tracker.js';
 import { BrowserVideoCapture } from './browser-video-capture.js';
 import { BrowserDialogHandler } from './browser-dialog-handler.js';
 import { BrowserNativeUIHandler } from './browser-native-ui-handler.js';
+import { BrowserHostBridge, type HostResponse } from './browser-host-bridge.js';
 import { browserMcpControl } from './browser-mcp-control.js';
 import { ws } from '$backend/utils/ws';
 import { debug } from '$shared/utils/logger';
@@ -21,6 +22,8 @@ import type {
 	BrowserSelectResponse,
 	BrowserContextMenuResponse,
 	BrowserContextMenuInfo,
+	BrowserHistoryState,
+	BrowserTabMeta,
 	ClientCodecSupport,
 	ClientDisplayMetrics,
 	ClientStreamFeedback
@@ -47,6 +50,7 @@ export class BrowserPreviewService extends EventEmitter {
 	private videoCapture: BrowserVideoCapture;
 	private dialogHandler: BrowserDialogHandler;
 	private nativeUIHandler: BrowserNativeUIHandler;
+	private hostBridge: BrowserHostBridge;
 
 	// Store context menu info for later action execution
 	private contextMenus = new Map<string, BrowserContextMenuInfo>();
@@ -71,6 +75,7 @@ export class BrowserPreviewService extends EventEmitter {
 		this.videoCapture = new BrowserVideoCapture();
 		this.dialogHandler = new BrowserDialogHandler();
 		this.nativeUIHandler = new BrowserNativeUIHandler();
+		this.hostBridge = new BrowserHostBridge();
 
 		// Forward events from handlers to main service
 		this.setupEventForwarding();
@@ -104,6 +109,10 @@ export class BrowserPreviewService extends EventEmitter {
 			// After navigation completes, restart video streaming for the tab
 			// This re-injects the peer script and restarts CDP screencast
 			const { sessionId } = data;
+
+			// Title/favicon/history changed with the document — push the new
+			// values so the tab strip and Back/Forward buttons stay truthful.
+			void this.refreshTabMeta(sessionId);
 			if (this.videoCapture.isStreaming(sessionId)) {
 				const tab = this.getTab(sessionId);
 				if (tab) {
@@ -129,6 +138,9 @@ export class BrowserPreviewService extends EventEmitter {
 		// No streaming restart needed — page context is unchanged
 		this.navigationTracker.on('navigation-spa', (data) => {
 			this.emit('preview:browser-navigation-spa', data);
+			// pushState/replaceState mutate history without a document swap, so
+			// the Back/Forward affordances still have to be recomputed.
+			void this.refreshTabMeta(data.sessionId);
 		});
 
 		// Forward new window events
@@ -172,8 +184,22 @@ export class BrowserPreviewService extends EventEmitter {
 		this.dialogHandler.on('dialog', (data) => {
 			this.emit('preview:browser-dialog', data);
 		});
+		this.dialogHandler.on('dialog-closed', (data) => {
+			this.emit('preview:browser-dialog-closed', data);
+		});
 		this.dialogHandler.on('print', (data) => {
 			this.emit('preview:browser-print', data);
+		});
+
+		// Forward host bridge events (capability requests + relayed downloads)
+		this.hostBridge.on('request', (data) => {
+			this.emit('preview:browser-host-request', data);
+		});
+		this.hostBridge.on('download', (data) => {
+			this.emit('preview:browser-download', data);
+		});
+		this.hostBridge.on('request-settled', (data) => {
+			this.emit('preview:browser-host-request-settled', data);
 		});
 
 		// Forward native UI events
@@ -188,6 +214,15 @@ export class BrowserPreviewService extends EventEmitter {
 		});
 		this.nativeUIHandler.on('copy-image-to-clipboard', (data) => {
 			this.emit('preview:browser-copy-image-to-clipboard', data);
+		});
+		this.nativeUIHandler.on('open-url-host-browser', (data) => {
+			this.emit('preview:browser-open-url-host', data);
+		});
+		this.nativeUIHandler.on('print-page', (data) => {
+			this.emit('preview:browser-print', { sessionId: this.getActiveTab()?.id ?? '', ...data });
+		});
+		this.nativeUIHandler.on('open-inspector', (data) => {
+			this.emit('preview:browser-open-inspector', data);
 		});
 	}
 
@@ -215,9 +250,14 @@ export class BrowserPreviewService extends EventEmitter {
 	async createTab(url?: string, deviceSize: DeviceSize = 'laptop', rotation?: Rotation): Promise<BrowserTab> {
 		// Use device-appropriate default rotation if not specified
 		const actualRotation = rotation || ((deviceSize === 'desktop' || deviceSize === 'laptop') ? 'landscape' : 'portrait');
-		// Pre-navigation setup callback for dialog bindings
-		const preNavigationSetup = async (page: Page) => {
-			// Note: We'll setup dialog bindings using tabId after tab is created
+
+		// Dialog interception and the capability shims both have to be in place
+		// before the first navigation: a page can call alert() or getUserMedia()
+		// from its very first inline script, and anything installed afterwards
+		// would miss it.
+		const preNavigationSetup = async (page: Page, tabId: string) => {
+			await this.dialogHandler.setupDialogHandling(tabId, page);
+			await this.hostBridge.setup(tabId, page);
 		};
 
 		// Create tab
@@ -236,6 +276,9 @@ export class BrowserPreviewService extends EventEmitter {
 		// Fire-and-forget: failure here is non-fatal, startStreaming() will retry injection
 		this.videoCapture.preInjectScripts(tab.id, tab).catch(() => {});
 
+		await this.captureHistoryBase(tab.id);
+		void this.refreshTabMeta(tab.id);
+
 		return tab;
 	}
 
@@ -243,12 +286,155 @@ export class BrowserPreviewService extends EventEmitter {
 	 * Navigate tab to a new URL
 	 */
 	async navigateTab(tabId: string, url: string): Promise<string> {
+		const wasBlank = this.getTab(tabId)?.url === 'about:blank';
+
 		const actualUrl = await this.tabManager.navigateTab(tabId, url);
 
 		// Mark navigation for frame deduplication
 		this.markNavigation(tabId, url);
 
+		// Chrome replaces a new tab's blank entry rather than stacking on top of
+		// it, so Back stays disabled after the first real navigation. Re-baselining
+		// here reproduces that instead of offering "back to about:blank".
+		if (wasBlank) {
+			await this.captureHistoryBase(tabId);
+		}
+
+		void this.refreshTabMeta(tabId);
+
 		return actualUrl;
+	}
+
+	// ============================================================================
+	// Navigation History (Back / Forward)
+	// ============================================================================
+
+	/**
+	 * Read the tab's history, clamped to the entries it actually owns.
+	 *
+	 * CDP reports every entry including the `about:blank` the tab was born on.
+	 * Offering that as a Back target would let the user reverse out of their page
+	 * into a blank one — Chrome replaces that entry instead, so we hide anything
+	 * before the index the tab settled on after its first navigation.
+	 */
+	async getHistoryState(tabId: string): Promise<BrowserHistoryState | null> {
+		const tab = this.getTab(tabId);
+		if (!tab) return null;
+
+		const history = await this.navigationTracker.getNavigationHistory(tabId, tab.page);
+		if (!history) return null;
+
+		const base = Math.min(tab.historyBaseIndex ?? 0, history.currentIndex);
+		const entries = history.entries.slice(base);
+		const currentIndex = history.currentIndex - base;
+
+		return {
+			entries,
+			currentIndex,
+			canGoBack: currentIndex > 0,
+			canGoForward: currentIndex < entries.length - 1
+		};
+	}
+
+	/**
+	 * Move the tab by `delta` steps through its history.
+	 * Returns false when the move would leave the tab's own range.
+	 */
+	async goHistory(tabId: string, delta: number): Promise<boolean> {
+		const tab = this.getTab(tabId);
+		if (!tab || delta === 0) return false;
+
+		const state = await this.getHistoryState(tabId);
+		if (!state) return false;
+
+		const targetIndex = state.currentIndex + delta;
+		const target = state.entries[targetIndex];
+		if (!target) return false;
+
+		const moved = await this.navigationTracker.navigateToHistoryEntry(tabId, tab.page, target.id);
+		if (moved) {
+			this.markNavigation(tabId, target.url);
+			// The entry is committed asynchronously; let the navigation settle
+			// before reading title/favicon back off the page.
+			setTimeout(() => void this.refreshTabMeta(tabId), 250);
+		}
+		return moved;
+	}
+
+	/**
+	 * Record where a freshly created tab's own history begins.
+	 */
+	private async captureHistoryBase(tabId: string): Promise<void> {
+		const tab = this.getTab(tabId);
+		if (!tab) return;
+
+		const history = await this.navigationTracker.getNavigationHistory(tabId, tab.page);
+		if (history) {
+			tab.historyBaseIndex = history.currentIndex;
+		}
+	}
+
+	/**
+	 * Re-read the page's own title, favicon and history state, then push them to
+	 * the frontend. Called after every navigation — these are the three things
+	 * the toolbar and tab strip cannot derive from the URL alone.
+	 */
+	async refreshTabMeta(tabId: string): Promise<void> {
+		const tab = this.getTab(tabId);
+		if (!tab) return;
+
+		try {
+			const [pageTitle, favicon] = await Promise.all([
+				tab.page.title().catch(() => ''),
+				this.readFavicon(tab.page)
+			]);
+
+			if (pageTitle && pageTitle.trim()) {
+				tab.title = pageTitle.trim();
+			}
+			if (favicon) {
+				tab.favicon = favicon;
+			}
+
+			const history = await this.getHistoryState(tabId);
+			tab.canGoBack = history?.canGoBack ?? false;
+			tab.canGoForward = history?.canGoForward ?? false;
+
+			const meta: BrowserTabMeta = {
+				tabId,
+				url: tab.url,
+				title: tab.title,
+				favicon: tab.favicon,
+				canGoBack: tab.canGoBack,
+				canGoForward: tab.canGoForward,
+				timestamp: Date.now()
+			};
+
+			this.emit('preview:browser-tab-meta', meta);
+		} catch (error) {
+			debug.warn('preview', `⚠️ Failed to refresh tab meta for ${tabId}:`, error);
+		}
+	}
+
+	/**
+	 * Resolve the page's favicon to an absolute URL, falling back to the
+	 * origin's /favicon.ico the way a browser does.
+	 */
+	private async readFavicon(page: Page): Promise<string | undefined> {
+		try {
+			return await page.evaluate(() => {
+				const link = document.querySelector<HTMLLinkElement>(
+					'link[rel~="icon"], link[rel="shortcut icon"], link[rel="apple-touch-icon"]'
+				);
+				if (link?.href) return link.href;
+				if (location.origin && location.origin !== 'null') {
+					return `${location.origin}/favicon.ico`;
+				}
+				return undefined;
+			});
+		} catch {
+			return undefined;
+		}
 	}
 
 	/**
@@ -271,6 +457,9 @@ export class BrowserPreviewService extends EventEmitter {
 
 		// Clear dialogs for this tab
 		this.dialogHandler.clearSessionDialogs(tabId);
+
+		// Settle anything the page left waiting on the viewer, drop its scratch dir
+		await this.hostBridge.teardown(tabId);
 
 		// Close the tab (this will cleanup context, page, etc.)
 		const result = await this.tabManager.closeTab(tabId);
@@ -371,7 +560,7 @@ export class BrowserPreviewService extends EventEmitter {
 	// ============================================================================
 	async startWebCodecsStreaming(
 		tabId: string,
-		options?: { codecSupport?: ClientCodecSupport; display?: ClientDisplayMetrics }
+		options: { viewerId: string; codecSupport?: ClientCodecSupport; display?: ClientDisplayMetrics }
 	): Promise<boolean> {
 		const tab = this.getTab(tabId);
 		if (!tab) {
@@ -389,32 +578,42 @@ export class BrowserPreviewService extends EventEmitter {
 	 * Viewer display metrics (fit-scale + pixel density) — drives capture
 	 * resolution so we never encode more pixels than the viewer can show.
 	 */
-	applyWebCodecsDisplayMetrics(tabId: string, metrics: ClientDisplayMetrics): boolean {
+	applyWebCodecsDisplayMetrics(tabId: string, viewerId: string, metrics: ClientDisplayMetrics): boolean {
 		const tab = this.getTab(tabId);
 		if (!tab) {
 			return false;
 		}
-		this.videoCapture.applyDisplayMetrics(tabId, tab, metrics);
+		this.videoCapture.applyDisplayMetrics(tabId, tab, viewerId, metrics);
 		return true;
 	}
 
 	/** Viewer decoder health — closes the adaptation loop back to the source. */
-	applyWebCodecsClientFeedback(tabId: string, feedback: ClientStreamFeedback): boolean {
-		this.videoCapture.applyClientFeedback(tabId, feedback);
+	applyWebCodecsClientFeedback(tabId: string, viewerId: string, feedback: ClientStreamFeedback): boolean {
+		this.videoCapture.applyClientFeedback(tabId, viewerId, feedback);
 		return true;
 	}
 
-	/** Suspend capture while nobody is looking at the preview. */
-	async setWebCodecsPaused(tabId: string, paused: boolean): Promise<boolean> {
+	/** Suspend capture once every viewer has the preview off screen. */
+	async setWebCodecsPaused(tabId: string, viewerId: string, paused: boolean): Promise<boolean> {
 		const tab = this.getTab(tabId);
 		if (!tab) {
 			return false;
 		}
-		return await this.videoCapture.setPaused(tabId, tab, paused);
+		return await this.videoCapture.setViewerVisibility(tabId, tab, viewerId, !paused);
 	}
 
-	async stopWebCodecsStreaming(tabId: string): Promise<void> {
+	/**
+	 * One viewer left. The capture only stops when the last one does — a second
+	 * device closing its panel must not blank the first.
+	 */
+	async stopWebCodecsStreaming(tabId: string, viewerId?: string): Promise<void> {
 		const tab = this.getTab(tabId);
+
+		if (viewerId) {
+			await this.videoCapture.detachViewer(tabId, tab ?? undefined, viewerId);
+			return;
+		}
+
 		await this.videoCapture.stopStreaming(tabId, tab ?? undefined);
 	}
 
@@ -442,28 +641,36 @@ export class BrowserPreviewService extends EventEmitter {
 		return await this.videoCapture.updateViewport(tabId, tab, width, height);
 	}
 
-	async getWebCodecsOffer(tabId: string): Promise<RTCSessionDescriptionInit | null> {
+	async getWebCodecsOffer(tabId: string, viewerId: string): Promise<RTCSessionDescriptionInit | null> {
 		const tab = this.getTab(tabId);
 		if (!tab) {
 			return null;
 		}
-		return await this.videoCapture.createOffer(tabId, tab);
+		return await this.videoCapture.createOffer(tabId, tab, viewerId);
 	}
 
-	async handleWebCodecsAnswer(tabId: string, answer: RTCSessionDescriptionInit): Promise<boolean> {
+	async handleWebCodecsAnswer(
+		tabId: string,
+		viewerId: string,
+		answer: RTCSessionDescriptionInit
+	): Promise<boolean> {
 		const tab = this.getTab(tabId);
 		if (!tab) {
 			return false;
 		}
-		return await this.videoCapture.handleAnswer(tabId, tab, answer);
+		return await this.videoCapture.handleAnswer(tabId, tab, viewerId, answer);
 	}
 
-	async addWebCodecsIceCandidate(tabId: string, candidate: RTCIceCandidateInit): Promise<boolean> {
+	async addWebCodecsIceCandidate(
+		tabId: string,
+		viewerId: string,
+		candidate: RTCIceCandidateInit
+	): Promise<boolean> {
 		const tab = this.getTab(tabId);
 		if (!tab) {
 			return false;
 		}
-		return await this.videoCapture.addIceCandidate(tabId, tab, candidate);
+		return await this.videoCapture.addIceCandidate(tabId, tab, viewerId, candidate);
 	}
 
 	isWebCodecsActive(tabId: string): boolean {
@@ -583,7 +790,13 @@ export class BrowserPreviewService extends EventEmitter {
 		const tab = this.getTab(tabId);
 		if (!tab) return null;
 
-		const menuInfo = await this.nativeUIHandler.checkForContextMenu(tabId, tab.page, x, y);
+		// Back/Forward are page-level, so their availability comes from the tab's
+		// history rather than from the element under the cursor.
+		const history = await this.getHistoryState(tabId);
+		const menuInfo = await this.nativeUIHandler.checkForContextMenu(tabId, tab.page, x, y, {
+			canGoBack: history?.canGoBack ?? false,
+			canGoForward: history?.canGoForward ?? false
+		});
 		if (menuInfo) {
 			// Store menu info for later action execution
 			this.contextMenus.set(menuInfo.menuId, menuInfo);
@@ -609,11 +822,60 @@ export class BrowserPreviewService extends EventEmitter {
 	}
 
 	// ============================================================================
+	// Host Bridge Methods
+	// ============================================================================
+
+	/**
+	 * Deliver the viewer's answer to a pending capability request.
+	 */
+	respondToHostRequest(requestId: string, response: HostResponse): boolean {
+		return this.hostBridge.respond(requestId, response);
+	}
+
+	/**
+	 * Push a streamed host event into a tab's page — speech recognition results
+	 * keep arriving long after the request that started them was answered.
+	 */
+	async dispatchHostEvent(tabId: string, kind: string, payload: unknown): Promise<void> {
+		const tab = this.getTab(tabId);
+		if (!tab) return;
+		await this.hostBridge.dispatchEvent(tab.page, tabId, kind, payload);
+	}
+
+	// ============================================================================
+	// Native Picker Methods (colour / date inputs)
+	// ============================================================================
+
+	/**
+	 * Chrome draws colour and date pickers in the browser process, so they never
+	 * reach the screencast. Detecting the input lets the viewer render the
+	 * equivalent control over the canvas instead.
+	 */
+	async checkForNativePicker(tabId: string, x: number, y: number) {
+		const tab = this.getTab(tabId);
+		if (!tab) return null;
+
+		const info = await this.nativeUIHandler.checkForNativePicker(tabId, tab.page, x, y);
+		if (info) {
+			this.emit('preview:browser-native-picker', info);
+		}
+		return info;
+	}
+
+	async handleNativePickerResponse(tabId: string, pickerId: string, value: string): Promise<boolean> {
+		const tab = this.getTab(tabId);
+		if (!tab) return false;
+		return await this.nativeUIHandler.handleNativePickerResponse(tab.page, pickerId, value);
+	}
+
+	// ============================================================================
 	// Cleanup Methods
 	// ============================================================================
 	async cleanup() {
 		// Clear all cursor tracking
 		this.interactionHandler.clearAllSessionCursors();
+		// Release host-bridge scratch dirs and unblock any parked page promises
+		await this.hostBridge.cleanup();
 		// Cleanup tabs (this will also cleanup all contexts/pages/browser pool)
 		await this.tabManager.cleanup();
 	}
@@ -641,6 +903,7 @@ export class BrowserPreviewService extends EventEmitter {
 		this.videoCapture.removeAllListeners();
 		this.dialogHandler.removeAllListeners();
 		this.nativeUIHandler.removeAllListeners();
+		this.hostBridge.removeAllListeners();
 	}
 }
 
@@ -661,8 +924,12 @@ class BrowserPreviewServiceManager {
 	 * Get or create a BrowserPreviewService for a project
 	 */
 	getService(projectId: string): BrowserPreviewService {
-		if (!projectId) {
-			throw new Error('projectId is required and cannot be empty');
+		// Typed as string, but this is reached from MCP tool handlers whose
+		// arguments are untyped at runtime. A non-string key silently mints an
+		// empty service (and leaks its WS forwarding listeners), so reject it
+		// loudly rather than returning a service with no tabs.
+		if (typeof projectId !== 'string' || !projectId) {
+			throw new Error(`projectId must be a non-empty string, received: ${typeof projectId}`);
 		}
 
 		// Register singleton MCP control forwarding once (idempotent).
@@ -688,10 +955,15 @@ class BrowserPreviewServiceManager {
 	private setupWebSocketForwarding(service: BrowserPreviewService, projectId: string): void {
 		debug.log('preview', `🔌 Setting up WebSocket forwarding for project: ${projectId}...`);
 
-		// Forward WebCodecs events
+		// Forward WebCodecs events.
+		//
+		// The room is the whole project, so several viewers of the same tab all
+		// receive these. `viewerId` is what lets each of them recognise the half
+		// of the handshake that is theirs.
 		service.on('preview:browser-webcodecs-ice-candidate', (data) => {
 			ws.emit.project(projectId, 'preview:browser-stream-ice', {
 				sessionId: data.sessionId,
+				viewerId: data.viewerId,
 				candidate: data.candidate,
 				from: data.from
 			});
@@ -744,6 +1016,26 @@ class BrowserPreviewServiceManager {
 			ws.emit.project(projectId, 'preview:browser-viewport-changed', { ...data, projectId });
 		});
 
+		// Forward live tab metadata (title, favicon, back/forward availability)
+		service.on('preview:browser-tab-meta', (data) => {
+			ws.emit.project(projectId, 'preview:browser-tab-meta', { ...data, projectId });
+		});
+
+		// Forward host-capability requests (geolocation, camera, clipboard, …)
+		// and relayed downloads — both are answered by the viewer's own browser.
+		service.on('preview:browser-host-request', (data) => {
+			ws.emit.project(projectId, 'preview:browser-host-request', data);
+		});
+
+		// Answered (or expired) — every viewer that was shown this prompt drops it.
+		service.on('preview:browser-host-request-settled', (data) => {
+			ws.emit.project(projectId, 'preview:browser-host-request-settled', data);
+		});
+
+		service.on('preview:browser-download', (data) => {
+			ws.emit.project(projectId, 'preview:browser-download', data);
+		});
+
 		// Forward console events
 		service.on('preview:browser-console-message', (data) => {
 			ws.emit.project(projectId, 'preview:browser-console-message', data);
@@ -771,11 +1063,21 @@ class BrowserPreviewServiceManager {
 			ws.emit.project(projectId, 'preview:browser-dialog', data);
 		});
 
+		// A dialog belongs to the page, not to whoever answered it: every viewer
+		// was shown the same prompt, so all of them are told it is settled.
+		service.on('preview:browser-dialog-closed', (data) => {
+			ws.emit.project(projectId, 'preview:browser-dialog-closed', data);
+		});
+
 		service.on('preview:browser-print', (data) => {
 			ws.emit.project(projectId, 'preview:browser-print', data);
 		});
 
 		// Forward native UI events
+		service.on('preview:browser-native-picker', (data) => {
+			ws.emit.project(projectId, 'preview:browser-native-picker', data);
+		});
+
 		service.on('preview:browser-select', (data) => {
 			ws.emit.project(projectId, 'preview:browser-select', data);
 		});
@@ -794,6 +1096,14 @@ class BrowserPreviewServiceManager {
 
 		service.on('preview:browser-download-image', (data) => {
 			ws.emit.project(projectId, 'preview:browser-download-image', data);
+		});
+
+		service.on('preview:browser-open-url-host', (data) => {
+			ws.emit.project(projectId, 'preview:browser-open-url-host', data);
+		});
+
+		service.on('preview:browser-open-inspector', (data) => {
+			ws.emit.project(projectId, 'preview:browser-open-inspector', data);
 		});
 
 		service.on('preview:browser-copy-image-to-clipboard', (data) => {

--- a/backend/preview/browser/browser-tab-manager.ts
+++ b/backend/preview/browser/browser-tab-manager.ts
@@ -80,7 +80,7 @@ export class BrowserTabManager extends EventEmitter {
 		rotation: Rotation = 'landscape',
 		options?: {
 			setActive?: boolean;
-			preNavigationSetup?: (page: Page) => Promise<void>;
+			preNavigationSetup?: (page: Page, tabId: string) => Promise<void>;
 		}
 	): Promise<BrowserTab> {
 		const tabId = `tab-${this.nextTabNumber++}`;
@@ -121,7 +121,7 @@ export class BrowserTabManager extends EventEmitter {
 		// Run pre-navigation setup if provided (e.g., dialog handling)
 		if (options?.preNavigationSetup) {
 			debug.log('preview', `🔧 Running pre-navigation setup...`);
-			await options.preNavigationSetup(page);
+			await options.preNavigationSetup(page, tabId);
 			debug.log('preview', `✅ Pre-navigation setup complete`);
 		}
 
@@ -480,11 +480,14 @@ export class BrowserTabManager extends EventEmitter {
 			id: tab.id,
 			url: tab.url,
 			title: tab.title,
+			favicon: tab.favicon,
 			quality: tab.quality,
 			isStreaming: tab.isStreaming,
 			deviceSize: tab.deviceSize,
 			rotation: tab.rotation,
-			isActive: tab.isActive
+			isActive: tab.isActive,
+			canGoBack: tab.canGoBack,
+			canGoForward: tab.canGoForward
 		};
 	}
 
@@ -496,11 +499,14 @@ export class BrowserTabManager extends EventEmitter {
 			id: tab.id,
 			url: tab.url,
 			title: tab.title,
+			favicon: tab.favicon,
 			quality: tab.quality,
 			isStreaming: tab.isStreaming,
 			deviceSize: tab.deviceSize,
 			rotation: tab.rotation,
-			isActive: tab.isActive
+			isActive: tab.isActive,
+			canGoBack: tab.canGoBack,
+			canGoForward: tab.canGoForward
 		}));
 	}
 
@@ -709,18 +715,12 @@ export class BrowserTabManager extends EventEmitter {
 			})();
 		});
 
-		// Auto-dismiss native browser dialogs to prevent page hang in headless mode.
-		// alert() → accept (one-way informational, safe to dismiss)
-		// confirm()/prompt() → dismiss/cancel (avoid unintended side effects)
-		// CAPTCHA-related alerts are silently dismissed.
-		page.on('dialog', async (dialog) => {
-			const type = dialog.type();
-			if (type === 'alert') {
-				await dialog.accept().catch(() => {});
-			} else {
-				await dialog.dismiss().catch(() => {});
-			}
-		});
+		// NOTE: no `page.on('dialog')` here on purpose. Dialogs are owned by
+		// BrowserDialogHandler, which forwards them to the viewer and renders a
+		// real dialog there. Puppeteer hands a dialog to whichever listener
+		// answers first, so an auto-dismiss registered at this point would win
+		// every race and the user would never see alert()/confirm()/prompt().
+		// The handler auto-dismisses on its own timeout if nobody is watching.
 	}
 
 	/**

--- a/backend/preview/browser/browser-video-capture.ts
+++ b/backend/preview/browser/browser-video-capture.ts
@@ -40,6 +40,30 @@ import type {
 import { DEFAULT_STREAMING_CONFIG, resolveCodecCandidates } from './types';
 import { videoEncoderScript } from './scripts/video-stream';
 import { audioCaptureScript } from './scripts/audio-stream';
+
+/**
+ * Install the audio tap in every frame.
+ *
+ * `page.evaluate` only reaches the main frame, so a `<video>` or AudioContext
+ * inside an iframe — an embedded player, anything served from a CDN origin —
+ * was never tapped and the preview played silently. The script's own
+ * idempotency guard makes the repeat injections harmless, and it relays its
+ * encoded chunks up to the top frame's DataChannel.
+ */
+async function injectAudioCaptureIntoAllFrames(
+	page: Page,
+	audioConfig: StreamingConfig['audio']
+): Promise<void> {
+	await Promise.all(
+		page.frames().map(async (frame) => {
+			try {
+				await frame.evaluate(audioCaptureScript, audioConfig);
+			} catch {
+				// Detached or navigating; the on-new-document copy covers it.
+			}
+		})
+	);
+}
 import {
 	computeBitrate,
 	computeCaptureSize,
@@ -71,18 +95,43 @@ interface EncoderStats {
 	height: number;
 }
 
+/**
+ * One connected viewer of a tab.
+ *
+ * A tab is not watched by "the client" — it can be watched from a laptop and a
+ * phone at once through Remote Access, or from two split panels in the same
+ * window. Everything that used to live directly on the session and describe a
+ * single viewer (its codecs, its screen, its ICE state) belongs here; what the
+ * session keeps is the reduction across all of them.
+ */
+interface StreamViewer {
+	id: string;
+	/** Which codecs this viewer can decode. */
+	codecSupport: ClientCodecSupport;
+	/** Its fit-scale and screen density. */
+	display: ClientDisplayMetrics;
+	/** Answer received — ICE can be forwarded instead of queued. */
+	connected: boolean;
+	pendingCandidates: RTCIceCandidateInit[];
+	/** Whether this viewer currently has the preview on screen. */
+	visible: boolean;
+	/** Latest decoder verdict — the ladder follows the worst viewer. */
+	decoderSaturated: boolean;
+}
+
 interface VideoStreamSession {
 	sessionId: string;
 	isActive: boolean;
 	paused: boolean;
-	clientConnected: boolean;
 	headlessReady: boolean;
-	pendingCandidates: RTCIceCandidateInit[];
+	viewers: Map<string, StreamViewer>;
 	scriptInjected: boolean; // Track if persistent script was injected
 	scriptsPreInjected: boolean; // Track if scripts were pre-injected during tab creation
 	audioOnNewDocumentInjected: boolean; // Track if evaluateOnNewDocument was registered for audio
-	codecSupport: ClientCodecSupport; // Client decode capability (negotiated at stream start)
-	display: ClientDisplayMetrics; // Viewer fit-scale + pixel density
+	/** Codecs every viewer can decode — one encoder serves them all. */
+	codecSupport: ClientCodecSupport;
+	/** Display metrics of the most demanding viewer. */
+	display: ClientDisplayMetrics;
 	profile: CaptureProfile;
 	capture: CaptureSize;
 	/** Extra resolution derate applied when the fps floor isn't enough. */
@@ -98,6 +147,8 @@ interface VideoStreamSession {
 	 * seconds was enough to walk the stream to its floor and pin it there.
 	 */
 	saturatedWindows: number;
+	/** When client feedback last moved the ladder — see applyClientFeedback. */
+	lastClientAdaptAt: number;
 	/**
 	 * The tab this session streams. Kept here so adaptation triggered from the
 	 * page (encoder stats arrive through an exposed binding, with no tab in
@@ -451,6 +502,13 @@ export class BrowserVideoCapture extends EventEmitter {
 	/** Debounce for viewer resize storms before touching the encoder. */
 	private static readonly DISPLAY_METRICS_DEBOUNCE_MS = 250;
 
+	/**
+	 * Minimum gap between ladder moves driven by viewer feedback. Matches the
+	 * viewers' own reporting interval, so N viewers still produce one verdict
+	 * per window rather than N.
+	 */
+	private static readonly CLIENT_ADAPT_INTERVAL_MS = 1500;
+
 	private sessions = new Map<string, VideoStreamSession>();
 	private feeders = new Map<string, ScreencastFeeder>();
 	private preInjectPromises = new Map<string, Promise<boolean>>();
@@ -512,15 +570,56 @@ export class BrowserVideoCapture extends EventEmitter {
 		};
 	}
 
+	/**
+	 * Fold every viewer's capabilities into the one configuration the shared
+	 * encoder can have.
+	 *
+	 * Codecs intersect: a codec only one viewer can decode is useless, because
+	 * the same encoded chunks go to all of them. Resolution takes the maximum:
+	 * capturing for the sharpest screen costs the others nothing but a downscale
+	 * at paint time, whereas capturing for the smallest would leave the sharpest
+	 * viewer permanently blurry. The host's pixel budget still caps the result.
+	 */
+	private refreshViewerConfig(videoSession: VideoStreamSession): void {
+		const viewers = Array.from(videoSession.viewers.values());
+		if (viewers.length === 0) return;
+
+		videoSession.codecSupport = {
+			vp8: viewers.every((viewer) => viewer.codecSupport.vp8),
+			vp9: viewers.every((viewer) => viewer.codecSupport.vp9),
+			avc: viewers.every((viewer) => viewer.codecSupport.avc),
+			hardware: (['vp8', 'vp9', 'avc'] as const).filter((codec) =>
+				viewers.every((viewer) => viewer.codecSupport.hardware.includes(codec))
+			)
+		};
+
+		// Collapsed to a single factor rather than max(scale) × max(dpr): those
+		// maxima can come from different viewers, and their product would be a
+		// resolution nobody asked for.
+		let demand = 0;
+		for (const viewer of viewers) {
+			const scale = viewer.display.scale && viewer.display.scale > 0 ? viewer.display.scale : 1;
+			const dpr = viewer.display.dpr && viewer.display.dpr > 0 ? viewer.display.dpr : 1;
+			demand = Math.max(demand, scale * dpr);
+		}
+
+		videoSession.display = demand > 0 ? { scale: Math.min(1, demand), dpr: 1 } : {};
+	}
+
+	/** A stream is only worth pausing once nobody is looking at it. */
+	private allViewersHidden(videoSession: VideoStreamSession): boolean {
+		if (videoSession.viewers.size === 0) return true;
+		return Array.from(videoSession.viewers.values()).every((viewer) => !viewer.visible);
+	}
+
 	private createSessionState(sessionId: string): VideoStreamSession {
 		const profile = getHostCaptureProfile();
 		return {
 			sessionId,
 			isActive: false,
 			paused: false,
-			clientConnected: false,
 			headlessReady: false,
-			pendingCandidates: [],
+			viewers: new Map(),
 			scriptInjected: false,
 			scriptsPreInjected: false,
 			audioOnNewDocumentInjected: false,
@@ -533,6 +632,7 @@ export class BrowserVideoCapture extends EventEmitter {
 			captureMode: 'push',
 			healthyWindows: 0,
 			saturatedWindows: 0,
+			lastClientAdaptAt: 0,
 			stats: {
 				videoBytesSent: 0,
 				audioBytesSent: 0,
@@ -600,42 +700,57 @@ export class BrowserVideoCapture extends EventEmitter {
 			return typeof (window as any).__sendIceCandidate === 'function';
 		});
 
-		// Expose signaling functions (persists across navigations)
+		// Expose signaling functions (persists across navigations).
+		//
+		// Every one of these is bound to the tab whose page it was injected into.
+		// They used to resolve their session by picking the first active one in
+		// the whole project, which is correct only while exactly one tab streams:
+		// with several open, one page's ICE candidates, connection states, cursor
+		// and encoder stats were all attributed to a different tab. The viewer
+		// filters those by tab, so its candidates were silently discarded and the
+		// connection never completed — and because the first refresh frame is
+		// pushed from the `connected` state, a still page also never produced a
+		// first frame. That is the "Loading preview…" that never resolves.
 		if (!bindingsExist) {
-			await page.exposeFunction('__sendIceCandidate', (candidate: RTCIceCandidateInit) => {
-				const activeSession = Array.from(this.sessions.values()).find(s => s.isActive);
-				if (!activeSession) return;
-				this.emit('ice-candidate', { sessionId: activeSession.sessionId, candidate, from: 'headless' });
+			await page.exposeFunction('__sendIceCandidate', (viewerId: string, candidate: RTCIceCandidateInit) => {
+				this.emit('ice-candidate', { sessionId, viewerId, candidate, from: 'headless' });
 			});
 
-			await page.exposeFunction('__sendConnectionState', (state: string) => {
-				const activeSession = Array.from(this.sessions.values()).find(s => s.isActive);
-				if (!activeSession) return;
+			await page.exposeFunction('__sendConnectionState', (viewerId: string, state: string) => {
+				const videoSession = this.sessions.get(sessionId);
+				if (!videoSession) return;
 
-				activeSession.stats.connectionState = state;
-				this.emit('connection-state', { sessionId: activeSession.sessionId, state });
+				videoSession.stats.connectionState = state;
+				this.emit('connection-state', { sessionId, viewerId, state });
 
 				// Capture sources only produce frames on damage, so a viewer
 				// that connects to an already-still page would otherwise wait
 				// for the first mouse move to see anything. Push one refresh
 				// frame as soon as the peer is up.
-				if (state === 'connected' && activeSession.tab) {
-					void this.requestKeyframe(activeSession.sessionId, activeSession.tab);
+				if (state === 'connected' && videoSession.tab) {
+					void this.requestKeyframe(sessionId, videoSession.tab);
 				}
+
+				if (state === 'closed' || state === 'failed') {
+					videoSession.viewers.delete(viewerId);
+				}
+			});
+
+			// A channel that has just opened has no frame to show yet on a still
+			// page — see the matching comment in video-stream.ts.
+			await page.exposeFunction('__requestRefreshFrame', (viewerId: string) => {
+				const videoSession = this.sessions.get(sessionId);
+				if (!videoSession?.tab) return;
+				debug.log('webcodecs', `Refresh frame requested by viewer ${viewerId} on ${sessionId}`);
+				void this.requestKeyframe(sessionId, videoSession.tab);
 			});
 
 			await page.exposeFunction('__sendCursorChange', (cursor: string) => {
-				const activeSession = Array.from(this.sessions.values()).find(s => s.isActive);
-				if (activeSession) {
-					this.emit('cursor-change', { sessionId: activeSession.sessionId, cursor });
-				}
+				this.emit('cursor-change', { sessionId, cursor });
 			});
 
 			await page.exposeFunction('__sendEncoderStats', (stats: EncoderStats) => {
-				const activeSession = Array.from(this.sessions.values()).find(s => s.isActive);
-				if (activeSession) {
-					this.applyEncoderStats(activeSession.sessionId, stats);
-				}
+				this.applyEncoderStats(sessionId, stats);
 			});
 		}
 
@@ -650,7 +765,112 @@ export class BrowserVideoCapture extends EventEmitter {
 
 		// Inject video encoder + audio capture scripts into the current page context
 		await page.evaluate(videoEncoderScript, videoConfig);
-		await page.evaluate(audioCaptureScript, audioConfig);
+		await injectAudioCaptureIntoAllFrames(page, audioConfig);
+	}
+
+	// ------------------------------------------------------------------
+	// Viewers
+	// ------------------------------------------------------------------
+
+	/**
+	 * Record (or refresh) a viewer and re-derive the shared encoder config.
+	 */
+	private registerViewer(
+		videoSession: VideoStreamSession,
+		options: {
+			viewerId: string;
+			codecSupport?: ClientCodecSupport;
+			display?: ClientDisplayMetrics;
+		}
+	): StreamViewer {
+		const existing = videoSession.viewers.get(options.viewerId);
+
+		const viewer: StreamViewer = existing ?? {
+			id: options.viewerId,
+			codecSupport: { ...DEFAULT_CODEC_SUPPORT },
+			display: {},
+			connected: false,
+			pendingCandidates: [],
+			visible: true,
+			decoderSaturated: false
+		};
+
+		if (options.codecSupport) viewer.codecSupport = options.codecSupport;
+		if (options.display) viewer.display = { ...viewer.display, ...options.display };
+		// A fresh handshake means a fresh peer: whatever ICE was queued for the
+		// previous one belongs to a connection that no longer exists.
+		viewer.connected = false;
+		viewer.pendingCandidates = [];
+		viewer.visible = true;
+
+		videoSession.viewers.set(viewer.id, viewer);
+		this.refreshViewerConfig(videoSession);
+
+		return viewer;
+	}
+
+	/**
+	 * Add a viewer to a stream that is already running.
+	 *
+	 * Nothing about the capture is disturbed — the existing viewers keep their
+	 * channels. Only the shared geometry is re-derived, in case the newcomer has
+	 * a sharper screen than anyone already watching.
+	 */
+	private async attachViewer(
+		sessionId: string,
+		session: BrowserTab,
+		options: {
+			viewerId: string;
+			codecSupport?: ClientCodecSupport;
+			display?: ClientDisplayMetrics;
+		}
+	): Promise<boolean> {
+		const videoSession = this.sessions.get(sessionId);
+		if (!videoSession?.isActive) return false;
+
+		this.registerViewer(videoSession, options);
+		videoSession.tab = session;
+
+		// The stream may have been paused because everyone watching had it off
+		// screen; someone is watching again.
+		await this.setPaused(sessionId, session, false);
+		await this.applyCaptureGeometry(sessionId, session);
+		return true;
+	}
+
+	/**
+	 * Drop a viewer. The capture only stops once the last one is gone —
+	 * otherwise closing one device's panel would blank every other device.
+	 * Returns whether the whole stream was torn down.
+	 */
+	async detachViewer(sessionId: string, session: BrowserTab | undefined, viewerId: string): Promise<boolean> {
+		const videoSession = this.sessions.get(sessionId);
+		if (!videoSession) return false;
+
+		videoSession.viewers.delete(viewerId);
+
+		if (session?.page && !session.page.isClosed()) {
+			await session.page
+				.evaluate((id: string) => {
+					(window as any).__webCodecsPeer?.closePeer(id);
+				}, viewerId)
+				.catch(() => {});
+		}
+
+		if (videoSession.viewers.size > 0) {
+			this.refreshViewerConfig(videoSession);
+			debug.log(
+				'webcodecs',
+				`Viewer ${viewerId} left ${sessionId}, ${videoSession.viewers.size} still watching`
+			);
+			if (session && this.allViewersHidden(videoSession)) {
+				await this.setPaused(sessionId, session, true);
+			}
+			return false;
+		}
+
+		await this.stopStreaming(sessionId, session);
+		return true;
 	}
 
 	// ------------------------------------------------------------------
@@ -664,12 +884,14 @@ export class BrowserVideoCapture extends EventEmitter {
 		sessionId: string,
 		session: BrowserTab,
 		isValidSession: () => boolean,
-		options?: {
+		options: {
+			viewerId: string;
 			codecSupport?: ClientCodecSupport;
 			display?: ClientDisplayMetrics;
 		}
 	): Promise<boolean> {
-		debug.log('webcodecs', `Starting streaming for session ${sessionId}`);
+		const { viewerId } = options;
+		debug.log('webcodecs', `Starting streaming for session ${sessionId} (viewer ${viewerId})`);
 
 		// Wait for any pending pre-injection to complete
 		const pendingPreInject = this.preInjectPromises.get(sessionId);
@@ -678,13 +900,25 @@ export class BrowserVideoCapture extends EventEmitter {
 			await pendingPreInject.catch(() => {});
 		}
 
-		// If session is already actively streaming, stop it for a clean reconnect.
-		// This ensures the old PeerConnection + DataChannel are torn down and
-		// a fresh one is created, preventing stale connections where no frames flow.
+		// A viewer re-handshaking (its own recovery path) gets a clean restart
+		// only when it is the sole viewer — that is the case the recovery logic
+		// was written for. Tearing the capture down because a *second* viewer
+		// arrived is what made two devices fight over one tab: each new
+		// handshake killed the other side's channel, whose health check
+		// reconnected and killed this one straight back.
 		const existingSession = this.sessions.get(sessionId);
-		if (existingSession && existingSession.isActive) {
-			debug.log('webcodecs', `Session ${sessionId} already active, stopping for clean reconnect`);
-			await this.stopStreaming(sessionId, session);
+		if (existingSession?.isActive) {
+			const others = Array.from(existingSession.viewers.keys()).filter((id) => id !== viewerId);
+			if (others.length === 0) {
+				debug.log('webcodecs', `Session ${sessionId} already active for its only viewer, restarting clean`);
+				await this.stopStreaming(sessionId, session);
+			} else {
+				debug.log(
+					'webcodecs',
+					`Session ${sessionId} already streaming to ${others.length} other viewer(s), attaching ${viewerId}`
+				);
+				return this.attachViewer(sessionId, session, options);
+			}
 		}
 
 		if (!session.page || session.page.isClosed()) {
@@ -704,10 +938,7 @@ export class BrowserVideoCapture extends EventEmitter {
 			}
 
 			videoSession.tab = session;
-
-			// Viewer capabilities/metrics always come from the newest handshake
-			if (options?.codecSupport) videoSession.codecSupport = options.codecSupport;
-			if (options?.display) videoSession.display = { ...videoSession.display, ...options.display };
+			this.registerViewer(videoSession, options);
 			videoSession.paused = false;
 			videoSession.captureMode = 'push';
 			videoSession.healthyWindows = 0;
@@ -1112,19 +1343,34 @@ export class BrowserVideoCapture extends EventEmitter {
 	 * the same stutter with an empty network buffer and an idle encoder, so the
 	 * decode queue has to close the loop back to the source.
 	 */
-	applyClientFeedback(sessionId: string, feedback: ClientStreamFeedback): void {
+	applyClientFeedback(sessionId: string, viewerId: string, feedback: ClientStreamFeedback): void {
 		const videoSession = this.sessions.get(sessionId);
-		if (!videoSession?.isActive) return;
+		const viewer = videoSession?.viewers.get(viewerId);
+		if (!videoSession?.isActive || !viewer) return;
 
 		// Thresholds sit well clear of healthy operation for the same reason as
 		// the encoder ones: decodeQueueSize is a spot sample and dropRatio has
 		// window-boundary skew, so tight limits fire on a stream that is fine.
-		const decoderSaturated =
+		viewer.decoderSaturated =
 			feedback.decodeQueueSize >= 4 ||
 			feedback.dropRatio > 0.4 ||
 			feedback.decodeLatencyMs > 300;
 
-		this.adaptQuality(sessionId, decoderSaturated);
+		// Every viewer reports on its own two-second timer, so folding each
+		// report straight into the ladder would step it once per viewer per
+		// window — and a healthy phone would keep cancelling out a struggling
+		// laptop, since a healthy window resets the saturation counter. One
+		// verdict per window, taken from the worst viewer: the stream is shared,
+		// so it can only be as fast as its slowest decoder.
+		const now = Date.now();
+		if (now - videoSession.lastClientAdaptAt < BrowserVideoCapture.CLIENT_ADAPT_INTERVAL_MS) return;
+		videoSession.lastClientAdaptAt = now;
+
+		const anySaturated = Array.from(videoSession.viewers.values()).some(
+			(entry) => entry.decoderSaturated
+		);
+
+		this.adaptQuality(sessionId, anySaturated);
 	}
 
 	/**
@@ -1132,11 +1378,18 @@ export class BrowserVideoCapture extends EventEmitter {
 	 * move to a different-density screen). Debounced because a resize drag
 	 * emits a continuous stream of these.
 	 */
-	applyDisplayMetrics(sessionId: string, session: BrowserTab, metrics: ClientDisplayMetrics): void {
+	applyDisplayMetrics(
+		sessionId: string,
+		session: BrowserTab,
+		viewerId: string,
+		metrics: ClientDisplayMetrics
+	): void {
 		const videoSession = this.sessions.get(sessionId);
-		if (!videoSession) return;
+		const viewer = videoSession?.viewers.get(viewerId);
+		if (!videoSession || !viewer) return;
 
-		videoSession.display = { ...videoSession.display, ...metrics };
+		viewer.display = { ...viewer.display, ...metrics };
+		this.refreshViewerConfig(videoSession);
 
 		const existing = this.displayMetricsTimers.get(sessionId);
 		if (existing) clearTimeout(existing);
@@ -1155,7 +1408,27 @@ export class BrowserVideoCapture extends EventEmitter {
 	 * hidden). An unwatched preview otherwise keeps a headless renderer and an
 	 * encoder busy for nothing — the dominant idle cost on a shared VPS.
 	 */
-	async setPaused(sessionId: string, session: BrowserTab, paused: boolean): Promise<boolean> {
+	/**
+	 * Record one viewer's visibility and pause only when nobody is watching.
+	 *
+	 * Visibility is per viewer: collapsing the panel on a laptop must not stop
+	 * the capture a phone is still watching.
+	 */
+	async setViewerVisibility(
+		sessionId: string,
+		session: BrowserTab,
+		viewerId: string,
+		visible: boolean
+	): Promise<boolean> {
+		const videoSession = this.sessions.get(sessionId);
+		const viewer = videoSession?.viewers.get(viewerId);
+		if (!videoSession || !viewer) return false;
+
+		viewer.visible = visible;
+		return this.setPaused(sessionId, session, this.allViewersHidden(videoSession));
+	}
+
+	private async setPaused(sessionId: string, session: BrowserTab, paused: boolean): Promise<boolean> {
 		const videoSession = this.sessions.get(sessionId);
 		if (!videoSession?.isActive) return false;
 		if (videoSession.paused === paused) return true;
@@ -1201,13 +1474,31 @@ export class BrowserVideoCapture extends EventEmitter {
 	// ------------------------------------------------------------------
 
 	/**
-	 * Create offer from headless browser
+	 * Create an offer for one viewer.
 	 */
-	async createOffer(sessionId: string, session: BrowserTab): Promise<RTCSessionDescriptionInit | null> {
+	async createOffer(
+		sessionId: string,
+		session: BrowserTab,
+		viewerId: string
+	): Promise<RTCSessionDescriptionInit | null> {
 		const videoSession = this.sessions.get(sessionId);
 		if (!videoSession?.isActive || !session.page) {
 			return null;
 		}
+
+		// A new offer means a new peer for this viewer, so anything the previous
+		// one had accepted no longer applies: candidates must queue again until
+		// the fresh peer has a remote description. Reconnecting after a page
+		// navigation goes straight through here, and skipping this left the
+		// viewer forwarding candidates into a peer that could not take them yet.
+		//
+		// A viewer reconnecting to a still-running stream arrives here without
+		// going through a handshake, and may have been dropped in between (its
+		// socket closed, its panel was hidden), so it is registered on demand
+		// rather than being refused a peer.
+		const viewer = videoSession.viewers.get(viewerId) ?? this.registerViewer(videoSession, { viewerId });
+		viewer.connected = false;
+		viewer.pendingCandidates = [];
 
 		const maxRetries = 6;
 		const retryDelay = 150;
@@ -1215,11 +1506,11 @@ export class BrowserVideoCapture extends EventEmitter {
 		for (let attempt = 0; attempt < maxRetries; attempt++) {
 			try {
 				// Single evaluate: check peer + create offer in one IPC round-trip
-				const offer = await session.page.evaluate(async () => {
+				const offer = await session.page.evaluate(async (id: string) => {
 					const peer = (window as any).__webCodecsPeer;
 					if (typeof peer?.createOffer !== 'function') return null;
-					return peer.createOffer();
-				});
+					return peer.createOffer(id);
+				}, viewerId);
 
 				if (offer) return offer;
 
@@ -1243,26 +1534,31 @@ export class BrowserVideoCapture extends EventEmitter {
 	async handleAnswer(
 		sessionId: string,
 		session: BrowserTab,
+		viewerId: string,
 		answer: RTCSessionDescriptionInit
 	): Promise<boolean> {
 		const videoSession = this.sessions.get(sessionId);
-		if (!videoSession?.isActive || !session.page) {
+		const viewer = videoSession?.viewers.get(viewerId);
+		if (!videoSession?.isActive || !viewer || !session.page) {
 			return false;
 		}
 
 		try {
-			const success = await session.page.evaluate((ans) => {
-				return (window as any).__webCodecsPeer?.handleAnswer(ans);
-			}, answer);
+			const success = await session.page.evaluate(
+				(params: { id: string; ans: RTCSessionDescriptionInit }) => {
+					return (window as any).__webCodecsPeer?.handleAnswer(params.id, params.ans);
+				},
+				{ id: viewerId, ans: answer }
+			);
 
 			if (success) {
-				videoSession.clientConnected = true;
+				viewer.connected = true;
 
 				// Process pending ICE candidates
-				for (const candidate of videoSession.pendingCandidates) {
-					await this.addIceCandidate(sessionId, session, candidate);
+				for (const candidate of viewer.pendingCandidates) {
+					await this.addIceCandidate(sessionId, session, viewerId, candidate);
 				}
-				videoSession.pendingCandidates = [];
+				viewer.pendingCandidates = [];
 			}
 
 			return success;
@@ -1273,28 +1569,33 @@ export class BrowserVideoCapture extends EventEmitter {
 	}
 
 	/**
-	 * Add ICE candidate from client
+	 * Add ICE candidate from one viewer
 	 */
 	async addIceCandidate(
 		sessionId: string,
 		session: BrowserTab,
+		viewerId: string,
 		candidate: RTCIceCandidateInit
 	): Promise<boolean> {
 		const videoSession = this.sessions.get(sessionId);
-		if (!videoSession?.isActive || !session.page) {
+		const viewer = videoSession?.viewers.get(viewerId);
+		if (!videoSession?.isActive || !viewer || !session.page) {
 			return false;
 		}
 
-		// Queue if not connected yet
-		if (!videoSession.clientConnected) {
-			videoSession.pendingCandidates.push(candidate);
+		// Queue until this viewer's peer has a remote description
+		if (!viewer.connected) {
+			viewer.pendingCandidates.push(candidate);
 			return true;
 		}
 
 		try {
-			return await session.page.evaluate((cand) => {
-				return (window as any).__webCodecsPeer?.addIceCandidate(cand);
-			}, candidate);
+			return await session.page.evaluate(
+				(params: { id: string; cand: RTCIceCandidateInit }) => {
+					return (window as any).__webCodecsPeer?.addIceCandidate(params.id, params.cand);
+				},
+				{ id: viewerId, cand: candidate }
+			);
 		} catch (error) {
 			debug.error('webcodecs', `Add ICE candidate error:`, error);
 			return false;
@@ -1417,7 +1718,7 @@ export class BrowserVideoCapture extends EventEmitter {
 
 			// Re-inject video encoder and audio capture scripts to new page context
 			await page.evaluate(videoEncoderScript, videoConfig);
-			await page.evaluate(audioCaptureScript, audioConfig);
+			await injectAudioCaptureIntoAllFrames(page, audioConfig);
 
 			// Single batched call: verify peer + start streaming + init audio
 			const initResult = await page.evaluate(async () => {

--- a/backend/preview/browser/frame-targeting.ts
+++ b/backend/preview/browser/frame-targeting.ts
@@ -1,0 +1,92 @@
+/**
+ * Frame Targeting
+ *
+ * Everything the preview inspects at a coordinate — the select under a click,
+ * the element under a right-click, the field a paste lands in — used to run
+ * `page.evaluate`, which only ever sees the **main frame**. Inside an iframe
+ * `document.elementFromPoint()` returns the `<iframe>` element itself, so every
+ * one of those features silently did nothing there.
+ *
+ * This walks the frame tree to find the frame that actually owns a point and
+ * converts the coordinate into that frame's own viewport space, so the caller
+ * can evaluate against the real element.
+ *
+ * `ElementHandle.boundingBox()` reports **main-frame** coordinates at every
+ * depth, which is what makes the walk simple: the containment test always runs
+ * against the original point, and only the returned offset accumulates.
+ */
+
+import type { Frame, Page } from 'puppeteer';
+
+export interface FrameTarget {
+	frame: Frame;
+	/** The point, in `frame`'s own viewport coordinates. */
+	x: number;
+	y: number;
+}
+
+/**
+ * Depth cap. Real pages nest an ad in a widget in a consent wrapper and stop;
+ * anything deeper is far more likely to be a frame loop than a real target.
+ */
+const MAX_FRAME_DEPTH = 8;
+
+/**
+ * Resolve which frame owns a point, and where the point sits inside it.
+ * Falls back to the main frame whenever the tree cannot be walked.
+ */
+export async function resolveFrameTarget(page: Page, x: number, y: number): Promise<FrameTarget> {
+	let frame: Frame = page.mainFrame();
+	let localX = x;
+	let localY = y;
+
+	for (let depth = 0; depth < MAX_FRAME_DEPTH; depth += 1) {
+		const children = frame.childFrames();
+		if (children.length === 0) break;
+
+		let descended = false;
+
+		for (const child of children) {
+			try {
+				const element = await child.frameElement();
+				if (!element) continue;
+
+				const box = await element.boundingBox();
+				if (!box) {
+					await element.dispose();
+					continue;
+				}
+
+				const contains = x >= box.x && x <= box.x + box.width && y >= box.y && y <= box.y + box.height;
+				if (!contains) {
+					await element.dispose();
+					continue;
+				}
+
+				// The frame's viewport starts inside its border and padding, so the
+				// element box alone would be off by however thick those are.
+				const inset = await element.evaluate((node) => {
+					const style = getComputedStyle(node);
+					return {
+						left: parseFloat(style.borderLeftWidth) + parseFloat(style.paddingLeft),
+						top: parseFloat(style.borderTopWidth) + parseFloat(style.paddingTop)
+					};
+				});
+				await element.dispose();
+
+				localX = x - box.x - (inset.left || 0);
+				localY = y - box.y - (inset.top || 0);
+				frame = child;
+				descended = true;
+				break;
+			} catch {
+				// Detached mid-walk (frames come and go constantly on real pages) —
+				// try the next sibling rather than abandoning the whole resolution.
+			}
+		}
+
+		if (!descended) break;
+	}
+
+	return { frame, x: Math.round(localX), y: Math.round(localY) };
+}

--- a/backend/preview/browser/scripts/audio-stream.ts
+++ b/backend/preview/browser/scripts/audio-stream.ts
@@ -45,6 +45,64 @@ export function audioCaptureScript(config: StreamingConfig['audio']) {
 	const interceptedContexts = new WeakSet();
 	const captureNodes = new Map();
 
+	// ── Cross-frame delivery ────────────────────────────────────────────────
+	//
+	// The DataChannel lives on `__webCodecsPeer`, which only exists in the top
+	// frame. This script runs in every frame (it is injected on new document),
+	// so audio produced inside an iframe — embedded players, ad frames, anything
+	// on a CDN origin — encoded fine and was then dropped for want of a channel.
+	// Same-origin frames can reach the peer directly; cross-origin ones hand the
+	// encoded chunk to the top frame over postMessage.
+	const RELAY_KEY = '__clopenAudioChunk';
+	const isTopFrame = window === window.top;
+
+	/** The peer, if this frame can legally reach it. */
+	function resolvePeer(): any | null {
+		const local = (window as any).__webCodecsPeer;
+		if (local) return local;
+
+		try {
+			// Throws for cross-origin parents, which is the signal to relay.
+			const top = (window.top as any)?.__webCodecsPeer;
+			return top ?? null;
+		} catch {
+			return null;
+		}
+	}
+
+	function deliverChunk(timestamp: number, data: Uint8Array) {
+		const peer = resolvePeer();
+		if (peer) {
+			if (!peer.isActive()) return;
+			peer.sendAudioChunk(timestamp, data);
+			return;
+		}
+
+		if (isTopFrame) return;
+
+		try {
+			// Copy into a fresh buffer: the encoder's view may be reused, and the
+			// transfer would neuter it out from under the next chunk.
+			const copy = new Uint8Array(data);
+			window.top?.postMessage({ [RELAY_KEY]: { timestamp, data: copy } }, '*', [copy.buffer]);
+		} catch {
+			// Frame is detached or the post was refused — drop the chunk; audio
+			// gaps are handled by the client's playback scheduler.
+		}
+	}
+
+	// Top frame: accept chunks relayed up from cross-origin children.
+	if (isTopFrame) {
+		window.addEventListener('message', (event: MessageEvent) => {
+			const relayed = (event.data as Record<string, any> | null)?.[RELAY_KEY];
+			if (!relayed) return;
+
+			const peer = (window as any).__webCodecsPeer;
+			if (!peer || !peer.isActive()) return;
+			peer.sendAudioChunk(relayed.timestamp, new Uint8Array(relayed.data));
+		});
+	}
+
 	// Initialize audio encoder
 	async function initAudioEncoder() {
 		if (audioEncoder && audioEncoder.state === 'configured') {
@@ -54,17 +112,12 @@ export function audioCaptureScript(config: StreamingConfig['audio']) {
 		try {
 			audioEncoder = new AudioEncoder({
 				output: (chunk: EncodedAudioChunk) => {
-					// Send audio chunk directly via __webCodecsPeer DataChannel
-					const peer = (window as any).__webCodecsPeer;
-					if (!peer || !peer.isActive()) {
-						return;
-					}
-
 					const data = new Uint8Array(chunk.byteLength);
 					chunk.copyTo(data);
 
-					// Send via the same DataChannel used for video
-					peer.sendAudioChunk(chunk.timestamp, data);
+					// Reaches the DataChannel directly in the top frame, or via the
+					// relay when this encoder is running inside an iframe.
+					deliverChunk(chunk.timestamp, data);
 				},
 				error: (e: Error) => {}
 			});

--- a/backend/preview/browser/scripts/host-bridge.ts
+++ b/backend/preview/browser/scripts/host-bridge.ts
@@ -1,0 +1,899 @@
+/**
+ * Host Bridge Client Script
+ *
+ * Runs inside the headless page and re-points the capability APIs that a real
+ * browser answers from the device — geolocation, camera/microphone, screen
+ * capture, speech recognition, clipboard, notifications — at the *viewer's*
+ * browser instead. Headless Chrome has none of those, so without this every one
+ * of them fails outright and the preview stops behaving like a browser the
+ * moment a page asks for anything real.
+ *
+ * Also stands in for the Fullscreen API. Real fullscreen resizes the renderer to
+ * the browser *window*, which throws away the emulated viewport the preview is
+ * built on — the page comes back zoomed, off-centre and letterboxed, with no way
+ * out because the exit affordance lives in browser chrome that does not exist
+ * here. A CSS-based fullscreen keeps the viewport intact and stays exitable.
+ *
+ * Runs in **every** frame. Cross-origin frames have no binding of their own, so
+ * they relay through the top frame over `postMessage`, keyed by the same
+ * randomised name the binding uses.
+ */
+export function hostBridgeScript(bindingName: string) {
+	const scope = window as unknown as Record<string, unknown>;
+	if (scope.__clopenHostBridgeReady) return;
+	scope.__clopenHostBridgeReady = true;
+
+	const RELAY_KEY = `${bindingName}R`;
+	const EVENT_HOOK = `${bindingName}E`;
+
+	interface BridgeError {
+		name?: string;
+		message?: string;
+		code?: number;
+	}
+
+	interface BridgeResponse {
+		ok: boolean;
+		result?: unknown;
+		error?: BridgeError;
+	}
+
+	function namedError(name: string, message: string, code?: number): Error {
+		const error = new Error(message);
+		error.name = name;
+		if (typeof code === 'number') {
+			(error as Error & { code?: number }).code = code;
+		}
+		return error;
+	}
+
+	function unwrap(response: BridgeResponse): unknown {
+		if (!response.ok) {
+			throw namedError(
+				response.error?.name || 'NotAllowedError',
+				response.error?.message || 'Permission denied',
+				response.error?.code
+			);
+		}
+		return response.result;
+	}
+
+	// ── Transport ───────────────────────────────────────────────────────────
+
+	const relayWaiters = new Map<string, (response: BridgeResponse) => void>();
+	let relaySeq = 0;
+
+	/**
+	 * Round-trip one request to the viewer.
+	 *
+	 * The binding only exists where Chrome installed it — the main frame and any
+	 * same-process iframe. Everything else (a cross-origin embed, which is most
+	 * of them under site isolation) hops through the top frame instead, which is
+	 * why an embedded page could not open a picker or ask for a camera.
+	 */
+	function call(kind: string, payload?: unknown): Promise<any> {
+		const binding = scope[bindingName] as ((raw: string) => Promise<string>) | undefined;
+
+		if (typeof binding === 'function') {
+			return binding(JSON.stringify({ kind, payload })).then((raw: string) =>
+				unwrap(JSON.parse(raw) as BridgeResponse)
+			);
+		}
+
+		if (window === window.top) {
+			return Promise.reject(namedError('NotSupportedError', 'Preview host bridge is unavailable'));
+		}
+
+		relaySeq += 1;
+		const id = `${relaySeq}`;
+
+		return new Promise((resolve, reject) => {
+			relayWaiters.set(id, (response) => {
+				try {
+					resolve(unwrap(response));
+				} catch (error) {
+					reject(error);
+				}
+			});
+
+			try {
+				window.top?.postMessage({ [RELAY_KEY]: { id, kind, payload } }, '*');
+			} catch {
+				relayWaiters.delete(id);
+				reject(namedError('NotSupportedError', 'Preview host bridge is unreachable'));
+			}
+
+			setTimeout(() => {
+				if (!relayWaiters.delete(id)) return;
+				reject(namedError('AbortError', 'Preview host bridge timed out'));
+			}, 180000);
+		});
+	}
+
+	window.addEventListener('message', (event: MessageEvent) => {
+		const data = event.data as Record<string, any> | null;
+		if (!data || typeof data !== 'object') return;
+
+		// Top frame: forward a child's request and post the answer back.
+		const request = data[RELAY_KEY];
+		if (request && window === window.top) {
+			const binding = scope[bindingName] as ((raw: string) => Promise<string>) | undefined;
+			const source = event.source as WindowProxy | null;
+			if (!source) return;
+
+			const reply = (response: BridgeResponse) => {
+				try {
+					source.postMessage({ [`${RELAY_KEY}Reply`]: { id: request.id, response } }, '*');
+				} catch {
+					// Frame went away mid-flight.
+				}
+			};
+
+			if (typeof binding !== 'function') {
+				reply({ ok: false, error: { name: 'NotSupportedError', message: 'Bridge unavailable' } });
+				return;
+			}
+
+			binding(JSON.stringify({ kind: request.kind, payload: request.payload }))
+				.then((raw: string) => reply(JSON.parse(raw) as BridgeResponse))
+				.catch((error: Error) => reply({ ok: false, error: { name: error.name, message: error.message } }));
+			return;
+		}
+
+		// Child frame: settle the promise the relay is holding.
+		const replyPayload = data[`${RELAY_KEY}Reply`];
+		if (replyPayload) {
+			const waiter = relayWaiters.get(replyPayload.id);
+			if (waiter) {
+				relayWaiters.delete(replyPayload.id);
+				waiter(replyPayload.response);
+			}
+			return;
+		}
+
+		// Top frame broadcasts host events down to children.
+		const forwarded = data[`${RELAY_KEY}Event`];
+		if (forwarded) {
+			deliverEvent(forwarded.kind, forwarded.payload, false);
+		}
+	});
+
+	// ── Host → page events ──────────────────────────────────────────────────
+	//
+	// The request/response channel cannot carry a stream, and speech recognition
+	// is a stream: results keep arriving until the page stops listening.
+
+	const eventListeners = new Map<string, Set<(payload: any) => void>>();
+
+	function onHostEvent(kind: string, listener: (payload: any) => void): () => void {
+		let listeners = eventListeners.get(kind);
+		if (!listeners) {
+			listeners = new Set();
+			eventListeners.set(kind, listeners);
+		}
+		listeners.add(listener);
+		return () => listeners?.delete(listener);
+	}
+
+	function deliverEvent(kind: string, payload: unknown, broadcast: boolean): void {
+		const listeners = eventListeners.get(kind);
+		if (listeners) {
+			for (const listener of Array.from(listeners)) {
+				try {
+					listener(payload);
+				} catch {
+					// A page listener throwing must not stop the rest.
+				}
+			}
+		}
+
+		// Only the top frame receives the injected call, so it repeats the event
+		// to every child — the frame that asked may be several levels down.
+		if (!broadcast) return;
+		for (let i = 0; i < window.frames.length; i += 1) {
+			try {
+				window.frames[i].postMessage({ [`${RELAY_KEY}Event`]: { kind, payload } }, '*');
+			} catch {
+				// Cross-origin child that refused the post; nothing to do.
+			}
+		}
+	}
+
+	// Entry point the backend calls into with `page.evaluate`.
+	scope[EVENT_HOOK] = (raw: string) => {
+		try {
+			const parsed = JSON.parse(raw) as { kind: string; payload: unknown };
+			deliverEvent(parsed.kind, parsed.payload, true);
+		} catch {
+			// Malformed event — ignore.
+		}
+	};
+
+	/**
+	 * Wrap a replacement so it reports itself as the built-in it stands in for.
+	 * Bot-detection scripts read `Function.prototype.toString` far more often
+	 * than they probe behaviour.
+	 */
+	function nativeLike<T extends (...args: never[]) => unknown>(fn: T, name: string): T {
+		try {
+			Object.defineProperty(fn, 'name', { value: name, configurable: true });
+			return new Proxy(fn, {
+				get(target, prop, receiver) {
+					if (prop === 'toString') {
+						return function toString() {
+							return `function ${name}() { [native code] }`;
+						};
+					}
+					return Reflect.get(target, prop, receiver);
+				}
+			}) as T;
+		} catch {
+			return fn;
+		}
+	}
+
+	function define(target: object, key: string, value: unknown): void {
+		try {
+			Object.defineProperty(target, key, { value, configurable: true, writable: true });
+		} catch {
+			try {
+				(target as Record<string, unknown>)[key] = value;
+			} catch {
+				// Frozen prototype — leave the original in place.
+			}
+		}
+	}
+
+	// ── Geolocation ─────────────────────────────────────────────────────────
+	// Answered by the viewer's device, so the page sees the location of the
+	// person actually looking at it rather than the server's datacentre.
+	const geolocation = navigator.geolocation;
+	if (geolocation) {
+		const watchers = new Map<number, ReturnType<typeof setInterval>>();
+		let watchSeq = 0;
+
+		// Fixed cadence rather than honouring `maximumAge`: each poll may surface
+		// a permission prompt on the viewer, so a page asking for 100ms updates
+		// must not be able to drive that.
+		const WATCH_INTERVAL_MS = 15000;
+
+		const toPosition = (raw: Record<string, number | null>) => ({
+			coords: {
+				latitude: raw.latitude,
+				longitude: raw.longitude,
+				accuracy: raw.accuracy,
+				altitude: raw.altitude ?? null,
+				altitudeAccuracy: raw.altitudeAccuracy ?? null,
+				heading: raw.heading ?? null,
+				speed: raw.speed ?? null
+			},
+			timestamp: raw.timestamp || Date.now()
+		});
+
+		const toPositionError = (error: Error & { code?: number }) => ({
+			code: typeof error.code === 'number' ? error.code : 1,
+			message: error.message || 'User denied Geolocation',
+			PERMISSION_DENIED: 1,
+			POSITION_UNAVAILABLE: 2,
+			TIMEOUT: 3
+		});
+
+		const requestPosition = (
+			success?: (position: unknown) => void,
+			failure?: (error: unknown) => void,
+			options?: PositionOptions
+		) => {
+			call('geolocation', {
+				enableHighAccuracy: !!options?.enableHighAccuracy,
+				timeout: options?.timeout,
+				maximumAge: options?.maximumAge
+			})
+				.then((raw) => {
+					if (typeof success === 'function') success(toPosition(raw));
+				})
+				.catch((error: Error & { code?: number }) => {
+					if (typeof failure === 'function') failure(toPositionError(error));
+				});
+		};
+
+		define(
+			geolocation,
+			'getCurrentPosition',
+			nativeLike(function getCurrentPosition(
+				success?: (position: unknown) => void,
+				failure?: (error: unknown) => void,
+				options?: PositionOptions
+			) {
+				requestPosition(success, failure, options);
+			} as never, 'getCurrentPosition')
+		);
+
+		define(
+			geolocation,
+			'watchPosition',
+			nativeLike(function watchPosition(
+				success?: (position: unknown) => void,
+				failure?: (error: unknown) => void,
+				options?: PositionOptions
+			) {
+				watchSeq += 1;
+				const id = watchSeq;
+				requestPosition(success, failure, options);
+				watchers.set(id, setInterval(() => requestPosition(success, failure, options), WATCH_INTERVAL_MS));
+				return id;
+			} as never, 'watchPosition')
+		);
+
+		define(
+			geolocation,
+			'clearWatch',
+			nativeLike(function clearWatch(id: number) {
+				const handle = watchers.get(id);
+				if (handle !== undefined) {
+					clearInterval(handle);
+					watchers.delete(id);
+				}
+			} as never, 'clearWatch')
+		);
+	}
+
+	// ── Camera / microphone / screen ────────────────────────────────────────
+	const mediaDevices = navigator.mediaDevices;
+	if (mediaDevices) {
+		const ICE_SERVERS = [
+			{ urls: 'stun:stun.l.google.com:19302' },
+			{ urls: 'stun:stun1.l.google.com:19302' }
+		];
+
+		/** Resolve once ICE gathering settles, or give up and send what we have. */
+		function waitForIce(pc: RTCPeerConnection): Promise<void> {
+			if (pc.iceGatheringState === 'complete') return Promise.resolve();
+			return new Promise((resolve) => {
+				let settled = false;
+				const finish = () => {
+					if (settled) return;
+					settled = true;
+					pc.removeEventListener('icegatheringstatechange', onChange);
+					resolve();
+				};
+				const onChange = () => {
+					if (pc.iceGatheringState === 'complete') finish();
+				};
+				pc.addEventListener('icegatheringstatechange', onChange);
+				// Non-trickle signalling: a slow or unreachable STUN server must
+				// not stall the request forever, host candidates alone are enough
+				// whenever the viewer and the server share a network.
+				setTimeout(finish, 2500);
+			});
+		}
+
+		async function requestHostMedia(
+			constraints: MediaStreamConstraints,
+			display: boolean
+		): Promise<MediaStream> {
+			const wantsVideo = display ? true : !!constraints?.video;
+			const wantsAudio = !!constraints?.audio;
+			if (!wantsVideo && !wantsAudio) {
+				throw namedError('TypeError', 'At least one of audio and video must be requested');
+			}
+
+			const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+			const stream = new MediaStream();
+			const expectedTracks = (wantsVideo ? 1 : 0) + (wantsAudio ? 1 : 0);
+
+			let markReady: () => void = () => {};
+			const tracksReady = new Promise<void>((resolve) => {
+				markReady = resolve;
+			});
+
+			pc.ontrack = (event) => {
+				stream.addTrack(event.track);
+				if (stream.getTracks().length >= expectedTracks) markReady();
+			};
+
+			if (wantsAudio) pc.addTransceiver('audio', { direction: 'recvonly' });
+			if (wantsVideo) pc.addTransceiver('video', { direction: 'recvonly' });
+
+			let sessionId = '';
+			try {
+				const offer = await pc.createOffer();
+				await pc.setLocalDescription(offer);
+				await waitForIce(pc);
+
+				const answer = await call('media-request', {
+					video: wantsVideo,
+					audio: wantsAudio,
+					display,
+					constraints: JSON.parse(JSON.stringify(constraints ?? {})),
+					sdp: pc.localDescription?.sdp || ''
+				});
+
+				sessionId = answer.sessionId;
+				await pc.setRemoteDescription({ type: 'answer', sdp: answer.sdp });
+
+				await Promise.race([
+					tracksReady,
+					new Promise((_, reject) =>
+						setTimeout(() => reject(namedError('NotReadableError', 'Timed out waiting for host media')), 15000)
+					)
+				]);
+			} catch (error) {
+				try {
+					pc.close();
+				} catch {
+					// Already closed.
+				}
+				if (sessionId) call('media-stop', { sessionId }).catch(() => {});
+				throw error;
+			}
+
+			// Tear the relay down when the page releases the last track, the way
+			// a real capture releases the device.
+			let released = false;
+			const releaseIfDone = () => {
+				if (released) return;
+				if (!stream.getTracks().every((track) => track.readyState === 'ended')) return;
+				released = true;
+				try {
+					pc.close();
+				} catch {
+					// Already closed.
+				}
+				call('media-stop', { sessionId }).catch(() => {});
+			};
+
+			for (const track of stream.getTracks()) {
+				const nativeStop = track.stop.bind(track);
+				define(
+					track,
+					'stop',
+					nativeLike(function stop() {
+						nativeStop();
+						releaseIfDone();
+					} as never, 'stop')
+				);
+				track.addEventListener('ended', releaseIfDone);
+			}
+
+			return stream;
+		}
+
+		define(
+			mediaDevices,
+			'getUserMedia',
+			nativeLike(function getUserMedia(constraints: MediaStreamConstraints) {
+				return requestHostMedia(constraints, false);
+			} as never, 'getUserMedia')
+		);
+
+		// The preview's own capture pipeline calls getDisplayMedia to grab this
+		// tab's compositor output. Keep the real implementation reachable under a
+		// private name *before* replacing it — routing that internal call at the
+		// viewer would ask for their camera on every single page load.
+		const nativeGetDisplayMedia = mediaDevices.getDisplayMedia?.bind(mediaDevices);
+		if (nativeGetDisplayMedia) {
+			scope.__clopenNativeGetDisplayMedia = nativeGetDisplayMedia;
+		}
+
+		// Screen sharing is the same relay with a different source on the viewer's
+		// side, so a page that offers "share your screen" works end to end.
+		define(
+			mediaDevices,
+			'getDisplayMedia',
+			nativeLike(function getDisplayMedia(constraints: MediaStreamConstraints) {
+				return requestHostMedia(constraints ?? { video: true }, true);
+			} as never, 'getDisplayMedia')
+		);
+
+		const originalEnumerateDevices = mediaDevices.enumerateDevices?.bind(mediaDevices);
+		define(
+			mediaDevices,
+			'enumerateDevices',
+			nativeLike(function enumerateDevices() {
+				return call('media-devices')
+					.then((devices: MediaDeviceInfo[]) =>
+						devices.map((device) => ({
+							deviceId: device.deviceId,
+							groupId: device.groupId,
+							kind: device.kind,
+							label: device.label,
+							toJSON() {
+								return device;
+							}
+						}))
+					)
+					.catch(() => (originalEnumerateDevices ? originalEnumerateDevices() : []));
+			} as never, 'enumerateDevices')
+		);
+	}
+
+	// ── Speech recognition ──────────────────────────────────────────────────
+	// Headless Chrome ships no speech engine, so the API exists and always fails
+	// with `not-allowed`. The viewer's browser has both the engine and the
+	// microphone permission, so recognition runs there and streams back.
+	{
+		let sessionSeq = 0;
+
+		class HostSpeechRecognition extends EventTarget {
+			lang = '';
+			continuous = false;
+			interimResults = false;
+			maxAlternatives = 1;
+
+			onresult: ((event: Event) => void) | null = null;
+			onerror: ((event: Event) => void) | null = null;
+			onend: ((event: Event) => void) | null = null;
+			onstart: ((event: Event) => void) | null = null;
+			onaudiostart: ((event: Event) => void) | null = null;
+			onspeechstart: ((event: Event) => void) | null = null;
+
+			#sessionId = '';
+			#unsubscribe: Array<() => void> = [];
+			#running = false;
+
+			#emit(type: string, init: Record<string, unknown> = {}) {
+				const event = new Event(type) as Event & Record<string, unknown>;
+				Object.assign(event, init);
+				this.dispatchEvent(event);
+				const handler = (this as unknown as Record<string, ((e: Event) => void) | null>)[`on${type}`];
+				if (typeof handler === 'function') handler(event);
+			}
+
+			#teardown() {
+				for (const off of this.#unsubscribe) off();
+				this.#unsubscribe = [];
+				this.#running = false;
+			}
+
+			start() {
+				if (this.#running) {
+					throw namedError('InvalidStateError', 'recognition has already started');
+				}
+				sessionSeq += 1;
+				this.#sessionId = `speech-${sessionSeq}-${Date.now()}`;
+				this.#running = true;
+
+				const matches = (payload: any) => payload?.sessionId === this.#sessionId;
+
+				this.#unsubscribe.push(
+					onHostEvent('speech-result', (payload) => {
+						if (!matches(payload)) return;
+
+						// SpeechRecognitionEvent shape: results is an indexed,
+						// array-like collection of alternatives with a final flag.
+						const results = (payload.results ?? []).map((entry: any) => {
+							const alternatives = (entry.alternatives ?? []).map((alt: any) => ({
+								transcript: alt.transcript ?? '',
+								confidence: alt.confidence ?? 0
+							}));
+							return Object.assign(alternatives, {
+								isFinal: !!entry.isFinal,
+								length: alternatives.length,
+								item: (index: number) => alternatives[index]
+							});
+						});
+
+						this.#emit('result', {
+							resultIndex: payload.resultIndex ?? 0,
+							results: Object.assign(results, {
+								length: results.length,
+								item: (index: number) => results[index]
+							})
+						});
+					})
+				);
+
+				this.#unsubscribe.push(
+					onHostEvent('speech-error', (payload) => {
+						if (!matches(payload)) return;
+						this.#emit('error', { error: payload.error || 'aborted', message: payload.message || '' });
+					})
+				);
+
+				this.#unsubscribe.push(
+					onHostEvent('speech-end', (payload) => {
+						if (!matches(payload)) return;
+						this.#teardown();
+						this.#emit('end');
+					})
+				);
+
+				call('speech-start', {
+					sessionId: this.#sessionId,
+					lang: this.lang,
+					continuous: this.continuous,
+					interimResults: this.interimResults,
+					maxAlternatives: this.maxAlternatives
+				})
+					.then(() => {
+						this.#emit('start');
+						this.#emit('audiostart');
+					})
+					.catch((error: Error) => {
+						this.#teardown();
+						this.#emit('error', {
+							error: error.name === 'NotAllowedError' ? 'not-allowed' : 'service-not-allowed',
+							message: error.message
+						});
+						this.#emit('end');
+					});
+			}
+
+			stop() {
+				if (!this.#running) return;
+				call('speech-stop', { sessionId: this.#sessionId, abort: false }).catch(() => {});
+			}
+
+			abort() {
+				if (!this.#running) return;
+				call('speech-stop', { sessionId: this.#sessionId, abort: true }).catch(() => {});
+				this.#teardown();
+				this.#emit('end');
+			}
+		}
+
+		try {
+			Object.defineProperty(HostSpeechRecognition, 'name', {
+				value: 'SpeechRecognition',
+				configurable: true
+			});
+			define(scope, 'SpeechRecognition', HostSpeechRecognition);
+			define(scope, 'webkitSpeechRecognition', HostSpeechRecognition);
+		} catch {
+			// Locked down — leave the (non-functional) original in place.
+		}
+	}
+
+	// ── Fullscreen ──────────────────────────────────────────────────────────
+	// Chrome's real fullscreen resizes the renderer to the browser window, which
+	// discards the emulated viewport the whole preview pipeline is built on: the
+	// captured frame comes back zoomed, off-centre and letterboxed, and survives
+	// a reload because the renderer stays in that state. A CSS fullscreen gives
+	// the page what it asked for without touching the viewport.
+	{
+		const STYLE_ID = '__clopen-fullscreen-style';
+		let fullscreenElement: Element | null = null;
+
+		const ensureStyle = () => {
+			if (document.getElementById(STYLE_ID)) return;
+			const style = document.createElement('style');
+			style.id = STYLE_ID;
+			style.textContent = `
+				[data-clopen-fullscreen] {
+					position: fixed !important;
+					inset: 0 !important;
+					width: 100vw !important;
+					height: 100vh !important;
+					max-width: 100vw !important;
+					max-height: 100vh !important;
+					margin: 0 !important;
+					z-index: 2147483647 !important;
+					background: #000;
+					object-fit: contain;
+				}
+				html.clopen-fullscreen-active, body.clopen-fullscreen-active {
+					overflow: hidden !important;
+				}
+			`;
+			(document.head || document.documentElement).appendChild(style);
+		};
+
+		const notify = () => {
+			const event = new Event('fullscreenchange', { bubbles: true });
+			document.dispatchEvent(event);
+			document.dispatchEvent(new Event('webkitfullscreenchange', { bubbles: true }));
+		};
+
+		const enter = (element: Element) => {
+			ensureStyle();
+			if (fullscreenElement && fullscreenElement !== element) {
+				fullscreenElement.removeAttribute('data-clopen-fullscreen');
+			}
+			fullscreenElement = element;
+			element.setAttribute('data-clopen-fullscreen', '');
+			document.documentElement.classList.add('clopen-fullscreen-active');
+			document.body?.classList.add('clopen-fullscreen-active');
+			notify();
+			return Promise.resolve();
+		};
+
+		const exit = () => {
+			if (!fullscreenElement) return Promise.resolve();
+			fullscreenElement.removeAttribute('data-clopen-fullscreen');
+			fullscreenElement = null;
+			document.documentElement.classList.remove('clopen-fullscreen-active');
+			document.body?.classList.remove('clopen-fullscreen-active');
+			notify();
+			return Promise.resolve();
+		};
+
+		define(Element.prototype, 'requestFullscreen', nativeLike(function requestFullscreen(this: Element) {
+			return enter(this);
+		} as never, 'requestFullscreen'));
+		define(Element.prototype, 'webkitRequestFullscreen', nativeLike(function webkitRequestFullscreen(this: Element) {
+			return enter(this);
+		} as never, 'webkitRequestFullscreen'));
+		define(Element.prototype, 'webkitRequestFullScreen', nativeLike(function webkitRequestFullScreen(this: Element) {
+			return enter(this);
+		} as never, 'webkitRequestFullScreen'));
+
+		define(document, 'exitFullscreen', nativeLike(function exitFullscreen() {
+			return exit();
+		} as never, 'exitFullscreen'));
+		define(document, 'webkitExitFullscreen', nativeLike(function webkitExitFullscreen() {
+			return exit();
+		} as never, 'webkitExitFullscreen'));
+
+		try {
+			for (const key of ['fullscreenElement', 'webkitFullscreenElement']) {
+				Object.defineProperty(document, key, {
+					configurable: true,
+					get: () => fullscreenElement
+				});
+			}
+			for (const key of ['fullscreenEnabled', 'webkitFullscreenEnabled']) {
+				Object.defineProperty(document, key, { configurable: true, get: () => true });
+			}
+		} catch {
+			// Already non-configurable in this engine.
+		}
+
+		// Escape is how every browser leaves fullscreen, and it is the only exit
+		// the page itself can offer once browser chrome is out of the picture.
+		document.addEventListener(
+			'keydown',
+			(event: KeyboardEvent) => {
+				if (event.key === 'Escape' && fullscreenElement) {
+					event.preventDefault();
+					void exit();
+				}
+			},
+			true
+		);
+
+		// A video going fullscreen usually also asks to lock orientation, which
+		// would throw here and abort the page's own handler.
+		const orientation = (screen as unknown as { orientation?: Record<string, unknown> }).orientation;
+		if (orientation && typeof orientation.lock !== 'function') {
+			define(orientation, 'lock', nativeLike(function lock() {
+				return Promise.resolve();
+			} as never, 'lock'));
+			define(orientation, 'unlock', nativeLike(function unlock() {} as never, 'unlock'));
+		}
+	}
+
+	// ── Clipboard ───────────────────────────────────────────────────────────
+	// The headless clipboard is invisible to the user; theirs is the one that
+	// matters, and it is the one a paste in another app will read from.
+	const clipboard = navigator.clipboard;
+	if (clipboard) {
+		define(
+			clipboard,
+			'readText',
+			nativeLike(function readText() {
+				return call('clipboard-read').then((text: string) => text ?? '');
+			} as never, 'readText')
+		);
+
+		define(
+			clipboard,
+			'writeText',
+			nativeLike(function writeText(text: string) {
+				return call('clipboard-write', { text: String(text ?? '') }).then(() => undefined);
+			} as never, 'writeText')
+		);
+	}
+
+	// ── Notifications ───────────────────────────────────────────────────────
+	const NativeNotification = scope.Notification as (typeof Notification) | undefined;
+	if (NativeNotification) {
+		let permission: NotificationPermission = 'default';
+
+		class HostNotification extends EventTarget {
+			static get permission(): NotificationPermission {
+				return permission;
+			}
+
+			static requestPermission(callback?: (result: NotificationPermission) => void): Promise<NotificationPermission> {
+				return call('notification-permission')
+					.then((granted: boolean) => {
+						permission = granted ? 'granted' : 'denied';
+						if (typeof callback === 'function') callback(permission);
+						return permission;
+					})
+					.catch(() => {
+						permission = 'denied';
+						if (typeof callback === 'function') callback(permission);
+						return permission;
+					});
+			}
+
+			title: string;
+			body: string;
+			icon: string;
+			tag: string;
+			data: unknown;
+			onclick: ((event: Event) => void) | null = null;
+			onclose: ((event: Event) => void) | null = null;
+			onerror: ((event: Event) => void) | null = null;
+			onshow: ((event: Event) => void) | null = null;
+
+			constructor(title: string, options?: NotificationOptions) {
+				super();
+				this.title = String(title ?? '');
+				this.body = options?.body ?? '';
+				this.icon = options?.icon ?? '';
+				this.tag = options?.tag ?? '';
+				this.data = options?.data;
+
+				call('notification-show', {
+					title: this.title,
+					body: this.body,
+					icon: this.icon,
+					tag: this.tag
+				})
+					.then(() => {
+						const event = new Event('show');
+						this.dispatchEvent(event);
+						if (typeof this.onshow === 'function') this.onshow(event);
+					})
+					.catch(() => {
+						const event = new Event('error');
+						this.dispatchEvent(event);
+						if (typeof this.onerror === 'function') this.onerror(event);
+					});
+			}
+
+			close() {
+				const event = new Event('close');
+				this.dispatchEvent(event);
+				if (typeof this.onclose === 'function') this.onclose(event);
+			}
+		}
+
+		try {
+			Object.defineProperty(HostNotification, 'name', { value: 'Notification', configurable: true });
+			Object.defineProperty(scope, 'Notification', {
+				value: HostNotification,
+				configurable: true,
+				writable: true
+			});
+		} catch {
+			// Notification is locked down — keep the native (non-functional) one.
+		}
+	}
+
+	// ── Permissions ─────────────────────────────────────────────────────────
+	// Report `prompt` for everything the bridge owns: the real answer lives in
+	// the viewer's browser and is only known once the page actually asks, so
+	// claiming `denied` up front would make pages hide features that do work.
+	const permissions = navigator.permissions;
+	if (permissions?.query) {
+		const BRIDGED = new Set([
+			'geolocation',
+			'camera',
+			'microphone',
+			'notifications',
+			'clipboard-read',
+			'clipboard-write',
+			'speaker-selection',
+			'display-capture'
+		]);
+		const originalQuery = permissions.query.bind(permissions);
+
+		define(
+			permissions,
+			'query',
+			nativeLike(function query(descriptor: PermissionDescriptor) {
+				if (descriptor && BRIDGED.has(descriptor.name as string)) {
+					const status = new EventTarget() as PermissionStatus;
+					Object.defineProperty(status, 'name', { value: descriptor.name, configurable: true });
+					Object.defineProperty(status, 'state', { value: 'prompt', configurable: true });
+					Object.defineProperty(status, 'onchange', { value: null, writable: true, configurable: true });
+					return Promise.resolve(status);
+				}
+				return originalQuery(descriptor);
+			} as never, 'query')
+		);
+	}
+}

--- a/backend/preview/browser/scripts/video-stream.ts
+++ b/backend/preview/browser/scripts/video-stream.ts
@@ -36,8 +36,26 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		(window as any).__webCodecsPeer = null;
 	}
 
-	let peerConnection: RTCPeerConnection | null = null;
-	let dataChannel: RTCDataChannel | null = null;
+	/**
+	 * One peer per viewer, all fed by a single encoder.
+	 *
+	 * A tab can legitimately be watched from several places at once — the same
+	 * project open on a laptop and a phone through Remote Access, or the preview
+	 * shown in two split panels. With a single connection each new viewer's
+	 * handshake tore down the previous one's channel, whose health check then
+	 * reconnected and tore down the newcomer's: the tab flickered between them
+	 * and at least one side sat on "Loading preview…" forever.
+	 *
+	 * Encoding once and fanning the chunks out is what keeps that affordable —
+	 * a second encoder would double the most expensive stage of the pipeline.
+	 */
+	interface ViewerPeer {
+		id: string;
+		pc: RTCPeerConnection;
+		dc: RTCDataChannel | null;
+	}
+
+	const viewers = new Map<string, ViewerPeer>();
 	let videoEncoder: VideoEncoder | null = null;
 	let isCapturing = false;
 	let videoFrameCount = 0;
@@ -245,63 +263,145 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		return null;
 	}
 
-	// Initialize RTCPeerConnection
-	async function initPeerConnection() {
-		if (peerConnection) {
-			peerConnection.close();
-		}
+	/** Channels that can be written to right now. */
+	function openChannels(): RTCDataChannel[] {
+		const channels: RTCDataChannel[] = [];
+		viewers.forEach((viewer) => {
+			if (viewer.dc && viewer.dc.readyState === 'open') channels.push(viewer.dc);
+		});
+		return channels;
+	}
 
-		peerConnection = new RTCPeerConnection({ iceServers });
+	function hasOpenChannel(): boolean {
+		let open = false;
+		viewers.forEach((viewer) => {
+			if (viewer.dc && viewer.dc.readyState === 'open') open = true;
+		});
+		return open;
+	}
+
+	/**
+	 * Congestion of the *worst* viewer.
+	 *
+	 * Every backpressure decision below is about whether to produce the next
+	 * frame at all, and a frame is produced once for everyone. Pacing to the
+	 * slowest link is therefore the only coherent answer: the encoded stream is
+	 * a delta chain, so chunks cannot be dropped for one viewer and kept for
+	 * another without corrupting that viewer's picture until the next keyframe.
+	 */
+	function peakBufferedAmount(): number {
+		let peak = 0;
+		viewers.forEach((viewer) => {
+			if (viewer.dc && viewer.dc.readyState === 'open' && viewer.dc.bufferedAmount > peak) {
+				peak = viewer.dc.bufferedAmount;
+			}
+		});
+		return peak;
+	}
+
+	function broadcast(packet: ArrayBuffer) {
+		const channels = openChannels();
+		for (let i = 0; i < channels.length; i++) {
+			try {
+				channels[i].send(packet);
+			} catch (e) {
+				// One stalled viewer must not cost the others their frame.
+			}
+		}
+	}
+
+	function closePeer(viewerId: string) {
+		const viewer = viewers.get(viewerId);
+		if (!viewer) return false;
+
+		viewers.delete(viewerId);
+		try {
+			viewer.dc?.close();
+		} catch (e) {}
+		try {
+			viewer.pc.close();
+		} catch (e) {}
+		return true;
+	}
+
+	// Create a peer connection for one viewer
+	function createViewerPeer(viewerId: string): ViewerPeer {
+		closePeer(viewerId);
+
+		const pc = new RTCPeerConnection({ iceServers });
+		const viewer: ViewerPeer = { id: viewerId, pc, dc: null };
+		viewers.set(viewerId, viewer);
 
 		// Handle ICE candidates
-		peerConnection.onicecandidate = (event) => {
+		pc.onicecandidate = (event) => {
 			if (event.candidate && (window as any).__sendIceCandidate) {
 				const candidateInit = {
 					candidate: event.candidate.candidate,
 					sdpMid: event.candidate.sdpMid,
 					sdpMLineIndex: event.candidate.sdpMLineIndex
 				};
-				(window as any).__sendIceCandidate(candidateInit);
+				// The viewer is named explicitly: several handshakes can be in
+				// flight at once, and a candidate that reaches the wrong one is
+				// simply dropped there — which is a connection that never completes.
+				(window as any).__sendIceCandidate(viewerId, candidateInit);
 
 				// Also send loopback version for VPN compatibility (same-machine peers)
 				const loopback = createLoopbackCandidate(candidateInit);
 				if (loopback) {
-					(window as any).__sendIceCandidate(loopback);
+					(window as any).__sendIceCandidate(viewerId, loopback);
 				}
 			}
 		};
 
 		// Handle connection state
-		peerConnection.onconnectionstatechange = () => {
-			if ((window as any).__sendConnectionState && peerConnection) {
-				(window as any).__sendConnectionState(peerConnection.connectionState);
+		pc.onconnectionstatechange = () => {
+			const state = pc.connectionState;
+			if ((window as any).__sendConnectionState) {
+				(window as any).__sendConnectionState(viewerId, state);
+			}
+			// A viewer that closed its tab or lost the network leaves a peer
+			// behind that would otherwise keep pacing the encoder forever.
+			if (state === 'closed' || state === 'failed') {
+				if (viewers.get(viewerId) === viewer) closePeer(viewerId);
 			}
 		};
 
-		peerConnection.oniceconnectionstatechange = () => {};
+		pc.oniceconnectionstatechange = () => {};
 
 		// Create DataChannel for encoded chunks.
 		// Reliable + ordered: VP8/VP9/H.264 delta chains require in-order,
 		// lossless delivery — a single lost/reordered chunk corrupts decoding
 		// until the next keyframe (smearing/ghosting). Latency is bounded by
 		// source-side frame dropping instead (see MAX_BUFFERED_BYTES).
-		dataChannel = peerConnection.createDataChannel('media', {
+		const dc = pc.createDataChannel('media', {
 			ordered: true
 		});
 
-		dataChannel.binaryType = 'arraybuffer';
+		dc.binaryType = 'arraybuffer';
 
-		dataChannel.onopen = () => {
-			// Force keyframe when DataChannel opens — the decoder on the other
-			// side needs a sync point (keyframes are on-demand only)
+		dc.onopen = () => {
+			// Force keyframe when a DataChannel opens — the decoder on the other
+			// side needs a sync point (keyframes are on-demand only). A viewer
+			// joining an established stream needs one just as much as the first.
 			forceNextKeyframe = true;
+
+			// And produce a frame to carry it. The source pushes a refresh frame
+			// when the *peer* reports connected, which is typically a moment before
+			// this channel exists — that frame was encoded and then dropped for
+			// want of anywhere to send it. On a page that is not moving, nothing
+			// else would ever be encoded, and the viewer sits on "Loading
+			// preview…" over a perfectly healthy connection.
+			forceKeyframe();
+			(window as any).__requestRefreshFrame?.(viewerId);
 		};
 
-		dataChannel.onclose = () => {};
+		dc.onclose = () => {};
 
-		dataChannel.onerror = (error) => {};
+		dc.onerror = (error) => {};
 
-		return peerConnection;
+		viewer.dc = dc;
+
+		return viewer;
 	}
 
 	// Initialize VideoEncoder
@@ -396,7 +496,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 
 	// Handle encoded video chunk
 	function handleEncodedVideoChunk(chunk: EncodedVideoChunk, metadata: any) {
-		if (!dataChannel || dataChannel.readyState !== 'open') return;
+		if (!hasOpenChannel()) return;
 
 		const isKeyframe = chunk.type === 'key' ? 1 : 0;
 		const timestamp = chunk.timestamp;
@@ -424,7 +524,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 				// Copy data
 				packetData.set(data, 15);
 
-				dataChannel.send(packet);
+				broadcast(packet);
 			} else {
 				// Large frame (e.g. near-lossless top-off keyframe) — fragment.
 				// The channel is reliable + ordered, so fragments arrive in order
@@ -450,7 +550,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 					view.setUint32(15, fragData.byteLength, true);
 					packetData.set(fragData, 19);
 
-					dataChannel.send(packet);
+					broadcast(packet);
 				}
 			}
 
@@ -460,11 +560,11 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 
 	// Send audio chunk (called from AudioContext interception)
 	function sendAudioChunk(timestamp: number, data: Uint8Array) {
-		if (!dataChannel || dataChannel.readyState !== 'open') return;
+		if (!hasOpenChannel()) return;
 
 		// Backpressure: drop audio when the channel is congested — the client's
 		// playback scheduler handles gaps cleanly, and stale audio is worthless
-		if (dataChannel.bufferedAmount > MAX_BUFFERED_BYTES) return;
+		if (peakBufferedAmount() > MAX_BUFFERED_BYTES) return;
 
 		// Format: [type(1)][timestamp(8)][size(4)][data]
 		const packet = new ArrayBuffer(1 + 8 + 4 + data.byteLength);
@@ -481,7 +581,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		packetData.set(data, 13);
 
 		try {
-			dataChannel.send(packet);
+			broadcast(packet);
 			audioFrameCount++;
 		} catch (e) {}
 	}
@@ -491,7 +591,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 	// still-page top-off restores full quality once motion stops, so temporary
 	// coarseness during congestion is invisible in the end result.
 	function currentMotionQuantizer(): number {
-		const buffered = dataChannel ? dataChannel.bufferedAmount : 0;
+		const buffered = peakBufferedAmount();
 		if (buffered > MAX_BUFFERED_BYTES / 2) return Math.min(60, config.motionQuantizer + 16);
 		if (buffered > MAX_BUFFERED_BYTES / 4) return Math.min(60, config.motionQuantizer + 8);
 		return config.motionQuantizer;
@@ -509,7 +609,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 	function shouldSkipMotionFrame(): boolean {
 		framesAttempted++;
 
-		if (dataChannel && dataChannel.bufferedAmount > MAX_BUFFERED_BYTES) {
+		if (peakBufferedAmount() > MAX_BUFFERED_BYTES) {
 			framesSkippedNetwork++;
 			return true;
 		}
@@ -603,7 +703,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 			if (!isTopOff) {
 				motionSeq++;
 				if (shouldSkipMotionFrame()) return;
-			} else if (dataChannel && dataChannel.bufferedAmount > MAX_BUFFERED_BYTES) {
+			} else if (peakBufferedAmount() > MAX_BUFFERED_BYTES) {
 				// Channel congested — dumping a large near-lossless frame on it
 				// now would spike latency. Defer briefly; abandon if new motion
 				// arrives (the backend captures a fresh top-off after the next
@@ -691,7 +791,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		nativeIdleTimer = setTimeout(() => {
 			nativeIdleTimer = null;
 			if (!isCapturing || !lastNativeFrame || !videoEncoder) return;
-			if (dataChannel && dataChannel.bufferedAmount > MAX_BUFFERED_BYTES) {
+			if (peakBufferedAmount() > MAX_BUFFERED_BYTES) {
 				scheduleNativeTopOff();
 				return;
 			}
@@ -769,14 +869,24 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 			// navigates to arbitrary URLs — plain-http targets simply use the
 			// fallback path.
 			if (!window.isSecureContext) return false;
-			if (!navigator.mediaDevices || typeof navigator.mediaDevices.getDisplayMedia !== 'function') return false;
+			// Use the pre-shim implementation the host bridge stashed for us. The
+			// public `getDisplayMedia` is relayed to the viewer's browser, so
+			// calling it here would prompt them for a capture source on every page.
+			const captureTab =
+				((window as any).__clopenNativeGetDisplayMedia as
+					| ((options: unknown) => Promise<MediaStream>)
+					| undefined) ??
+				(navigator.mediaDevices && typeof navigator.mediaDevices.getDisplayMedia === 'function'
+					? navigator.mediaDevices.getDisplayMedia.bind(navigator.mediaDevices)
+					: undefined);
+			if (!captureTab) return false;
 			if (typeof (window as any).MediaStreamTrackProcessor !== 'function') return false;
 
 			const withTimeout = <T,>(promise: Promise<T>, ms: number): Promise<T | null> =>
 				Promise.race([promise, new Promise<null>((resolve) => setTimeout(() => resolve(null), ms))]);
 
 			const stream = await withTimeout(
-				navigator.mediaDevices.getDisplayMedia({
+				captureTab({
 					video: {
 						frameRate: { max: Math.max(1, targetFramerate) },
 						width: { max: encoderWidth },
@@ -893,7 +1003,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 				codec: activeCodec.name,
 				avgFrameCostMs: frameCostSamples > 0 ? frameCostTotalMs / frameCostSamples : 0,
 				encodeQueueMax,
-				bufferedAmount: dataChannel ? dataChannel.bufferedAmount : 0,
+				bufferedAmount: peakBufferedAmount(),
 				framesAttempted,
 				framesSkippedEncoder,
 				framesSkippedNetwork,
@@ -933,7 +1043,6 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		if (isCapturing) return true;
 
 		try {
-			await initPeerConnection();
 			await initVideoEncoder();
 
 			isCapturing = true;
@@ -981,42 +1090,41 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 			videoEncoder = null;
 		}
 
-		if (dataChannel) {
-			dataChannel.close();
-			dataChannel = null;
-		}
-
-		if (peerConnection) {
-			peerConnection.close();
-			peerConnection = null;
-		}
+		viewers.forEach((viewer) => {
+			try {
+				viewer.dc?.close();
+			} catch (e) {}
+			try {
+				viewer.pc.close();
+			} catch (e) {}
+		});
+		viewers.clear();
 	}
 
-	// Create and send offer
-	async function createOffer() {
-		if (!peerConnection) {
-			await initPeerConnection();
-		}
-
+	// Create and send an offer for one viewer
+	async function createOffer(viewerId: string) {
 		try {
-			const offer = await peerConnection!.createOffer();
-			await peerConnection!.setLocalDescription(offer);
+			const viewer = createViewerPeer(viewerId);
+			const offer = await viewer.pc.createOffer();
+			await viewer.pc.setLocalDescription(offer);
 
 			return {
 				type: offer.type,
 				sdp: offer.sdp
 			};
 		} catch (error) {
+			closePeer(viewerId);
 			return null;
 		}
 	}
 
-	// Handle answer from client
-	async function handleAnswer(answer: RTCSessionDescriptionInit) {
-		if (!peerConnection) return false;
+	// Handle answer from a viewer
+	async function handleAnswer(viewerId: string, answer: RTCSessionDescriptionInit) {
+		const viewer = viewers.get(viewerId);
+		if (!viewer) return false;
 
 		try {
-			await peerConnection.setRemoteDescription(new RTCSessionDescription(answer));
+			await viewer.pc.setRemoteDescription(new RTCSessionDescription(answer));
 			return true;
 		} catch (error) {
 			return false;
@@ -1024,11 +1132,12 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 	}
 
 	// Add ICE candidate (+ loopback variant for VPN compatibility)
-	async function addIceCandidate(candidate: RTCIceCandidateInit) {
-		if (!peerConnection) return false;
+	async function addIceCandidate(viewerId: string, candidate: RTCIceCandidateInit) {
+		const viewer = viewers.get(viewerId);
+		if (!viewer) return false;
 
 		try {
-			await peerConnection.addIceCandidate(new RTCIceCandidate(candidate));
+			await viewer.pc.addIceCandidate(new RTCIceCandidate(candidate));
 		} catch (error) {
 			return false;
 		}
@@ -1037,7 +1146,7 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		const loopback = createLoopbackCandidate(candidate);
 		if (loopback) {
 			try {
-				await peerConnection.addIceCandidate(new RTCIceCandidate(loopback as RTCIceCandidateInit));
+				await viewer.pc.addIceCandidate(new RTCIceCandidate(loopback as RTCIceCandidateInit));
 			} catch {
 				// Expected to fail if loopback is not applicable
 			}
@@ -1094,28 +1203,36 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		}
 	}
 
-	// Get stats
+	// Get stats. Bytes are summed across viewers — that is what actually left
+	// the host — while the connection state reports the healthiest peer, since
+	// one viewer reconnecting doesn't mean the stream is down.
 	async function getStats() {
-		if (!peerConnection) return null;
+		const peers = Array.from(viewers.values());
+		if (peers.length === 0) return null;
 
 		try {
-			const stats = await peerConnection.getStats();
 			const result = {
 				videoBytesSent: 0,
 				audioBytesSent: 0,
 				videoFramesEncoded: videoFrameCount,
 				audioFramesEncoded: audioFrameCount,
-				connectionState: peerConnection.connectionState,
+				connectionState: peers.some((viewer) => viewer.pc.connectionState === 'connected')
+					? 'connected'
+					: peers[0].pc.connectionState,
 				videoCodec: activeCodec.name,
 				audioCodec: 'opus' as const,
-				captureMode
+				captureMode,
+				viewerCount: peers.length
 			};
 
-			stats.forEach(report => {
-				if (report.type === 'data-channel') {
-					result.videoBytesSent = (report as any).bytesSent || 0;
-				}
-			});
+			for (const viewer of peers) {
+				const stats = await viewer.pc.getStats();
+				stats.forEach((report) => {
+					if (report.type === 'data-channel') {
+						result.videoBytesSent += (report as any).bytesSent || 0;
+					}
+				});
+			}
 
 			return result;
 		} catch (error) {
@@ -1130,6 +1247,8 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		createOffer,
 		handleAnswer,
 		addIceCandidate,
+		closePeer,
+		viewerCount: () => viewers.size,
 		encodeFrame,
 		forceKeyframe,
 		sendAudioChunk,

--- a/backend/preview/browser/types.ts
+++ b/backend/preview/browser/types.ts
@@ -4,17 +4,57 @@ import type { DeviceSize, Rotation } from '$shared/constants/preview.js';
 // Re-export types from preview config
 export type { DeviceSize, Rotation };
 
+/**
+ * A console argument rendered for display.
+ *
+ * `jsonValue()` cannot represent most of what a page logs — DOM nodes, class
+ * instances, functions and anything circular all throw — so values are
+ * flattened in the page to a shape the console panel can render and expand
+ * without holding a live handle to the object.
+ */
+export interface BrowserConsoleValue {
+	type:
+		| 'string'
+		| 'number'
+		| 'boolean'
+		| 'null'
+		| 'undefined'
+		| 'bigint'
+		| 'symbol'
+		| 'function'
+		| 'array'
+		| 'object'
+		| 'error'
+		| 'node'
+		| 'date'
+		| 'regexp'
+		| 'map'
+		| 'set';
+	/** Single-line rendering, e.g. `Array(3)` or `<div class="row">`. */
+	preview: string;
+	/** Expandable children, present for arrays/objects/maps/sets. */
+	entries?: Array<{ key: string; value: BrowserConsoleValue }>;
+	/** True when `entries` was cut short by the size cap. */
+	truncated?: boolean;
+}
+
 export interface BrowserConsoleMessage {
 	id: string;
-	type: 'log' | 'info' | 'warn' | 'error' | 'debug' | 'trace' | 'clear';
+	type: 'log' | 'info' | 'warn' | 'error' | 'debug' | 'trace' | 'clear' | 'input' | 'result';
 	text: string;
 	args?: unknown[];
+	/** Structured rendering of `args`, used by the console panel. */
+	values?: BrowserConsoleValue[];
 	location?: {
 		url: string;
 		lineNumber: number;
 		columnNumber: number;
 	};
 	stackTrace?: string;
+	/** Network status for messages raised from a failed response. */
+	status?: number;
+	/** Repeat counter for identical consecutive messages, as in DevTools. */
+	count?: number;
 	timestamp: number;
 }
 
@@ -56,6 +96,12 @@ export interface BrowserTab {
 	isLoading: boolean;
 	canGoBack: boolean;
 	canGoForward: boolean;
+	/**
+	 * CDP history index the tab started at, captured after its first real
+	 * navigation. Back is only offered beyond this point so a fresh tab behaves
+	 * like a real browser — you cannot walk back into its initial about:blank.
+	 */
+	historyBaseIndex?: number;
 	lastNavigationTime?: number;
 	currentUrl?: string;
 
@@ -109,15 +155,52 @@ export interface TabNavigatedEvent {
 	timestamp: number;
 }
 
+/**
+ * Live tab metadata pushed after every navigation.
+ *
+ * Bundles the three things the toolbar needs and cannot derive from the URL:
+ * the page's own title, its favicon, and whether Back/Forward are available.
+ */
+export interface BrowserTabMeta {
+	tabId: string;
+	url: string;
+	title: string;
+	favicon?: string;
+	canGoBack: boolean;
+	canGoForward: boolean;
+	timestamp: number;
+}
+
+/** A single entry in a tab's CDP navigation history. */
+export interface BrowserHistoryEntry {
+	id: number;
+	url: string;
+	title: string;
+}
+
+export interface BrowserHistoryState {
+	entries: BrowserHistoryEntry[];
+	currentIndex: number;
+	canGoBack: boolean;
+	canGoForward: boolean;
+}
+
 export interface BrowserTabInfo {
 	id: string;
 	url: string;
 	title: string;
+	/**
+	 * Carried through recovery so a page refresh restores the tab strip as it
+	 * looked, instead of falling back to the placeholder until the next reload.
+	 */
+	favicon?: string;
 	quality: 'perfect' | 'good';
 	isStreaming: boolean;
 	deviceSize: DeviceSize;
 	rotation: Rotation;
 	isActive: boolean;
+	canGoBack: boolean;
+	canGoForward: boolean;
 }
 
 export interface BrowserAutonomousAction {
@@ -451,6 +534,33 @@ export interface BrowserSelectOption {
 	text: string;
 	selected: boolean;
 	disabled?: boolean;
+	/** `<optgroup>` label this option belongs to, if any. */
+	group?: string;
+	groupDisabled?: boolean;
+}
+
+/**
+ * An input whose picker Chrome draws outside the page.
+ *
+ * Colour swatches and the date/time family open browser-process popups that the
+ * screencast cannot see, so the viewer renders the equivalent native control
+ * over the canvas and writes the result back.
+ */
+export interface BrowserNativePickerInfo {
+	tabId: string;
+	pickerId: string;
+	inputType: 'color' | 'date' | 'datetime-local' | 'month' | 'time' | 'week';
+	value: string;
+	min?: string;
+	max?: string;
+	step?: string;
+	boundingBox: {
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+	};
+	timestamp: number;
 }
 
 export interface BrowserSelectInfo {
@@ -488,22 +598,32 @@ export interface BrowserContextMenuItem {
 	submenu?: BrowserContextMenuItem[];
 }
 
+export interface BrowserContextMenuElementInfo {
+	tagName: string;
+	isLink: boolean;
+	isImage: boolean;
+	isInput: boolean;
+	/** Inputs plus contenteditable regions — everything the edit commands apply to. */
+	isEditable: boolean;
+	isTextSelected: boolean;
+	/** Truncated selection, used only to label the "Search for…" item. */
+	selectedText?: string;
+	linkUrl?: string;
+	linkText?: string;
+	imageUrl?: string;
+	mediaUrl?: string;
+	mediaType?: string;
+	inputType?: string;
+	pageUrl?: string;
+}
+
 export interface BrowserContextMenuInfo {
 	tabId: string;
 	menuId: string;
 	x: number; // Click coordinates
 	y: number;
 	items: BrowserContextMenuItem[];
-	elementInfo: {
-		tagName: string;
-		isLink: boolean;
-		isImage: boolean;
-		isInput: boolean;
-		isTextSelected: boolean;
-		linkUrl?: string;
-		imageUrl?: string;
-		inputType?: string;
-	};
+	elementInfo: BrowserContextMenuElementInfo;
 	timestamp: number;
 }
 

--- a/backend/ws/preview/browser/host.ts
+++ b/backend/ws/preview/browser/host.ts
@@ -1,0 +1,95 @@
+/**
+ * Browser Host Bridge WebSocket Handler
+ *
+ * Carries the viewer's answer back to a capability the headless browser asked
+ * for — a location fix, a camera stream, clipboard contents, a file selection.
+ * The request itself is pushed by BrowserHostBridge; this is the return leg.
+ *
+ * **PROJECT ISOLATION**: the request id is only meaningful inside the caller's
+ * own project service, so a response from one project can never settle
+ * another's pending request.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { debug } from '$shared/utils/logger';
+import { requireBrowserPreviewAccess } from '../access';
+
+export const hostPreviewHandler = createRouter()
+	.on('preview:browser-host-response', {
+		data: t.Object({
+			requestId: t.String({ minLength: 1 }),
+			ok: t.Boolean(),
+			result: t.Optional(t.Any()),
+			error: t.Optional(
+				t.Object({
+					name: t.Optional(t.String()),
+					message: t.Optional(t.String()),
+					code: t.Optional(t.Number())
+				})
+			)
+		})
+	}, async ({ data, conn }) => {
+		const { projectId, previewService } = requireBrowserPreviewAccess(conn);
+
+		const delivered = previewService.respondToHostRequest(data.requestId, {
+			ok: data.ok,
+			result: data.result,
+			error: data.error
+		});
+
+		if (!delivered) {
+			// Expected whenever the page gave up first or the tab closed while the
+			// viewer was still deciding — not worth surfacing as an error.
+			debug.log('preview', `⏭️ Host response for unknown request ${data.requestId} (project: ${projectId})`);
+		}
+	})
+
+	/**
+	 * Push a streamed result into the page.
+	 *
+	 * Speech recognition does not fit request/response: one `start()` produces a
+	 * run of interim and final results, so the viewer keeps sending these until
+	 * recognition ends.
+	 */
+	.on('preview:browser-host-event', {
+		data: t.Object({
+			tabId: t.String({ minLength: 1 }),
+			kind: t.String({ minLength: 1 }),
+			payload: t.Optional(t.Any())
+		})
+	}, async ({ data, conn }) => {
+		const { previewService } = requireBrowserPreviewAccess(conn);
+		await previewService.dispatchHostEvent(data.tabId, data.kind, data.payload);
+	})
+
+	/**
+	 * Deliver a value chosen in the viewer's own colour or date picker.
+	 */
+	.on('preview:browser-native-picker-input', {
+		data: t.Object({
+			tabId: t.String({ minLength: 1 }),
+			pickerId: t.String({ minLength: 1 }),
+			value: t.String()
+		})
+	}, async ({ data, conn }) => {
+		const { previewService } = requireBrowserPreviewAccess(conn);
+		await previewService.handleNativePickerResponse(data.tabId, data.pickerId, data.value);
+	})
+
+	.emit('preview:browser-native-picker', t.Object({
+		sessionId: t.String(),
+		pickerId: t.String(),
+		inputType: t.String(),
+		value: t.String(),
+		min: t.Optional(t.String()),
+		max: t.Optional(t.String()),
+		step: t.Optional(t.String()),
+		boundingBox: t.Object({
+			x: t.Number(),
+			y: t.Number(),
+			width: t.Number(),
+			height: t.Number()
+		}),
+		timestamp: t.Number()
+	}));

--- a/backend/ws/preview/browser/interact.ts
+++ b/backend/ws/preview/browser/interact.ts
@@ -10,7 +10,8 @@ import { ws } from '$backend/utils/ws';
 import type { KeyInput } from 'puppeteer';
 import { debug } from '$shared/utils/logger';
 import { sleep } from '$shared/utils/async';
-import { requireBrowserPreviewAccess } from '../access';
+import { requireBrowserPreviewAccess, requireBrowserTabAccess } from '../access';
+import { resolveFrameTarget } from '$backend/preview/browser/frame-targeting';
 
 // Throttle cursor detection evaluate calls per session (100ms = ~10/sec is plenty)
 const lastCursorEvalTime = new Map<string, number>();
@@ -153,6 +154,15 @@ export const interactPreviewHandler = createRouter()
 								break;
 							}
 
+							// Colour and date inputs open pickers Chrome draws in the
+							// browser process, which never reach the screencast — the
+							// viewer renders the equivalent control instead.
+							const pickerInfo = await previewService.checkForNativePicker(session.id, action.x!, action.y!);
+							if (pickerInfo) {
+								debug.log('preview', `🎨 Native picker input detected at (${action.x}, ${action.y})`);
+								break;
+							}
+
 							// Perform the click - this does down + up atomically
 							await session.page.mouse.click(action.x!, action.y!);
 						} catch (error) {
@@ -283,8 +293,65 @@ export const interactPreviewHandler = createRouter()
 						}
 						break;
 
+					case 'paste':
+						// Insert into whatever holds focus, in whichever frame that
+						// is. Synthesising Ctrl+V would paste the *headless* browser's
+						// clipboard, which is not the one the user copied into.
+						if (typeof action.text === 'string') {
+							for (const frame of session.page.frames()) {
+								try {
+									const inserted = await frame.evaluate((text: string) => {
+										const active = document.activeElement as HTMLElement | null;
+										if (!active) return false;
+
+										const isField = active.tagName === 'INPUT' || active.tagName === 'TEXTAREA';
+										if (!isField && !active.isContentEditable) return false;
+
+										if (isField) {
+											const field = active as HTMLInputElement | HTMLTextAreaElement;
+											const start = field.selectionStart ?? field.value.length;
+											const end = field.selectionEnd ?? field.value.length;
+											field.value = field.value.slice(0, start) + text + field.value.slice(end);
+											const caret = start + text.length;
+											field.setSelectionRange(caret, caret);
+										} else {
+											document.execCommand('insertText', false, text);
+										}
+
+										active.dispatchEvent(new Event('input', { bubbles: true }));
+										active.dispatchEvent(new Event('change', { bubbles: true }));
+										return true;
+									}, action.text);
+									if (inserted) break;
+								} catch {
+									// Frame detached mid-paste; try the next one.
+								}
+							}
+						}
+						break;
+
+					case 'stop':
+						// `window.stop()` is what the browser's own Stop button calls:
+						// it halts the current load and every pending subresource,
+						// leaving whatever has already rendered on screen.
+						try {
+							await session.page.evaluate(() => window.stop());
+						} catch {
+							// Mid-navigation the context can already be gone — the load
+							// it would have stopped is over either way.
+						}
+						break;
+
 					case 'scroll':
 						try {
+							// CDP dispatches a wheel at the *current* pointer position,
+							// so a scroll that arrives without one first lands wherever
+							// the last click left the cursor — scrolling the wrong
+							// container and stranding hover state there. Touch scrolling
+							// has no pointer of its own, hence the explicit move.
+							if (action.x !== undefined && action.y !== undefined) {
+								await session.page.mouse.move(action.x, action.y, { steps: 1 });
+							}
 							await session.page.mouse.wheel({ deltaX: action.deltaX || 0, deltaY: action.deltaY || 0 });
 						} catch (error) {
 							if (error instanceof Error && isNavigationError(error)) {
@@ -447,22 +514,24 @@ export const interactPreviewHandler = createRouter()
 
 					case 'scale-update':
 						// Recovery path: the frontend sends this when the stream
-						// looks stuck. It also carries the current display
-						// metrics, which capture resolution is derived from.
+						// looks stuck.
+						//
+						// It no longer carries display metrics. Those are tracked
+						// per viewer — a tab can be watched from several devices
+						// with different screens — and reach the source through
+						// `preview:browser-stream-display`, which says which
+						// viewer they describe. An interaction cannot.
 						if (action.scale && action.scale > 0 && action.scale <= 1) {
 							session.scale = action.scale;
-							previewService.applyWebCodecsDisplayMetrics(session.id, {
-								scale: action.scale,
-								dpr: action.dpr
-							});
 							debug.log('preview', `📐 Scale updated for tab ${tabId}: ${action.scale}, refreshing capture`);
 
 							const updated = await previewService.refreshWebCodecsScreencast(session.id);
 							if (!updated) {
-								debug.warn('preview', `⚠️ Screencast refresh failed, falling back to restart`);
-								// Fallback: restart if refresh fails
-								await previewService.stopWebCodecsStreaming(session.id);
-								await previewService.startWebCodecsStreaming(session.id);
+								// Restarting from here would tear the capture down for
+								// every viewer of this tab and rebuild it with none.
+								// The viewer that noticed the stall owns its own
+								// recovery and will re-handshake.
+								debug.warn('preview', `⚠️ Screencast refresh failed for tab ${tabId}, leaving recovery to the viewer`);
 							}
 						}
 						break;
@@ -476,13 +545,9 @@ export const interactPreviewHandler = createRouter()
 
 							debug.log('preview', `📱 Viewport updated for tab ${tabId}: ${action.width}x${action.height}`);
 
-							// The emulated viewport changed, so the derived
-							// capture size has to be recomputed from the new
-							// dimensions before the hot-swap.
-							previewService.applyWebCodecsDisplayMetrics(session.id, {
-								scale: action.scale,
-								dpr: action.dpr
-							});
+							// The hot-swap recomputes capture geometry from the new
+							// viewport and the viewers' own display metrics, which
+							// each of them reports separately.
 
 							// Hot-swap viewport without reconnection
 							const updated = await previewService.updateWebCodecsViewport(session.id, action.width, action.height);
@@ -529,6 +594,123 @@ export const interactPreviewHandler = createRouter()
 			});
 		}
 	})
+
+	/**
+	 * Read (and optionally cut) the page's current text selection.
+	 *
+	 * Ctrl+C inside the preview cannot be forwarded as a keystroke: that would
+	 * fill the *headless* browser's clipboard, which nothing the user can paste
+	 * into ever reads. The text is returned instead so the viewer can put it on
+	 * their own clipboard.
+	 */
+	.http('preview:browser-selection', {
+		data: t.Object({
+			cut: t.Optional(t.Boolean())
+		}),
+		response: t.Object({
+			text: t.String()
+		})
+	}, async ({ data, conn }) => {
+		const { tab } = requireBrowserTabAccess(conn);
+
+		// Selections inside an iframe are invisible to the top document, so every
+		// frame is asked until one reports a selection.
+		for (const frame of tab.page.frames()) {
+			try {
+				const text = await frame.evaluate((remove: boolean) => {
+					const selected = window.getSelection()?.toString() ?? '';
+					if (selected && remove) document.execCommand('delete');
+					return selected;
+				}, !!data.cut);
+				if (text) return { text };
+			} catch {
+				// Detached or cross-origin mid-navigation; keep looking.
+			}
+		}
+
+		return { text: '' };
+	})
+
+	/**
+	 * Report whether the element at a point accepts text.
+	 *
+	 * This is what decides the on-screen keyboard, and it is a *hit test* rather
+	 * than a focus read for a reason. Focus is only settled once the tap has been
+	 * dispatched and the page has run its handlers, so asking for it right after
+	 * a tap answered for the *previous* tap: the first tap on a field reported
+	 * "not editable" and only the second one raised the keyboard, while a tap on
+	 * empty space after typing still reported the old field and popped the
+	 * keyboard back up. The element under the finger is known before any of that
+	 * happens, so the viewer can ask on `touchstart` and act on `touchend` —
+	 * which is also the only moment iOS will honour a programmatic focus.
+	 */
+	.http('preview:browser-hit-test', {
+		data: t.Object({
+			x: t.Number(),
+			y: t.Number()
+		}),
+		response: t.Object({
+			editable: t.Boolean(),
+			inputType: t.Optional(t.String())
+		})
+	}, async ({ data, conn }) => {
+		const { tab } = requireBrowserTabAccess(conn);
+
+		try {
+			// Fields inside an iframe are invisible to the top document, where
+			// `elementFromPoint` returns the <iframe> element itself.
+			const target = await resolveFrameTarget(tab.page, data.x, data.y);
+
+			return await target.frame.evaluate(
+				(point: { x: number; y: number }) => {
+					const el = document.elementFromPoint(point.x, point.y) as HTMLElement | null;
+					if (!el) return { editable: false };
+
+					// A field is often wrapped — the tap lands on a label, an icon or
+					// the padded box around the input rather than the input itself.
+					const field = el.closest(
+						'input, textarea, [contenteditable=""], [contenteditable="true"]'
+					) as HTMLInputElement | HTMLTextAreaElement | HTMLElement | null;
+					if (!field) return { editable: false };
+
+					if (field.isContentEditable) return { editable: true, inputType: 'contenteditable' };
+
+					const tag = field.tagName;
+					if (tag === 'TEXTAREA') return { editable: true, inputType: 'textarea' };
+
+					const type = ((field as HTMLInputElement).type || 'text').toLowerCase();
+					const nonText = [
+						'checkbox',
+						'radio',
+						'button',
+						'submit',
+						'reset',
+						'file',
+						'image',
+						'range',
+						'color',
+						'date',
+						'datetime-local',
+						'month',
+						'time',
+						'week'
+					];
+					if (nonText.includes(type)) return { editable: false };
+					if ((field as HTMLInputElement).readOnly || (field as HTMLInputElement).disabled) {
+						return { editable: false };
+					}
+
+					return { editable: true, inputType: type };
+				},
+				{ x: target.x, y: target.y }
+			);
+		} catch {
+			// Detached or mid-navigation — treat as "no field" so the viewer leaves
+			// the keyboard alone rather than raising it over nothing.
+			return { editable: false };
+		}
+	})
+
 
 	// Server → Client Events (independent declarations)
 	.emit('preview:browser-interacted', t.Object({

--- a/backend/ws/preview/browser/native-ui.ts
+++ b/backend/ws/preview/browser/native-ui.ts
@@ -146,6 +146,19 @@ export const nativeUIPreviewHandler = createRouter()
 		timestamp: t.Number()
 	}))
 
+	/**
+	 * The page's dialog has been answered — by whoever got there first.
+	 *
+	 * A dialog belongs to the page, not to a viewer, but each viewer was shown
+	 * its own copy of the prompt. Without this the other devices keep an overlay
+	 * for a dialog that no longer exists, and answering it again does nothing.
+	 */
+	.emit('preview:browser-dialog-closed', t.Object({
+		sessionId: t.String(),
+		dialogId: t.String(),
+		timestamp: t.Number()
+	}))
+
 	.emit('preview:browser-print', t.Object({
 		sessionId: t.String(),
 		timestamp: t.Number()
@@ -194,10 +207,16 @@ export const nativeUIPreviewHandler = createRouter()
 			isLink: t.Boolean(),
 			isImage: t.Boolean(),
 			isInput: t.Boolean(),
+			isEditable: t.Boolean(),
 			isTextSelected: t.Boolean(),
+			selectedText: t.Optional(t.String()),
 			linkUrl: t.Optional(t.String()),
+			linkText: t.Optional(t.String()),
 			imageUrl: t.Optional(t.String()),
-			inputType: t.Optional(t.String())
+			mediaUrl: t.Optional(t.String()),
+			mediaType: t.Optional(t.String()),
+			inputType: t.Optional(t.String()),
+			pageUrl: t.Optional(t.String())
 		}),
 		timestamp: t.Number()
 	}))
@@ -208,6 +227,17 @@ export const nativeUIPreviewHandler = createRouter()
 
 	.emit('preview:browser-open-url-new-tab', t.Object({
 		url: t.String()
+	}))
+
+	// "Open in Your Browser" — leaves the preview entirely and hands the URL to
+	// the viewer's own browser.
+	.emit('preview:browser-open-url-host', t.Object({
+		url: t.String()
+	}))
+
+	// "Inspect" — asks the viewer to reveal the console panel.
+	.emit('preview:browser-open-inspector', t.Object({
+		timestamp: t.Number()
 	}))
 
 	.emit('preview:browser-download-image', t.Object({

--- a/backend/ws/preview/browser/tab-info.ts
+++ b/backend/ws/preview/browser/tab-info.ts
@@ -20,11 +20,14 @@ export const tabInfoPreviewHandler = createRouter()
 			tabId: t.String(),
 			url: t.String(),
 			title: t.String(),
+			favicon: t.Optional(t.String()),
 			quality: t.String(),
 			isStreaming: t.Boolean(),
 			deviceSize: t.String(),
 			rotation: t.String(),
-			isActive: t.Boolean()
+			isActive: t.Boolean(),
+			canGoBack: t.Boolean(),
+			canGoForward: t.Boolean()
 		})
 	}, async ({ data, conn }) => {
 		const { tabId } = data;
@@ -52,11 +55,14 @@ export const tabInfoPreviewHandler = createRouter()
 				tabId: t.String(),
 				url: t.String(),
 				title: t.String(),
+				favicon: t.Optional(t.String()),
 				quality: t.String(),
 				isStreaming: t.Boolean(),
 				deviceSize: t.String(),
 				rotation: t.String(),
 				isActive: t.Boolean(),
+				canGoBack: t.Boolean(),
+				canGoForward: t.Boolean(),
 				isMcpControlled: t.Boolean()
 			})),
 			activeTabId: t.Union([t.String(), t.Null()]),
@@ -77,11 +83,14 @@ export const tabInfoPreviewHandler = createRouter()
 				tabId: tab.id,
 				url: tab.url,
 				title: tab.title,
+				favicon: tab.favicon,
 				quality: tab.quality,
 				isStreaming: tab.isStreaming,
 				deviceSize: tab.deviceSize,
 				rotation: tab.rotation,
 				isActive: tab.isActive,
+				canGoBack: tab.canGoBack,
+				canGoForward: tab.canGoForward,
 				isMcpControlled: browserMcpControl.isTabControlled(tab.id, projectId)
 			})),
 			activeTabId: activeTab?.id || null,

--- a/backend/ws/preview/browser/tab.ts
+++ b/backend/ws/preview/browser/tab.ts
@@ -106,6 +106,49 @@ export const tabPreviewHandler = createRouter()
 		};
 	})
 
+	// Walk the tab's history (Back / Forward)
+	.http('preview:browser-tab-history-go', {
+		data: t.Object({
+			direction: t.Union([t.Literal('back'), t.Literal('forward')]),
+			tabId: t.Optional(t.String())
+		}),
+		response: t.Object({
+			moved: t.Boolean(),
+			tabId: t.String()
+		})
+	}, async ({ data, conn }) => {
+		const { projectId, previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
+
+		debug.log('preview', `↩️ History ${data.direction} for tab ${tab.id} (project: ${projectId})`);
+
+		const moved = await previewService.goHistory(tab.id, data.direction === 'back' ? -1 : 1);
+
+		return { moved, tabId: tab.id };
+	})
+
+	// Read the tab's history list — backs the long-press dropdown on Back
+	.http('preview:browser-tab-history', {
+		data: t.Object({
+			tabId: t.Optional(t.String())
+		}),
+		response: t.Object({
+			entries: t.Array(t.Object({
+				id: t.Number(),
+				url: t.String(),
+				title: t.String()
+			})),
+			currentIndex: t.Number(),
+			canGoBack: t.Boolean(),
+			canGoForward: t.Boolean()
+		})
+	}, async ({ data, conn }) => {
+		const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
+
+		const state = await previewService.getHistoryState(tab.id);
+
+		return state ?? { entries: [], currentIndex: 0, canGoBack: false, canGoForward: false };
+	})
+
 	// Close browser tab
 	.http('preview:browser-tab-close', {
 		data: t.Object({

--- a/backend/ws/preview/browser/webcodecs.ts
+++ b/backend/ws/preview/browser/webcodecs.ts
@@ -11,6 +11,13 @@ import { t } from 'elysia';
 import { ws } from '$backend/utils/ws';
 import { requireBrowserTabAccess } from '../access';
 
+/**
+ * Viewer/tab pairs that already have a disconnect cleanup registered.
+ * Keyed by project + tab + viewer; the entry is dropped when the cleanup runs,
+ * so a reconnecting viewer registers again.
+ */
+const registeredViewerCleanups = new Set<string>();
+
 export const streamPreviewHandler = createRouter()
 	// Start streaming
 	.http(
@@ -18,6 +25,10 @@ export const streamPreviewHandler = createRouter()
 		{
 			data: t.Object({
 				tabId: t.Optional(t.String()),
+				// Identifies this viewer for the whole session. A tab can be
+				// watched from several devices (and several panels) at once, so
+				// every signalling message has to say which peer it belongs to.
+				viewerId: t.String(),
 				// Legacy VP9-only capability flag — superseded by `codecs`,
 				// kept so an older client can still negotiate.
 				vp9: t.Optional(t.Boolean()),
@@ -54,7 +65,7 @@ export const streamPreviewHandler = createRouter()
 			})
 		},
 		async ({ data, conn }) => {
-			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
+			const { previewService, projectId, tab } = requireBrowserTabAccess(conn, data.tabId);
 
 			const sessionId = tab.id;
 
@@ -74,6 +85,7 @@ export const streamPreviewHandler = createRouter()
 
 			// Start WebCodecs streaming
 			const started = await previewService.startWebCodecsStreaming(sessionId, {
+				viewerId: data.viewerId,
 				codecSupport,
 				display: data.display
 			});
@@ -82,8 +94,25 @@ export const streamPreviewHandler = createRouter()
 				throw new Error('Failed to start WebCodecs streaming');
 			}
 
+			// A viewer that goes away without a stop — the tab is closed, the
+			// laptop sleeps, the tunnel drops — must not keep the capture alive
+			// for an audience of nobody.
+			//
+			// Registered once per viewer and tab: switching tabs back and forth
+			// re-runs this handler, and a fresh closure each time would pile up
+			// on a connection that can live for hours.
+			const viewerId = data.viewerId;
+			const cleanupKey = `${projectId}:${sessionId}:${viewerId}`;
+			if (!registeredViewerCleanups.has(cleanupKey)) {
+				registeredViewerCleanups.add(cleanupKey);
+				ws.addCleanup(conn, () => {
+					registeredViewerCleanups.delete(cleanupKey);
+					void previewService.stopWebCodecsStreaming(sessionId, viewerId);
+				});
+			}
+
 			// Get offer from headless browser
-			const offer = await previewService.getWebCodecsOffer(sessionId);
+			const offer = await previewService.getWebCodecsOffer(sessionId, data.viewerId);
 
 			return {
 				success: true,
@@ -103,7 +132,8 @@ export const streamPreviewHandler = createRouter()
 		'preview:browser-stream-offer',
 		{
 			data: t.Object({
-				tabId: t.Optional(t.String())
+				tabId: t.Optional(t.String()),
+				viewerId: t.String()
 			}),
 			response: t.Object({
 				success: t.Boolean(),
@@ -118,7 +148,7 @@ export const streamPreviewHandler = createRouter()
 		async ({ data, conn }) => {
 			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
 
-			const offer = await previewService.getWebCodecsOffer(tab.id);
+			const offer = await previewService.getWebCodecsOffer(tab.id, data.viewerId);
 
 			return {
 				success: !!offer,
@@ -141,7 +171,8 @@ export const streamPreviewHandler = createRouter()
 					type: t.String(),
 					sdp: t.Optional(t.String())
 				}),
-				tabId: t.Optional(t.String())
+				tabId: t.Optional(t.String()),
+				viewerId: t.String()
 			}),
 			response: t.Object({
 				success: t.Boolean()
@@ -151,7 +182,11 @@ export const streamPreviewHandler = createRouter()
 			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
 
 			const { answer } = data;
-			const success = await previewService.handleWebCodecsAnswer(tab.id, answer as RTCSessionDescriptionInit);
+			const success = await previewService.handleWebCodecsAnswer(
+				tab.id,
+				data.viewerId,
+				answer as RTCSessionDescriptionInit
+			);
 
 			return { success };
 		}
@@ -167,7 +202,8 @@ export const streamPreviewHandler = createRouter()
 					sdpMid: t.Optional(t.Union([t.String(), t.Null()])),
 					sdpMLineIndex: t.Optional(t.Union([t.Number(), t.Null()]))
 				}),
-				tabId: t.Optional(t.String())
+				tabId: t.Optional(t.String()),
+				viewerId: t.String()
 			}),
 			response: t.Object({
 				success: t.Boolean()
@@ -177,7 +213,11 @@ export const streamPreviewHandler = createRouter()
 			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
 
 			const { candidate } = data;
-			const success = await previewService.addWebCodecsIceCandidate(tab.id, candidate as RTCIceCandidateInit);
+			const success = await previewService.addWebCodecsIceCandidate(
+				tab.id,
+				data.viewerId,
+				candidate as RTCIceCandidateInit
+			);
 
 			return { success };
 		}
@@ -215,6 +255,7 @@ export const streamPreviewHandler = createRouter()
 		{
 			data: t.Object({
 				tabId: t.Optional(t.String()),
+				viewerId: t.String(),
 				decodeQueueSize: t.Number(),
 				decodeLatencyMs: t.Number(),
 				dropRatio: t.Number()
@@ -226,7 +267,7 @@ export const streamPreviewHandler = createRouter()
 		async ({ data, conn }) => {
 			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
 
-			previewService.applyWebCodecsClientFeedback(tab.id, {
+			previewService.applyWebCodecsClientFeedback(tab.id, data.viewerId, {
 				decodeQueueSize: data.decodeQueueSize,
 				decodeLatencyMs: data.decodeLatencyMs,
 				dropRatio: data.dropRatio
@@ -243,6 +284,7 @@ export const streamPreviewHandler = createRouter()
 		{
 			data: t.Object({
 				tabId: t.Optional(t.String()),
+				viewerId: t.String(),
 				scale: t.Optional(t.Number()),
 				dpr: t.Optional(t.Number())
 			}),
@@ -253,7 +295,7 @@ export const streamPreviewHandler = createRouter()
 		async ({ data, conn }) => {
 			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
 
-			const success = previewService.applyWebCodecsDisplayMetrics(tab.id, {
+			const success = previewService.applyWebCodecsDisplayMetrics(tab.id, data.viewerId, {
 				scale: data.scale,
 				dpr: data.dpr
 			});
@@ -270,6 +312,7 @@ export const streamPreviewHandler = createRouter()
 		{
 			data: t.Object({
 				tabId: t.Optional(t.String()),
+				viewerId: t.String(),
 				visible: t.Boolean()
 			}),
 			response: t.Object({
@@ -279,18 +322,20 @@ export const streamPreviewHandler = createRouter()
 		async ({ data, conn }) => {
 			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
 
-			const success = await previewService.setWebCodecsPaused(tab.id, !data.visible);
+			const success = await previewService.setWebCodecsPaused(tab.id, data.viewerId, !data.visible);
 
 			return { success };
 		}
 	)
 
-	// Stop streaming
+	// Stop streaming for one viewer. The capture itself only stops when the
+	// last viewer detaches.
 	.http(
 		'preview:browser-stream-stop',
 		{
 			data: t.Object({
-				tabId: t.Optional(t.String())
+				tabId: t.Optional(t.String()),
+				viewerId: t.String()
 			}),
 			response: t.Object({
 				success: t.Boolean()
@@ -299,17 +344,20 @@ export const streamPreviewHandler = createRouter()
 		async ({ data, conn }) => {
 			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
 
-			await previewService.stopWebCodecsStreaming(tab.id);
+			await previewService.stopWebCodecsStreaming(tab.id, data.viewerId);
 
 			return { success: true };
 		}
 	)
 
-	// Server → Client: ICE candidate from headless browser
+	// Server → Client: ICE candidate from headless browser.
+	// Broadcast to the project room, so `viewerId` is what tells each viewer
+	// which candidates belong to its own peer.
 	.emit(
 		'preview:browser-stream-ice',
 		t.Object({
 			sessionId: t.String(), // Internal session ID (kept for routing)
+			viewerId: t.String(),
 			candidate: t.Object({
 				candidate: t.Optional(t.String()),
 				sdpMid: t.Optional(t.Union([t.String(), t.Null()])),
@@ -324,6 +372,7 @@ export const streamPreviewHandler = createRouter()
 		'preview:browser-stream-state',
 		t.Object({
 			sessionId: t.String(), // Internal session ID (kept for routing)
+			viewerId: t.String(),
 			state: t.String()
 		})
 	)
@@ -370,40 +419,5 @@ export const streamPreviewHandler = createRouter()
 		})
 	);
 
-// Setup event forwarding from preview service to WebSocket
-// This needs to be done per-project service instance
-// We'll set up a helper function that the service manager can call
-
-/**
- * Setup event forwarding for a preview service instance
- * Should be called when a new service is created
- */
-export function setupEventForwarding(previewService: any, projectId: string) {
-	previewService.on('webcodecs-ice-candidate', (data: { sessionId: string; candidate: RTCIceCandidateInit; from: string }) => {
-		ws.emit.project(projectId, 'preview:browser-stream-ice', {
-			sessionId: data.sessionId,
-			candidate: data.candidate,
-			from: data.from
-		});
-	});
-
-	previewService.on('webcodecs-connection-state', (data: { sessionId: string; state: string }) => {
-		ws.emit.project(projectId, 'preview:browser-stream-state', data);
-	});
-
-	previewService.on('cursor-change', (data: { sessionId: string; cursor: string }) => {
-		ws.emit.project(projectId, 'preview:browser-cursor-change', data);
-	});
-
-	// Forward navigation events
-	previewService.on('preview:browser-navigation-loading', (data: { sessionId: string; type: string; url: string; timestamp: number }) => {
-		ws.emit.project(projectId, 'preview:browser-navigation-loading', data);
-	});
-
-	previewService.on('preview:browser-navigation', (data: { sessionId: string; type: string; url: string; timestamp: number }) => {
-		ws.emit.project(projectId, 'preview:browser-navigation', data);
-	});
-}
-
-// Note: Event forwarding is now set up per-project in BrowserPreviewService constructor
-// via the setupProjectEventForwarding method
+// Event forwarding lives in BrowserPreviewServiceManager, which owns the
+// per-project service instances and can name the project each event belongs to.

--- a/backend/ws/preview/index.ts
+++ b/backend/ws/preview/index.ts
@@ -15,11 +15,15 @@
  * - webcodecs.ts: WebCodecs streaming handlers
  * - native-ui.ts: Native UI handlers (dialogs, print, select, context menu)
  * - mcp.ts: MCP tab coordination response handlers
+ * - host.ts: Viewer-answered capabilities (geolocation, camera, clipboard, files)
  *
  * Available endpoints:
  * - preview:browser-tab-open - Open new browser tab (with optional URL)
  * - preview:browser-tab-close - Close browser tab
  * - preview:browser-tab-navigate - Navigate tab to new URL
+ * - preview:browser-tab-history-go - Walk the tab's history (back/forward)
+ * - preview:browser-tab-history - Read the tab's history entries
+ * - preview:browser-host-response - Answer a host-capability request
  * - preview:browser-interact - Execute mouse/keyboard interactions
  * - preview:browser-tab-info - Get tab information
  * - preview:browser-tab-stats - Get streaming statistics
@@ -47,6 +51,7 @@ import { cleanupPreviewHandler } from './browser/cleanup';
 import { streamPreviewHandler } from './browser/webcodecs';
 import { nativeUIPreviewHandler } from './browser/native-ui';
 import { mcpPreviewHandler } from './browser/mcp';
+import { hostPreviewHandler } from './browser/host';
 
 export const previewRouter = createRouter()
 	.merge(tabPreviewHandler)
@@ -58,6 +63,7 @@ export const previewRouter = createRouter()
 	.merge(streamPreviewHandler)
 	.merge(nativeUIPreviewHandler)
 	.merge(mcpPreviewHandler)
+	.merge(hostPreviewHandler)
 	// Server-emitted events (for type safety)
 	.emit('preview:browser-tab-opened', t.Object({
 		// projectId lets the frontend reject events that belong to a project it has
@@ -99,16 +105,23 @@ export const previewRouter = createRouter()
 				t.Literal('error'),
 				t.Literal('debug'),
 				t.Literal('trace'),
-				t.Literal('clear')
+				t.Literal('clear'),
+				t.Literal('input'),
+				t.Literal('result')
 			]),
 			text: t.String(),
 			args: t.Optional(t.Array(t.Any())),
+			// Recursive by nature (objects contain objects), which TypeBox cannot
+			// express inline; the shape is pinned by BrowserConsoleValue instead.
+			values: t.Optional(t.Array(t.Any())),
 			location: t.Optional(t.Object({
 				url: t.String(),
 				lineNumber: t.Number(),
 				columnNumber: t.Number()
 			})),
 			stackTrace: t.Optional(t.String()),
+			status: t.Optional(t.Number()),
+			count: t.Optional(t.Number()),
 			timestamp: t.Number()
 		})
 	}))
@@ -159,5 +172,45 @@ export const previewRouter = createRouter()
 		rotation: t.String(),
 		width: t.Number(),
 		height: t.Number(),
+		timestamp: t.Number()
+	}))
+	// Live tab metadata: the page's own title and favicon plus whether
+	// Back/Forward have anywhere to go. None of it can be derived from the URL.
+	.emit('preview:browser-tab-meta', t.Object({
+		projectId: t.String(),
+		tabId: t.String(),
+		url: t.String(),
+		title: t.String(),
+		favicon: t.Optional(t.String()),
+		canGoBack: t.Boolean(),
+		canGoForward: t.Boolean(),
+		timestamp: t.Number()
+	}))
+	// A capability the headless browser cannot satisfy on its own — answered by
+	// the viewer's browser and returned via preview:browser-host-response.
+	.emit('preview:browser-host-request', t.Object({
+		tabId: t.String(),
+		requestId: t.String(),
+		kind: t.String(),
+		payload: t.Any(),
+		timestamp: t.Number()
+	}))
+	// The request has been answered, timed out, or lost its tab. Prompted
+	// capabilities raise a prompt on every viewer of the tab, and only the first
+	// answer counts — this is what takes the rest of them down.
+	.emit('preview:browser-host-request-settled', t.Object({
+		tabId: t.String(),
+		requestId: t.String()
+	}))
+	// A file the page downloaded, relayed so it lands on the viewer's machine.
+	.emit('preview:browser-download', t.Object({
+		tabId: t.String(),
+		downloadId: t.String(),
+		filename: t.String(),
+		url: t.String(),
+		state: t.Union([t.Literal('started'), t.Literal('completed'), t.Literal('failed')]),
+		data: t.Optional(t.String()),
+		totalBytes: t.Optional(t.Number()),
+		error: t.Optional(t.String()),
 		timestamp: t.Number()
 	}));

--- a/frontend/components/preview/browser/BrowserPreview.svelte
+++ b/frontend/components/preview/browser/BrowserPreview.svelte
@@ -1,17 +1,31 @@
 <script lang="ts">
 	import Toolbar from './components/Toolbar.svelte';
 	import Container from './components/Container.svelte';
-	import VirtualCursor from './components/VirtualCursor.svelte';
 	import SelectDropdown from './components/SelectDropdown.svelte';
 	import ContextMenu from './components/ContextMenu.svelte';
-	import type { BrowserSelectInfo, BrowserContextMenuInfo } from '$frontend/utils/native-ui';
+	import NativePicker from './components/NativePicker.svelte';
+	import ConsolePanel from './components/ConsolePanel.svelte';
+	import DialogOverlay from './components/DialogOverlay.svelte';
+	import PermissionPrompt from './components/PermissionPrompt.svelte';
+	import Dialog from '$frontend/components/common/overlay/Dialog.svelte';
+	import type {
+		BrowserSelectInfo,
+		BrowserContextMenuInfo,
+		BrowserConsoleMessage,
+		BrowserDialogEvent,
+		BrowserNativePickerInfo,
+		PendingPermission
+	} from '$frontend/utils/native-ui';
 	import { fly } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import { onMount, onDestroy } from 'svelte';
 	import type { DeviceSize, Rotation } from '$frontend/utils/preview-constants';
 	import { debug } from '$shared/utils/logger';
 	import { createBrowserCoordinator } from './core/coordinator.svelte';
-	import { sendDisplayUpdate } from './core/interactions.svelte';
+	import { setDisplayScale, goHistory } from './core/interactions.svelte';
+	import { previewHostBridge } from '$frontend/services/preview/browser/host-bridge.service';
+	import { browserConsoleService } from '$frontend/services/preview/browser/browser-console.service';
+	import { addNotification } from '$frontend/stores/ui/notification.svelte';
 	import { projectState } from '$frontend/stores/core/projects.svelte';
 	import { appState } from '$frontend/stores/core/app.svelte';
 
@@ -40,8 +54,63 @@
 	let isConnected = $state(false);
 	let isStreamReady = $state(false);
 	let errorMessage = $state<string | null>(null);
-	let isConsoleOpen = $state(false); // Console temporarily disabled
-	let consoleLogs = $state<any[]>([]);
+	let isConsoleOpen = $state(false);
+	let consoleDock = $state<'bottom' | 'right'>('bottom');
+	let consoleHeight = $state(240);
+	let consoleWidth = $state(380);
+	/** Panel width, which decides whether the console may dock to the side. */
+	let panelWidth = $state(0);
+	let consoleLogs = $state<BrowserConsoleMessage[]>([]);
+
+	// Navigation affordances, pushed by the backend after every navigation
+	let canGoBack = $state(false);
+	let canGoForward = $state(false);
+
+	/**
+	 * Native UI answered by the viewer, keyed by the backend tab that raised it.
+	 *
+	 * A dialog or permission prompt belongs to one page. Holding a single global
+	 * slot meant a prompt raised by tab 1 followed the user to tab 2 and appeared
+	 * to be asking on that page's behalf — and answering it there granted access
+	 * to a page they were not looking at. Pending requests now stay with their
+	 * tab and reappear when the user returns to it.
+	 */
+	let dialogsByTab = $state<Record<string, BrowserDialogEvent>>({});
+	let permissionsByTab = $state<Record<string, PendingPermission[]>>({});
+	let pendingFilePick = $state<PendingPermission | null>(null);
+	let filePickerElement = $state<HTMLInputElement | undefined>();
+
+	const currentDialog = $derived(sessionId ? (dialogsByTab[sessionId] ?? null) : null);
+	const pendingPermission = $derived(
+		sessionId ? (permissionsByTab[sessionId]?.[0] ?? null) : null
+	);
+
+	function queuePermission(request: PendingPermission) {
+		const queue = permissionsByTab[request.tabId] ?? [];
+		permissionsByTab = { ...permissionsByTab, [request.tabId]: [...queue, request] };
+	}
+
+	function dequeuePermission(request: PendingPermission) {
+		const queue = (permissionsByTab[request.tabId] ?? []).filter(
+			(entry) => entry.requestId !== request.requestId
+		);
+		permissionsByTab = { ...permissionsByTab, [request.tabId]: queue };
+	}
+
+	// Bounds the context menu and select popup are kept inside
+	let panelElement = $state<HTMLDivElement | undefined>();
+	let panelBounds = $state<DOMRect | null>(null);
+
+	let isMobile = $state(false);
+
+	/** Errors and warnings drive the badge on the console button. */
+	const consoleIssueCount = $derived(
+		consoleLogs.reduce(
+			(total, entry) =>
+				entry.type === 'error' || entry.type === 'warn' ? total + (entry.count ?? 1) : total,
+			0
+		)
+	);
 
 	// Virtual cursors
 	let virtualCursor = $state<{x: number, y: number, visible: boolean, clicking?: boolean}>({
@@ -54,10 +123,12 @@
 	// Native UI state
 	let currentSelectInfo = $state<BrowserSelectInfo | null>(null);
 	let currentContextMenuInfo = $state<BrowserContextMenuInfo | null>(null);
+	let currentNativePicker = $state<BrowserNativePickerInfo | null>(null);
 
 	// Canvas and preview state
 	let canvasAPI = $state<any>(null);
 	let currentTabLastFrameData = $state<any>(null);
+	let toolbarRef = $state<any>(null);
 
 	// Flag to prevent URL watcher from double-launching during MCP session creation
 	const mcpLaunchInProgress = $state(false);
@@ -84,10 +155,36 @@
 			errorMessage = error;
 		},
 		onSelectOpen: (selectInfo) => {
+			refreshPanelBounds();
 			currentSelectInfo = selectInfo;
 		},
 		onContextMenuOpen: (menuInfo) => {
+			refreshPanelBounds();
 			currentContextMenuInfo = menuInfo;
+		},
+		onNativePickerOpen: (picker) => {
+			refreshPanelBounds();
+			currentNativePicker = picker;
+		},
+		onDialogOpen: (dialogEvent) => {
+			dialogsByTab = { ...dialogsByTab, [dialogEvent.sessionId]: dialogEvent };
+		},
+		onDialogClose: (closed) => {
+			if (!closed) return;
+			// Keyed by dialog id as well as tab: a stale close must not clear a
+			// second dialog the page raised straight after the first.
+			const current = dialogsByTab[closed.sessionId];
+			if (!current || current.dialogId !== closed.dialogId) return;
+
+			const next = { ...dialogsByTab };
+			delete next[closed.sessionId];
+			dialogsByTab = next;
+		},
+		onOpenInspector: () => {
+			isConsoleOpen = true;
+		},
+		onOpenUrlInHostBrowser: (targetUrl) => {
+			window.open(targetUrl, '_blank', 'noopener');
 		},
 		onVirtualCursorUpdate: (x, y, clicking) => {
 			virtualCursor = { x, y, visible: true, clicking: clicking || false };
@@ -126,14 +223,110 @@
 	// Initialize event listeners. Tab recovery itself is driven by the
 	// preview-tabs dock's load() inside the workspace switch barrier — we just
 	// adopt the singleton state below.
+	let stopHostBridge: (() => void) | null = null;
+
 	onMount(() => {
 		coordinator.initialize();
+
+		const syncLayout = () => {
+			isMobile = window.innerWidth < 1024;
+			const rect = panelElement?.getBoundingClientRect() ?? null;
+			panelBounds = rect;
+			panelWidth = rect?.width ?? 0;
+		};
+		syncLayout();
+		window.addEventListener('resize', syncLayout);
+
+		// The panel is resizable independently of the window, so its own width has
+		// to be observed rather than inferred from the viewport.
+		const observer =
+			typeof ResizeObserver !== 'undefined'
+				? new ResizeObserver((entries) => {
+						for (const entry of entries) panelWidth = entry.contentRect.width;
+					})
+				: null;
+		if (panelElement && observer) observer.observe(panelElement);
+
+		// The bridge answers the page's requests for the viewer's own devices, so
+		// it lives for as long as the panel is mounted rather than per tab.
+		stopHostBridge = previewHostBridge.start({
+			onPermissionRequest: (request) => {
+				queuePermission(request);
+			},
+			onFilePickRequest: (request) => {
+				// Routed through the same prompt as the other capabilities rather
+				// than opening the picker straight away: browsers only raise a file
+				// dialog for a page that just received a user gesture, and a
+				// WebSocket event is not one. The Choose button supplies it.
+				pendingFilePick = request;
+				queuePermission(request);
+			},
+			onRequestSettled: ({ tabId, requestId }) => {
+				// Answered somewhere — possibly on another device. The page has its
+				// answer either way, so this prompt is now asking about nothing.
+				const queue = permissionsByTab[tabId];
+				if (queue?.some((entry) => entry.requestId === requestId)) {
+					permissionsByTab = {
+						...permissionsByTab,
+						[tabId]: queue.filter((entry) => entry.requestId !== requestId)
+					};
+				}
+				if (pendingFilePick?.requestId === requestId) pendingFilePick = null;
+			},
+			onDownload: (event) => {
+				if (event.state === 'failed') {
+					addNotification({
+						type: 'error',
+						title: 'Download failed',
+						message: event.error || `Could not download ${event.filename}`
+					});
+				} else if (event.state === 'completed') {
+					addNotification({
+						type: 'success',
+						title: 'Download ready',
+						message: `${event.filename} was saved to your device`
+					});
+				}
+			},
+			getTabOrigin: (tabId) => {
+				const tab = tabManager.tabs.find((entry) => entry.sessionId === tabId);
+				try {
+					return new URL(tab?.url ?? url).origin;
+				} catch {
+					return tab?.url || 'This page';
+				}
+			}
+		});
+
+		return () => {
+			window.removeEventListener('resize', syncLayout);
+			observer?.disconnect();
+		};
 	});
 
 	// Cleanup
 	onDestroy(async () => {
+		stopHostBridge?.();
+		stopHostBridge = null;
 		await coordinator.cleanup();
 	});
+
+	// Transient overlays belong to the page that raised them, so a tab switch
+	// dismisses them rather than leaving a menu pointing at content that is no
+	// longer on screen. Dialogs and permissions are queued per tab instead.
+	let lastOverlayTabId: string | null = null;
+	$effect(() => {
+		if (sessionId === lastOverlayTabId) return;
+		lastOverlayTabId = sessionId;
+		currentSelectInfo = null;
+		currentContextMenuInfo = null;
+		currentNativePicker = null;
+	});
+
+	/** Bounds are only read when a popup opens, so refreshing then is enough. */
+	function refreshPanelBounds() {
+		panelBounds = panelElement?.getBoundingClientRect() ?? null;
+	}
 
 	// Watch for project changes and reload sessions.
 	//
@@ -165,12 +358,34 @@
 		}
 	});
 
+	/**
+	 * Address-bar ownership.
+	 *
+	 * The sync effect below re-runs on *any* tab mutation — a console line, a
+	 * stream flag — because `updateTab` replaces the tab object. Writing
+	 * `urlInput` unconditionally therefore wiped whatever was being typed, and
+	 * clearing the field brought the old URL straight back. So the field is only
+	 * refilled when the tab's URL genuinely changed, and never while the user has
+	 * the address bar focused.
+	 */
+	let lastSyncedUrl = $state<string | null>(null);
+	let lastSyncedTabId = $state<string | null>(null);
+	let isEditingAddress = $state(false);
+
 	// Sync state from active tab
 	$effect(() => {
 		const tab = activeTab;
 		if (tab) {
 			url = tab.url;
-			urlInput = tab.url;
+
+			// A tab switch always adopts the new tab's URL: a half-typed address
+			// belongs to the tab it was typed in.
+			const switchedTab = tab.id !== lastSyncedTabId;
+			if (switchedTab || tab.url !== lastSyncedUrl) {
+				lastSyncedTabId = tab.id;
+				lastSyncedUrl = tab.url;
+				if (switchedTab || !isEditingAddress) urlInput = tab.url;
+			}
 			sessionId = tab.sessionId;
 			sessionInfo = tab.sessionInfo;
 			isConnected = tab.isConnected;
@@ -182,7 +397,16 @@
 			deviceSize = tab.deviceSize;
 			rotation = tab.rotation;
 			consoleLogs = tab.consoleLogs;
-			canvasAPI = tab.canvasAPI;
+			canGoBack = tab.canGoBack;
+			canGoForward = tab.canGoForward;
+			// Only ever adopted, never cleared. There is a single Canvas instance
+			// behind every tab, and it publishes its API once on mount — so
+			// overwriting this with a tab that has no copy stored yet left the
+			// panel with no canvas API at all, and nothing to re-publish it.
+			// Everything that maps page coordinates to the screen goes through it,
+			// which is why select popups and pickers stopped appearing after a
+			// tab switch ("coordinate transformation failed").
+			if (tab.canvasAPI) canvasAPI = tab.canvasAPI;
 			previewDimensions = tab.previewDimensions || { scale: 1 };
 			currentTabLastFrameData = tab.lastFrameData;
 
@@ -291,7 +515,8 @@
 		const currentScale = previewDimensions?.scale || 1;
 		if (currentScale !== lastSentScale && sessionId && isStreamReady) {
 			debug.log('preview', `📐 Scale changed to ${currentScale}, sending to backend`);
-			sendDisplayUpdate(currentScale);
+			setDisplayScale(currentScale);
+			canvasAPI?.sendDisplayMetrics?.();
 			lastSentScale = currentScale;
 		}
 	});
@@ -342,14 +567,226 @@
 		}
 	}
 
-	async function closePreview() {
-		if (activeTabId && tabs.length > 0) {
+	/**
+	 * Stop loading.
+	 *
+	 * Halts the page's own load via `window.stop()`, then clears the local
+	 * loading flags — Puppeteer offers no cancel for an in-flight `goto`, so the
+	 * indicator has to be released here rather than waiting for it to settle.
+	 */
+	function stopLoading() {
+		if (!activeTabId) return;
+
+		const tab = activeTab;
+		if (tab?.sessionId) {
+			coordinator.sendInteraction({ type: 'stop' });
+		}
+
+		tabManager.updateTab(activeTabId, {
+			isLoading: false,
+			isNavigating: false,
+			isLaunchingBrowser: false
+		});
+		isLoading = false;
+		isNavigating = false;
+		isReconnecting = false;
+	}
+
+	async function navigateHistory(direction: 'back' | 'forward') {
+		const tab = activeTab;
+		if (!tab?.sessionId) return;
+
+		// Optimistic: the arrow greys out immediately, then the authoritative
+		// state arrives with the tab-meta push once the entry commits.
+		if (activeTabId) {
+			tabManager.updateTab(activeTabId, { isNavigating: true });
+		}
+		await goHistory(direction, tab.sessionId);
+	}
+
+	function handleDialogResponse(accept: boolean, promptText?: string) {
+		const dialog = currentDialog;
+		if (!dialog) return;
+
+		// The overlay is dismissed by the resulting `onDialogClose`, which is the
+		// same path every other viewer of this tab takes.
+		nativeUIHandler.respondToDialog(dialog, accept, promptText);
+	}
+
+	function handlePermissionAllow(request: PendingPermission) {
+		dequeuePermission(request);
+
+		if (request.kind === 'file-pick') {
+			if (!filePickerElement) return;
+			// Reset first: re-picking the same file fires no change event otherwise.
+			filePickerElement.value = '';
+			filePickerElement.multiple = !!request.payload?.multiple;
+			filePickerElement.click();
+			return;
+		}
+
+		// Not awaited: the device API must run inside this click's task so Safari
+		// still counts it as user-initiated.
+		void previewHostBridge.approve(request);
+	}
+
+	function handlePermissionDeny(request: PendingPermission) {
+		dequeuePermission(request);
+
+		if (request.kind === 'file-pick') {
+			pendingFilePick = null;
+			// The page is blocked on an answer; an empty selection is how a
+			// cancelled chooser is reported.
+			void previewHostBridge.submitFiles(request, []);
+			return;
+		}
+
+		previewHostBridge.deny(request);
+	}
+
+	function handleFilesPicked(event: Event) {
+		const request = pendingFilePick;
+		pendingFilePick = null;
+		if (!request) return;
+
+		const input = event.currentTarget as HTMLInputElement;
+		void previewHostBridge.submitFiles(request, Array.from(input.files ?? []));
+		input.value = '';
+	}
+
+	/**
+	 * Seed the panel from the backend's buffer the first time it is opened.
+	 *
+	 * Live messages only start arriving once the panel mounts its listeners, so
+	 * anything the page logged during load would otherwise be missing from the
+	 * one view where it matters most.
+	 */
+	const seededConsoleTabs = new Set<string>();
+
+	$effect(() => {
+		if (!isConsoleOpen || !activeTabId || !sessionId) return;
+		if (seededConsoleTabs.has(sessionId)) return;
+
+		const tabId = activeTabId;
+		const seedFor = sessionId;
+		seededConsoleTabs.add(seedFor);
+
+		void browserConsoleService
+			.getConsoleLogs(seedFor)
+			.then((logs) => {
+				const tab = tabManager.getTab(tabId);
+				if (!tab || logs.length === 0) return;
+
+				// Merge rather than replace: live messages may already have landed
+				// while this request was in flight.
+				const known = new Set((tab.consoleLogs ?? []).map((entry) => entry.id));
+				const missing = logs.filter((entry) => !known.has(entry.id));
+				if (missing.length === 0) return;
+
+				tabManager.updateTab(tabId, {
+					consoleLogs: [...missing, ...(tab.consoleLogs ?? [])].sort((a, b) => a.timestamp - b.timestamp)
+				});
+			})
+			.catch(() => {
+				// Backend buffer unavailable — the live stream still fills the panel.
+				seededConsoleTabs.delete(seedFor);
+			});
+	});
+
+	async function clearConsole() {
+		if (activeTabId) tabManager.updateTab(activeTabId, { consoleLogs: [] });
+		try {
+			await browserConsoleService.clearConsoleLogs(sessionId ?? '');
+		} catch {
+			// The local view is already cleared; a failed backend clear only means
+			// its buffer keeps older entries, which no longer surface anywhere.
+		}
+	}
+
+	async function executeConsoleCommand(commandText: string) {
+		try {
+			await browserConsoleService.executeConsoleCommand(sessionId ?? '', commandText);
+		} catch (error) {
+			debug.error('preview', 'Console command failed:', error);
+		}
+	}
+
+	/**
+	 * Browser-style shortcuts, scoped to the panel so they never shadow Clopen's
+	 * own bindings while the user is working elsewhere.
+	 */
+	function handlePanelKeydown(event: KeyboardEvent) {
+		const mod = event.metaKey || event.ctrlKey;
+
+		if (mod && event.key.toLowerCase() === 'l') {
+			event.preventDefault();
+			toolbarRef?.focusAddressBar();
+			return;
+		}
+		if (mod && event.key.toLowerCase() === 'r') {
+			event.preventDefault();
+			refreshPreview();
+			return;
+		}
+		if (mod && event.key.toLowerCase() === 't') {
+			event.preventDefault();
+			coordinator.createNewTab();
+			return;
+		}
+		if (mod && event.key.toLowerCase() === 'w') {
+			if (!activeTabId) return;
+			event.preventDefault();
 			coordinator.closeTab(activeTabId);
-			if (tabs.length === 0) {
-				isOpen = false;
-			}
-		} else {
-			isOpen = false;
+			return;
+		}
+		if (event.altKey && event.key === 'ArrowLeft') {
+			event.preventDefault();
+			void navigateHistory('back');
+			return;
+		}
+		if (event.altKey && event.key === 'ArrowRight') {
+			event.preventDefault();
+			void navigateHistory('forward');
+			return;
+		}
+		// Chrome's own console shortcut, minus the DevTools it cannot open.
+		if (mod && event.shiftKey && event.key.toLowerCase() === 'j') {
+			event.preventDefault();
+			isConsoleOpen = !isConsoleOpen;
+		}
+	}
+
+	// ── Close all tabs ────────────────────────────────────────────────────────
+
+	let showCloseAllConfirm = $state(false);
+
+	/** Agent-driven tabs survive: closing one mid-run would fail the automation. */
+	function closableTabIds(): string[] {
+		const controlled = mcpHandler.getControlledTabIds();
+		return tabs.filter((tab) => !controlled.has(tab.id)).map((tab) => tab.id);
+	}
+
+	const closeAllMessage = $derived.by(() => {
+		const controlled = mcpHandler.getControlledTabIds();
+		const closable = tabs.filter((tab) => !controlled.has(tab.id)).length;
+		const locked = tabs.length - closable;
+
+		if (locked > 0) {
+			return `Close ${closable} tabs? ${locked} controlled by an agent will stay open.`;
+		}
+		return `Close all ${closable} tabs?`;
+	});
+
+	function requestCloseAllTabs() {
+		if (closableTabIds().length === 0) return;
+		showCloseAllConfirm = true;
+	}
+
+	function closeAllTabs() {
+		showCloseAllConfirm = false;
+		// Snapshot first: closing mutates the tab list this is derived from.
+		for (const tabId of closableTabIds()) {
+			coordinator.closeTab(tabId);
 		}
 	}
 
@@ -363,25 +800,14 @@
 	}
 
 	function transformBrowserToDisplayCoordinates(browserX: number, browserY: number): { x: number, y: number } | null {
-		let canvasElement: HTMLCanvasElement | null = null;
-		if (canvasAPI && canvasAPI.getCanvasElement) {
-			canvasElement = canvasAPI.getCanvasElement();
-		}
-		if (!canvasElement && typeof document !== 'undefined') {
-			canvasElement = document.querySelector('canvas[tabindex="0"]') as HTMLCanvasElement;
-		}
-		if (!canvasElement) return null;
-
+		// The canvas owns this conversion: it is the only place that knows both
+		// where the frame is painted (the canvas is `object-contain`, so it is
+		// letterboxed whenever the aspect ratios differ) and that the page's
+		// coordinate space is the emulated viewport rather than the adaptive
+		// capture bitmap. Re-deriving it here is how these overlays drifted away
+		// from the element they were anchored to.
 		try {
-			const canvasRect = canvasElement.getBoundingClientRect();
-			if (!canvasRect || canvasElement.width === 0 || canvasElement.height === 0) return null;
-			
-			const scaleX = canvasRect.width / canvasElement.width;
-			const scaleY = canvasRect.height / canvasElement.height;
-			const screenX = canvasRect.left + (browserX * scaleX);
-			const screenY = canvasRect.top + (browserY * scaleY);
-
-			return { x: screenX, y: screenY };
+			return canvasAPI?.pageToScreen?.(browserX, browserY) ?? null;
 		} catch (e) {
 			return null;
 		}
@@ -445,13 +871,17 @@
 </script>
 
 {#if isOpen && mode === 'split'}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
+		bind:this={panelElement}
 		class="h-full flex flex-col theme-transition bg-slate-50 dark:bg-slate-900 dot-pattern"
+		onkeydown={handlePanelKeydown}
 		in:fly={{ x: 300, duration: 300, easing: cubicOut }}
 		out:fly={{ x: 300, duration: 250, easing: cubicOut }}
 	>
 		<!-- Preview Toolbar -->
 		<Toolbar
+			bind:this={toolbarRef}
 			bind:url
 			bind:urlInput
 			bind:isLoading
@@ -463,24 +893,42 @@
 			bind:isConnected
 			bind:isStreamReady
 			bind:errorMessage
-			bind:isConsoleOpen
+			{isConsoleOpen}
+			{consoleIssueCount}
+			{canGoBack}
+			{canGoForward}
+			{isMobile}
+			showKeyboardToggle={!!canvasAPI?.supportsKeyboardToggle?.()}
 			{tabs}
 			{activeTabId}
 			mcpControlledTabIds={mcpHandler.getControlledTabIds()}
 			onGoClick={handleGoClick}
 			onRefresh={refreshPreview}
+			onStop={stopLoading}
+			onBack={() => navigateHistory('back')}
+			onForward={() => navigateHistory('forward')}
 			onOpenInExternalBrowser={() => {}}
-			onClosePreview={closePreview}
-			onToggleConsole={() => {}}
+			onToggleConsole={() => (isConsoleOpen = !isConsoleOpen)}
+			onToggleKeyboard={() => {
+				if (canvasAPI?.isKeyboardActive?.()) canvasAPI.closeKeyboard();
+				else canvasAPI?.openKeyboard?.();
+			}}
 			onUrlInput={() => {}}
+			onAddressFocusChange={(focused: boolean) => (isEditingAddress = focused)}
 			onUrlKeydown={() => {}}
 			onSwitchTab={(tabId: string) => coordinator.switchToTab(tabId)}
 			onCloseTab={(tabId: string) => coordinator.closeTab(tabId)}
+			onReorderTab={(tabId: string, targetTabId: string) => tabManager.reorderTab(tabId, targetTabId)}
 			onNewTab={() => coordinator.createNewTab()}
+			onCloseAllTabs={requestCloseAllTabs}
 		/>
 
-		<!-- Preview Container -->
-		<div class="flex-1 flex min-h-0">
+		<!--
+			Preview + console. The console docks below or beside, so the axis of
+			this row flips with it rather than the console being repositioned.
+		-->
+		<div class="flex min-h-0 flex-1 {consoleDock === 'right' && isConsoleOpen ? 'flex-row' : 'flex-col'}">
+		<div class="relative flex min-h-0 min-w-0 flex-1">
 			<Container
 				projectId={projectId}
 				bind:url
@@ -505,19 +953,96 @@
 				onInteraction={handleCanvasInteraction}
 				onRetry={handleGoClick}
 			/>
+
+			<!-- Page-owned prompts. Anchored to the preview area rather than the
+			     app so they read as coming from the page, like a browser's own. -->
+			<PermissionPrompt
+				request={pendingPermission}
+				onAllow={handlePermissionAllow}
+				onDeny={handlePermissionDeny}
+			/>
+
+			<DialogOverlay
+				dialog={currentDialog}
+				origin={(() => {
+					try {
+						return new URL(url).origin;
+					} catch {
+						return '';
+					}
+				})()}
+				onRespond={handleDialogResponse}
+			/>
+		</div>
+
+		{#if isConsoleOpen}
+			<ConsolePanel
+				logs={consoleLogs}
+				{isMobile}
+				{panelWidth}
+				bind:dock={consoleDock}
+				bind:height={consoleHeight}
+				bind:width={consoleWidth}
+				onClose={() => (isConsoleOpen = false)}
+				onClear={clearConsole}
+				onExecute={executeConsoleCommand}
+			/>
+		{/if}
 		</div>
 
 		<!-- Native UI Overlays -->
 		<SelectDropdown
-			bind:selectInfo={currentSelectInfo}
+			selectInfo={currentSelectInfo}
+			scale={previewDimensions?.scale ?? 1}
+			bounds={panelBounds}
 			onSelect={handleSelectOption}
 			onClose={closeSelectDropdown}
 		/>
 
+		<NativePicker
+			picker={currentNativePicker}
+			onCommit={(value: string) => {
+				if (currentNativePicker) nativeUIHandler.respondNativePicker(currentNativePicker, value);
+			}}
+			onClose={() => (currentNativePicker = null)}
+		/>
+
 		<ContextMenu
-			bind:menuInfo={currentContextMenuInfo}
+			menuInfo={currentContextMenuInfo}
+			scale={previewDimensions?.scale ?? 1}
+			bounds={panelBounds}
 			onSelectItem={handleContextMenuItem}
 			onClose={closeContextMenu}
+		/>
+
+		<!-- Closing several tabs at once is worth a beat of confirmation. -->
+		<Dialog
+			bind:isOpen={showCloseAllConfirm}
+			onClose={() => (showCloseAllConfirm = false)}
+			type="warning"
+			title="Close all tabs"
+			message={closeAllMessage}
+			confirmText="Close tabs"
+			onConfirm={closeAllTabs}
+		/>
+
+		<!--
+			File picker for intercepted `<input type="file">` in the page. Opened
+			programmatically from the host bridge so the viewer chooses from their
+			own filesystem — the headless browser has nothing worth picking.
+		-->
+		<input
+			bind:this={filePickerElement}
+			type="file"
+			class="hidden"
+			onchange={handleFilesPicked}
+			oncancel={() => {
+				const request = pendingFilePick;
+				pendingFilePick = null;
+				// The page is blocked on an answer; an empty selection is how a
+				// cancelled chooser is reported.
+				if (request) void previewHostBridge.submitFiles(request, []);
+			}}
 		/>
 	</div>
 {/if}

--- a/frontend/components/preview/browser/components/Canvas.svelte
+++ b/frontend/components/preview/browser/components/Canvas.svelte
@@ -2,7 +2,16 @@
 	import { onDestroy } from 'svelte';
 	import { getViewportDimensions, type DeviceSize, type Rotation } from '$frontend/utils/preview-constants';
 	import { BrowserWebCodecsService, type BrowserWebCodecsStreamStats } from '$frontend/services/preview/browser/browser-webcodecs.service';
+	import { probeHitTest, readPageSelection, type RemoteFocusState } from '../core/interactions.svelte';
 	import { debug } from '$shared/utils/logger';
+
+	/**
+	 * Touch capability, resolved once. Only touch devices get the hidden keyboard
+	 * field — on a desktop it would steal focus from the canvas and break the
+	 * physical keyboard path.
+	 */
+	const isTouchDevice =
+		typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0);
 
 	let {
 		projectId = '', // REQUIRED for project isolation (read-only from parent)
@@ -29,6 +38,26 @@
 		touchTarget = undefined as HTMLElement | undefined, // Container element for touch events
 		onTouchCursorUpdate = $bindable<(pos: { x: number; y: number; visible: boolean; clicking?: boolean }) => void>(() => {})
 	} = $props();
+
+	/**
+	 * The page's own coordinate space — the emulated viewport, in CSS pixels.
+	 *
+	 * Deliberately *not* derived from the canvas bitmap. The renderer sizes the
+	 * backing store to whatever resolution the stream is currently captured at,
+	 * and that resolution is adaptive: it follows fit-scale × devicePixelRatio and
+	 * is clamped by the host's pixel budget. Mapping through the bitmap therefore
+	 * produced coordinates scaled by `capture ÷ viewport` — exact whenever that
+	 * ratio happened to be 1 (a Retina screen at half fit, which is why it looked
+	 * accurate most of the time) and off by a few percent, growing toward the
+	 * bottom-right, whenever it wasn't. The backend dispatches these as CSS
+	 * pixels, so CSS pixels is what this has to produce.
+	 */
+	const pageSize = $derived(
+		getViewportDimensions(
+			(deviceSize || sessionInfo?.deviceSize || 'laptop') as DeviceSize,
+			(rotation || sessionInfo?.rotation || 'landscape') as Rotation
+		)
+	);
 
 	// WebCodecs service instance
 	let webCodecsService: BrowserWebCodecsService | null = null;
@@ -200,33 +229,138 @@
 		onInteraction(action);
 	}
 
+	/**
+	 * Map a viewport point onto the page's own coordinate space.
+	 *
+	 * `getBoundingClientRect()` already accounts for the fit-scale transform the
+	 * device frame applies, so the ratio between the bitmap size and the rendered
+	 * box is the whole conversion.
+	 *
+	 * `inside` matters because touch gestures are bound to the *panel*, not the
+	 * canvas — the trackpad mode needs the whole panel as a surface. A tap on the
+	 * bezel or the dot-pattern backdrop therefore lands here with coordinates
+	 * outside the page, and forwarding those unclamped is what made taps register
+	 * in the wrong place.
+	 */
+	/**
+	 * Where the frame is actually painted inside the canvas element.
+	 *
+	 * The canvas is `object-contain`, so whenever the element's box and the
+	 * bitmap disagree on aspect ratio the image is letterboxed and centred inside
+	 * it. Mapping against the element box then reports every point offset by
+	 * however wide those bars are — which is what put clicks up-and-left of the
+	 * pointer after a rotation change, and the virtual cursor down-and-right on
+	 * mobile. The painted rect is the only correct frame of reference.
+	 */
+	function paintedRect(canvas: HTMLCanvasElement): DOMRect | null {
+		const rect = canvas.getBoundingClientRect();
+		if (rect.width === 0 || rect.height === 0 || canvas.width === 0 || canvas.height === 0) {
+			return null;
+		}
+
+		const boxAspect = rect.width / rect.height;
+		const bitmapAspect = canvas.width / canvas.height;
+
+		if (Math.abs(boxAspect - bitmapAspect) < 0.0001) return rect;
+
+		if (bitmapAspect > boxAspect) {
+			// Limited by width — bars above and below.
+			const height = rect.width / bitmapAspect;
+			return new DOMRect(rect.left, rect.top + (rect.height - height) / 2, rect.width, height);
+		}
+
+		// Limited by height — bars left and right.
+		const width = rect.height * bitmapAspect;
+		return new DOMRect(rect.left + (rect.width - width) / 2, rect.top, width, rect.height);
+	}
+
+	function toPageCoordinates(
+		clientX: number,
+		clientY: number,
+		canvas: HTMLCanvasElement
+	): { x: number; y: number; inside: boolean } {
+		const rect = paintedRect(canvas);
+		if (!rect) return { x: 0, y: 0, inside: false };
+
+		// Painted box → page, never bitmap → page. See `pageSize`.
+		const scaleX = pageSize.width / rect.width;
+		const scaleY = pageSize.height / rect.height;
+
+		const rawX = (clientX - rect.left) * scaleX;
+		const rawY = (clientY - rect.top) * scaleY;
+
+		const inside =
+			clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom;
+
+		return {
+			// Clamped so a gesture that drifts off the edge mid-drag keeps
+			// tracking against the nearest page pixel instead of jumping.
+			x: Math.round(Math.max(0, Math.min(pageSize.width, rawX))),
+			y: Math.round(Math.max(0, Math.min(pageSize.height, rawY))),
+			inside
+		};
+	}
+
+	/**
+	 * How many page pixels one CSS pixel of the panel covers.
+	 *
+	 * Gesture deltas (touch scroll, trackpad travel) need the same conversion as
+	 * points do, or a scroll moves the page by a different distance than the
+	 * finger travelled.
+	 */
+	function pageScale(canvas: HTMLCanvasElement): number {
+		const rect = paintedRect(canvas);
+		if (!rect || rect.width === 0) return 1;
+		return pageSize.width / rect.width;
+	}
+
 	// Utility function to convert canvas display coordinates to browser coordinates
 	function getCanvasCoordinates(event: MouseEvent | TouchEvent, canvas: HTMLCanvasElement): { x: number, y: number } {
-		const rect = canvas.getBoundingClientRect();
-		const scaleX = canvas.width / rect.width;
-		const scaleY = canvas.height / rect.height;
-
 		let clientX: number, clientY: number;
 
 		if (event instanceof MouseEvent) {
 			clientX = event.clientX;
 			clientY = event.clientY;
 		} else {
-			// Touch event - use first touch
 			const touch = event.touches[0] || event.changedTouches[0];
 			clientX = touch.clientX;
 			clientY = touch.clientY;
 		}
 
-		const x = (clientX - rect.left) * scaleX;
-		const y = (clientY - rect.top) * scaleY;
-
-		return {
-			x: Math.round(x),
-			y: Math.round(y)
-		};
+		const { x, y } = toPageCoordinates(clientX, clientY, canvas);
+		return { x, y };
 	}
 
+	/**
+	 * Follow one finger for the length of a gesture.
+	 *
+	 * `touches[0]` is not stable: a second finger touching down can reorder the
+	 * list, and the tracked point jumps to the new finger mid-scroll. Matching on
+	 * `identifier` pins the gesture to the finger that started it.
+	 */
+	function findTouch(event: TouchEvent, identifier: number | null): Touch | null {
+		if (identifier === null) return event.touches[0] ?? event.changedTouches[0] ?? null;
+
+		for (const list of [event.touches, event.changedTouches]) {
+			for (let i = 0; i < list.length; i += 1) {
+				if (list[i].identifier === identifier) return list[i];
+			}
+		}
+		return null;
+	}
+
+
+	/**
+	 * How far the pointer must travel, in page pixels, before a press counts as a
+	 * drag rather than a click.
+	 *
+	 * Nothing is dispatched until it is crossed — the press has to stay a
+	 * candidate click, because that path is what detects selects and pickers. So
+	 * the distance is also how much of a text selection is missing before it
+	 * starts: at 10px that was the first character or so. 4px matches what
+	 * browsers themselves use to start a drag.
+	 */
+	const DRAG_THRESHOLD_PX = 4;
 
 	function handleCanvasMouseMove(event: MouseEvent, canvas: HTMLCanvasElement) {
 		if (!sessionId) return;
@@ -241,7 +375,7 @@
 			);
 
 			// Start drag when distance exceeds threshold
-			if (dragDistance > 10) {
+			if (dragDistance > DRAG_THRESHOLD_PX) {
 				// Send mousedown on first drag detection
 				if (!dragStarted) {
 					sendInteraction({
@@ -289,6 +423,47 @@
 		sendInteraction({ type: 'scroll', deltaX: event.deltaX, deltaY: event.deltaY });
 	}
 
+	/**
+	 * Bridge the clipboard shortcuts between the page and the user's own machine.
+	 *
+	 * Forwarding Ctrl+C as a keystroke fills the *headless* browser's clipboard,
+	 * which nothing outside the preview can read — and Ctrl+V would paste from
+	 * that same invisible clipboard rather than the user's. Both directions have
+	 * to be carried explicitly.
+	 */
+	async function handleClipboardShortcut(event: KeyboardEvent): Promise<boolean> {
+		const mod = event.metaKey || event.ctrlKey;
+		if (!mod || event.altKey) return false;
+
+		const key = event.key.toLowerCase();
+
+		if (key === 'c' || key === 'x') {
+			const text = await readPageSelection(key === 'x');
+			if (text) {
+				try {
+					await navigator.clipboard.writeText(text);
+				} catch (error) {
+					debug.warn('preview', 'Could not write the preview selection to the clipboard:', error);
+				}
+			}
+			return true;
+		}
+
+		if (key === 'v') {
+			try {
+				// A keydown counts as a user gesture, which is what Chrome requires
+				// before it will hand over clipboard contents.
+				const text = await navigator.clipboard.readText();
+				if (text) sendInteraction({ type: 'paste', text });
+			} catch (error) {
+				debug.warn('preview', 'Could not read the clipboard for paste:', error);
+			}
+			return true;
+		}
+
+		return false;
+	}
+
 	function handleCanvasKeydown(event: KeyboardEvent) {
 		if (!sessionId) return;
 
@@ -296,6 +471,15 @@
 		// This prevents Ctrl+A, Ctrl+C, arrow keys, etc. from affecting the parent
 		event.preventDefault();
 		event.stopPropagation();
+
+		// Copy/cut/paste are handled here rather than forwarded as keystrokes.
+		if (event.metaKey || event.ctrlKey) {
+			const key = event.key.toLowerCase();
+			if (key === 'c' || key === 'x' || key === 'v') {
+				void handleClipboardShortcut(event);
+				return;
+			}
+		}
 
 		const isNavigationKey = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Tab', 'Enter', 'Escape'].includes(event.key);
 		const isModifierKey = event.ctrlKey || event.metaKey || event.altKey || event.shiftKey;
@@ -335,6 +519,8 @@
 	let longPressTimer: ReturnType<typeof setTimeout> | null = null;
 	let touchLongPressed = false;
 	let lastTouchCoords: { x: number; y: number } | null = null;
+	/** Identifier of the finger that owns the current gesture. */
+	let activeTouchId: number | null = null;
 
 	// Trackpad cursor state (cursor/trackpad mode - persists between touch gestures)
 	let trackpadCursorX = 0;
@@ -1079,9 +1265,13 @@
 			let lastMoveTime = 0;
 			const handleMouseMove = (e: MouseEvent) => {
 				const now = Date.now();
+				// The move that begins a drag is never throttled: it is the one that
+				// dispatches the deferred mousedown, so delaying it by up to a frame
+				// delays the whole selection with it.
+				const startsDrag = isMouseDown && !dragStarted;
 				// 32ms = ~30fps — enough for smooth hover/drag while keeping CDP pipeline clear
 				// for clicks and keypresses (halving the rate halves CDP queue pressure)
-				if (now - lastMoveTime >= 32) {
+				if (startsDrag || now - lastMoveTime >= 32) {
 					lastMoveTime = now;
 					handleCanvasMouseMove(e, canvas);
 				}
@@ -1145,31 +1335,61 @@
 		touchTarget.addEventListener('touchstart', touchStartHandler, { passive: false });
 		touchTarget.addEventListener('touchmove', touchMoveHandler, { passive: false });
 		touchTarget.addEventListener('touchend', touchEndHandler, { passive: false });
+		// The OS can take a gesture away mid-flight (a system edge swipe, an
+		// incoming call). Without this the tracked finger is never released and
+		// the next touch reads as a continuation of the interrupted one.
+		touchTarget.addEventListener('touchcancel', touchEndHandler, { passive: false });
 
 		return () => {
 			touchTarget.removeEventListener('touchstart', touchStartHandler);
 			touchTarget.removeEventListener('touchmove', touchMoveHandler);
 			touchTarget.removeEventListener('touchend', touchEndHandler);
+			touchTarget.removeEventListener('touchcancel', touchEndHandler);
 		};
 	});
 
-	// Convert canvas coordinates to viewport (screen) coordinates for VirtualCursor display
-	function canvasToScreen(cx: number, cy: number): { x: number; y: number } {
-		if (!canvasElement) return { x: 0, y: 0 };
-		const rect = canvasElement.getBoundingClientRect();
+	/**
+	 * Page → screen. Null when the canvas has no geometry yet (mid-mount, panel
+	 * collapsed), which callers must treat as "cannot place this" — an overlay
+	 * that falls back to the origin lands in the corner of the window, nowhere
+	 * near the element it belongs to.
+	 */
+	function pageToScreen(cx: number, cy: number): { x: number; y: number } | null {
+		if (!canvasElement) return null;
+		// Painted rect, not element box — see paintedRect(). Using the box put the
+		// virtual cursor off by the letterbox bars.
+		const rect = paintedRect(canvasElement);
+		if (!rect) return null;
 		return {
-			x: rect.left + cx * (rect.width / canvasElement.width),
-			y: rect.top + cy * (rect.height / canvasElement.height)
+			x: rect.left + cx * (rect.width / pageSize.width),
+			y: rect.top + cy * (rect.height / pageSize.height)
 		};
 	}
+
+	// Convert page coordinates to viewport (screen) coordinates for VirtualCursor display
+	function canvasToScreen(cx: number, cy: number): { x: number; y: number } {
+		return pageToScreen(cx, cy) ?? { x: 0, y: 0 };
+	}
+
+	// Keep the virtual cursor inside the page when the viewport changes.
+	// Rotating to portrait or switching to a phone shrinks the page under the
+	// cursor, which would otherwise be left pointing past its edge.
+	$effect(() => {
+		void deviceSize;
+		void rotation;
+		if (!canvasElement) return;
+
+		trackpadCursorX = Math.max(0, Math.min(pageSize.width, trackpadCursorX));
+		trackpadCursorY = Math.max(0, Math.min(pageSize.height, trackpadCursorY));
+	});
 
 	// Show / hide cursor when touchMode changes
 	$effect(() => {
 		if (touchMode === 'cursor') {
-			// Init cursor at canvas center on first activation
+			// Init cursor at page centre on first activation
 			if (canvasElement && trackpadCursorX === 0 && trackpadCursorY === 0) {
-				trackpadCursorX = canvasElement.width / 2;
-				trackpadCursorY = canvasElement.height / 2;
+				trackpadCursorX = pageSize.width / 2;
+				trackpadCursorY = pageSize.height / 2;
 			}
 			if (canvasElement) {
 				const pos = canvasToScreen(trackpadCursorX, trackpadCursorY);
@@ -1218,6 +1438,9 @@
 		dragStarted = false;
 		touchLongPressed = false;
 
+		// The tap lands at the virtual cursor, not the finger — probe there.
+		beginKeyboardProbe({ x: Math.round(trackpadCursorX), y: Math.round(trackpadCursorY) });
+
 		// Long-press (600ms without movement) → drag mode
 		longPressTimer = setTimeout(() => {
 			if (!isMouseDown) return;
@@ -1228,6 +1451,7 @@
 			if (dist < 8) {
 				touchLongPressed = true;
 				dragStarted = true;
+				cancelKeyboardProbe();
 				sendInteraction({ type: 'mousedown', x: Math.round(trackpadCursorX), y: Math.round(trackpadCursorY), button: 'left' });
 			}
 		}, 600);
@@ -1248,9 +1472,16 @@
 			trackpadTwoFingerLastCenterY = centerY;
 			trackpadTwoFingerTotalDist += Math.sqrt(deltaX * deltaX + deltaY * deltaY);
 			if (Math.abs(deltaX) > 0.3 || Math.abs(deltaY) > 0.3) {
-				const rect = canvasElement.getBoundingClientRect();
-				const scale = canvasElement.width / rect.width;
-				sendInteraction({ type: 'scroll', deltaX: deltaX * scale * 2, deltaY: deltaY * scale * 2 });
+				const scale = pageScale(canvasElement);
+				// Scroll at the virtual cursor, so two-finger scrolling affects
+				// whichever container the cursor is hovering.
+				sendInteraction({
+					type: 'scroll',
+					deltaX: deltaX * scale * 2,
+					deltaY: deltaY * scale * 2,
+					x: Math.round(trackpadCursorX),
+					y: Math.round(trackpadCursorY)
+				});
 			}
 			return;
 		}
@@ -1268,16 +1499,20 @@
 			Math.pow(touch.clientX - trackpadTouchStartClientX, 2) +
 			Math.pow(touch.clientY - trackpadTouchStartClientY, 2)
 		);
-		if (totalDist > 8 && longPressTimer) {
-			clearTimeout(longPressTimer);
-			longPressTimer = null;
+		if (totalDist > 8) {
+			if (longPressTimer) {
+				clearTimeout(longPressTimer);
+				longPressTimer = null;
+			}
+			// Moving the cursor is not a tap; the probed point is no longer where
+			// the gesture will land.
+			cancelKeyboardProbe();
 		}
 
-		// Convert screen delta → canvas delta and move cursor
-		const rect = canvasElement.getBoundingClientRect();
-		const scale = canvasElement.width / rect.width;
-		trackpadCursorX = Math.max(0, Math.min(canvasElement.width, trackpadCursorX + deltaClientX * scale));
-		trackpadCursorY = Math.max(0, Math.min(canvasElement.height, trackpadCursorY + deltaClientY * scale));
+		// Convert screen delta → page delta and move cursor
+		const scale = pageScale(canvasElement);
+		trackpadCursorX = Math.max(0, Math.min(pageSize.width, trackpadCursorX + deltaClientX * scale));
+		trackpadCursorY = Math.max(0, Math.min(pageSize.height, trackpadCursorY + deltaClientY * scale));
 
 		// Send mousemove so the browser sees hover state changes
 		sendInteraction({ type: 'mousemove', x: Math.round(trackpadCursorX), y: Math.round(trackpadCursorY) });
@@ -1326,7 +1561,11 @@
 				Math.pow(trackpadLastClientY - trackpadTouchStartClientY, 2)
 			);
 			if (duration < 250 && moveDist < 10) {
-				sendInteraction({ type: 'click', x: Math.round(trackpadCursorX), y: Math.round(trackpadCursorY) });
+				const anchor = { x: Math.round(trackpadCursorX), y: Math.round(trackpadCursorY) };
+				sendInteraction({ type: 'click', x: anchor.x, y: anchor.y });
+				settleKeyboard(anchor);
+			} else {
+				cancelKeyboardProbe();
 			}
 		}
 
@@ -1340,17 +1579,31 @@
 	// Touch event handlers
 	function handleTouchStart(event: TouchEvent, canvas: HTMLCanvasElement) {
 		if (!sessionId || event.touches.length === 0) return;
-		event.preventDefault();
 
 		if (touchMode === 'cursor') {
+			// Trackpad mode treats the whole panel as a surface, so a touch that
+			// starts on the bezel is legitimate.
+			event.preventDefault();
 			handleTrackpadTouchStart(event);
 			return;
 		}
 
-		// ── Scroll mode ──────────────────────────────────────────────────────────
+		// ── Direct-touch mode ───────────────────────────────────────────────────
 		if (event.touches.length > 1) return;
 
-		const coords = getCanvasCoordinates(event, canvas);
+		const touch = event.touches[0];
+		const coords = toPageCoordinates(touch.clientX, touch.clientY, canvas);
+
+		// Gestures that begin off the page belong to the panel, not the page —
+		// forwarding them is what made scrolling register a pointer somewhere else.
+		if (!coords.inside) {
+			activeTouchId = null;
+			return;
+		}
+
+		event.preventDefault();
+
+		activeTouchId = touch.identifier;
 		isMouseDown = true;
 		mouseDownTime = Date.now();
 		dragStartPos = { x: coords.x, y: coords.y };
@@ -1359,7 +1612,12 @@
 		touchLongPressed = false;
 		lastTouchCoords = { x: coords.x, y: coords.y };
 
-		// Long-press detection: after 500ms without significant movement → drag mode
+		// Ask what is under the finger now, while the tap is still happening.
+		beginKeyboardProbe({ x: coords.x, y: coords.y });
+
+		// Long-press opens the context menu, as it does in every mobile browser.
+		// Mouse-style press-and-drag lives in the trackpad mode instead — here the
+		// same gesture is how the page is scrolled, so it cannot mean both.
 		longPressTimer = setTimeout(() => {
 			if (!isMouseDown || !dragStartPos) return;
 			const dist = dragCurrentPos
@@ -1370,44 +1628,58 @@
 				: 0;
 			if (dist < 10) {
 				touchLongPressed = true;
-				dragStarted = true;
-				sendInteraction({ type: 'mousedown', x: dragStartPos.x, y: dragStartPos.y, button: 'left' });
+				cancelKeyboardProbe();
+				sendInteraction({ type: 'rightclick', x: dragStartPos.x, y: dragStartPos.y });
+				// A short buzz confirms the menu is coming, matching the platform.
+				navigator.vibrate?.(10);
 			}
 		}, 500);
 	}
 
 	function handleTouchMove(event: TouchEvent, canvas: HTMLCanvasElement) {
 		if (!sessionId || event.touches.length === 0) return;
-		event.preventDefault();
 
 		if (touchMode === 'cursor') {
+			event.preventDefault();
 			handleTrackpadTouchMove(event);
 			return;
 		}
 
-		// ── Scroll mode ──────────────────────────────────────────────────────────
+		// ── Direct-touch mode ───────────────────────────────────────────────────
 		if (!isMouseDown || !dragStartPos) return;
 
-		const coords = getCanvasCoordinates(event, canvas);
+		const touch = findTouch(event, activeTouchId);
+		if (!touch) return;
+
+		event.preventDefault();
+
+		const coords = toPageCoordinates(touch.clientX, touch.clientY, canvas);
 		dragCurrentPos = { x: coords.x, y: coords.y };
 
 		const dist = Math.sqrt(
 			Math.pow(coords.x - dragStartPos.x, 2) + Math.pow(coords.y - dragStartPos.y, 2)
 		);
 
-		if (dist > 10 && longPressTimer) {
-			clearTimeout(longPressTimer);
-			longPressTimer = null;
+		if (dist > 10) {
+			if (longPressTimer) {
+				clearTimeout(longPressTimer);
+				longPressTimer = null;
+			}
+			// The gesture is a scroll now. Scrolling in a mobile browser leaves the
+			// keyboard exactly as it was, so the pending answer must not act.
+			cancelKeyboardProbe();
 		}
 
 		if (touchLongPressed) {
-			isDragging = true;
-			sendInteraction({ type: 'mousemove', x: coords.x, y: coords.y });
+			// The context menu owns this gesture now; further movement must not
+			// scroll the page out from under it.
 		} else {
 			if (lastTouchCoords) {
 				const deltaX = lastTouchCoords.x - coords.x;
 				const deltaY = lastTouchCoords.y - coords.y;
-				sendInteraction({ type: 'scroll', deltaX, deltaY });
+				// Coordinates travel with the wheel: CDP dispatches it at the
+				// pointer, and a touch scroll has no pointer of its own to place.
+				sendInteraction({ type: 'scroll', deltaX, deltaY, x: coords.x, y: coords.y });
 			}
 			lastTouchCoords = { x: coords.x, y: coords.y };
 		}
@@ -1415,21 +1687,22 @@
 
 	function handleTouchEnd(event: TouchEvent, canvas: HTMLCanvasElement) {
 		if (!sessionId) return;
-		event.preventDefault();
 
 		if (touchMode === 'cursor') {
+			event.preventDefault();
 			handleTrackpadTouchEnd(event);
 			return;
 		}
 
-		// ── Scroll mode ──────────────────────────────────────────────────────────
+		// ── Direct-touch mode ───────────────────────────────────────────────────
 		if (!isMouseDown) return;
+
+		event.preventDefault();
 
 		if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
 
-		if (touchLongPressed && dragStarted) {
-			const endPos = dragCurrentPos || dragStartPos;
-			if (endPos) sendInteraction({ type: 'mouseup', x: endPos.x, y: endPos.y, button: 'left' });
+		if (touchLongPressed) {
+			// Already handled as a context-menu open on the press itself.
 		} else if (!isDragging && dragStartPos) {
 			const touchDuration = Date.now() - mouseDownTime;
 			const dist = dragCurrentPos
@@ -1439,7 +1712,11 @@
 					)
 				: 0;
 			if (touchDuration < 300 && dist < 15) {
-				sendInteraction({ type: 'click', x: dragStartPos.x, y: dragStartPos.y });
+				const anchor = { x: dragStartPos.x, y: dragStartPos.y };
+				sendInteraction({ type: 'click', x: anchor.x, y: anchor.y });
+				settleKeyboard(anchor);
+			} else {
+				cancelKeyboardProbe();
 			}
 		}
 
@@ -1450,6 +1727,223 @@
 		dragStarted = false;
 		touchLongPressed = false;
 		lastTouchCoords = null;
+		activeTouchId = null;
+	}
+
+	// ── On-screen keyboard bridge (touch devices) ─────────────────────────────
+	//
+	// A `<canvas>` can hold DOM focus but will never raise a mobile keyboard —
+	// only a real editable element does. So a hidden field sits over the canvas,
+	// takes the keyboard, and its text is forwarded to the page as keystrokes.
+	//
+	// Text is diffed rather than intercepted per key: Android IMEs (GBoard,
+	// autocorrect, swipe input) do not emit meaningful `keydown` events, and
+	// preventing the default on `beforeinput` breaks composition outright.
+
+	let keyboardInput = $state<HTMLTextAreaElement | undefined>();
+	let keyboardValue = '';
+	let isKeyboardActive = $state(false);
+	let keyboardConfirmToken = 0;
+	let keyboardInputMode = $state<'text' | 'email' | 'tel' | 'url' | 'decimal' | 'search'>('text');
+
+	/**
+	 * Where the keyboard proxy sits, in page coordinates.
+	 *
+	 * It follows the tap rather than covering the canvas: a full-size focused
+	 * field makes the browser scroll toward it and resize the visual viewport,
+	 * which is what produced the white flashes and the empty band above the
+	 * preview. A 1px target at the point already being touched has nowhere to
+	 * scroll to.
+	 */
+	let keyboardAnchor = $state({ x: 0, y: 0 });
+
+	/**
+	 * Focus the hidden field.
+	 *
+	 * Must run synchronously inside the touch handler wherever possible: iOS only
+	 * raises the keyboard for a programmatic focus that happens while the user
+	 * gesture is still active, and an `await` in between forfeits that.
+	 */
+	function captureKeyboard(anchor?: { x: number; y: number }) {
+		if (!keyboardInput || !isTouchDevice) return;
+
+		if (anchor) keyboardAnchor = anchor;
+		keyboardValue = '';
+		keyboardInput.value = '';
+		keyboardInput.focus({ preventScroll: true });
+		isKeyboardActive = true;
+	}
+
+	/**
+	 * The hit test for the gesture currently under way.
+	 *
+	 * Started on `touchstart` so its answer is usually in hand by `touchend` —
+	 * the tap is the slow part, not the round-trip. A stale answer from an
+	 * earlier gesture must never act on the newest one, hence the token.
+	 */
+	let pendingHitTest: {
+		token: number;
+		result: RemoteFocusState | null;
+		promise: Promise<RemoteFocusState>;
+	} | null = null;
+
+	function beginKeyboardProbe(anchor: { x: number; y: number }) {
+		if (!isTouchDevice) return;
+
+		keyboardConfirmToken += 1;
+		const token = keyboardConfirmToken;
+
+		const entry: { token: number; result: RemoteFocusState | null; promise: Promise<RemoteFocusState> } = {
+			token,
+			result: null,
+			promise: probeHitTest(anchor.x, anchor.y).then((state) => {
+				if (keyboardConfirmToken === token) entry.result = state;
+				return state;
+			})
+		};
+
+		pendingHitTest = entry;
+	}
+
+	/**
+	 * Abandon the gesture's keyboard decision — it turned into a scroll or a
+	 * long-press, neither of which should disturb an open keyboard.
+	 */
+	function cancelKeyboardProbe() {
+		keyboardConfirmToken += 1;
+		pendingHitTest = null;
+	}
+
+	/**
+	 * Phone keyboards specialise by input type — a numeric pad for `tel`, an
+	 * `@` key for `email`. The proxy is what the OS actually sees, so the type
+	 * has to be carried across to it or every field gets a plain alphabetic one.
+	 */
+	function inputModeFor(inputType?: string): 'text' | 'email' | 'tel' | 'url' | 'decimal' | 'search' {
+		switch (inputType) {
+			case 'email':
+				return 'email';
+			case 'tel':
+				return 'tel';
+			case 'url':
+				return 'url';
+			case 'number':
+				return 'decimal';
+			case 'search':
+				return 'search';
+			default:
+				return 'text';
+		}
+	}
+
+	function applyKeyboardTarget(state: RemoteFocusState, anchor: { x: number; y: number }) {
+		if (state.editable) {
+			keyboardInputMode = inputModeFor(state.inputType);
+			captureKeyboard(anchor);
+		} else if (isKeyboardActive) {
+			releaseKeyboard();
+		}
+	}
+
+	/**
+	 * Settle the keyboard for the tap that just finished.
+	 *
+	 * The fast path is synchronous, which is the whole point of probing early.
+	 * When the answer is still in flight — a slow link, a busy page — it is
+	 * applied on arrival instead: Android raises the keyboard from that just
+	 * fine, and on iOS the toolbar's keyboard button covers the gap.
+	 */
+	function settleKeyboard(anchor: { x: number; y: number }) {
+		if (!isTouchDevice) return;
+
+		const entry = pendingHitTest;
+		if (entry && entry.token === keyboardConfirmToken && entry.result) {
+			applyKeyboardTarget(entry.result, anchor);
+			return;
+		}
+
+		const token = entry?.token ?? ++keyboardConfirmToken;
+		const answer = entry?.promise ?? probeHitTest(anchor.x, anchor.y);
+		void answer.then((state) => {
+			if (token !== keyboardConfirmToken) return;
+			applyKeyboardTarget(state, anchor);
+		});
+	}
+
+	function releaseKeyboard() {
+		isKeyboardActive = false;
+		keyboardValue = '';
+		if (keyboardInput) {
+			keyboardInput.value = '';
+			keyboardInput.blur();
+		}
+	}
+
+	/**
+	 * Turn the hidden field's new contents into keystrokes for the page.
+	 *
+	 * Only the common-prefix delta is sent, so an IME that rewrites the tail of
+	 * a word replaces exactly that tail.
+	 */
+	function handleKeyboardInput() {
+		if (!keyboardInput || !sessionId) return;
+
+		const next = keyboardInput.value;
+		const previous = keyboardValue;
+		if (next === previous) return;
+
+		let shared = 0;
+		while (shared < next.length && shared < previous.length && next[shared] === previous[shared]) {
+			shared += 1;
+		}
+
+		const deletions = previous.length - shared;
+		for (let i = 0; i < deletions; i += 1) {
+			sendInteraction({ type: 'key', key: 'Backspace' });
+		}
+
+		const inserted = next.slice(shared);
+		if (inserted) {
+			sendInteraction({ type: 'type', text: inserted, delay: 0 });
+		}
+
+		keyboardValue = next;
+
+		// The mirror only exists to diff against; letting it grow unbounded would
+		// keep an ever-longer string in a field the user cannot see.
+		if (next.length > 512) {
+			keyboardValue = '';
+			keyboardInput.value = '';
+		}
+	}
+
+	function handleKeyboardKeydown(event: KeyboardEvent) {
+		if (!sessionId) return;
+
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			sendInteraction({ type: 'keynav', key: 'Enter' });
+			keyboardValue = '';
+			if (keyboardInput) keyboardInput.value = '';
+			return;
+		}
+
+		// Backspace at the start of the mirror has nothing to delete locally, so
+		// `input` never fires — forward it directly.
+		if (event.key === 'Backspace' && keyboardValue.length === 0) {
+			event.preventDefault();
+			sendInteraction({ type: 'key', key: 'Backspace' });
+			return;
+		}
+
+		if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Tab', 'Escape'].includes(event.key)) {
+			event.preventDefault();
+			sendInteraction({
+				type: 'keynav',
+				key: event.key,
+				shiftKey: event.shiftKey
+			});
+		}
 	}
 
 	function getCanvasElement() {
@@ -1485,6 +1979,24 @@
 			updateCanvasCursor,
 			setupCanvas,
 			getCanvasElement,
+			/** Where the frame is actually painted — overlays anchor to this. */
+			getPaintedRect: () => (canvasElement ? paintedRect(canvasElement) : null),
+			/**
+			 * Page → screen, the inverse of what pointer events go through.
+			 * Shared so overlays the page positions itself (select popups, context
+			 * menus, native pickers, the agent's cursor) cannot drift away from the
+			 * point the user actually clicked.
+			 */
+			pageToScreen: (x: number, y: number) => pageToScreen(x, y),
+			getPageSize: () => ({ width: pageSize.width, height: pageSize.height }),
+			/**
+			 * Report new display metrics without restarting capture.
+			 *
+			 * Goes through the streaming service rather than straight to the
+			 * socket: the source tracks these per viewer now, and only the
+			 * service knows which viewer this is.
+			 */
+			sendDisplayMetrics: () => webCodecsService?.sendDisplayMetrics(),
 			// Streaming control
 			startStreaming,
 			stopStreaming,
@@ -1493,7 +2005,12 @@
 			getLatency: () => latencyMs,
 			// Navigation handling
 			notifyNavigationComplete,
-			freezeForSpaNavigation: () => webCodecsService?.freezeForSpaNavigation()
+			freezeForSpaNavigation: () => webCodecsService?.freezeForSpaNavigation(),
+			// On-screen keyboard control, for the toolbar's explicit toggle
+			supportsKeyboardToggle: () => isTouchDevice,
+			isKeyboardActive: () => isKeyboardActive,
+			openKeyboard: () => captureKeyboard(),
+			closeKeyboard: releaseKeyboard
 		};
 	});
 
@@ -1521,3 +2038,26 @@
 	tabindex="0"
 	style="cursor: default;"
 ></canvas>
+
+{#if isTouchDevice}
+	<!--
+		Keyboard proxy. Invisible and non-interactive, but a genuine editable
+		element — the only thing a mobile browser will raise its keyboard for.
+		16px font size is not cosmetic: iOS Safari auto-zooms the page whenever a
+		focused field is smaller than that.
+	-->
+	<textarea
+		bind:this={keyboardInput}
+		oninput={handleKeyboardInput}
+		onkeydown={handleKeyboardKeydown}
+		onblur={() => (isKeyboardActive = false)}
+		class="pointer-events-none absolute h-px w-px resize-none overflow-hidden border-0 bg-transparent p-0 opacity-0 outline-none"
+		style="left: {keyboardAnchor.x}px; top: {keyboardAnchor.y}px; font-size: 16px;"
+		aria-hidden="true"
+		tabindex="-1"
+		inputmode={keyboardInputMode}
+		autocomplete="off"
+		autocapitalize="sentences"
+		spellcheck="false"
+	></textarea>
+{/if}

--- a/frontend/components/preview/browser/components/ConsolePanel.svelte
+++ b/frontend/components/preview/browser/components/ConsolePanel.svelte
@@ -1,0 +1,511 @@
+<script lang="ts">
+	/**
+	 * Console panel for the preview browser.
+	 *
+	 * Shows what the previewed page logged and evaluates expressions in it.
+	 * Everything arrives as events from the backend, so the panel holds no live
+	 * handles and survives navigation without going stale.
+	 *
+	 * Two layout decisions are load-bearing:
+	 * - The prompt lives at the **bottom of the log stream**, not in a separate
+	 *   field. That is what a real console is: input and output are one
+	 *   transcript, and a detached input box breaks the reading order.
+	 * - It docks to the bottom or the right, and the choice only appears once the
+	 *   panel is wide enough to make a side dock usable — the same
+	 *   width-driven rule the Files panel uses for its second column.
+	 */
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import ConsoleValue from './ConsoleValue.svelte';
+	import { addNotification } from '$frontend/stores/ui/notification.svelte';
+	import type { BrowserConsoleMessage, BrowserConsoleType } from '$frontend/utils/native-ui';
+	import type { IconName } from '$shared/types/ui/icons';
+
+	let {
+		logs = [] as BrowserConsoleMessage[],
+		isMobile = false,
+		/** Width of the preview panel, which decides whether side-docking is offered. */
+		panelWidth = 0,
+		dock = $bindable<'bottom' | 'right'>('bottom'),
+		height = $bindable(240),
+		width = $bindable(380),
+		onClose = () => {},
+		onClear = () => {},
+		onExecute = (_command: string) => {}
+	} = $props();
+
+	type LevelFilter = 'all' | 'error' | 'warn' | 'info' | 'log';
+
+	let levelFilter = $state<LevelFilter>('all');
+	let searchTerm = $state('');
+	let showTimestamps = $state(false);
+	let autoScroll = $state(true);
+	let command = $state('');
+	let scrollContainer = $state<HTMLDivElement | undefined>();
+	let promptElement = $state<HTMLTextAreaElement | undefined>();
+
+	/**
+	 * Side-docking needs room for both the preview and a readable transcript.
+	 * Below this the bottom dock is the only sensible layout, so the control is
+	 * hidden rather than offered and then fought with.
+	 */
+	const SIDE_DOCK_THRESHOLD = 900;
+	const canSideDock = $derived(!isMobile && panelWidth >= SIDE_DOCK_THRESHOLD);
+
+	// Falling below the threshold (panel resized, window shrunk) has to pull the
+	// console back to the bottom, or it would be stuck in an unusable sliver.
+	$effect(() => {
+		if (!canSideDock && dock === 'right') dock = 'bottom';
+	});
+
+	/** REPL history, newest last; `historyIndex` walks backwards through it. */
+	let history = $state<string[]>([]);
+	let historyIndex = $state(-1);
+	let draftBeforeHistory = '';
+
+	const counts = $derived.by(() => {
+		const tally = { error: 0, warn: 0, info: 0, log: 0 };
+		for (const entry of logs) {
+			const weight = entry.count ?? 1;
+			if (entry.type === 'error') tally.error += weight;
+			else if (entry.type === 'warn') tally.warn += weight;
+			else if (entry.type === 'info') tally.info += weight;
+			else if (entry.type !== 'clear') tally.log += weight;
+		}
+		return tally;
+	});
+
+	const visibleLogs = $derived.by(() => {
+		const needle = searchTerm.trim().toLowerCase();
+
+		return logs.filter((entry) => {
+			if (entry.type === 'clear') return false;
+
+			if (levelFilter !== 'all') {
+				if (levelFilter === 'log') {
+					// "Logs" is the everything-else bucket, but REPL echo and its
+					// result always show — hiding your own input is disorienting.
+					if (['error', 'warn', 'info'].includes(entry.type)) return false;
+				} else if (entry.type !== levelFilter && entry.type !== 'input' && entry.type !== 'result') {
+					return false;
+				}
+			}
+
+			if (!needle) return true;
+			return (
+				entry.text.toLowerCase().includes(needle) ||
+				entry.location?.url.toLowerCase().includes(needle) ||
+				entry.values?.some((value) => value.preview.toLowerCase().includes(needle))
+			);
+		});
+	});
+
+	const levels: Array<{ id: LevelFilter; label: string; icon: IconName }> = [
+		{ id: 'all', label: 'All messages', icon: 'lucide:list' },
+		{ id: 'error', label: 'Errors', icon: 'lucide:circle-x' },
+		{ id: 'warn', label: 'Warnings', icon: 'lucide:triangle-alert' },
+		{ id: 'info', label: 'Info', icon: 'lucide:info' },
+		{ id: 'log', label: 'Logs', icon: 'lucide:message-square' }
+	];
+
+	function rowClass(type: BrowserConsoleType): string {
+		switch (type) {
+			case 'error':
+				return 'bg-red-50/70 dark:bg-red-950/30 border-l-2 border-red-500';
+			case 'warn':
+				return 'bg-amber-50/70 dark:bg-amber-950/30 border-l-2 border-amber-500';
+			case 'input':
+				return 'bg-slate-50 dark:bg-slate-800/60 border-l-2 border-violet-500';
+			default:
+				return 'border-l-2 border-transparent';
+		}
+	}
+
+	function rowIcon(type: BrowserConsoleType): { name: IconName; class: string } | null {
+		switch (type) {
+			case 'error':
+				return { name: 'lucide:circle-x', class: 'text-red-500' };
+			case 'warn':
+				return { name: 'lucide:triangle-alert', class: 'text-amber-500' };
+			case 'info':
+				return { name: 'lucide:info', class: 'text-sky-500' };
+			case 'input':
+				return { name: 'lucide:chevron-right', class: 'text-violet-500' };
+			case 'result':
+				return { name: 'lucide:corner-down-left', class: 'text-slate-400' };
+			default:
+				return null;
+		}
+	}
+
+	function formatTime(timestamp: number): string {
+		return new Date(timestamp).toLocaleTimeString(undefined, { hour12: false });
+	}
+
+	/** Strip the origin so the source column stays readable at panel width. */
+	function shortSource(url: string, line?: number): string {
+		try {
+			const parsed = new URL(url);
+			const file = parsed.pathname.split('/').pop() || parsed.hostname;
+			return line ? `${file}:${line}` : file;
+		} catch {
+			return line ? `${url}:${line}` : url;
+		}
+	}
+
+	function submit() {
+		const trimmed = command.trim();
+		if (!trimmed) return;
+
+		history = [...history.filter((entry) => entry !== trimmed), trimmed].slice(-100);
+		historyIndex = -1;
+		command = '';
+		autoScroll = true;
+		resizePrompt();
+		onExecute(trimmed);
+	}
+
+	/** Grow the prompt with its content, up to a third of the transcript. */
+	function resizePrompt() {
+		if (!promptElement) return;
+		promptElement.style.height = 'auto';
+		promptElement.style.height = `${Math.min(promptElement.scrollHeight, 160)}px`;
+	}
+
+	function handlePromptKeydown(event: KeyboardEvent) {
+		// Shift+Enter inserts a newline; Enter runs. Multi-line entry is the whole
+		// reason this is a textarea rather than an input.
+		if (event.key === 'Enter' && !event.shiftKey) {
+			event.preventDefault();
+			submit();
+			return;
+		}
+
+		const isMultiline = command.includes('\n');
+
+		if (event.key === 'ArrowUp' && !isMultiline) {
+			if (history.length === 0) return;
+			event.preventDefault();
+			if (historyIndex === -1) draftBeforeHistory = command;
+			historyIndex = Math.min(historyIndex + 1, history.length - 1);
+			command = history[history.length - 1 - historyIndex] ?? '';
+			queueMicrotask(resizePrompt);
+			return;
+		}
+
+		if (event.key === 'ArrowDown' && !isMultiline) {
+			if (historyIndex === -1) return;
+			event.preventDefault();
+			historyIndex -= 1;
+			command = historyIndex === -1 ? draftBeforeHistory : (history[history.length - 1 - historyIndex] ?? '');
+			queueMicrotask(resizePrompt);
+			return;
+		}
+
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			if (command) {
+				command = '';
+				queueMicrotask(resizePrompt);
+			} else {
+				onClose();
+			}
+		}
+	}
+
+	async function copyMessage(entry: BrowserConsoleMessage) {
+		const text = entry.stackTrace ? `${entry.text}\n${entry.stackTrace}` : entry.text;
+		try {
+			await navigator.clipboard.writeText(text);
+			addNotification({ type: 'success', title: 'Copied', message: 'Console message copied to clipboard' });
+		} catch {
+			addNotification({ type: 'error', title: 'Copy failed', message: 'Could not access the clipboard' });
+		}
+	}
+
+	// Follow the tail only while the user is already at the bottom — yanking the
+	// view down while they are reading an earlier error is the classic console
+	// annoyance.
+	$effect(() => {
+		void visibleLogs.length;
+		if (!autoScroll || !scrollContainer) return;
+		queueMicrotask(() => {
+			if (scrollContainer) scrollContainer.scrollTop = scrollContainer.scrollHeight;
+		});
+	});
+
+	function handleScroll() {
+		if (!scrollContainer) return;
+		const distanceFromBottom =
+			scrollContainer.scrollHeight - scrollContainer.scrollTop - scrollContainer.clientHeight;
+		autoScroll = distanceFromBottom < 40;
+	}
+
+	// ── Resize handle ───────────────────────────────────────────────────────
+	function startResize(event: PointerEvent) {
+		if (isMobile) return;
+
+		const isSide = dock === 'right';
+		const start = isSide ? event.clientX : event.clientY;
+		const startSize = isSide ? width : height;
+		(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+
+		const move = (moveEvent: PointerEvent) => {
+			// Both handles sit on the leading edge, so dragging toward the panel
+			// centre grows the console — hence the inverted delta.
+			const delta = start - (isSide ? moveEvent.clientX : moveEvent.clientY);
+			if (isSide) {
+				width = Math.max(260, Math.min(window.innerWidth * 0.7, startSize + delta));
+			} else {
+				height = Math.max(120, Math.min(window.innerHeight * 0.8, startSize + delta));
+			}
+		};
+		const end = () => {
+			window.removeEventListener('pointermove', move);
+			window.removeEventListener('pointerup', end);
+		};
+
+		window.addEventListener('pointermove', move);
+		window.addEventListener('pointerup', end);
+	}
+
+	const sizeStyle = $derived(
+		isMobile ? 'height: 55vh;' : dock === 'right' ? `width: ${width}px;` : `height: ${height}px;`
+	);
+</script>
+
+<div
+	class="relative flex min-h-0 min-w-0 shrink-0 flex-col bg-white dark:bg-slate-900
+		{dock === 'right' && !isMobile
+		? 'border-l border-slate-200 dark:border-slate-700'
+		: 'border-t border-slate-200 dark:border-slate-700'}"
+	style={sizeStyle}
+>
+	{#if !isMobile}
+		<div
+			class="shrink-0 bg-transparent transition-colors hover:bg-violet-500/30 {dock === 'right'
+				? 'absolute inset-y-0 left-0 w-1.5 cursor-ew-resize'
+				: 'h-1.5 cursor-ns-resize'}"
+			role="separator"
+			aria-label="Resize console"
+			aria-orientation={dock === 'right' ? 'vertical' : 'horizontal'}
+			onpointerdown={startResize}
+		></div>
+	{/if}
+
+	<!-- Toolbar -->
+	<div
+		class="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-slate-200 px-1.5 py-1.5 dark:border-slate-700"
+	>
+		<div class="flex shrink-0 items-center gap-0.5 rounded-md bg-slate-100/80 p-0.5 dark:bg-slate-800/60">
+			{#each levels as level (level.id)}
+				{@const tally = level.id === 'all' ? 0 : counts[level.id]}
+				<button
+					type="button"
+					class="flex items-center gap-1 rounded px-1.5 py-1 text-[11px] font-medium transition-colors
+						{levelFilter === level.id
+						? 'bg-white text-violet-600 shadow-sm dark:bg-slate-700 dark:text-violet-300'
+						: 'text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200'}"
+					onclick={() => (levelFilter = level.id)}
+					title={level.label}
+					aria-label={level.label}
+					aria-pressed={levelFilter === level.id}
+				>
+					<Icon name={level.icon} class="h-3.5 w-3.5" />
+					{#if tally > 0}
+						<span
+							class="rounded-full px-1 text-[10px] leading-4
+								{level.id === 'error'
+								? 'bg-red-500/15 text-red-600 dark:text-red-400'
+								: level.id === 'warn'
+									? 'bg-amber-500/15 text-amber-600 dark:text-amber-400'
+									: 'bg-slate-500/15 text-slate-600 dark:text-slate-300'}"
+						>
+							{tally > 999 ? '999+' : tally}
+						</span>
+					{/if}
+				</button>
+			{/each}
+		</div>
+
+		<div class="relative min-w-20 flex-1">
+			<Icon
+				name="lucide:search"
+				class="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-slate-400"
+			/>
+			<input
+				type="text"
+				bind:value={searchTerm}
+				placeholder="Filter"
+				class="w-full rounded-md border border-slate-200 bg-transparent py-1 pl-7 pr-2 text-xs text-slate-700 placeholder:text-slate-400 focus:border-violet-500 focus:outline-none dark:border-slate-700 dark:text-slate-200"
+			/>
+		</div>
+
+		{#if !isMobile}
+			<button
+				type="button"
+				class="flex shrink-0 items-center justify-center rounded-md p-1.5 transition-colors
+					{showTimestamps
+					? 'bg-violet-500/10 text-violet-600 dark:text-violet-400'
+					: 'text-slate-400 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200'}"
+				onclick={() => (showTimestamps = !showTimestamps)}
+				title="Show timestamps"
+				aria-label="Show timestamps"
+			>
+				<Icon name="lucide:clock" class="h-3.5 w-3.5" />
+			</button>
+		{/if}
+
+		{#if canSideDock}
+			<button
+				type="button"
+				class="flex shrink-0 items-center justify-center rounded-md p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+				onclick={() => (dock = dock === 'bottom' ? 'right' : 'bottom')}
+				title={dock === 'bottom' ? 'Dock to the right' : 'Dock to the bottom'}
+				aria-label={dock === 'bottom' ? 'Dock to the right' : 'Dock to the bottom'}
+			>
+				<Icon name={dock === 'bottom' ? 'lucide:panel-right' : 'lucide:panel-bottom'} class="h-3.5 w-3.5" />
+			</button>
+		{/if}
+
+		<button
+			type="button"
+			class="flex shrink-0 items-center justify-center rounded-md p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+			onclick={() => onClear()}
+			title="Clear console"
+			aria-label="Clear console"
+		>
+			<Icon name="lucide:ban" class="h-3.5 w-3.5" />
+		</button>
+
+		<button
+			type="button"
+			class="flex shrink-0 items-center justify-center rounded-md p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+			onclick={() => onClose()}
+			title="Close console"
+			aria-label="Close console"
+		>
+			<Icon name="lucide:x" class="h-4 w-4" />
+		</button>
+	</div>
+
+	<!-- Transcript: log stream with the prompt as its last line -->
+	<div
+		bind:this={scrollContainer}
+		onscroll={handleScroll}
+		class="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden font-mono text-[12px] leading-relaxed"
+	>
+		{#if visibleLogs.length === 0}
+			<div class="flex flex-col items-center justify-center gap-2 px-6 py-8 text-center">
+				<Icon name="lucide:terminal" class="h-8 w-8 text-slate-300 dark:text-slate-600" />
+				<p class="font-sans text-xs text-slate-400 dark:text-slate-500">
+					{logs.length === 0
+						? 'Nothing logged yet — messages from the page appear here.'
+						: 'No messages match this filter.'}
+				</p>
+			</div>
+		{:else}
+			{#each visibleLogs as entry (entry.id)}
+				{@const icon = rowIcon(entry.type)}
+				<div
+					class="group flex items-start gap-2 px-2 py-1 {rowClass(entry.type)} hover:bg-slate-50 dark:hover:bg-slate-800/50"
+				>
+					<span class="flex w-4 shrink-0 justify-center pt-0.5">
+						{#if icon}
+							<Icon name={icon.name} class="h-3.5 w-3.5 {icon.class}" />
+						{/if}
+					</span>
+
+					{#if showTimestamps}
+						<span class="shrink-0 pt-0.5 text-[11px] tabular-nums text-slate-400">{formatTime(entry.timestamp)}</span>
+					{/if}
+
+					<div class="min-w-0 flex-1">
+						<div class="flex flex-wrap items-start gap-x-2 gap-y-0.5">
+							{#if entry.count && entry.count > 1}
+								<span
+									class="shrink-0 rounded-full bg-slate-500/15 px-1.5 text-[10px] leading-4 text-slate-600 dark:text-slate-300"
+									title="{entry.count} identical messages"
+								>
+									{entry.count > 999 ? '999+' : entry.count}
+								</span>
+							{/if}
+							{#if entry.status}
+								<span class="shrink-0 rounded bg-red-500/15 px-1.5 text-[10px] leading-4 text-red-600 dark:text-red-400">
+									{entry.status}
+								</span>
+							{/if}
+
+							{#if entry.values && entry.values.length > 0}
+								{#each entry.values as value, index (index)}
+									<ConsoleValue {value} bare />
+								{/each}
+							{:else}
+								<span
+									class="min-w-0 whitespace-pre-wrap break-all
+										{entry.type === 'error'
+										? 'text-red-700 dark:text-red-300'
+										: entry.type === 'warn'
+											? 'text-amber-700 dark:text-amber-300'
+											: entry.type === 'input'
+												? 'text-violet-700 dark:text-violet-300'
+												: 'text-slate-700 dark:text-slate-200'}">{entry.text}</span
+								>
+							{/if}
+						</div>
+
+						{#if entry.location?.url}
+							<span
+								class="mt-0.5 block truncate text-[11px] text-slate-400"
+								title={`${entry.location.url}:${entry.location.lineNumber}`}
+							>
+								{shortSource(entry.location.url, entry.location.lineNumber)}
+							</span>
+						{/if}
+
+						{#if entry.stackTrace}
+							<pre class="mt-0.5 whitespace-pre-wrap break-all text-[11px] text-slate-500 dark:text-slate-400">{entry.stackTrace}</pre>
+						{/if}
+					</div>
+
+					<button
+						type="button"
+						class="shrink-0 rounded p-0.5 text-slate-400 transition-colors hover:bg-slate-200/60 hover:text-slate-700 dark:text-slate-500 dark:hover:bg-slate-700 dark:hover:text-slate-200"
+						onclick={() => copyMessage(entry)}
+						title="Copy message"
+						aria-label="Copy message"
+					>
+						<Icon name="lucide:copy" class="h-3 w-3" />
+					</button>
+				</div>
+			{/each}
+		{/if}
+
+		<!-- The prompt is part of the transcript, not a separate field. -->
+		<div class="flex items-start gap-2 border-l-2 border-violet-500 bg-slate-50/60 px-2 py-1 dark:bg-slate-800/40">
+			<span class="flex w-4 shrink-0 justify-center pt-0.5">
+				<Icon name="lucide:chevron-right" class="h-3.5 w-3.5 text-violet-500" />
+			</span>
+			<textarea
+				bind:this={promptElement}
+				bind:value={command}
+				oninput={resizePrompt}
+				onkeydown={handlePromptKeydown}
+				rows="1"
+				placeholder="Run JavaScript in the page — Shift+Enter for a new line"
+				autocomplete="off"
+				autocapitalize="off"
+				spellcheck="false"
+				class="min-w-0 flex-1 resize-none overflow-hidden break-all bg-transparent font-mono text-[12px] leading-relaxed text-slate-700 outline-none placeholder:font-sans placeholder:text-slate-400 dark:text-slate-200"
+			></textarea>
+			{#if command.trim()}
+				<button
+					type="button"
+					class="mt-0.5 shrink-0 rounded-md bg-violet-500 px-2 py-0.5 text-[11px] font-medium text-white transition-colors hover:bg-violet-600"
+					onclick={submit}
+				>
+					Run
+				</button>
+			{/if}
+		</div>
+	</div>
+</div>

--- a/frontend/components/preview/browser/components/ConsoleValue.svelte
+++ b/frontend/components/preview/browser/components/ConsoleValue.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	/**
+	 * One console argument, rendered DevTools-style.
+	 *
+	 * Values arrive pre-flattened from the page (see BrowserConsoleValue), so
+	 * expanding a node is a pure render of data already held — no round-trip and
+	 * no live handle that could go stale when the page navigates.
+	 */
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import Self from './ConsoleValue.svelte';
+	import type { BrowserConsoleValue } from '$frontend/utils/native-ui';
+
+	let {
+		value,
+		depth = 0,
+		/** Top-level strings print bare, the way `console.log('hi')` shows `hi`. */
+		bare = false
+	}: { value: BrowserConsoleValue; depth?: number; bare?: boolean } = $props();
+
+	let expanded = $state(false);
+
+	const expandable = $derived(!!value.entries && value.entries.length > 0);
+
+	const toneClass = $derived.by(() => {
+		switch (value.type) {
+			case 'string':
+				return bare ? 'text-slate-700 dark:text-slate-200' : 'text-rose-600 dark:text-rose-400';
+			case 'number':
+			case 'bigint':
+				return 'text-sky-600 dark:text-sky-400';
+			case 'boolean':
+				return 'text-purple-600 dark:text-purple-400';
+			case 'null':
+			case 'undefined':
+				return 'text-slate-400 dark:text-slate-500';
+			case 'function':
+				return 'text-amber-600 dark:text-amber-400 italic';
+			case 'error':
+				return 'text-red-600 dark:text-red-400';
+			case 'node':
+				return 'text-teal-600 dark:text-teal-400';
+			case 'regexp':
+				return 'text-orange-600 dark:text-orange-400';
+			default:
+				return 'text-slate-600 dark:text-slate-300';
+		}
+	});
+
+	const label = $derived(
+		value.type === 'string' && !bare ? `"${value.preview}"` : value.preview
+	);
+</script>
+
+<span class="inline-flex flex-col align-top max-w-full">
+	<span class="inline-flex items-start gap-1 min-w-0">
+		{#if expandable}
+			<button
+				type="button"
+				class="mt-0.5 flex shrink-0 items-center justify-center text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+				onclick={() => (expanded = !expanded)}
+				aria-expanded={expanded}
+				title={expanded ? 'Collapse' : 'Expand'}
+			>
+				<Icon name={expanded ? 'lucide:chevron-down' : 'lucide:chevron-right'} class="w-3 h-3" />
+			</button>
+		{/if}
+		<span class="{toneClass} break-words whitespace-pre-wrap min-w-0">{label}</span>
+	</span>
+
+	{#if expandable && expanded}
+		<span class="flex flex-col gap-0.5 pl-4 mt-0.5 border-l border-slate-200 dark:border-slate-700">
+			{#each value.entries ?? [] as entry (entry.key)}
+				<span class="flex items-start gap-1.5 min-w-0">
+					<span class="shrink-0 text-violet-600 dark:text-violet-400">{entry.key}:</span>
+					<Self value={entry.value} depth={depth + 1} />
+				</span>
+			{/each}
+			{#if value.truncated}
+				<span class="text-slate-400 dark:text-slate-500 italic">…more entries not shown</span>
+			{/if}
+		</span>
+	{/if}
+</span>

--- a/frontend/components/preview/browser/components/Container.svelte
+++ b/frontend/components/preview/browser/components/Container.svelte
@@ -421,12 +421,7 @@
 						transition: none;
 					"
 				>
-					<DeviceFrame
-						deviceSize={deviceSize as DeviceSize}
-						rotation={rotation as Rotation}
-						canvasWidth={previewDimensions.canvasWidth}
-						canvasHeight={previewDimensions.canvasHeight}
-					>
+					<DeviceFrame deviceSize={deviceSize as DeviceSize} rotation={rotation as Rotation}>
 						<Canvas
 							projectId={projectId}
 							bind:sessionId

--- a/frontend/components/preview/browser/components/ContextMenu.svelte
+++ b/frontend/components/preview/browser/components/ContextMenu.svelte
@@ -1,85 +1,136 @@
 <script lang="ts">
+	/**
+	 * Context menu for the preview canvas.
+	 *
+	 * Headless Chrome cannot draw its own menu, so the backend reports what was
+	 * right-clicked and this renders the menu over the video. Two things make it
+	 * read as the page's own menu rather than an app overlay:
+	 *
+	 * - It is drawn at the preview's scale. A menu at 1× floating over a page
+	 *   shrunk to 0.4× looks pasted on; scaling it with the page keeps the
+	 *   proportions a real browser would have.
+	 * - It flips rather than slides. Chrome opens up-left near the bottom-right
+	 *   corner so the click point stays visible; nudging a down-right menu back
+	 *   inside the panel would cover exactly what was clicked.
+	 */
+	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import type { BrowserContextMenuInfo, BrowserContextMenuItem } from '$frontend/utils/native-ui';
-	import { onMount } from 'svelte';
+	import type { IconName } from '$shared/types/ui/icons';
 
 	let {
-		menuInfo = $bindable<BrowserContextMenuInfo | null>(null),
-		onSelectItem = $bindable<(itemId: string) => void>(() => {}),
-		onClose = $bindable<() => void>(() => {})
+		menuInfo = null as BrowserContextMenuInfo | null,
+		scale = 1,
+		bounds = null as DOMRect | null,
+		onSelectItem = (_itemId: string) => {},
+		onClose = () => {}
 	} = $props();
 
-	let menuElement = $state<HTMLDivElement | undefined>(undefined);
+	let menuElement = $state<HTMLDivElement | undefined>();
 	let highlightedItemId = $state<string | null>(null);
+	let openSubmenuId = $state<string | null>(null);
 
-	// Position the context menu
-	function getMenuPosition() {
-		if (!menuInfo) return { top: '0px', left: '0px' };
+	/** Natural (unscaled) size, measured once the menu is in the DOM. */
+	let naturalWidth = $state(0);
+	let naturalHeight = $state(0);
 
-		let x = menuInfo.x;
-		let y = menuInfo.y;
+	/** Gap kept between the menu and the edge it flipped away from. */
+	const EDGE_PADDING = 6;
 
-		// Adjust if menu would go off screen
-		if (menuElement) {
-			const menuRect = menuElement.getBoundingClientRect();
-			const windowWidth = window.innerWidth;
-			const windowHeight = window.innerHeight;
+	const selectableItems = $derived(
+		(menuInfo?.items ?? []).filter(
+			(item: BrowserContextMenuItem) => item.enabled && item.type !== 'separator'
+		)
+	);
 
-			if (x + menuRect.width > windowWidth) {
-				x = windowWidth - menuRect.width - 10;
-			}
-
-			if (y + menuRect.height > windowHeight) {
-				y = windowHeight - menuRect.height - 10;
-			}
-		}
-
-		return {
-			top: `${y}px`,
-			left: `${x}px`
-		};
+	/**
+	 * Place the menu at the click point, flipping whichever axis would overflow
+	 * and clamping if it overflows even after flipping (a menu taller than the
+	 * panel, which the body's own scroll then handles).
+	 */
+	function viewportRect(): DOMRect {
+		return new DOMRect(0, 0, window.innerWidth, window.innerHeight);
 	}
 
-	// Handle item click
+	const position = $derived.by(() => {
+		if (!menuInfo) return { left: 0, top: 0 };
+
+		const area = bounds ?? viewportRect();
+		const width = naturalWidth * scale;
+		const height = naturalHeight * scale;
+
+		let left = menuInfo.x;
+		let top = menuInfo.y;
+
+		if (width > 0 && left + width > area.right - EDGE_PADDING) {
+			left = menuInfo.x - width;
+		}
+		if (height > 0 && top + height > area.bottom - EDGE_PADDING) {
+			top = menuInfo.y - height;
+		}
+
+		left = Math.max(area.left + EDGE_PADDING, Math.min(left, area.right - width - EDGE_PADDING));
+		top = Math.max(area.top + EDGE_PADDING, Math.min(top, area.bottom - height - EDGE_PADDING));
+
+		return { left, top };
+	});
+
+	/** Keep the menu inside the panel even when the page has very long labels. */
+	const maxHeight = $derived.by(() => {
+		const area = bounds ?? viewportRect();
+		return Math.max(120, area.height / Math.max(scale, 0.05) - EDGE_PADDING * 2);
+	});
+
+	function measure() {
+		if (!menuElement) return;
+		naturalWidth = menuElement.offsetWidth;
+		naturalHeight = menuElement.offsetHeight;
+	}
+
 	function handleItemClick(item: BrowserContextMenuItem) {
 		if (!item.enabled || item.type === 'separator') return;
+
+		if (item.submenu?.length) {
+			openSubmenuId = openSubmenuId === item.id ? null : item.id;
+			return;
+		}
+
 		onSelectItem(item.id);
 		onClose();
 	}
 
-	// Handle keyboard navigation
 	function handleKeydown(event: KeyboardEvent) {
 		if (!menuInfo) return;
 
-		const enabledItems = menuInfo.items.filter(
-			(item: BrowserContextMenuItem) => item.enabled && item.type !== 'separator'
-		);
+		const items = selectableItems;
 
 		switch (event.key) {
 			case 'ArrowDown': {
 				event.preventDefault();
-				const currentIndex = enabledItems.findIndex((item: BrowserContextMenuItem) => item.id === highlightedItemId);
-				const nextIndex = (currentIndex + 1) % enabledItems.length;
-				highlightedItemId = enabledItems[nextIndex]?.id || null;
+				const index = items.findIndex((item: BrowserContextMenuItem) => item.id === highlightedItemId);
+				highlightedItemId = items[(index + 1) % items.length]?.id ?? null;
 				break;
 			}
-
 			case 'ArrowUp': {
 				event.preventDefault();
-				const currentIndex = enabledItems.findIndex((item: BrowserContextMenuItem) => item.id === highlightedItemId);
-				const prevIndex = currentIndex <= 0 ? enabledItems.length - 1 : currentIndex - 1;
-				highlightedItemId = enabledItems[prevIndex]?.id || null;
+				const index = items.findIndex((item: BrowserContextMenuItem) => item.id === highlightedItemId);
+				highlightedItemId = items[index <= 0 ? items.length - 1 : index - 1]?.id ?? null;
 				break;
 			}
-
-			case 'Enter': {
+			case 'Home':
 				event.preventDefault();
-				const item = enabledItems.find((item: BrowserContextMenuItem) => item.id === highlightedItemId);
-				if (item) {
-					handleItemClick(item);
-				}
+				highlightedItemId = items[0]?.id ?? null;
+				break;
+			case 'End':
+				event.preventDefault();
+				highlightedItemId = items[items.length - 1]?.id ?? null;
+				break;
+			case 'Enter':
+			case ' ': {
+				event.preventDefault();
+				const item = items.find((entry: BrowserContextMenuItem) => entry.id === highlightedItemId);
+				if (item) handleItemClick(item);
 				break;
 			}
-
 			case 'Escape':
 				event.preventDefault();
 				onClose();
@@ -87,150 +138,129 @@
 		}
 	}
 
-	// Handle click outside to close
-	function handleClickOutside(event: MouseEvent) {
-		if (menuElement && !menuElement.contains(event.target as Node)) {
-			onClose();
-		}
-	}
-
-	// Initialize
+	// Dismiss on anything that would move the menu away from what it points at.
+	// `pointerdown` rather than `mousedown` so a tap outside closes it on touch
+	// devices too — the old mouse-only listener left it stranded on mobile.
 	$effect(() => {
-		if (menuInfo) {
-			// Focus menu for keyboard navigation
-			if (menuElement) {
-				menuElement.focus();
-			}
+		if (!menuInfo) return;
 
-			// Add click outside listener
-			setTimeout(() => {
-				document.addEventListener('mousedown', handleClickOutside);
-			}, 0);
-		}
+		openSubmenuId = null;
+		highlightedItemId = null;
+
+		queueMicrotask(() => {
+			measure();
+			menuElement?.focus();
+		});
+
+		const dismissOutside = (event: Event) => {
+			if (menuElement && !menuElement.contains(event.target as Node)) onClose();
+		};
+		const dismiss = () => onClose();
+
+		// Deferred by a frame so the pointerup of the right-click that opened the
+		// menu cannot immediately close it again.
+		const attach = requestAnimationFrame(() => {
+			document.addEventListener('pointerdown', dismissOutside, true);
+			window.addEventListener('wheel', dismiss, { passive: true });
+			window.addEventListener('resize', dismiss);
+			window.addEventListener('blur', dismiss);
+		});
 
 		return () => {
-			document.removeEventListener('mousedown', handleClickOutside);
+			cancelAnimationFrame(attach);
+			document.removeEventListener('pointerdown', dismissOutside, true);
+			window.removeEventListener('wheel', dismiss);
+			window.removeEventListener('resize', dismiss);
+			window.removeEventListener('blur', dismiss);
 		};
 	});
-
-	const position = $derived(getMenuPosition());
 </script>
+
+{#snippet menuItem(item: BrowserContextMenuItem)}
+	<div
+		class="group flex items-center gap-2.5 px-3 py-1.5 cursor-default select-none whitespace-nowrap rounded-[3px] mx-1
+			{item.enabled
+			? highlightedItemId === item.id
+				? 'bg-violet-600 text-white'
+				: 'text-slate-700 dark:text-slate-200'
+			: 'text-slate-400 dark:text-slate-600 cursor-not-allowed'}"
+		role="menuitem"
+		tabindex={item.enabled ? 0 : -1}
+		aria-disabled={!item.enabled}
+		aria-haspopup={item.submenu?.length ? 'menu' : undefined}
+		onclick={() => handleItemClick(item)}
+		onkeydown={(event) => {
+			if (event.key === 'Enter' || event.key === ' ') {
+				event.preventDefault();
+				handleItemClick(item);
+			}
+		}}
+		onmouseenter={() => {
+			if (item.enabled) highlightedItemId = item.id;
+			if (!item.submenu?.length) openSubmenuId = null;
+		}}
+	>
+		<span class="flex w-4 shrink-0 items-center justify-center">
+			{#if item.icon}
+				<Icon name={item.icon as IconName} class="w-3.5 h-3.5" />
+			{/if}
+		</span>
+		<span class="flex-1 text-[13px] leading-5">{item.label}</span>
+		{#if item.submenu?.length}
+			<Icon name="lucide:chevron-right" class="w-3.5 h-3.5 shrink-0 opacity-70" />
+		{/if}
+	</div>
+
+	{#if item.submenu?.length && openSubmenuId === item.id}
+		<div class="ml-6 border-l border-slate-200 dark:border-slate-700">
+			{#each item.submenu as child (child.id)}
+				{#if child.type === 'separator'}
+					<div class="my-1 h-px bg-slate-200 dark:bg-slate-700" role="separator"></div>
+				{:else}
+					{@render menuItem(child)}
+				{/if}
+			{/each}
+		</div>
+	{/if}
+{/snippet}
 
 {#if menuInfo}
 	<div
 		bind:this={menuElement}
-		class="browser-context-menu"
-		style="top: {position.top}; left: {position.left};"
+		class="context-menu fixed z-[999999] min-w-[13rem] py-1 rounded-lg overflow-y-auto
+			bg-white/95 dark:bg-slate-800/95 backdrop-blur-sm
+			border border-slate-200 dark:border-slate-700
+			shadow-xl shadow-slate-900/20 dark:shadow-black/50
+			outline-none origin-top-left"
+		style="left: {position.left}px; top: {position.top}px; transform: scale({scale}); max-height: {maxHeight}px;"
 		tabindex="-1"
 		onkeydown={handleKeydown}
 		role="menu"
-		aria-label="Context menu"
+		aria-label="Page context menu"
 	>
 		{#each menuInfo.items as item (item.id)}
 			{#if item.type === 'separator'}
-				<div class="context-menu-separator" role="separator"></div>
+				<div class="my-1 h-px bg-slate-200 dark:bg-slate-700" role="separator"></div>
 			{:else}
-				<div
-					class="context-menu-item"
-					class:disabled={!item.enabled}
-					class:highlighted={item.id === highlightedItemId}
-					role="menuitem"
-					tabindex={item.enabled ? 0 : -1}
-					aria-disabled={!item.enabled}
-					onclick={() => handleItemClick(item)}
-					onkeydown={(e) => {
-						if (e.key === 'Enter' || e.key === ' ') {
-							e.preventDefault();
-							handleItemClick(item);
-						}
-					}}
-					onmouseenter={() => {
-						if (item.enabled) highlightedItemId = item.id;
-					}}
-				>
-					<span class="menu-item-label">{item.label}</span>
-				</div>
+				{@render menuItem(item)}
 			{/if}
 		{/each}
 	</div>
 {/if}
 
 <style>
-	.browser-context-menu {
-		position: fixed;
-		z-index: 999999;
-		min-width: 200px;
-		background: white;
-		border: 1px solid #ccc;
-		border-radius: 4px;
-		box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
-		padding: 4px 0;
-		outline: none;
-		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+	/* Opacity only — the element already carries a scale transform for the
+	   preview fit, and animating transform here would fight it. */
+	.context-menu {
+		animation: context-menu-in 90ms ease-out;
 	}
 
-	.context-menu-item {
-		padding: 8px 24px 8px 16px;
-		cursor: pointer;
-		user-select: none;
-		font-size: 14px;
-		line-height: 1.5;
-		color: #333;
-		display: flex;
-		align-items: center;
-		transition: background-color 0.1s ease;
-	}
-
-	.context-menu-item:hover:not(.disabled) {
-		background: #f0f0f0;
-	}
-
-	.context-menu-item.highlighted:not(.disabled) {
-		background: #e6f7ff;
-	}
-
-	.context-menu-item.disabled {
-		color: #999;
-		cursor: not-allowed;
-		opacity: 0.5;
-	}
-
-	.context-menu-separator {
-		height: 1px;
-		background: #e0e0e0;
-		margin: 4px 0;
-	}
-
-	.menu-item-label {
-		flex: 1;
-	}
-
-	/* Dark mode support */
-	@media (prefers-color-scheme: dark) {
-		.browser-context-menu {
-			background: #2d2d2d;
-			border-color: #444;
-			box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
+	@keyframes context-menu-in {
+		from {
+			opacity: 0;
 		}
-
-		.context-menu-item {
-			color: #e0e0e0;
-		}
-
-		.context-menu-item:hover:not(.disabled) {
-			background: #3a3a3a;
-		}
-
-		.context-menu-item.highlighted:not(.disabled) {
-			background: #003d66;
-		}
-
-		.context-menu-item.disabled {
-			color: #666;
-		}
-
-		.context-menu-separator {
-			background: #444;
+		to {
+			opacity: 1;
 		}
 	}
 </style>

--- a/frontend/components/preview/browser/components/DeviceFrame.svelte
+++ b/frontend/components/preview/browser/components/DeviceFrame.svelte
@@ -1,16 +1,33 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
-	import { getFrameMetrics, type DeviceSize, type Rotation } from '$frontend/utils/preview-constants';
+	import {
+		getFrameMetrics,
+		getViewportDimensions,
+		type DeviceSize,
+		type Rotation
+	} from '$frontend/utils/preview-constants';
 
 	interface Props {
 		deviceSize: DeviceSize;
 		rotation: Rotation;
-		canvasWidth: number;
-		canvasHeight: number;
 		children: Snippet;
 	}
 
-	const { deviceSize, rotation, canvasWidth, canvasHeight, children }: Props = $props();
+	const { deviceSize, rotation, children }: Props = $props();
+
+	/**
+	 * The screen box is derived here rather than passed in.
+	 *
+	 * The canvas sizes its bitmap from `getViewportDimensions(deviceSize,
+	 * rotation)` directly, while the parent recomputes its own copy on a timer.
+	 * Taking the size from the parent let the two disagree for a few frames after
+	 * a rotation change — and because the canvas is `object-contain`, a mismatched
+	 * box letterboxes the image inside it, which is exactly the offset that made
+	 * clicks land up and to the left of the pointer.
+	 */
+	const viewport = $derived(getViewportDimensions(deviceSize, rotation));
+	const canvasWidth = $derived(viewport.width);
+	const canvasHeight = $derived(viewport.height);
 
 	const metrics = $derived(getFrameMetrics(deviceSize, rotation));
 	const bodyWidth = $derived(canvasWidth + metrics.left + metrics.right);

--- a/frontend/components/preview/browser/components/DialogOverlay.svelte
+++ b/frontend/components/preview/browser/components/DialogOverlay.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+	/**
+	 * `alert()` / `confirm()` / `prompt()` for the preview.
+	 *
+	 * A JS dialog blocks the page's renderer, which in a streamed preview means
+	 * the video freezes until it is answered — so it has to be answered *here*,
+	 * by the person watching. Rendering our own also avoids `window.confirm`,
+	 * which would block Clopen's own UI thread and stall the stream decoder.
+	 *
+	 * Dialogs are modal by nature, so this traps focus and blocks the canvas
+	 * beneath it, exactly like the real thing.
+	 */
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { fade, scale } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
+	import type { BrowserDialogEvent } from '$frontend/utils/native-ui';
+
+	let {
+		dialog = null as BrowserDialogEvent | null,
+		origin = '',
+		onRespond = (_accept: boolean, _promptText?: string) => {}
+	} = $props();
+
+	let promptValue = $state('');
+	let inputElement = $state<HTMLInputElement | undefined>();
+	let confirmButton = $state<HTMLButtonElement | undefined>();
+
+	const isPrompt = $derived(dialog?.type === 'prompt');
+	const isAlert = $derived(dialog?.type === 'alert');
+	const isBeforeUnload = $derived(dialog?.type === 'beforeunload');
+
+	const heading = $derived.by(() => {
+		if (!dialog) return '';
+		if (isBeforeUnload) return 'Leave site?';
+		return origin ? `${origin} says` : 'This page says';
+	});
+
+	const confirmLabel = $derived(isBeforeUnload ? 'Leave' : 'OK');
+	const cancelLabel = $derived(isBeforeUnload ? 'Stay' : 'Cancel');
+
+	function accept() {
+		onRespond(true, isPrompt ? promptValue : undefined);
+	}
+
+	function dismiss() {
+		onRespond(false);
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			accept();
+		} else if (event.key === 'Escape') {
+			event.preventDefault();
+			// alert() has no cancel path — Escape resolves it the same way OK does.
+			if (isAlert) accept();
+			else dismiss();
+		}
+	}
+
+	$effect(() => {
+		if (!dialog) return;
+
+		promptValue = dialog.defaultValue ?? '';
+		queueMicrotask(() => {
+			if (isPrompt) {
+				inputElement?.focus();
+				inputElement?.select();
+			} else {
+				confirmButton?.focus();
+			}
+		});
+	});
+</script>
+
+{#if dialog}
+	<div
+		class="absolute inset-0 z-40 flex items-start justify-center bg-slate-900/40 px-4 pt-10 backdrop-blur-[1px]"
+		role="dialog"
+		aria-modal="true"
+		aria-label={heading}
+		tabindex="-1"
+		onkeydown={handleKeydown}
+		transition:fade={{ duration: 120 }}
+	>
+		<div
+			class="w-full max-w-md overflow-hidden rounded-xl border border-slate-200 bg-white shadow-2xl dark:border-slate-700 dark:bg-slate-800"
+			in:scale={{ duration: 160, easing: cubicOut, start: 0.96 }}
+		>
+			<div class="flex items-start gap-3 px-5 pt-4">
+				<span
+					class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full
+						{isBeforeUnload ? 'bg-amber-500/15 text-amber-500' : 'bg-violet-500/15 text-violet-500'}"
+				>
+					<Icon name={isBeforeUnload ? 'lucide:triangle-alert' : 'lucide:message-square'} class="h-4 w-4" />
+				</span>
+				<div class="min-w-0 flex-1">
+					<p class="truncate text-sm font-semibold text-slate-800 dark:text-slate-100">{heading}</p>
+					<p class="mt-1 max-h-48 overflow-y-auto whitespace-pre-wrap break-words text-sm text-slate-600 dark:text-slate-300">
+						{dialog.message || (isBeforeUnload ? 'Changes you made may not be saved.' : '')}
+					</p>
+				</div>
+			</div>
+
+			{#if isPrompt}
+				<div class="px-5 pt-3">
+					<input
+						bind:this={inputElement}
+						bind:value={promptValue}
+						type="text"
+						class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 outline-none focus:border-violet-500 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+					/>
+				</div>
+			{/if}
+
+			<div class="mt-4 flex justify-end gap-2 bg-slate-50 px-5 py-3 dark:bg-slate-900/50">
+				{#if !isAlert}
+					<button
+						type="button"
+						class="rounded-lg px-3.5 py-1.5 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-200/70 dark:text-slate-300 dark:hover:bg-slate-700"
+						onclick={dismiss}
+					>
+						{cancelLabel}
+					</button>
+				{/if}
+				<button
+					bind:this={confirmButton}
+					type="button"
+					class="rounded-lg bg-violet-600 px-3.5 py-1.5 text-sm font-medium text-white transition-colors hover:bg-violet-700"
+					onclick={accept}
+				>
+					{confirmLabel}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/frontend/components/preview/browser/components/NativePicker.svelte
+++ b/frontend/components/preview/browser/components/NativePicker.svelte
@@ -1,0 +1,331 @@
+<script lang="ts">
+	/**
+	 * Stand-in for the pickers Chrome draws outside the page.
+	 *
+	 * A colour swatch or a date field opens a popup rendered by the *browser
+	 * process*, not the renderer — so it never appears in the captured frame, and
+	 * the page looks unresponsive to a click that did in fact land.
+	 *
+	 * Colour is drawn here rather than delegated to the viewer's own control.
+	 * `showPicker()` needs transient activation, which a WebSocket event does not
+	 * carry, so the invisible native input only opened on a *second* click — and
+	 * on macOS what it opens is the system colour panel: a window that ignores
+	 * the page's layout and stays up until it is dismissed on its own terms.
+	 * Neither is what a browser does. Date and time keep the native control,
+	 * whose popup anchors to the element and closes on an outside click.
+	 */
+	import type { BrowserNativePickerInfo } from '$frontend/utils/native-ui';
+
+	let {
+		picker = null as BrowserNativePickerInfo | null,
+		onCommit = (_value: string) => {},
+		onClose = () => {}
+	} = $props();
+
+	let inputElement = $state<HTMLInputElement | undefined>();
+	let panelElement = $state<HTMLDivElement | undefined>();
+	let value = $state('');
+
+	const isColor = $derived(picker?.inputType === 'color');
+
+	/**
+	 * Sized to the element's real on-screen box, which already carries the
+	 * preview's fit-scale — so no separate scaling is applied.
+	 */
+	const box = $derived(picker?.boundingBox ?? { x: 0, y: 0, width: 0, height: 0 });
+
+	function commit(next: string) {
+		if (!next || next === value) return;
+		value = next;
+		onCommit(next);
+	}
+
+	// ── Colour model ──────────────────────────────────────────────────────────
+	//
+	// HSV, because that is what a saturation/value square plus a hue strip maps
+	// onto directly; the page only ever sees the hex it produces.
+
+	let hue = $state(0);
+	let saturation = $state(0);
+	let brightness = $state(0);
+
+	const PANEL_WIDTH = 208;
+	const SV_HEIGHT = 132;
+
+	function clamp01(n: number): number {
+		return Math.max(0, Math.min(1, n));
+	}
+
+	function hexToHsv(hex: string): { h: number; s: number; v: number } {
+		const clean = hex.replace('#', '').trim();
+		const full =
+			clean.length === 3
+				? clean
+						.split('')
+						.map((c) => c + c)
+						.join('')
+				: clean.padEnd(6, '0').slice(0, 6);
+
+		const r = parseInt(full.slice(0, 2), 16) / 255;
+		const g = parseInt(full.slice(2, 4), 16) / 255;
+		const b = parseInt(full.slice(4, 6), 16) / 255;
+		if (![r, g, b].every((n) => Number.isFinite(n))) return { h: 0, s: 0, v: 0 };
+
+		const max = Math.max(r, g, b);
+		const min = Math.min(r, g, b);
+		const delta = max - min;
+
+		let h = 0;
+		if (delta > 0) {
+			if (max === r) h = ((g - b) / delta) % 6;
+			else if (max === g) h = (b - r) / delta + 2;
+			else h = (r - g) / delta + 4;
+			h *= 60;
+			if (h < 0) h += 360;
+		}
+
+		return { h, s: max === 0 ? 0 : delta / max, v: max };
+	}
+
+	function hsvToHex(h: number, s: number, v: number): string {
+		const c = v * s;
+		const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+		const m = v - c;
+
+		const [r, g, b] =
+			h < 60
+				? [c, x, 0]
+				: h < 120
+					? [x, c, 0]
+					: h < 180
+						? [0, c, x]
+						: h < 240
+							? [0, x, c]
+							: h < 300
+								? [x, 0, c]
+								: [c, 0, x];
+
+		const channel = (n: number) =>
+			Math.round((n + m) * 255)
+				.toString(16)
+				.padStart(2, '0');
+
+		return `#${channel(r)}${channel(g)}${channel(b)}`;
+	}
+
+	function pushColor() {
+		commit(hsvToHex(hue, saturation, brightness));
+	}
+
+	/** Follow the pointer for the whole gesture, including outside the element. */
+	function track(event: PointerEvent, apply: (rect: DOMRect, e: PointerEvent) => void) {
+		const target = event.currentTarget as HTMLElement;
+		const rect = target.getBoundingClientRect();
+
+		apply(rect, event);
+		pushColor();
+		target.setPointerCapture(event.pointerId);
+
+		const move = (moveEvent: PointerEvent) => {
+			apply(rect, moveEvent);
+			pushColor();
+		};
+		const up = () => {
+			target.removeEventListener('pointermove', move);
+			target.removeEventListener('pointerup', up);
+			target.removeEventListener('pointercancel', up);
+		};
+
+		target.addEventListener('pointermove', move);
+		target.addEventListener('pointerup', up);
+		target.addEventListener('pointercancel', up);
+	}
+
+	function onSaturationPointer(event: PointerEvent) {
+		event.preventDefault();
+		track(event, (rect, e) => {
+			saturation = clamp01((e.clientX - rect.left) / rect.width);
+			brightness = 1 - clamp01((e.clientY - rect.top) / rect.height);
+		});
+	}
+
+	function onHuePointer(event: PointerEvent) {
+		event.preventDefault();
+		track(event, (rect, e) => {
+			hue = clamp01((e.clientX - rect.left) / rect.width) * 360;
+		});
+	}
+
+	function onHexInput(event: Event) {
+		const raw = (event.currentTarget as HTMLInputElement).value.trim();
+		if (!/^#?[0-9a-fA-F]{6}$/.test(raw)) return;
+
+		const hex = raw.startsWith('#') ? raw : `#${raw}`;
+		const hsv = hexToHsv(hex);
+		hue = hsv.h;
+		saturation = hsv.s;
+		brightness = hsv.v;
+		commit(hex);
+	}
+
+	/**
+	 * Anchor below the swatch, flipping above when there is no room — the same
+	 * choice the platform popup makes.
+	 */
+	const panelPosition = $derived.by(() => {
+		if (!picker) return { left: 0, top: 0 };
+
+		const height = SV_HEIGHT + 92;
+		const left = Math.max(6, Math.min(box.x, window.innerWidth - PANEL_WIDTH - 6));
+		const below = box.y + box.height + 4;
+		const top =
+			below + height > window.innerHeight - 6 && box.y - height - 4 >= 6
+				? box.y - height - 4
+				: Math.min(below, Math.max(6, window.innerHeight - height - 6));
+
+		return { left, top };
+	});
+
+	$effect(() => {
+		if (!picker) return;
+
+		value = picker.value;
+
+		if (picker.inputType === 'color') {
+			const hsv = hexToHsv(picker.value || '#000000');
+			hue = hsv.h;
+			saturation = hsv.s;
+			brightness = hsv.v;
+		} else {
+			queueMicrotask(() => {
+				inputElement?.focus({ preventScroll: true });
+				try {
+					// Opening it immediately is the point: the user already clicked the
+					// field in the page, and a second click on an invisible input would
+					// be a step they cannot see.
+					(inputElement as HTMLInputElement & { showPicker?: () => void })?.showPicker?.();
+				} catch {
+					// Needs transient activation in some browsers; the input still works.
+				}
+			});
+		}
+
+		const dismissOutside = (event: Event) => {
+			const target = event.target as Node | null;
+			if (panelElement && target && panelElement.contains(target)) return;
+			if (target === inputElement) return;
+			onClose();
+		};
+
+		const dismiss = () => onClose();
+
+		const attach = requestAnimationFrame(() => {
+			document.addEventListener('pointerdown', dismissOutside, true);
+			window.addEventListener('resize', dismiss);
+		});
+
+		return () => {
+			cancelAnimationFrame(attach);
+			document.removeEventListener('pointerdown', dismissOutside, true);
+			window.removeEventListener('resize', dismiss);
+		};
+	});
+
+	function onKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			onClose();
+		}
+	}
+</script>
+
+{#if picker && isColor}
+	<!-- Drawn here, so it opens on the click that reached the page and closes
+	     when the user clicks anywhere else — like a browser's own. -->
+	<div
+		bind:this={panelElement}
+		role="dialog"
+		aria-label="Colour picker"
+		tabindex="-1"
+		onkeydown={onKeydown}
+		class="fixed z-[999999] rounded-lg border border-slate-200 bg-white p-2 shadow-xl outline-none dark:border-slate-700 dark:bg-slate-800"
+		style="left: {panelPosition.left}px; top: {panelPosition.top}px; width: {PANEL_WIDTH}px;"
+	>
+		<div
+			role="slider"
+			tabindex="-1"
+			aria-label="Saturation and brightness"
+			aria-valuenow={Math.round(saturation * 100)}
+			onpointerdown={onSaturationPointer}
+			class="relative cursor-crosshair rounded-md"
+			style="height: {SV_HEIGHT}px; background:
+				linear-gradient(to top, #000, rgba(0,0,0,0)),
+				linear-gradient(to right, #fff, rgba(255,255,255,0)),
+				hsl({hue}, 100%, 50%);"
+		>
+			<span
+				class="pointer-events-none absolute h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white shadow-[0_0_0_1px_rgba(0,0,0,0.4)]"
+				style="left: {saturation * 100}%; top: {(1 - brightness) * 100}%;"
+			></span>
+		</div>
+
+		<div
+			role="slider"
+			tabindex="-1"
+			aria-label="Hue"
+			aria-valuenow={Math.round(hue)}
+			onpointerdown={onHuePointer}
+			class="relative mt-2 h-3 cursor-pointer rounded-full"
+			style="background: linear-gradient(to right, #f00 0%, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%);"
+		>
+			<span
+				class="pointer-events-none absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white shadow-[0_0_0_1px_rgba(0,0,0,0.4)]"
+				style="left: {(hue / 360) * 100}%; background: hsl({hue}, 100%, 50%);"
+			></span>
+		</div>
+
+		<div class="mt-2 flex items-center gap-2">
+			<span
+				class="h-6 w-6 shrink-0 rounded border border-slate-300 dark:border-slate-600"
+				style="background: {value};"
+			></span>
+			<input
+				type="text"
+				value={value}
+				spellcheck="false"
+				aria-label="Hex colour"
+				oninput={onHexInput}
+				class="min-w-0 flex-1 rounded border border-slate-200 bg-white px-1.5 py-1 font-mono text-xs uppercase text-slate-800 outline-none focus:border-violet-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+			/>
+		</div>
+	</div>
+{:else if picker}
+	<!--
+		Date and time: the control is laid directly over the real element at its
+		on-screen size and kept invisible, because the page's own field is already
+		painted underneath in the video. The viewer's native popup then anchors to
+		the right place, and values are written back as they change — a picker
+		with a confirm button is not what any browser does.
+	-->
+	<input
+		bind:this={inputElement}
+		type={picker.inputType}
+		{value}
+		min={picker.min || undefined}
+		max={picker.max || undefined}
+		step={picker.step || undefined}
+		aria-label="Value picker"
+		class="fixed z-[999999] cursor-pointer border-0 bg-transparent p-0 opacity-0 outline-none"
+		style="left: {box.x}px; top: {box.y}px; width: {Math.max(box.width, 8)}px; height: {Math.max(box.height, 8)}px;"
+		oninput={(event) => {
+			commit((event.currentTarget as HTMLInputElement).value);
+		}}
+		onchange={(event) => {
+			commit((event.currentTarget as HTMLInputElement).value);
+			// `change` means the popup closed, so the overlay's job is done.
+			onClose();
+		}}
+		onkeydown={onKeydown}
+		onblur={() => onClose()}
+	/>
+{/if}

--- a/frontend/components/preview/browser/components/PermissionPrompt.svelte
+++ b/frontend/components/preview/browser/components/PermissionPrompt.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+	/**
+	 * Chrome-style permission bubble for the preview.
+	 *
+	 * The previewed page asked for something only the viewer's device can give —
+	 * their location, camera, microphone or clipboard. This is where that ask
+	 * surfaces, and the Allow button is load-bearing rather than cosmetic: Safari
+	 * and iOS only grant `getUserMedia` and `clipboard.read` when the call
+	 * originates inside a user gesture, so the real API call runs from this click.
+	 */
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { fly } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
+	import type { PendingPermission } from '$frontend/utils/native-ui';
+	import type { IconName } from '$shared/types/ui/icons';
+
+	let {
+		request = null as PendingPermission | null,
+		onAllow = (_request: PendingPermission) => {},
+		onDeny = (_request: PendingPermission) => {}
+	} = $props();
+
+	const details = $derived.by(() => {
+		if (!request) return null;
+
+		switch (request.kind) {
+			case 'geolocation':
+				return {
+					icon: 'lucide:map-pin',
+					title: 'wants to know your location',
+					note: 'Your device will be asked for a position fix and the page will receive it.',
+					confirm: 'Allow',
+					cancel: 'Block'
+				};
+			case 'media-request': {
+				const wantsVideo = !!request.payload?.video;
+				const wantsAudio = !!request.payload?.audio;
+
+				// Screen sharing rides the same relay as the camera, but asking to
+				// record a screen is a very different decision from lending a camera.
+				if (request.payload?.display) {
+					return {
+						icon: 'lucide:monitor-up',
+						title: 'wants to share your screen',
+						note: 'You choose what to share; the page receives that capture live.',
+						confirm: 'Choose…',
+						cancel: 'Block'
+					};
+				}
+
+				const what =
+					wantsVideo && wantsAudio ? 'camera and microphone' : wantsVideo ? 'camera' : 'microphone';
+				return {
+					icon: wantsVideo ? 'lucide:video' : 'lucide:mic',
+					title: `wants to use your ${what}`,
+					note: `Your ${what} will be streamed into the preview for as long as the page uses it.`,
+					confirm: 'Allow',
+					cancel: 'Block'
+				};
+			}
+			case 'clipboard-read':
+				return {
+					icon: 'lucide:clipboard',
+					title: 'wants to read your clipboard',
+					note: 'The page will receive whatever text you last copied.',
+					confirm: 'Allow',
+					cancel: 'Block'
+				};
+			case 'speech-start':
+				return {
+					icon: 'lucide:audio-lines',
+					title: 'wants to listen to your microphone',
+					note: 'Speech is recognised by your own browser; only the transcript reaches the page.',
+					confirm: 'Allow',
+					cancel: 'Block'
+				};
+			case 'notification-permission':
+				return {
+					icon: 'lucide:bell',
+					title: 'wants to show notifications',
+					note: 'Notifications will be delivered by your own browser.',
+					confirm: 'Allow',
+					cancel: 'Block'
+				};
+			case 'file-pick':
+				return {
+					icon: 'lucide:paperclip',
+					title: request.payload?.multiple ? 'wants to open files' : 'wants to open a file',
+					// The picker has to be opened from a click: browsers refuse to
+					// raise one for a page that did not just receive a user gesture.
+					note: 'Files are read from your device and uploaded to the page.',
+					confirm: 'Choose…',
+					cancel: 'Cancel'
+				};
+			default:
+				return {
+					icon: 'lucide:shield-question',
+					title: 'is requesting a permission',
+					note: '',
+					confirm: 'Allow',
+					cancel: 'Block'
+				};
+		}
+	});
+</script>
+
+{#if request && details}
+	<div
+		class="absolute left-1/2 top-3 z-40 w-[min(24rem,calc(100%-1.5rem))] -translate-x-1/2 overflow-hidden rounded-xl border border-slate-200 bg-white/95 shadow-2xl backdrop-blur dark:border-slate-700 dark:bg-slate-800/95"
+		role="alertdialog"
+		aria-label="Permission request"
+		transition:fly={{ y: -12, duration: 180, easing: cubicOut }}
+	>
+		<div class="flex items-start gap-3 px-4 pt-3.5">
+			<span class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-violet-500/15 text-violet-500">
+				<Icon name={details.icon as IconName} class="h-4 w-4" />
+			</span>
+			<div class="min-w-0 flex-1">
+				<p class="text-sm text-slate-800 dark:text-slate-100">
+					<span class="font-semibold break-all">{request.origin}</span>
+					<span class="text-slate-600 dark:text-slate-300"> {details.title}</span>
+				</p>
+				{#if details.note}
+					<p class="mt-1 text-xs leading-relaxed text-slate-500 dark:text-slate-400">{details.note}</p>
+				{/if}
+			</div>
+		</div>
+
+		<div class="mt-3 flex justify-end gap-2 bg-slate-50 px-4 py-2.5 dark:bg-slate-900/50">
+			<button
+				type="button"
+				class="rounded-lg px-3 py-1.5 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-200/70 dark:text-slate-300 dark:hover:bg-slate-700"
+				onclick={() => onDeny(request)}
+			>
+				{details.cancel}
+			</button>
+			<button
+				type="button"
+				class="rounded-lg bg-violet-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-violet-700"
+				onclick={() => onAllow(request)}
+			>
+				{details.confirm}
+			</button>
+		</div>
+	</div>
+{/if}

--- a/frontend/components/preview/browser/components/SelectDropdown.svelte
+++ b/frontend/components/preview/browser/components/SelectDropdown.svelte
@@ -1,74 +1,113 @@
 <script lang="ts">
+	/**
+	 * Native `<select>` replacement for the preview canvas.
+	 *
+	 * Headless Chrome renders a select's popup outside the page, so it never
+	 * appears in the captured frame. The backend reports the options instead and
+	 * this draws them over the canvas, matched to the preview's scale and to the
+	 * real element's box so it lands where the popup would have.
+	 */
+	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import type { BrowserSelectInfo, BrowserSelectOption } from '$frontend/utils/native-ui';
-	import { onMount } from 'svelte';
 
 	let {
-		selectInfo = $bindable<BrowserSelectInfo | null>(null),
-		onSelect = $bindable<(selectedIndex: number) => void>(() => {}),
-		onClose = $bindable<() => void>(() => {})
+		selectInfo = null as BrowserSelectInfo | null,
+		scale = 1,
+		bounds = null as DOMRect | null,
+		onSelect = (_index: number) => {},
+		onClose = () => {}
 	} = $props();
 
-	let dropdownElement = $state<HTMLDivElement | undefined>(undefined);
-	let selectedIndex = $state(-1);
+	let dropdownElement = $state<HTMLDivElement | undefined>();
 	let highlightedIndex = $state(-1);
+	let naturalHeight = $state(0);
 
-	// Position the dropdown overlay
-	function getDropdownPosition() {
-		if (!selectInfo) return { top: '0px', left: '0px', width: '200px' };
+	const EDGE_PADDING = 6;
 
-		const { boundingBox } = selectInfo;
-		return {
-			top: `${boundingBox.y + boundingBox.height}px`,
-			left: `${boundingBox.x}px`,
-			width: `${Math.max(boundingBox.width, 200)}px`
-		};
+	const selectedIndex = $derived(selectInfo?.selectedIndex ?? -1);
+
+	function viewportRect(): DOMRect {
+		return new DOMRect(0, 0, window.innerWidth, window.innerHeight);
 	}
 
-	// Handle option click
+	/**
+	 * Anchor below the field, flipping above it when there is no room — the same
+	 * choice the platform popup makes.
+	 */
+	const position = $derived.by(() => {
+		if (!selectInfo) return { left: 0, top: 0, width: 200 };
+
+		const area = bounds ?? viewportRect();
+		const box = selectInfo.boundingBox;
+		const height = naturalHeight * scale;
+
+		// The reported box is already in display pixels; keep the popup at least
+		// as wide as the field so it reads as belonging to it.
+		const width = Math.max(box.width / Math.max(scale, 0.05), 180);
+
+		let top = box.y + box.height;
+		if (height > 0 && top + height > area.bottom - EDGE_PADDING) {
+			const above = box.y - height;
+			top = above >= area.top + EDGE_PADDING ? above : Math.max(area.top + EDGE_PADDING, area.bottom - height - EDGE_PADDING);
+		}
+
+		const left = Math.max(
+			area.left + EDGE_PADDING,
+			Math.min(box.x, area.right - width * scale - EDGE_PADDING)
+		);
+
+		return { left, top, width };
+	});
+
+	const maxHeight = $derived.by(() => {
+		const area = bounds ?? viewportRect();
+		return Math.max(120, (area.height * 0.6) / Math.max(scale, 0.05));
+	});
+
+	function measure() {
+		if (dropdownElement) naturalHeight = dropdownElement.offsetHeight;
+	}
+
 	function handleOptionClick(option: BrowserSelectOption) {
 		if (option.disabled) return;
 		onSelect(option.index);
 		onClose();
 	}
 
-	// Handle keyboard navigation
 	function handleKeydown(event: KeyboardEvent) {
 		if (!selectInfo) return;
-
 		const options = selectInfo.options;
+
+		const step = (direction: 1 | -1) => {
+			let next = highlightedIndex + direction;
+			while (next >= 0 && next < options.length && options[next].disabled) next += direction;
+			if (next >= 0 && next < options.length) highlightedIndex = next;
+		};
 
 		switch (event.key) {
 			case 'ArrowDown':
 				event.preventDefault();
-				// Move to next enabled option
-				let nextIndex = highlightedIndex + 1;
-				while (nextIndex < options.length && options[nextIndex].disabled) {
-					nextIndex++;
-				}
-				if (nextIndex < options.length) {
-					highlightedIndex = nextIndex;
-				}
+				step(1);
 				break;
-
 			case 'ArrowUp':
 				event.preventDefault();
-				// Move to previous enabled option
-				let prevIndex = highlightedIndex - 1;
-				while (prevIndex >= 0 && options[prevIndex].disabled) {
-					prevIndex--;
-				}
-				if (prevIndex >= 0) {
-					highlightedIndex = prevIndex;
-				}
+				step(-1);
 				break;
-
-			case 'Enter':
+			case 'Home':
 				event.preventDefault();
-				if (highlightedIndex >= 0 && !options[highlightedIndex].disabled) {
+				highlightedIndex = options.findIndex((option) => !option.disabled);
+				break;
+			case 'End':
+				event.preventDefault();
+				highlightedIndex = options.length - 1;
+				break;
+			case 'Enter':
+			case ' ':
+				event.preventDefault();
+				if (highlightedIndex >= 0 && !options[highlightedIndex]?.disabled) {
 					handleOptionClick(options[highlightedIndex]);
 				}
 				break;
-
 			case 'Escape':
 				event.preventDefault();
 				onClose();
@@ -76,149 +115,113 @@
 		}
 	}
 
-	// Handle click outside to close
-	function handleClickOutside(event: MouseEvent) {
-		if (dropdownElement && !dropdownElement.contains(event.target as Node)) {
-			onClose();
-		}
-	}
-
-	// Initialize
 	$effect(() => {
-		if (selectInfo) {
-			selectedIndex = selectInfo.selectedIndex;
-			highlightedIndex = selectInfo.selectedIndex;
+		if (!selectInfo) return;
 
-			// Focus dropdown for keyboard navigation
-			if (dropdownElement) {
-				dropdownElement.focus();
-			}
+		highlightedIndex = selectInfo.selectedIndex;
 
-			// Add click outside listener
-			setTimeout(() => {
-				document.addEventListener('mousedown', handleClickOutside);
-			}, 0);
-		}
+		queueMicrotask(() => {
+			measure();
+			dropdownElement?.focus();
+			dropdownElement?.querySelector('[data-selected="true"]')?.scrollIntoView({ block: 'nearest' });
+		});
+
+		const dismissOutside = (event: Event) => {
+			if (dropdownElement && !dropdownElement.contains(event.target as Node)) onClose();
+		};
+		const dismiss = () => onClose();
+
+		const attach = requestAnimationFrame(() => {
+			document.addEventListener('pointerdown', dismissOutside, true);
+			window.addEventListener('resize', dismiss);
+			window.addEventListener('blur', dismiss);
+		});
 
 		return () => {
-			document.removeEventListener('mousedown', handleClickOutside);
+			cancelAnimationFrame(attach);
+			document.removeEventListener('pointerdown', dismissOutside, true);
+			window.removeEventListener('resize', dismiss);
+			window.removeEventListener('blur', dismiss);
 		};
 	});
-
-	const position = $derived(getDropdownPosition());
 </script>
 
 {#if selectInfo}
 	<div
 		bind:this={dropdownElement}
-		class="browser-select-dropdown"
-		style="top: {position.top}; left: {position.left}; width: {position.width};"
+		class="select-popup fixed z-[999999] py-1 rounded-lg overflow-y-auto outline-none origin-top-left
+			bg-white/95 dark:bg-slate-800/95 backdrop-blur-sm
+			border border-slate-200 dark:border-slate-700
+			shadow-xl shadow-slate-900/20 dark:shadow-black/50"
+		style="left: {position.left}px; top: {position.top}px; width: {position.width}px; max-height: {maxHeight}px; transform: scale({scale});"
 		tabindex="-1"
 		onkeydown={handleKeydown}
 		role="listbox"
 		aria-label="Select options"
 	>
-		<div class="select-dropdown-list">
-			{#each selectInfo.options as option (option.index)}
+		{#each selectInfo.options as option, listIndex (option.index)}
+			{@const group = option.group}
+			{@const startsGroup = !!group && group !== selectInfo.options[listIndex - 1]?.group}
+			{#if startsGroup}
+				<!-- `<optgroup>` labels are part of the control's meaning, not decoration:
+				     flattening them loses the only thing distinguishing same-named
+				     options across groups. -->
 				<div
-					class="select-option"
-					class:selected={option.index === selectedIndex}
-					class:highlighted={option.index === highlightedIndex}
-					class:disabled={option.disabled}
-					role="option"
-					tabindex={option.disabled ? -1 : 0}
-					aria-selected={option.index === selectedIndex}
-					aria-disabled={option.disabled}
-					onclick={() => handleOptionClick(option)}
-					onkeydown={(e) => {
-						if (e.key === 'Enter' || e.key === ' ') {
-							e.preventDefault();
-							handleOptionClick(option);
-						}
-					}}
-					onmouseenter={() => {
-						if (!option.disabled) highlightedIndex = option.index;
-					}}
+					class="mt-1 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide first:mt-0
+						{option.groupDisabled
+						? 'text-slate-300 dark:text-slate-600'
+						: 'text-slate-400 dark:text-slate-500'}"
+					role="presentation"
 				>
-					{option.text}
+					{group}
 				</div>
-			{/each}
-		</div>
+			{/if}
+			<div
+				class="flex items-center gap-2 mx-1 px-2.5 py-1.5 rounded-[3px] cursor-default select-none text-[13px] leading-5
+					{option.group ? 'pl-5' : ''}
+					{option.disabled
+					? 'text-slate-400 dark:text-slate-600 cursor-not-allowed'
+					: highlightedIndex === option.index
+						? 'bg-violet-600 text-white'
+						: 'text-slate-700 dark:text-slate-200'}"
+				role="option"
+				tabindex={option.disabled ? -1 : 0}
+				aria-selected={option.index === selectedIndex}
+				aria-disabled={option.disabled}
+				data-selected={option.index === selectedIndex}
+				onclick={() => handleOptionClick(option)}
+				onkeydown={(event) => {
+					if (event.key === 'Enter' || event.key === ' ') {
+						event.preventDefault();
+						handleOptionClick(option);
+					}
+				}}
+				onmouseenter={() => {
+					if (!option.disabled) highlightedIndex = option.index;
+				}}
+			>
+				<span class="flex w-3.5 shrink-0 items-center justify-center">
+					{#if option.index === selectedIndex}
+						<Icon name="lucide:check" class="w-3.5 h-3.5" />
+					{/if}
+				</span>
+				<span class="flex-1 truncate">{option.text}</span>
+			</div>
+		{/each}
 	</div>
 {/if}
 
 <style>
-	.browser-select-dropdown {
-		position: fixed;
-		z-index: 999999;
-		background: white;
-		border: 1px solid #ccc;
-		border-radius: 4px;
-		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-		max-height: 300px;
-		overflow-y: auto;
-		outline: none;
+	.select-popup {
+		animation: select-popup-in 90ms ease-out;
 	}
 
-	.select-dropdown-list {
-		padding: 4px 0;
-	}
-
-	.select-option {
-		padding: 6px 12px;
-		cursor: pointer;
-		user-select: none;
-		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-		font-size: 14px;
-		line-height: 1.5;
-		color: #333;
-	}
-
-	.select-option:hover:not(.disabled) {
-		background: #f0f0f0;
-	}
-
-	.select-option.highlighted:not(.disabled) {
-		background: #e6f7ff;
-	}
-
-	.select-option.selected {
-		background: #1890ff;
-		color: white;
-	}
-
-	.select-option.disabled {
-		color: #999;
-		cursor: not-allowed;
-		opacity: 0.6;
-	}
-
-	/* Dark mode support */
-	@media (prefers-color-scheme: dark) {
-		.browser-select-dropdown {
-			background: #2d2d2d;
-			border-color: #444;
+	@keyframes select-popup-in {
+		from {
+			opacity: 0;
 		}
-
-		.select-option {
-			color: #e0e0e0;
-		}
-
-		.select-option:hover:not(.disabled) {
-			background: #3a3a3a;
-		}
-
-		.select-option.highlighted:not(.disabled) {
-			background: #003d66;
-		}
-
-		.select-option.selected {
-			background: #1890ff;
-			color: white;
-		}
-
-		.select-option.disabled {
-			color: #666;
+		to {
+			opacity: 1;
 		}
 	}
 </style>

--- a/frontend/components/preview/browser/components/Toolbar.svelte
+++ b/frontend/components/preview/browser/components/Toolbar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Icon from '$frontend/components/common/display/Icon.svelte';
-	import { addNotification } from '$frontend/stores/ui/notification.svelte';
+	import type { IconName } from '$shared/types/ui/icons';
 	import { onDestroy } from 'svelte';
 
 	let {
@@ -20,29 +20,103 @@
 		errorMessage = $bindable<string | null>(null),
 
 		// Console state
-		isConsoleOpen = $bindable(false),
+		isConsoleOpen = false,
+		consoleIssueCount = 0,
+
+		// Navigation state
+		canGoBack = false,
+		canGoForward = false,
+
+		// Layout
+		isMobile = false,
+		/** Touch devices get an explicit keyboard button, as the tap heuristic
+		 *  cannot cover every case (a page that focuses a field on its own). */
+		showKeyboardToggle = false,
 
 		// Tab state
-		tabs = $bindable<any[]>([]),
-		activeTabId = $bindable<string | null>(null),
-		mcpControlledTabIds = $bindable<Set<string>>(new Set()),
+		tabs = [] as any[],
+		activeTabId = null as string | null,
+		mcpControlledTabIds = new Set<string>(),
 
 		// Callbacks
-		onGoClick = $bindable<() => void>(() => {}),
-		onRefresh = $bindable<() => void>(() => {}),
-		onOpenInExternalBrowser = $bindable<() => void>(() => {}),
-		onClosePreview = $bindable<() => void>(() => {}),
-		onToggleConsole = $bindable<() => void>(() => {}),
-		onUrlInput = $bindable<() => void>(() => {}),
-		onUrlKeydown = $bindable<(event: KeyboardEvent) => void>(() => {}),
-		onSwitchTab = $bindable<(tabId: string) => void | Promise<void>>(() => {}),
-		onCloseTab = $bindable<(tabId: string) => void>(() => {}),
-		onNewTab = $bindable<() => void>(() => {})
+		onGoClick = () => {},
+		onRefresh = () => {},
+		onStop = () => {},
+		onBack = () => {},
+		onForward = () => {},
+		onOpenInExternalBrowser = () => {},
+		onToggleConsole = () => {},
+		onToggleKeyboard = () => {},
+		onUrlInput = () => {},
+		onAddressFocusChange = (_focused: boolean) => {},
+		onUrlKeydown = (_event: KeyboardEvent) => {},
+		onSwitchTab = (_tabId: string) => {},
+		onCloseTab = (_tabId: string) => {},
+		onReorderTab = (_tabId: string, _targetTabId: string) => {},
+		onNewTab = () => {},
+		onCloseAllTabs = () => {}
 	} = $props();
 
-	// User typing detection
-	let isUserTyping = $state(false);
-	let typingTimeout: NodeJS.Timeout;
+	/**
+	 * Tabs an agent is driving are left alone by "close all" — closing one out
+	 * from under a running automation would fail it mid-step.
+	 */
+	const closableTabs = $derived(tabs.filter((tab: any) => !mcpControlledTabIds.has(tab.id)));
+	const lockedTabCount = $derived(tabs.length - closableTabs.length);
+
+	const closeAllTitle = $derived(
+		closableTabs.length === 0
+			? 'Every tab is being controlled by an agent'
+			: lockedTabCount > 0
+				? `Close ${closableTabs.length} tabs (${lockedTabCount} controlled by an agent stay open)`
+				: 'Close all tabs'
+	);
+
+	let urlInputElement = $state<HTMLInputElement | undefined>();
+	let tabStripElement = $state<HTMLDivElement | undefined>();
+
+	// Drag-to-reorder state
+	let draggingTabId = $state<string | null>(null);
+	let dragOverTabId = $state<string | null>(null);
+
+	/**
+	 * Favicon URLs that failed to load, so the strip falls back to the
+	 * placeholder instead of leaving a hole. Keyed by URL rather than tab so a
+	 * reload of the same page does not retry a known-bad icon on every render.
+	 */
+	let brokenFavicons = $state(new Set<string>());
+
+	function markFaviconBroken(src: string | undefined) {
+		if (!src || brokenFavicons.has(src)) return;
+		brokenFavicons = new Set(brokenFavicons).add(src);
+	}
+
+	/**
+	 * Turn a vertical wheel into horizontal scrolling over the strip, which is
+	 * how every editor tab bar behaves — a trackpad or mouse wheel is the only
+	 * way to reach overflowed tabs without a visible scrollbar.
+	 */
+	function handleTabStripWheel(event: WheelEvent) {
+		if (!tabStripElement) return;
+		if (event.deltaY === 0 || event.shiftKey) return;
+		if (tabStripElement.scrollWidth <= tabStripElement.clientWidth) return;
+
+		event.preventDefault();
+		tabStripElement.scrollLeft += event.deltaY;
+	}
+
+	// Keep the active tab in view when it changes from outside the strip —
+	// a new tab, an MCP-opened one, or a Ctrl+Tab style switch.
+	$effect(() => {
+		const id = activeTabId;
+		if (!id || !tabStripElement) return;
+
+		queueMicrotask(() => {
+			tabStripElement
+				?.querySelector(`[data-tab-id="${CSS.escape(id)}"]`)
+				?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+		});
+	});
 
 	// Progress bar state
 	let progressPercent = $state(0);
@@ -50,90 +124,91 @@
 	let progressAnimationId: number | null = null;
 	let progressCompleteTimeout: ReturnType<typeof setTimeout> | null = null;
 
+	/**
+	 * Anything that means "the page is still coming". Drives both the progress
+	 * bar and the reload/stop swap, so the two can never disagree.
+	 */
+	const isBusy = $derived(
+		isLoading ||
+			isLaunchingBrowser ||
+			isNavigating ||
+			isReconnecting ||
+			(!!sessionInfo && !isStreamReady && !isNavigating && !isReconnecting)
+	);
+
+	/** Whether the currently active tab is under MCP control */
+	const isMcpControlled = $derived(activeTabId != null && mcpControlledTabIds.has(activeTabId));
+
+	/**
+	 * Scheme badge, the way a browser's omnibox shows it. `file:` counts as
+	 * trusted; plain http over a non-loopback host does not.
+	 */
+	const security = $derived.by(() => {
+		if (!url) return null;
+		try {
+			const parsed = new URL(url);
+			if (parsed.protocol === 'https:' || parsed.protocol === 'file:') {
+				return { icon: 'lucide:lock' as IconName, class: 'text-emerald-500', label: 'Connection is secure' };
+			}
+			if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '[::1]') {
+				return { icon: 'lucide:monitor-dot' as IconName, class: 'text-slate-400', label: 'Local development server' };
+			}
+			return { icon: 'lucide:lock-open' as IconName, class: 'text-amber-500', label: 'Connection is not secure' };
+		} catch {
+			return null;
+		}
+	});
+
 	function handleUrlInput() {
-		isUserTyping = true;
 		onUrlInput();
-		
-		// Reset typing flag after user stops typing for 1 second
-		clearTimeout(typingTimeout);
-		typingTimeout = setTimeout(() => {
-			isUserTyping = false;
-		}, 1000);
 	}
 
 	function handleUrlKeydown(event: KeyboardEvent) {
 		if (event.key === 'Enter') {
-			isUserTyping = false;
 			onGoClick();
+			urlInputElement?.blur();
+		} else if (event.key === 'Escape') {
+			// Escape reverts the edit, matching the omnibox.
+			urlInput = url;
+			urlInputElement?.blur();
 		}
 		onUrlKeydown(event);
 	}
 
-	function handleGoClick() {
-		if (!urlInput.trim()) return;
-		isUserTyping = false;
-		clearTimeout(typingTimeout);
-		onGoClick();
-	}
-
-	function handleRefresh() {
-		onRefresh();
-	}
-
 	function handleOpenInExternalBrowser() {
-		if (url) {
-			window.open(url, '_blank');
-			// User already knows from new browser tab opening
-		}
+		if (url) window.open(url, '_blank');
 		onOpenInExternalBrowser();
 	}
 
-	function handleClosePreview() {
-		onClosePreview();
-		// User already knows from UI panel disappearing
+	/** Focus and select the address bar — used by the Cmd/Ctrl+L shortcut. */
+	export function focusAddressBar() {
+		urlInputElement?.focus();
+		urlInputElement?.select();
 	}
 
-	function handleToggleConsole() {
-		onToggleConsole();
-	}
+	// ── Progress bar ────────────────────────────────────────────────────────
 
-	// Progress bar animation functions
 	function startProgressAnimation() {
-		if (progressAnimationId) {
-			cancelAnimationFrame(progressAnimationId);
-		}
-		
+		if (progressAnimationId) cancelAnimationFrame(progressAnimationId);
+
 		showProgress = true;
 		progressPercent = 0;
-		
+
 		const startTime = Date.now();
-		
-		// Simulate realistic browser loading progress
+
+		// Ease toward 95% and wait there: real load time is unknowable, and a bar
+		// that stalls at the end reads better than one that jumps backwards.
 		const animate = () => {
 			const elapsed = Date.now() - startTime;
-			
-			// Fast initial loading (0-30% in first 300ms)
-			if (elapsed < 300) {
-				progressPercent = (elapsed / 300) * 30;
-			}
-			// Medium loading (30-70% in next 700ms)
-			else if (elapsed < 1000) {
-				progressPercent = 30 + ((elapsed - 300) / 700) * 40;
-			}
-			// Slow loading (70-90% in next 1000ms)
-			else if (elapsed < 2000) {
-				progressPercent = 70 + ((elapsed - 1000) / 1000) * 20;
-			}
-			// Very slow final loading (90-95% in remaining time)
-			else {
-				progressPercent = Math.min(90 + ((elapsed - 2000) / 2000) * 5, 95);
-			}
-			
-			if (progressPercent < 95) {
-				progressAnimationId = requestAnimationFrame(animate);
-			}
+
+			if (elapsed < 300) progressPercent = (elapsed / 300) * 30;
+			else if (elapsed < 1000) progressPercent = 30 + ((elapsed - 300) / 700) * 40;
+			else if (elapsed < 2000) progressPercent = 70 + ((elapsed - 1000) / 1000) * 20;
+			else progressPercent = Math.min(90 + ((elapsed - 2000) / 2000) * 5, 95);
+
+			if (progressPercent < 95) progressAnimationId = requestAnimationFrame(animate);
 		};
-		
+
 		progressAnimationId = requestAnimationFrame(animate);
 	}
 
@@ -142,11 +217,8 @@
 			cancelAnimationFrame(progressAnimationId);
 			progressAnimationId = null;
 		}
-		
-		// Complete the progress bar
+
 		progressPercent = 100;
-		
-		// Hide after a short delay
 		setTimeout(() => {
 			showProgress = false;
 			progressPercent = 0;
@@ -158,14 +230,14 @@
 			cancelAnimationFrame(progressAnimationId);
 			progressAnimationId = null;
 		}
-		
+
 		showProgress = false;
 		progressPercent = 0;
 	}
 
-	// Reset progress bar immediately when active tab changes.
-	// A brief suppression window prevents the loading $effect from
-	// restarting progress before global state has synced to the new tab.
+	// Reset progress immediately on tab change. The brief suppression window
+	// stops the loading effect below from restarting it before global state has
+	// synced to the new tab.
 	let previousActiveTabId = $state<string | null>(null);
 	let tabSwitchSuppressUntil = 0;
 	$effect(() => {
@@ -176,22 +248,16 @@
 				clearTimeout(progressCompleteTimeout);
 				progressCompleteTimeout = null;
 			}
-			// Suppress loading $effect for a short window to allow state sync
 			tabSwitchSuppressUntil = Date.now() + 150;
 		}
 	});
 
-	// Watch loading states to control progress bar
 	$effect(() => {
-		const waitingForInitialFrame = sessionInfo && !isStreamReady && !isNavigating && !isReconnecting;
-		const shouldShowProgress = isLoading || isLaunchingBrowser || isNavigating || isReconnecting || waitingForInitialFrame;
+		const shouldShowProgress = isBusy;
 
 		// Skip during tab switch suppression window — state may be stale from old tab
-		if (Date.now() < tabSwitchSuppressUntil) {
-			return;
-		}
+		if (Date.now() < tabSwitchSuppressUntil) return;
 
-		// Cancel any pending completion when a loading state becomes active
 		if (shouldShowProgress && progressCompleteTimeout) {
 			clearTimeout(progressCompleteTimeout);
 			progressCompleteTimeout = null;
@@ -199,160 +265,343 @@
 
 		if (shouldShowProgress && !showProgress) {
 			startProgressAnimation();
-		}
-		else if (!shouldShowProgress && showProgress && !progressCompleteTimeout) {
+		} else if (!shouldShowProgress && showProgress && !progressCompleteTimeout) {
 			progressCompleteTimeout = setTimeout(() => {
 				progressCompleteTimeout = null;
-				const stillShouldComplete = !isLoading && !isLaunchingBrowser && !isNavigating && !isReconnecting;
-				const stillWaitingForFrame = sessionInfo && !isStreamReady && !isNavigating && !isReconnecting;
-				if (stillShouldComplete && !stillWaitingForFrame) {
-					completeProgress();
-				}
+				if (!isBusy) completeProgress();
 			}, 100);
 		}
 	});
 
-	// Whether the currently active tab is under MCP control
-	const isMcpControlled = $derived(activeTabId != null && mcpControlledTabIds.has(activeTabId));
-
-	// Cleanup animation frame on component destroy
 	onDestroy(() => {
-		if (progressAnimationId) {
-			cancelAnimationFrame(progressAnimationId);
-		}
-		if (typingTimeout) {
-			clearTimeout(typingTimeout);
-		}
-		if (progressCompleteTimeout) {
-			clearTimeout(progressCompleteTimeout);
-		}
+		if (progressAnimationId) cancelAnimationFrame(progressAnimationId);
+		if (progressCompleteTimeout) clearTimeout(progressCompleteTimeout);
 	});
 </script>
 
 <!-- Preview Toolbar -->
 <div class="relative bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-700">
-	<!-- Tabs bar (Git-style underline tabs) — separated with its own border-bottom -->
+	<!-- Tab strip -->
 	{#if tabs.length > 0}
-		<div class="relative flex items-center overflow-x-auto border-b border-slate-200 dark:border-slate-700">
-			{#each tabs as tab}
+		<!--
+			The tab actions live *inside* the scroller as a sticky block, so they
+			sit immediately after the last tab while there is room and pin
+			themselves to the right edge once the tabs overflow — reachable either
+			way, and never marooned at the far side of a half-empty strip.
+		-->
+		<div
+			bind:this={tabStripElement}
+			onwheel={handleTabStripWheel}
+			class="tab-strip flex items-center overflow-x-auto border-b border-slate-200 dark:border-slate-700"
+		>
+			{#each tabs as tab (tab.id)}
 				{@const isActive = tab.id === activeTabId}
+				{@const isControlled = mcpControlledTabIds.has(tab.id)}
 				<button
 					type="button"
-					class="group relative flex items-center justify-center gap-1 pr-2 pl-3 py-2 text-xs font-medium transition-colors min-w-0 max-w-xs cursor-pointer
+					data-tab-id={tab.id}
+					draggable="true"
+					ondragstart={(event) => {
+						draggingTabId = tab.id;
+						event.dataTransfer?.setData('text/plain', tab.id);
+						if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move';
+					}}
+					ondragover={(event) => {
+						if (!draggingTabId || draggingTabId === tab.id) return;
+						// Default is "reject the drop"; allowing it is what turns the
+						// pointer into a move cursor and lets `drop` fire at all.
+						event.preventDefault();
+						if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+						dragOverTabId = tab.id;
+					}}
+					ondragleave={() => {
+						if (dragOverTabId === tab.id) dragOverTabId = null;
+					}}
+					ondrop={(event) => {
+						event.preventDefault();
+						const sourceId = draggingTabId ?? event.dataTransfer?.getData('text/plain');
+						if (sourceId && sourceId !== tab.id) onReorderTab(sourceId, tab.id);
+						draggingTabId = null;
+						dragOverTabId = null;
+					}}
+					ondragend={() => {
+						draggingTabId = null;
+						dragOverTabId = null;
+					}}
+					class="group relative flex shrink-0 items-center justify-center gap-1.5 pr-1.5 pl-2.5 py-2 text-xs font-medium transition-colors max-w-52 cursor-pointer
 						{isActive
-							? 'text-violet-600 dark:text-violet-400'
-							: 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'}"
+						? 'text-violet-600 dark:text-violet-400'
+						: 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'}
+						{draggingTabId === tab.id ? 'opacity-40' : ''}
+						{dragOverTabId === tab.id ? 'bg-violet-500/10' : ''}"
 					onclick={() => onSwitchTab(tab.id)}
+					onauxclick={(event) => {
+						// Middle-click closes, as in every browser.
+						if (event.button === 1 && !isControlled) {
+							event.preventDefault();
+							onCloseTab(tab.id);
+						}
+					}}
 					role="tab"
+					aria-selected={isActive}
 					tabindex="0"
+					title={tab.url || tab.title}
 				>
-					<span class="truncate max-w-28" title={tab.url}>
-						{tab.title || 'New Tab'}
+					<span class="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+						{#if tab.isLoading || tab.isLaunchingBrowser}
+							<Icon name="lucide:loader-circle" class="h-3 w-3 animate-spin" />
+						{:else if tab.favicon && !brokenFavicons.has(tab.favicon)}
+							<!--
+								Favicons fail constantly — a 404 on the /favicon.ico guess, CORS,
+								a data URL the page revoked. Falling back to the placeholder is
+								what a browser does; hiding the image left an empty gap instead.
+							-->
+							<img
+								src={tab.favicon}
+								alt=""
+								class="h-3.5 w-3.5 rounded-sm object-contain"
+								onerror={() => markFaviconBroken(tab.favicon)}
+							/>
+						{:else}
+							<Icon name="lucide:globe" class="h-3 w-3 opacity-60" />
+						{/if}
 					</span>
-					{#if mcpControlledTabIds.has(tab.id)}
-						<span title="MCP Controlled" class="flex"><Icon name="lucide:lock" class="w-3 h-3 flex-shrink-0 text-amber-500" /></span>
-					{/if}
-					<!-- Close button -->
-					{#if !mcpControlledTabIds.has(tab.id)}
+
+					<span class="truncate max-w-28">{tab.title || 'New Tab'}</span>
+
+					{#if isControlled}
+						<span title="Controlled by an AI agent" class="flex">
+							<Icon name="lucide:lock" class="h-3 w-3 shrink-0 text-amber-500" />
+						</span>
+					{:else}
 						<span
 							role="button"
 							tabindex="0"
-							onclick={(e) => {
-								e.stopPropagation();
+							onclick={(event) => {
+								event.stopPropagation();
 								onCloseTab(tab.id);
 							}}
-							onkeydown={(e) => {
-								if (e.key === 'Enter' || e.key === ' ') {
-									e.stopPropagation();
+							onkeydown={(event) => {
+								if (event.key === 'Enter' || event.key === ' ') {
+									event.stopPropagation();
 									onCloseTab(tab.id);
 								}
 							}}
-							class="flex items-center justify-center w-4 h-4 rounded hover:bg-slate-200 dark:hover:bg-slate-700 transition-all duration-200 flex-shrink-0"
+							class="flex h-4 w-4 shrink-0 items-center justify-center rounded transition-all duration-200 hover:bg-slate-200 dark:hover:bg-slate-700"
 							title="Close tab"
 						>
-							<Icon name="lucide:x" class="w-2.5 h-2.5" />
+							<Icon name="lucide:x" class="h-2.5 w-2.5" />
 						</span>
 					{/if}
+
 					{#if isActive}
-						<span class="absolute bottom-0 inset-x-0 h-px bg-violet-600 dark:bg-violet-400"></span>
+						<span class="absolute inset-x-0 bottom-0 h-px bg-violet-600 dark:bg-violet-400"></span>
 					{/if}
 				</button>
 			{/each}
 
-			<!-- New tab button -->
-			<button
-				type="button"
-				onclick={() => onNewTab()}
-				class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 hover:bg-slate-200/60 dark:hover:bg-slate-700/60 transition-all duration-200 flex-shrink-0 ml-1"
-				title="Open new tab"
-			>
-				<Icon name="lucide:plus" class="w-3 h-3" />
-			</button>
+			<!-- Sticky, and opaque so tabs scroll underneath rather than through. -->
+			<div class="sticky right-0 z-10 flex shrink-0 items-center gap-0.5 bg-white px-1 dark:bg-slate-900">
+				<button
+					type="button"
+					onclick={() => onNewTab()}
+					class="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-slate-400 transition-all duration-200 hover:bg-slate-200/60 hover:text-slate-600 dark:hover:bg-slate-700/60 dark:hover:text-slate-300"
+					title="New tab"
+					aria-label="New tab"
+				>
+					<Icon name="lucide:plus" class="h-3 w-3" />
+				</button>
+
+				{#if tabs.length > 1}
+					<button
+						type="button"
+						onclick={() => onCloseAllTabs()}
+						disabled={closableTabs.length === 0}
+						class="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-slate-400 transition-all duration-200 hover:bg-red-500/10 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-slate-400"
+						title={closeAllTitle}
+						aria-label={closeAllTitle}
+					>
+						<Icon name="lucide:list-x" class="h-3.5 w-3.5" />
+					</button>
+				{/if}
+			</div>
 		</div>
 	{/if}
 
-	<!-- Main toolbar header (URL bar) -->
-	<div class="px-2.5 py-1.5">
-		<div class="px-1 py-0.5 bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700">
-			<div class="flex items-center justify-between gap-3">
-				<!-- Left section: URL navigation -->
-				<div class="flex items-center gap-2 flex-1 min-w-0">
-					<!-- URL input with integrated controls -->
-					<input
-						type="text"
-						bind:value={urlInput}
-						onkeydown={handleUrlKeydown}
-						oninput={handleUrlInput}
-						onfocus={() => isUserTyping = true}
-						onblur={() => isUserTyping = false}
-						placeholder={isMcpControlled ? 'MCP controlled — navigation disabled' : 'Enter URL to preview...'}
-						disabled={isMcpControlled}
-						class="flex-1 pl-3 py-2 text-sm bg-transparent border-0 focus:outline-none min-w-0 text-ellipsis disabled:opacity-50 disabled:cursor-not-allowed"
-					/>
-					<div class="flex items-center gap-1 px-1.5">
-						{#if url}
-							<button
-								onclick={handleOpenInExternalBrowser}
-								class="flex p-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-700 transition-all duration-200"
-								title="Open in external browser"
-							>
-								<Icon name="lucide:external-link" class="w-4 h-4" />
-							</button>
-							<button
-								onclick={handleRefresh}
-								disabled={isLoading || isMcpControlled}
-								class="flex p-1.5 rounded-md hover:bg-slate-100 dark:hover:bg-slate-700 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-								title="Refresh current page"
-							>
-								<Icon name={isLoading ? 'lucide:loader-circle' : 'lucide:refresh-cw'} class="w-4 h-4 transition-transform duration-200 {isLoading ? 'animate-spin' : 'hover:rotate-180'}" />
-							</button>
-						{/if}
-						<button
-							onclick={handleGoClick}
-							disabled={!urlInput.trim() || isLoading || isMcpControlled}
-							class="ml-0.5 px-3.5 py-1 text-xs font-medium rounded-md bg-violet-500 hover:bg-violet-600 disabled:bg-slate-300 disabled:dark:bg-slate-600 text-white transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-							title={isMcpControlled ? 'Navigation disabled — MCP controlled' : 'Navigate to URL'}
-						>
-							Go
-						</button>
-					</div>
-				</div>
-			</div>
+	<!-- Address bar row -->
+	<div class="flex items-center gap-1 px-2 py-1.5">
+		<!-- Navigation cluster -->
+		<div class="flex shrink-0 items-center gap-0.5">
+			<button
+				type="button"
+				onclick={() => onBack()}
+				disabled={!canGoBack || isMcpControlled}
+				class="flex items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:bg-transparent dark:hover:bg-slate-800 dark:hover:text-slate-100 {isMobile
+					? 'h-9 w-9'
+					: 'h-7 w-7'}"
+				title="Back"
+				aria-label="Back"
+			>
+				<Icon name="lucide:arrow-left" class={isMobile ? 'h-5 w-5' : 'h-4 w-4'} />
+			</button>
+			<button
+				type="button"
+				onclick={() => onForward()}
+				disabled={!canGoForward || isMcpControlled}
+				class="flex items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:bg-transparent dark:hover:bg-slate-800 dark:hover:text-slate-100 {isMobile
+					? 'h-9 w-9'
+					: 'h-7 w-7'}"
+				title="Forward"
+				aria-label="Forward"
+			>
+				<Icon name="lucide:arrow-right" class={isMobile ? 'h-5 w-5' : 'h-4 w-4'} />
+			</button>
+			<button
+				type="button"
+				onclick={() => (isBusy ? onStop() : onRefresh())}
+				disabled={isMcpControlled || !url}
+				class="flex items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:bg-transparent dark:hover:bg-slate-800 dark:hover:text-slate-100 {isMobile
+					? 'h-9 w-9'
+					: 'h-7 w-7'}"
+				title={isBusy ? 'Stop loading' : 'Reload'}
+				aria-label={isBusy ? 'Stop loading' : 'Reload'}
+			>
+				<Icon name={isBusy ? 'lucide:x' : 'lucide:refresh-cw'} class={isMobile ? 'h-5 w-5' : 'h-4 w-4'} />
+			</button>
+		</div>
+
+		<!-- Address field -->
+		<div
+			class="flex min-w-0 flex-1 items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-2.5 transition-colors focus-within:border-violet-400 focus-within:bg-white dark:border-slate-700 dark:bg-slate-800 dark:focus-within:bg-slate-800 {isMobile
+				? 'py-1.5'
+				: 'py-1'}"
+		>
+			{#if security}
+				<span class="flex shrink-0" title={security.label}>
+					<Icon name={security.icon} class="h-3.5 w-3.5 {security.class}" />
+				</span>
+			{:else}
+				<Icon name="lucide:search" class="h-3.5 w-3.5 shrink-0 text-slate-400" />
+			{/if}
+
+			<input
+				bind:this={urlInputElement}
+				type="text"
+				bind:value={urlInput}
+				onkeydown={handleUrlKeydown}
+				oninput={handleUrlInput}
+				onfocus={() => {
+				onAddressFocusChange(true);
+				urlInputElement?.select();
+			}}
+			onblur={() => onAddressFocusChange(false)}
+				placeholder={isMcpControlled ? 'Controlled by an AI agent' : 'Enter a URL'}
+				disabled={isMcpControlled}
+				autocomplete="off"
+				autocapitalize="off"
+				spellcheck="false"
+				aria-label="Address bar"
+				class="min-w-0 flex-1 border-0 bg-transparent text-sm text-ellipsis text-slate-700 outline-none placeholder:text-slate-400 disabled:cursor-not-allowed disabled:opacity-50 dark:text-slate-200"
+			/>
+
+			{#if urlInput.trim() && urlInput !== url}
+				<button
+					type="button"
+					onclick={() => onGoClick()}
+					disabled={isMcpControlled}
+					class="shrink-0 rounded-full bg-violet-500 px-2.5 py-0.5 text-[11px] font-medium text-white transition-colors hover:bg-violet-600 disabled:opacity-50"
+					title="Go"
+				>
+					Go
+				</button>
+			{/if}
+		</div>
+
+		<!-- Utility cluster -->
+		<div class="flex shrink-0 items-center gap-0.5">
+			{#if showKeyboardToggle}
+				<button
+					type="button"
+					onclick={() => onToggleKeyboard()}
+					disabled={!url}
+					class="flex items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 disabled:opacity-35 dark:hover:bg-slate-800 dark:hover:text-slate-100 {isMobile
+						? 'h-9 w-9'
+						: 'h-7 w-7'}"
+					title="Show keyboard"
+					aria-label="Show keyboard"
+				>
+					<Icon name="lucide:keyboard" class={isMobile ? 'h-5 w-5' : 'h-4 w-4'} />
+				</button>
+			{/if}
+
+			<button
+				type="button"
+				onclick={() => onToggleConsole()}
+				class="relative flex items-center justify-center rounded-md transition-colors {isConsoleOpen
+					? 'bg-violet-500/10 text-violet-600 dark:text-violet-400'
+					: 'text-slate-500 hover:bg-slate-100 hover:text-slate-800 dark:hover:bg-slate-800 dark:hover:text-slate-100'} {isMobile
+					? 'h-9 w-9'
+					: 'h-7 w-7'}"
+				title="Toggle console"
+				aria-label="Toggle console"
+				aria-pressed={isConsoleOpen}
+			>
+				<Icon name="lucide:terminal" class={isMobile ? 'h-5 w-5' : 'h-4 w-4'} />
+				{#if consoleIssueCount > 0 && !isConsoleOpen}
+					<span
+						class="absolute -right-0.5 -top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-red-500 px-1 text-[9px] font-semibold leading-none text-white"
+					>
+						{consoleIssueCount > 99 ? '99+' : consoleIssueCount}
+					</span>
+				{/if}
+			</button>
+
+			{#if url}
+				<button
+					type="button"
+					onclick={() => handleOpenInExternalBrowser()}
+					class="flex items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 dark:hover:bg-slate-800 dark:hover:text-slate-100 {isMobile
+						? 'h-9 w-9'
+						: 'h-7 w-7'}"
+					title="Open in your browser"
+					aria-label="Open in your browser"
+				>
+					<Icon name="lucide:external-link" class={isMobile ? 'h-5 w-5' : 'h-4 w-4'} />
+				</button>
+			{/if}
 		</div>
 	</div>
 
-	<!-- Progress Bar - positioned at bottom of toolbar, overlapping the border -->
+	<!-- Progress bar, overlapping the bottom border -->
 	{#if showProgress}
-		<div class="absolute -bottom-px left-0 right-0 h-0.5 z-10 overflow-hidden rounded-b-xl">
+		<div class="absolute -bottom-px left-0 right-0 z-10 h-0.5 overflow-hidden">
 			<div
-				class="h-full bg-gradient-to-r from-violet-500 via-blue-600 to-purple-600 transition-all duration-100 ease-out relative"
+				class="relative h-full bg-gradient-to-r from-violet-500 via-blue-600 to-purple-600 transition-all duration-100 ease-out"
 				style="width: {progressPercent}%"
 			>
-				<!-- Glow effect -->
-				<div class="absolute inset-0 bg-gradient-to-r from-violet-400 to-purple-500 blur-sm opacity-60"></div>
-				<!-- Shimmer effect -->
-				<div class="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent animate-pulse"></div>
+				<div class="absolute inset-0 bg-gradient-to-r from-violet-400 to-purple-500 opacity-60 blur-sm"></div>
 			</div>
 		</div>
 	{/if}
 </div>
+
+<style>
+	/* Thin, unobtrusive scrollbar. The strip has to stay scrollable once tabs
+	   overflow, but a default-height bar under a 32px row reads as a defect. */
+	.tab-strip {
+		scrollbar-width: thin;
+	}
+
+	.tab-strip::-webkit-scrollbar {
+		height: 3px;
+	}
+
+	.tab-strip::-webkit-scrollbar-thumb {
+		background: rgb(148 163 184 / 0.5);
+		border-radius: 999px;
+	}
+
+	.tab-strip::-webkit-scrollbar-track {
+		background: transparent;
+	}
+</style>

--- a/frontend/components/preview/browser/core/coordinator.svelte.ts
+++ b/frontend/components/preview/browser/core/coordinator.svelte.ts
@@ -19,7 +19,12 @@ import {
 import { browserCleanup } from './cleanup.svelte';
 import { sendInteraction, updateViewport, setInteractionProjectId } from './interactions.svelte';
 import { previewTabManager } from '$frontend/stores/features/preview-tabs-workspace.svelte';
-import type { BrowserSelectInfo, BrowserContextMenuInfo } from '$frontend/utils/native-ui';
+import type {
+	BrowserSelectInfo,
+	BrowserContextMenuInfo,
+	BrowserDialogEvent,
+	BrowserNativePickerInfo
+} from '$frontend/utils/native-ui';
 
 export interface BrowserCoordinatorConfig {
 	// Project ID getter (REQUIRED for project isolation)
@@ -35,6 +40,12 @@ export interface BrowserCoordinatorConfig {
 	// UI state callbacks
 	onSelectOpen?: (selectInfo: BrowserSelectInfo) => void;
 	onContextMenuOpen?: (menuInfo: BrowserContextMenuInfo) => void;
+	onNativePickerOpen?: (picker: BrowserNativePickerInfo) => void;
+	onDialogOpen?: (dialog: BrowserDialogEvent) => void;
+	/** A dialog is settled — answered here, answered elsewhere, or expired. */
+	onDialogClose?: (closed?: { sessionId: string; dialogId: string }) => void;
+	onOpenInspector?: () => void;
+	onOpenUrlInHostBrowser?: (url: string) => void;
 	onVirtualCursorUpdate?: (x: number, y: number, clicking?: boolean) => void;
 	onVirtualCursorHide?: () => void;
 	onMcpCursorUpdate?: (x: number, y: number, clicking?: boolean) => void;
@@ -57,6 +68,11 @@ export function createBrowserCoordinator(config: BrowserCoordinatorConfig) {
 		onErrorChange,
 		onSelectOpen,
 		onContextMenuOpen,
+		onNativePickerOpen,
+		onDialogOpen,
+		onDialogClose,
+		onOpenInspector,
+		onOpenUrlInHostBrowser,
 		onVirtualCursorUpdate,
 		onVirtualCursorHide,
 		onMcpCursorUpdate,
@@ -114,6 +130,11 @@ export function createBrowserCoordinator(config: BrowserCoordinatorConfig) {
 		transformBrowserToDisplayCoordinates,
 		onSelectOpen,
 		onContextMenuOpen,
+		onNativePickerOpen,
+		onDialogOpen,
+		onDialogClose,
+		onOpenInspector,
+		onOpenUrlInHostBrowser,
 		onOpenUrlNewTab: (url) => {
 			createNewTab(url);
 		}
@@ -149,6 +170,16 @@ export function createBrowserCoordinator(config: BrowserCoordinatorConfig) {
 		const tab = tabManager.getTab(tabId);
 		if (!tab || !tabUrl) {
 			debug.error('preview', `❌ Tab not found or no URL: ${tabId}`);
+			return;
+		}
+
+		// A new tab reaches here twice: `createNewTab` schedules a launch, and
+		// setting the URL also trips BrowserPreview's URL watcher. Both used to
+		// run, opening two backend tabs for one link — one of which the dock could
+		// not attach to the frontend tab, so it rendered blank and took its twin
+		// down with it when closed.
+		if (tab.isLaunchingBrowser || tab.sessionId) {
+			debug.log('preview', `⏭️ Launch skipped for ${tabId} — already ${tab.sessionId ? 'attached' : 'launching'}`);
 			return;
 		}
 

--- a/frontend/components/preview/browser/core/interactions.svelte.ts
+++ b/frontend/components/preview/browser/core/interactions.svelte.ts
@@ -14,10 +14,15 @@ export interface InteractionAction {
 		| 'click'
 		| 'doubleclick'
 		| 'rightclick'
+		| 'mousedown'
+		| 'mouseup'
 		| 'mousemove'
 		| 'scroll'
+		| 'stop'
+		| 'paste'
 		| 'type'
 		| 'key'
+		| 'keynav'
 		| 'checkselectoptions'
 		| 'scale-update'
 		| 'viewport-update';
@@ -25,8 +30,13 @@ export interface InteractionAction {
 	y?: number;
 	deltaX?: number;
 	deltaY?: number;
+	button?: 'left' | 'right';
 	text?: string;
 	key?: string;
+	ctrlKey?: boolean;
+	metaKey?: boolean;
+	altKey?: boolean;
+	shiftKey?: boolean;
 	delay?: number;
 	steps?: number;
 	scale?: number;
@@ -35,6 +45,18 @@ export interface InteractionAction {
 	height?: number;
 	deviceSize?: string;
 	rotation?: string;
+}
+
+/**
+ * Whether a point in the page accepts text, and what kind of text.
+ *
+ * Drives the on-screen keyboard on touch devices: the viewer asks about the
+ * point under the finger as the tap begins, then raises the keyboard inside the
+ * `touchend` handler — the only moment iOS will honour a programmatic focus.
+ */
+export interface RemoteFocusState {
+	editable: boolean;
+	inputType?: string;
 }
 
 // Store current projectId for interactions
@@ -86,6 +108,54 @@ export function sendInteraction(action: InteractionAction): void {
 }
 
 /**
+ * Read the preview's current text selection, optionally cutting it.
+ *
+ * Used by the Ctrl+C / Ctrl+X bridge: the keystroke cannot simply be forwarded,
+ * because it would land on the headless browser's own clipboard rather than the
+ * user's.
+ */
+export async function readPageSelection(cut = false): Promise<string> {
+	try {
+		const result = await ws.http('preview:browser-selection', { cut }, 5000);
+		return result.text;
+	} catch {
+		return '';
+	}
+}
+
+/**
+ * Ask the page what sits at a point, before anything is dispatched there.
+ *
+ * The keyboard decision cannot be made from focus state, which only settles
+ * once the tap has been handled — so it always described the *previous* tap.
+ * The element under the finger is knowable at `touchstart`, which is early
+ * enough to have the answer in hand by `touchend`.
+ *
+ * Best-effort: a failure (mid-navigation, tab gone) reads as "not editable" so
+ * the viewer leaves the keyboard alone rather than raising it over nothing.
+ */
+export async function probeHitTest(x: number, y: number): Promise<RemoteFocusState> {
+	try {
+		return await ws.http('preview:browser-hit-test', { x, y }, 3000);
+	} catch {
+		return { editable: false };
+	}
+}
+
+/**
+ * Walk the active tab's history.
+ */
+export async function goHistory(direction: 'back' | 'forward', tabId?: string): Promise<boolean> {
+	try {
+		const result = await ws.http('preview:browser-tab-history-go', { direction, tabId }, 15000);
+		return result.moved;
+	} catch (error) {
+		debug.error('preview', `Error navigating ${direction}:`, error);
+		return false;
+	}
+}
+
+/**
  * Send scale update to active tab.
  *
  * Doubles as the stream-recovery path (the frontend re-sends the current scale
@@ -106,23 +176,6 @@ export function sendScaleUpdate(scale: number): void {
 	} catch (error) {
 		debug.error('preview', 'Error sending scale update:', error);
 	}
-}
-
-/**
- * Report display metrics without disturbing the stream.
- *
- * A resize only needs the capture resolution recomputed; `sendScaleUpdate`
- * additionally restarts capture, which is right for recovery but wasteful on
- * every drag frame of a panel resize.
- */
-export function sendDisplayUpdate(scale: number): void {
-	setDisplayScale(scale);
-	ws.http('preview:browser-stream-display', {
-		scale,
-		dpr: currentDpr()
-	}).catch(() => {
-		// Best-effort: the next scale-update or reconnect carries it anyway
-	});
 }
 
 /**

--- a/frontend/components/preview/browser/core/native-ui-handlers.svelte.ts
+++ b/frontend/components/preview/browser/core/native-ui-handlers.svelte.ts
@@ -5,7 +5,14 @@
 
 import { debug } from '$shared/utils/logger';
 import ws from '$frontend/utils/ws';
-import type { BrowserDialogEvent, BrowserPrintEvent, BrowserSelectInfo, BrowserContextMenuInfo } from '$frontend/utils/native-ui';
+import type {
+	BrowserConsoleMessage,
+	BrowserDialogEvent,
+	BrowserPrintEvent,
+	BrowserSelectInfo,
+	BrowserContextMenuInfo,
+	BrowserNativePickerInfo
+} from '$frontend/utils/native-ui';
 import type { TabManager } from './tab-manager.svelte';
 
 export interface NativeUIHandlerConfig {
@@ -13,8 +20,14 @@ export interface NativeUIHandlerConfig {
 	transformBrowserToDisplayCoordinates?: (x: number, y: number) => { x: number, y: number } | null;
 	onSelectOpen?: (selectInfo: BrowserSelectInfo) => void;
 	onContextMenuOpen?: (menuInfo: BrowserContextMenuInfo) => void;
+	onNativePickerOpen?: (picker: BrowserNativePickerInfo) => void;
+	onDialogOpen?: (dialog: BrowserDialogEvent) => void;
+	/** A dialog is settled — answered here, answered elsewhere, or expired. */
+	onDialogClose?: (closed?: { sessionId: string; dialogId: string }) => void;
 	onCopyToClipboard?: (text: string) => void;
 	onOpenUrlNewTab?: (url: string) => void;
+	onOpenUrlInHostBrowser?: (url: string) => void;
+	onOpenInspector?: () => void;
 	onDownloadImage?: (base64: string, type: string, filename: string) => void;
 	onCopyImageToClipboard?: (base64: string, type: string) => void;
 }
@@ -28,8 +41,13 @@ export function createNativeUIHandler(config: NativeUIHandlerConfig) {
 		transformBrowserToDisplayCoordinates,
 		onSelectOpen,
 		onContextMenuOpen,
+		onNativePickerOpen,
+		onDialogOpen,
+		onDialogClose,
 		onCopyToClipboard,
 		onOpenUrlNewTab,
+		onOpenUrlInHostBrowser,
+		onOpenInspector,
 		onDownloadImage,
 		onCopyImageToClipboard
 	} = config;
@@ -42,11 +60,21 @@ export function createNativeUIHandler(config: NativeUIHandlerConfig) {
 	function setupEventListeners(): () => void {
 		const unsubscribers = [
 			ws.on('preview:browser-dialog', handleDialogEvent),
+			ws.on('preview:browser-dialog-closed', handleDialogClosed),
 			ws.on('preview:browser-print', handlePrintEvent),
 			ws.on('preview:browser-select', handleSelectEvent),
 			ws.on('preview:browser-context-menu', handleContextMenuEvent),
+			ws.on('preview:browser-native-picker' as any, handleNativePickerEvent),
 			ws.on('preview:browser-copy-to-clipboard', handleCopyToClipboard),
 			ws.on('preview:browser-open-url-new-tab', handleOpenUrlNewTab),
+			ws.on('preview:browser-open-url-host' as any, (data: { url: string }) => {
+				onOpenUrlInHostBrowser?.(data.url);
+			}),
+			ws.on('preview:browser-open-inspector' as any, () => {
+				onOpenInspector?.();
+			}),
+			ws.on('preview:browser-console-message' as any, handleConsoleMessage),
+			ws.on('preview:browser-console-clear' as any, handleConsoleClear),
 			ws.on('preview:browser-download-image', handleDownloadImage),
 			ws.on('preview:browser-copy-image-to-clipboard', handleCopyImageToClipboard)
 		];
@@ -57,54 +85,76 @@ export function createNativeUIHandler(config: NativeUIHandlerConfig) {
 	}
 
 	/**
-	 * Handle dialog events (alert, confirm, prompt)
+	 * Surface alert/confirm/prompt for the viewer to answer.
+	 *
+	 * Deliberately not `window.alert` and friends: those block Clopen's own main
+	 * thread, which stalls the WebCodecs decoder and freezes the preview behind
+	 * the dialog. The overlay renders the same choice without stopping the app.
 	 */
-	async function handleDialogEvent(data: BrowserDialogEvent) {
+	function handleDialogEvent(data: BrowserDialogEvent) {
 		debug.log('preview', `🎭 Dialog event received: ${data.type} - ${data.message} (dialogId: ${data.dialogId})`);
 
-		let response: boolean | null = null;
-		let promptText: string | undefined = undefined;
+		// Handed over with its owning tab attached. A dialog raised by a background
+		// tab is held until the user goes back to it rather than being answered on
+		// their behalf — and never shown over a different tab's page.
+		onDialogOpen?.(data);
+	}
 
-		// Show native browser dialog based on type
-		switch (data.type) {
-			case 'alert':
-				window.alert(data.message);
-				response = true; // Alert always accepts
-				break;
+	/**
+	 * The page's dialog is gone.
+	 *
+	 * A dialog belongs to the page, so answering it on one device answers it for
+	 * everyone — the other viewers were only ever holding a copy of the prompt,
+	 * and this is what takes theirs down. Also covers the backend's own
+	 * auto-dismiss, which no viewer initiated at all.
+	 */
+	function handleDialogClosed(data: { sessionId: string; dialogId: string }) {
+		onDialogClose?.({ sessionId: data.sessionId, dialogId: data.dialogId });
+	}
 
-			case 'confirm':
-				response = window.confirm(data.message);
-				break;
+	/**
+	 * Answer the dialog the viewer just resolved.
+	 */
+	function respondToDialog(dialog: BrowserDialogEvent, accept: boolean, promptText?: string) {
+		debug.log('preview', `📤 Dialog response - dialogId: ${dialog.dialogId}, accept: ${accept}`);
 
-			case 'prompt':
-				const result = window.prompt(data.message, data.defaultValue || '');
-				if (result !== null) {
-					response = true;
-					promptText = result;
-				} else {
-					response = false;
-				}
-				break;
+		ws.emit('preview:browser-dialog-input', {
+			dialogId: dialog.dialogId,
+			accept,
+			promptText
+		});
 
-			case 'beforeunload':
-				response = window.confirm(data.message);
-				break;
-		}
+		// Locally too, so the overlay goes on the click rather than on the
+		// round-trip; the broadcast covers every other viewer.
+		onDialogClose?.({ sessionId: dialog.sessionId, dialogId: dialog.dialogId });
+	}
 
-		// Send response back to backend
-		if (response !== null) {
-			debug.log('preview', `📤 Sending dialog response - dialogId: ${data.dialogId}, accept: ${response}${promptText ? `, promptText: "${promptText}"` : ''}`);
+	/**
+	 * Append a console message to its own tab, so switching tabs shows that
+	 * tab's history rather than a merged stream.
+	 */
+	function handleConsoleMessage(data: { sessionId: string; message: BrowserConsoleMessage }) {
+		const tab = tabManager.tabs.find((entry) => entry.sessionId === data.sessionId);
+		if (!tab) return;
 
-			ws.emit('preview:browser-dialog-input', {
-				dialogId: data.dialogId,
-				accept: response,
-				promptText
-			});
+		const existing = tab.consoleLogs ?? [];
 
-			debug.log('preview', `✅ Dialog response sent successfully`);
-		} else {
-			debug.warn('preview', `⚠️ No response to send for dialog: ${data.dialogId}`);
-		}
+		// The backend collapses repeats by mutating the last message and
+		// re-emitting it, so a matching id is an update, not a new line.
+		const index = existing.findIndex((entry) => entry.id === data.message.id);
+		const next =
+			index >= 0
+				? existing.map((entry, i) => (i === index ? data.message : entry))
+				: [...existing, data.message];
+
+		// Mirrors the backend's own ring buffer; without a cap a long-running page
+		// grows this array without bound.
+		tabManager.updateTab(tab.id, { consoleLogs: next.length > 1000 ? next.slice(-500) : next });
+	}
+
+	function handleConsoleClear(data: { sessionId: string }) {
+		const tab = tabManager.tabs.find((entry) => entry.sessionId === data.sessionId);
+		if (tab) tabManager.updateTab(tab.id, { consoleLogs: [] });
 	}
 
 	/**
@@ -228,6 +278,44 @@ export function createNativeUIHandler(config: NativeUIHandlerConfig) {
 		if (onContextMenuOpen) {
 			onContextMenuOpen(transformedMenuInfo);
 		}
+	}
+
+	/**
+	 * Position a colour/date picker over the input that opened it.
+	 */
+	function handleNativePickerEvent(data: BrowserNativePickerInfo) {
+		const activeTab = tabManager.activeTab;
+		if (!activeTab || activeTab.sessionId !== data.sessionId) return;
+
+		if (!transformBrowserToDisplayCoordinates) return;
+
+		const topLeft = transformBrowserToDisplayCoordinates(data.boundingBox.x, data.boundingBox.y);
+		const bottomRight = transformBrowserToDisplayCoordinates(
+			data.boundingBox.x + data.boundingBox.width,
+			data.boundingBox.y + data.boundingBox.height
+		);
+		if (!topLeft || !bottomRight) return;
+
+		onNativePickerOpen?.({
+			...data,
+			boundingBox: {
+				x: topLeft.x,
+				y: topLeft.y,
+				width: bottomRight.x - topLeft.x,
+				height: bottomRight.y - topLeft.y
+			}
+		});
+	}
+
+	/**
+	 * Write a picked colour or date back into the page.
+	 */
+	function respondNativePicker(picker: BrowserNativePickerInfo, value: string) {
+		ws.emit('preview:browser-native-picker-input', {
+			tabId: picker.sessionId,
+			pickerId: picker.pickerId,
+			value
+		});
 	}
 
 	/**
@@ -369,11 +457,14 @@ export function createNativeUIHandler(config: NativeUIHandlerConfig) {
 	return {
 		setupEventListeners,
 		handleDialogEvent,
+		respondToDialog,
 		handlePrintEvent,
 		handleSelectEvent,
 		respondSelectOption,
 		handleContextMenuEvent,
 		respondContextMenuItem,
+		handleNativePickerEvent,
+		respondNativePicker,
 		handleCopyToClipboard,
 		handleOpenUrlNewTab,
 		handleDownloadImage,

--- a/frontend/components/preview/browser/core/tab-manager.svelte.ts
+++ b/frontend/components/preview/browser/core/tab-manager.svelte.ts
@@ -5,15 +5,15 @@
 
 import { debug } from '$shared/utils/logger';
 import type { DeviceSize, Rotation } from '$frontend/utils/preview-constants';
-
-// Console message type (temporary placeholder)
-type ConsoleMessage = any;
+import type { BrowserConsoleMessage } from '$frontend/utils/native-ui';
 
 // Tab interface
 export interface PreviewTab {
 	id: string;
 	url: string;
 	title: string;
+	/** Absolute favicon URL reported by the page, once it has one. */
+	favicon?: string;
 	sessionId: string | null;
 	sessionInfo: any;
 	isConnected: boolean;
@@ -21,9 +21,12 @@ export interface PreviewTab {
 	isLoading: boolean;
 	isLaunchingBrowser: boolean;
 	isNavigating: boolean; // True when navigating within same session (e.g., clicking a link)
+	/** Whether this tab's history has anywhere to go — drives the toolbar arrows. */
+	canGoBack: boolean;
+	canGoForward: boolean;
 	deviceSize: DeviceSize;
 	rotation: Rotation;
-	consoleLogs: ConsoleMessage[];
+	consoleLogs: BrowserConsoleMessage[];
 	canvasAPI: any;
 	previewDimensions: any;
 	lastFrameData: any;
@@ -76,6 +79,8 @@ export function createTabManager() {
 			isLoading: false,
 			isLaunchingBrowser: false,
 			isNavigating: false,
+			canGoBack: false,
+			canGoForward: false,
 			deviceSize,
 			rotation,
 			consoleLogs: [],
@@ -128,6 +133,26 @@ export function createTabManager() {
 		}
 
 		return { removedTab, newActiveTab };
+	}
+
+	/**
+	 * Move a tab so it sits where `targetTabId` currently is.
+	 *
+	 * Order is user-visible state — it is what the snapshot persists and what the
+	 * strip renders — so reordering has to mutate the list itself rather than
+	 * being a view-only sort.
+	 */
+	function reorderTab(tabId: string, targetTabId: string): void {
+		if (tabId === targetTabId) return;
+
+		const from = tabs.findIndex((tab) => tab.id === tabId);
+		const to = tabs.findIndex((tab) => tab.id === targetTabId);
+		if (from === -1 || to === -1) return;
+
+		const next = [...tabs];
+		const [moved] = next.splice(from, 1);
+		next.splice(to, 0, moved);
+		tabs = next;
 	}
 
 	/**
@@ -197,6 +222,7 @@ export function createTabManager() {
 		createTab,
 		switchTab,
 		closeTab,
+		reorderTab,
 		updateTab,
 		updateActiveTab,
 		getTab,

--- a/frontend/components/preview/browser/core/tab-operations.svelte.ts
+++ b/frontend/components/preview/browser/core/tab-operations.svelte.ts
@@ -39,11 +39,14 @@ export interface ExistingTabInfo {
 	tabId: string;
 	url: string;
 	title: string;
+	favicon?: string;
 	quality: string;
 	isStreaming: boolean;
 	deviceSize: string;
 	rotation: string;
 	isActive: boolean;
+	canGoBack?: boolean;
+	canGoForward?: boolean;
 	isMcpControlled?: boolean;
 }
 

--- a/frontend/components/terminal/Terminal.svelte
+++ b/frontend/components/terminal/Terminal.svelte
@@ -14,6 +14,7 @@
 	import { ptyClient, registerSession, unregisterSession } from '$frontend/services/terminal/ptykit-client';
 	import { settings } from '$frontend/stores/features/settings.svelte';
 	import TerminalTabs from './TerminalTabs.svelte';
+	import Dialog from '$frontend/components/common/overlay/Dialog.svelte';
 	import { PtyTerminal } from '@myrialabs/ptykit/svelte';
 	import type { ComponentProps } from 'svelte';
 
@@ -103,6 +104,8 @@
 		}
 	}
 
+	let showCloseAllConfirm = $state(false);
+
 	async function handleCloseSession(sessionId: string) {
 		const isLastSession = terminalStore.sessions.length <= 1;
 		// Close (and kill the PTY) while the session handle is still registered.
@@ -112,6 +115,27 @@
 		unregisterSession(sessionId);
 		terminals.delete(sessionId);
 		if (closed && isLastSession) {
+			await handleNewSession();
+		}
+	}
+
+	/**
+	 * Close every terminal, then leave one fresh shell behind.
+	 *
+	 * Sequential rather than parallel: each close kills a PTY and unregisters its
+	 * handle, and the store's active-session bookkeeping assumes one at a time.
+	 */
+	async function handleCloseAllSessions() {
+		showCloseAllConfirm = false;
+
+		// Snapshot: the list this iterates is the one being emptied.
+		for (const sessionId of terminalStore.sessions.map((session) => session.id)) {
+			await terminalStore.closeSession(sessionId);
+			unregisterSession(sessionId);
+			terminals.delete(sessionId);
+		}
+
+		if (terminalStore.sessions.length === 0) {
 			await handleNewSession();
 		}
 	}
@@ -161,8 +185,22 @@
 			onCloseSession={handleCloseSession}
 			onNewSession={handleNewSession}
 			onRenameSession={handleRenameSession}
+			onReorderSession={(sessionId, targetSessionId) =>
+				terminalStore.reorderSession(sessionId, targetSessionId)}
+			onCloseAllSessions={() => (showCloseAllConfirm = true)}
 		/>
 	</div>
+
+	<!-- Terminals can hold running processes, so closing several asks first. -->
+	<Dialog
+		bind:isOpen={showCloseAllConfirm}
+		onClose={() => (showCloseAllConfirm = false)}
+		type="warning"
+		title="Close all terminals"
+		message="Close all {sessions.length} terminals? Anything still running in them is stopped."
+		confirmText="Close terminals"
+		onConfirm={handleCloseAllSessions}
+	/>
 
 	{#if sessions.length > 0}
 		<div class="flex-1 relative min-h-0 overflow-hidden font-mono">

--- a/frontend/components/terminal/TerminalTabs.svelte
+++ b/frontend/components/terminal/TerminalTabs.svelte
@@ -12,7 +12,9 @@
 		onSwitchSession,
 		onCloseSession,
 		onNewSession,
-		onRenameSession
+		onRenameSession,
+		onReorderSession,
+		onCloseAllSessions
 	}: {
 		sessions: TerminalSession[];
 		activeSessionId: string | null;
@@ -20,10 +22,41 @@
 		onCloseSession?: (sessionId: string) => void;
 		onNewSession?: () => void;
 		onRenameSession?: (sessionId: string, name: string) => void;
+		onReorderSession?: (sessionId: string, targetSessionId: string) => void;
+		onCloseAllSessions?: () => void;
 	} = $props();
 
 	let editingSessionId = $state<string | null>(null);
 	let draftName = $state('');
+
+	let stripElement = $state<HTMLDivElement | undefined>();
+	let draggingSessionId = $state<string | null>(null);
+	let dragOverSessionId = $state<string | null>(null);
+
+	/**
+	 * Vertical wheel scrolls the strip horizontally, matching an editor tab bar —
+	 * without it, overflowed tabs are unreachable on a mouse.
+	 */
+	function handleWheel(event: WheelEvent) {
+		if (!stripElement) return;
+		if (event.deltaY === 0 || event.shiftKey) return;
+		if (stripElement.scrollWidth <= stripElement.clientWidth) return;
+
+		event.preventDefault();
+		stripElement.scrollLeft += event.deltaY;
+	}
+
+	// Keep the active tab visible when it changes from outside the strip.
+	$effect(() => {
+		const id = activeSessionId;
+		if (!id || !stripElement) return;
+
+		queueMicrotask(() => {
+			stripElement
+				?.querySelector(`[data-session-id="${CSS.escape(id)}"]`)
+				?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+		});
+	});
 
 	function focusAndSelect(node: HTMLInputElement) {
 		queueMicrotask(() => {
@@ -62,18 +95,53 @@
 </script>
 
 <!-- Terminal Tabs (Git-style underline tabs) -->
-<div class="relative flex items-center overflow-x-auto flex-1">
+<!--
+	The tab actions live inside the scroller as a sticky block: beside the last
+	tab while there is room, pinned to the right edge once the tabs overflow.
+-->
+<div bind:this={stripElement} onwheel={handleWheel} class="tab-strip flex items-center overflow-x-auto">
 	{#each sessions as session (session.id)}
 		{@const isActive = session.isActive}
 		<button
 			type="button"
-			class="group relative flex items-center justify-center gap-1 pr-2 pl-3 py-2 text-xs font-medium transition-colors min-w-0 max-w-xs cursor-pointer
+			data-session-id={session.id}
+			draggable={editingSessionId === session.id ? false : true}
+			ondragstart={(event) => {
+				draggingSessionId = session.id;
+				event.dataTransfer?.setData('text/plain', session.id);
+				if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move';
+			}}
+			ondragover={(event) => {
+				if (!draggingSessionId || draggingSessionId === session.id) return;
+				// Default is "reject the drop"; allowing it is what makes `drop` fire.
+				event.preventDefault();
+				if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+				dragOverSessionId = session.id;
+			}}
+			ondragleave={() => {
+				if (dragOverSessionId === session.id) dragOverSessionId = null;
+			}}
+			ondrop={(event) => {
+				event.preventDefault();
+				const sourceId = draggingSessionId ?? event.dataTransfer?.getData('text/plain');
+				if (sourceId && sourceId !== session.id) onReorderSession?.(sourceId, session.id);
+				draggingSessionId = null;
+				dragOverSessionId = null;
+			}}
+			ondragend={() => {
+				draggingSessionId = null;
+				dragOverSessionId = null;
+			}}
+			class="group relative flex shrink-0 items-center justify-center gap-1 pr-2 pl-3 py-2 text-xs font-medium transition-colors max-w-xs cursor-pointer
 				{isActive
 					? 'text-violet-600 dark:text-violet-400'
-					: 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'}"
+					: 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'}
+				{draggingSessionId === session.id ? 'opacity-40' : ''}
+				{dragOverSessionId === session.id ? 'bg-violet-500/10' : ''}"
 			onclick={() => onSwitchSession?.(session.id)}
 			ondblclick={() => startRename(session)}
 			role="tab"
+			aria-selected={isActive}
 			tabindex="0"
 		>
 			{#if editingSessionId === session.id}
@@ -123,16 +191,51 @@
 		</button>
 	{/each}
 
-	<!-- New terminal button -->
-	{#if onNewSession}
-		<button
-			type="button"
-			onclick={onNewSession}
-			class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 hover:bg-slate-200/60 dark:hover:bg-slate-700/60 transition-all duration-200 flex-shrink-0 ml-1"
-			title="New terminal"
-			aria-label="New terminal session"
-		>
-			<Icon name="lucide:plus" class="w-3 h-3" />
-		</button>
-	{/if}
+	<!-- Sticky, and opaque so tabs scroll underneath rather than through. -->
+	<div class="sticky right-0 z-10 flex shrink-0 items-center gap-0.5 bg-white px-1 dark:bg-slate-900">
+		{#if onNewSession}
+			<button
+				type="button"
+				onclick={onNewSession}
+				class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 hover:bg-slate-200/60 dark:hover:bg-slate-700/60 transition-all duration-200 flex-shrink-0"
+				title="New terminal"
+				aria-label="New terminal session"
+			>
+				<Icon name="lucide:plus" class="w-3 h-3" />
+			</button>
+		{/if}
+
+		{#if onCloseAllSessions && sessions.length > 1}
+			<button
+				type="button"
+				onclick={onCloseAllSessions}
+				class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:text-red-500 hover:bg-red-500/10 transition-all duration-200 flex-shrink-0"
+				title="Close all terminals"
+				aria-label="Close all terminal sessions"
+			>
+				<Icon name="lucide:list-x" class="w-3.5 h-3.5" />
+			</button>
+		{/if}
+	</div>
 </div>
+
+<style>
+	/* Thin scrollbar so overflowed tabs stay reachable without a bar that
+	   visually competes with a 32px-tall row. */
+	.tab-strip {
+		scrollbar-width: thin;
+	}
+
+	.tab-strip::-webkit-scrollbar {
+		height: 3px;
+	}
+
+	.tab-strip::-webkit-scrollbar-thumb {
+		background: rgb(148 163 184 / 0.5);
+		border-radius: 999px;
+	}
+
+	.tab-strip::-webkit-scrollbar-track {
+		background: transparent;
+	}
+</style>

--- a/frontend/services/preview/browser/browser-console.service.ts
+++ b/frontend/services/preview/browser/browser-console.service.ts
@@ -1,22 +1,9 @@
 import { debug } from '$shared/utils/logger';
 import ws from '$frontend/utils/ws';
-
-export interface ConsoleMessage {
-	id: string;
-	type: 'log' | 'info' | 'warn' | 'error' | 'debug' | 'trace' | 'clear';
-	text: string;
-	args?: unknown[];
-	location?: {
-		url: string;
-		lineNumber: number;
-		columnNumber: number;
-	};
-	stackTrace?: string;
-	timestamp: number;
-}
+import type { BrowserConsoleMessage } from '$frontend/utils/native-ui';
 
 export class BrowserConsoleService {
-	async getConsoleLogs(sessionId: string): Promise<ConsoleMessage[]> {
+	async getConsoleLogs(sessionId: string): Promise<BrowserConsoleMessage[]> {
 		try {
 			const result = await ws.http('preview:browser-console-get', {}, 5000);
 			return result.logs || [];

--- a/frontend/services/preview/browser/browser-webcodecs.service.ts
+++ b/frontend/services/preview/browser/browser-webcodecs.service.ts
@@ -31,6 +31,14 @@ const CODEC_NAMES: Record<number, 'vp8' | 'vp9' | 'avc'> = {
 	2: 'avc'
 };
 
+/** `randomUUID` needs a secure context, which a LAN preview over http is not. */
+function createViewerId(): string {
+	if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+		return crypto.randomUUID();
+	}
+	return `viewer-${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+}
+
 export interface ClientCodecSupportPayload {
 	vp8: boolean;
 	vp9: boolean;
@@ -231,6 +239,32 @@ export class BrowserWebCodecsService {
 
 	// User gesture listener for AudioContext resume (needed after page refresh)
 	private userGestureHandler: (() => void) | null = null;
+
+	/**
+	 * Identifies this viewer to the backend for its whole lifetime.
+	 *
+	 * A tab can be watched from more than one place at a time — the same project
+	 * open on a laptop and a phone, or two split panels showing the same
+	 * preview. Signalling used to be addressed by tab alone, so every viewer saw
+	 * every other viewer's ICE candidates and connection states, and each new
+	 * handshake replaced the last one's connection. Per-instance rather than
+	 * per-connection: it survives reconnects, so the backend can recognise a
+	 * recovering viewer as the same one rather than a second audience member.
+	 */
+	private readonly viewerId: string = createViewerId();
+
+	/**
+	 * Remote ICE candidates that arrived before this side could take them.
+	 *
+	 * The source starts gathering the moment it creates its offer, which is
+	 * *inside* the stream-start request — so its host candidates are usually on
+	 * the wire before that request has even returned, let alone before there is
+	 * a local peer with a remote description to attach them to. Dropping them
+	 * left the connection with nothing to try on a fast local network, which is
+	 * the "Loading preview…" that only clears after a reload or two.
+	 */
+	private pendingRemoteCandidates: RTCIceCandidateInit[] = [];
+	private hasRemoteDescription = false;
 
 	constructor(projectId: string) {
 		if (!projectId) {
@@ -501,6 +535,8 @@ export class BrowserWebCodecsService {
 
 		this.isCleaningUp = false;
 		this.stats.firstFrameRendered = false;
+		this.pendingRemoteCandidates = [];
+		this.hasRemoteDescription = false;
 
 		this.sessionId = sessionId;
 		this.canvas = canvas;
@@ -538,6 +574,7 @@ export class BrowserWebCodecsService {
 				'preview:browser-stream-start',
 				{
 					tabId: sessionId,
+					viewerId: this.viewerId,
 					vp9: codecs.vp9,
 					codecs,
 					display: this.currentDisplayMetrics()
@@ -573,7 +610,7 @@ export class BrowserWebCodecsService {
 						await new Promise(resolve => setTimeout(resolve, offerRetryDelay * attempt));
 					}
 					debug.log('webcodecs', `[DIAG] stream-offer attempt ${attempt + 1}/${offerMaxRetries}`);
-					const offerResponse = await ws.http('preview:browser-stream-offer', { tabId: sessionId }, 10000);
+					const offerResponse = await ws.http('preview:browser-stream-offer', { tabId: sessionId, viewerId: this.viewerId }, 10000);
 					if (offerResponse.offer) {
 						offer = offerResponse.offer;
 						break;
@@ -695,14 +732,14 @@ export class BrowserWebCodecsService {
 					sdpMLineIndex: event.candidate.sdpMLineIndex
 				};
 
-				ws.http('preview:browser-stream-ice', { candidate: candidateInit, tabId: this.sessionId }).catch((error) => {
+				ws.http('preview:browser-stream-ice', { candidate: candidateInit, tabId: this.sessionId, viewerId: this.viewerId }).catch((error) => {
 					debug.warn('webcodecs', 'Failed to send ICE candidate:', error);
 				});
 
 				// Also send loopback version for VPN compatibility (same-machine peers)
 				const loopback = this.createLoopbackCandidate(candidateInit);
 				if (loopback) {
-					ws.http('preview:browser-stream-ice', { candidate: loopback, tabId: this.sessionId }).catch(() => {});
+					ws.http('preview:browser-stream-ice', { candidate: loopback, tabId: this.sessionId, viewerId: this.viewerId }).catch(() => {});
 				}
 			}
 		};
@@ -781,7 +818,18 @@ export class BrowserWebCodecsService {
 		}
 
 		await this.peerConnection.setRemoteDescription(new RTCSessionDescription(offer));
+		this.hasRemoteDescription = true;
 		debug.log('webcodecs', 'Remote description set');
+
+		// Everything that arrived while there was nowhere to put it.
+		const buffered = this.pendingRemoteCandidates;
+		this.pendingRemoteCandidates = [];
+		if (buffered.length > 0) {
+			debug.log('webcodecs', `Applying ${buffered.length} buffered ICE candidate(s)`);
+			for (const candidate of buffered) {
+				await this.addIceCandidate(candidate);
+			}
+		}
 
 		const answer = await this.peerConnection.createAnswer();
 		await this.peerConnection.setLocalDescription(answer);
@@ -793,7 +841,8 @@ export class BrowserWebCodecsService {
 					type: answer.type,
 					sdp: answer.sdp
 				},
-				tabId: this.sessionId
+				tabId: this.sessionId,
+				viewerId: this.viewerId
 			});
 		}
 	}
@@ -1359,14 +1408,18 @@ export class BrowserWebCodecsService {
 	 * Setup WebSocket event listeners
 	 */
 	private setupEventListeners(): void {
+		// Both of these are broadcast to everyone in the project, so the tab
+		// alone is not a precise enough address: another device watching the same
+		// tab has its own peer, and feeding it that peer's candidates produces a
+		// connection that never completes on either side.
 		const cleanupIce = ws.on('preview:browser-stream-ice', async (data) => {
-			if (data.sessionId === this.sessionId && data.from === 'headless') {
+			if (data.sessionId === this.sessionId && data.viewerId === this.viewerId && data.from === 'headless') {
 				await this.addIceCandidate(data.candidate);
 			}
 		});
 
 		const cleanupState = ws.on('preview:browser-stream-state', (data) => {
-			if (data.sessionId === this.sessionId) {
+			if (data.sessionId === this.sessionId && data.viewerId === this.viewerId) {
 				debug.log('webcodecs', `Server connection state: ${data.state}`);
 			}
 		});
@@ -1467,7 +1520,12 @@ export class BrowserWebCodecsService {
 	 * Add ICE candidate (+ loopback variant for VPN compatibility)
 	 */
 	private async addIceCandidate(candidate: RTCIceCandidateInit): Promise<void> {
-		if (!this.peerConnection) return;
+		// Held rather than dropped: a candidate is only addable once the answer
+		// side has a remote description, and these routinely arrive first.
+		if (!this.peerConnection || !this.hasRemoteDescription) {
+			this.pendingRemoteCandidates.push(candidate);
+			return;
+		}
 
 		try {
 			await this.peerConnection.addIceCandidate(new RTCIceCandidate(candidate));
@@ -1548,6 +1606,7 @@ export class BrowserWebCodecsService {
 
 		ws.http('preview:browser-stream-feedback', {
 			tabId: this.sessionId,
+			viewerId: this.viewerId,
 			decodeQueueSize: this.lastFeedback.decodeQueueSize,
 			decodeLatencyMs: this.lastFeedback.decodeLatencyMs,
 			dropRatio: this.lastFeedback.dropRatio
@@ -1591,6 +1650,7 @@ export class BrowserWebCodecsService {
 		debug.log('webcodecs', `Viewer ${visible ? 'visible' : 'hidden'} — ${visible ? 'resuming' : 'suspending'} capture`);
 		ws.http('preview:browser-stream-visibility', {
 			tabId: this.sessionId,
+			viewerId: this.viewerId,
 			visible
 		}).catch(() => {});
 	}
@@ -1605,6 +1665,7 @@ export class BrowserWebCodecsService {
 		const metrics = this.currentDisplayMetrics();
 		ws.http('preview:browser-stream-display', {
 			tabId: this.sessionId,
+			viewerId: this.viewerId,
 			scale: metrics.scale,
 			dpr: metrics.dpr
 		}).catch(() => {});
@@ -1703,6 +1764,8 @@ export class BrowserWebCodecsService {
 		this.isCleaningUp = false;
 		this.stats.firstFrameRendered = false;
 		this.isNavigating = false;
+		this.pendingRemoteCandidates = [];
+		this.hasRemoteDescription = false;
 
 		this.sessionId = sessionId;
 		this.canvas = canvas;
@@ -1729,7 +1792,7 @@ export class BrowserWebCodecsService {
 			await this.createPeerConnection();
 
 			// Get offer from backend's existing peer (don't start new streaming)
-			const offerResponse = await ws.http('preview:browser-stream-offer', { tabId: sessionId }, 10000);
+			const offerResponse = await ws.http('preview:browser-stream-offer', { tabId: sessionId, viewerId: this.viewerId }, 10000);
 			if (offerResponse.offer) {
 				await this.handleOffer({
 					type: offerResponse.offer.type as RTCSdpType,
@@ -1884,7 +1947,7 @@ export class BrowserWebCodecsService {
 
 		// Notify server with explicit tabId (fire-and-forget for speed during rapid switching)
 		if (this.sessionId) {
-			ws.http('preview:browser-stream-stop', { tabId: this.sessionId }).catch(() => {});
+			ws.http('preview:browser-stream-stop', { tabId: this.sessionId, viewerId: this.viewerId }).catch(() => {});
 		}
 
 		// Drop the worker's decoder state too, or the next stream would resume

--- a/frontend/services/preview/browser/host-bridge.service.ts
+++ b/frontend/services/preview/browser/host-bridge.service.ts
@@ -1,0 +1,584 @@
+/**
+ * Preview Host Bridge (viewer side)
+ *
+ * Answers the capability requests the headless browser cannot satisfy itself.
+ * Every handler here runs a real Web API on the viewer's device, so the page
+ * being previewed sees the same thing it would see if the user had opened it in
+ * their own browser: their location, their camera, their clipboard.
+ *
+ * Requests split into two groups:
+ * - **Silent.** Device enumeration, clipboard writes and notification delivery
+ *   carry no privacy decision the user has not already made, so they are
+ *   answered immediately.
+ * - **Prompted.** Location, camera, microphone, clipboard reads, notification
+ *   permission and file selection surface a prompt first. The prompt is not
+ *   decoration: Safari only grants `getUserMedia` and `clipboard.read` to a
+ *   user gesture, so the API call has to originate from the click on Allow.
+ */
+
+import ws from '$frontend/utils/ws';
+import { debug } from '$shared/utils/logger';
+import type {
+	BrowserDownloadEvent,
+	BrowserHostRequestEvent,
+	HostRequestKind,
+	PendingPermission
+} from '$frontend/utils/native-ui';
+
+export interface HostBridgeCallbacks {
+	/** Show a prompt and resolve once the user decides. */
+	onPermissionRequest: (request: PendingPermission) => void;
+	/** Ask the viewer to pick files for an intercepted file input. */
+	onFilePickRequest: (request: PendingPermission) => void;
+	/**
+	 * A pending request no longer needs an answer — another viewer gave one, it
+	 * timed out, or its tab closed.
+	 */
+	onRequestSettled?: (request: { tabId: string; requestId: string }) => void;
+	/** Surface a relayed download so the user can see it land. */
+	onDownload?: (event: BrowserDownloadEvent) => void;
+	/** Resolve the origin shown in the prompt, so it reads like a real one. */
+	getTabOrigin: (tabId: string) => string;
+}
+
+/** Kinds that must wait for an explicit decision before touching a device API. */
+const PROMPTED: ReadonlySet<HostRequestKind> = new Set([
+	'geolocation',
+	'media-request',
+	'clipboard-read',
+	'notification-permission',
+	// Recognition opens the microphone on the viewer's device, and Chrome only
+	// starts it from a user gesture — the Allow click supplies both.
+	'speech-start'
+]);
+
+/** Ceiling on a single file handed to a page, matching the download relay. */
+const MAX_UPLOAD_BYTES = 32 * 1024 * 1024;
+
+export class PreviewHostBridge {
+	private callbacks: HostBridgeCallbacks | null = null;
+
+	/** Live camera/mic relays, keyed by the session id the page holds. */
+	private mediaSessions = new Map<string, { pc: RTCPeerConnection; stream: MediaStream }>();
+
+	/** Live speech-recognition runs, keyed by the page's session id. */
+	private speechSessions = new Map<string, any>();
+
+	private unsubscribers: Array<() => void> = [];
+
+	// Public STUN so the relay still connects when the viewer and the server are
+	// on different networks — mirrors the preview stream's own configuration.
+	private readonly iceServers: RTCIceServer[] = [
+		{ urls: 'stun:stun.l.google.com:19302' },
+		{ urls: 'stun:stun1.l.google.com:19302' }
+	];
+
+	start(callbacks: HostBridgeCallbacks): () => void {
+		this.callbacks = callbacks;
+
+		this.unsubscribers = [
+			// `kind` widens to `string` across the wire schema; the union it must
+			// belong to is enforced by the backend that emits it.
+			ws.on('preview:browser-host-request', (event) => {
+				void this.handleRequest(event as BrowserHostRequestEvent);
+			}),
+			ws.on('preview:browser-download', (event: BrowserDownloadEvent) => {
+				this.handleDownload(event);
+			}),
+			// The page asks once, but every viewer of the tab is prompted. Only the
+			// first answer reaches the page, so the rest have to be told to stop
+			// asking rather than being left holding a decision that no longer
+			// matters.
+			ws.on('preview:browser-host-request-settled', (event) => {
+				this.callbacks?.onRequestSettled?.(event);
+			})
+		];
+
+		return () => this.stop();
+	}
+
+	stop(): void {
+		for (const unsubscribe of this.unsubscribers) unsubscribe();
+		this.unsubscribers = [];
+
+		for (const session of this.mediaSessions.values()) {
+			this.closeMediaSession(session);
+		}
+		this.mediaSessions.clear();
+
+		for (const sessionId of Array.from(this.speechSessions.keys())) {
+			this.stopSpeechSession(sessionId, true);
+		}
+		this.speechSessions.clear();
+
+		this.callbacks = null;
+	}
+
+	// ── Request routing ─────────────────────────────────────────────────────
+
+	private async handleRequest(event: BrowserHostRequestEvent): Promise<void> {
+		if (PROMPTED.has(event.kind) || event.kind === 'file-pick') {
+			const pending: PendingPermission = {
+				requestId: event.requestId,
+				tabId: event.tabId,
+				kind: event.kind,
+				payload: event.payload,
+				origin: this.callbacks?.getTabOrigin(event.tabId) ?? 'This page'
+			};
+
+			if (event.kind === 'file-pick') {
+				this.callbacks?.onFilePickRequest(pending);
+			} else {
+				this.callbacks?.onPermissionRequest(pending);
+			}
+			return;
+		}
+
+		try {
+			const result = await this.runSilent(event);
+			this.respond(event.requestId, { ok: true, result });
+		} catch (error) {
+			this.respond(event.requestId, { ok: false, error: this.toWireError(error) });
+		}
+	}
+
+	/** Requests that carry no decision for the user to make. */
+	private async runSilent(event: BrowserHostRequestEvent): Promise<unknown> {
+		switch (event.kind) {
+			case 'speech-stop':
+				this.stopSpeechSession(String(event.payload?.sessionId ?? ''), !!event.payload?.abort);
+				return true;
+
+			case 'clipboard-write':
+				await navigator.clipboard.writeText(String(event.payload?.text ?? ''));
+				return true;
+
+			case 'media-devices': {
+				const devices = await navigator.mediaDevices.enumerateDevices();
+				return devices.map((device) => ({
+					deviceId: device.deviceId,
+					groupId: device.groupId,
+					kind: device.kind,
+					label: device.label
+				}));
+			}
+
+			case 'media-stop':
+				this.stopMediaSession(String(event.payload?.sessionId ?? ''));
+				return true;
+
+			case 'notification-show': {
+				// Only deliver if the viewer already granted it; asking here would
+				// pop a prompt with no context about which page wanted it.
+				if (typeof Notification === 'undefined' || Notification.permission !== 'granted') {
+					throw this.namedError('NotAllowedError', 'Notifications are not permitted');
+				}
+				new Notification(String(event.payload?.title ?? ''), {
+					body: event.payload?.body,
+					icon: event.payload?.icon,
+					tag: event.payload?.tag
+				});
+				return true;
+			}
+
+			default:
+				throw this.namedError('NotSupportedError', `Unsupported host request: ${event.kind}`);
+		}
+	}
+
+	// ── Prompted requests, resolved from the user's click ────────────────────
+
+	/**
+	 * Run the real API for a request the user just approved.
+	 *
+	 * Must be called synchronously from the Allow handler — the whole reason the
+	 * prompt exists is to give these calls a user gesture to run inside.
+	 */
+	async approve(pending: PendingPermission): Promise<void> {
+		try {
+			const result = await this.runApproved(pending);
+			this.respond(pending.requestId, { ok: true, result });
+		} catch (error) {
+			this.respond(pending.requestId, { ok: false, error: this.toWireError(error) });
+		}
+	}
+
+	/** Answer a prompt with a refusal, shaped the way each API reports one. */
+	deny(pending: PendingPermission): void {
+		if (pending.kind === 'notification-permission') {
+			// requestPermission() resolves with 'denied' rather than rejecting.
+			this.respond(pending.requestId, { ok: true, result: false });
+			return;
+		}
+
+		this.respond(pending.requestId, {
+			ok: false,
+			error: {
+				name: 'NotAllowedError',
+				message: 'Permission denied by the user',
+				// GeolocationPositionError.PERMISSION_DENIED
+				code: 1
+			}
+		});
+	}
+
+	/** Hand the chosen files to an intercepted file input (empty = cancelled). */
+	async submitFiles(pending: PendingPermission, files: File[]): Promise<void> {
+		try {
+			const encoded = [];
+			for (const file of files) {
+				if (file.size > MAX_UPLOAD_BYTES) {
+					throw this.namedError(
+						'NotReadableError',
+						`"${file.name}" is larger than the ${Math.round(MAX_UPLOAD_BYTES / 1024 / 1024)}MB preview upload limit`
+					);
+				}
+				encoded.push({ name: file.name, data: await this.toBase64(file) });
+			}
+
+			this.respond(pending.requestId, { ok: true, result: { files: encoded } });
+		} catch (error) {
+			this.respond(pending.requestId, { ok: false, error: this.toWireError(error) });
+		}
+	}
+
+	private async runApproved(pending: PendingPermission): Promise<unknown> {
+		switch (pending.kind) {
+			case 'geolocation':
+				return await this.readPosition(pending.payload);
+
+			case 'clipboard-read':
+				return await navigator.clipboard.readText();
+
+			case 'notification-permission': {
+				if (typeof Notification === 'undefined') return false;
+				const outcome =
+					Notification.permission === 'granted' ? 'granted' : await Notification.requestPermission();
+				return outcome === 'granted';
+			}
+
+			case 'media-request':
+				return await this.startMediaRelay(pending);
+
+			case 'speech-start':
+				return this.startSpeechRelay(pending);
+
+			default:
+				throw this.namedError('NotSupportedError', `Unsupported host request: ${pending.kind}`);
+		}
+	}
+
+	// ── Speech recognition relay ────────────────────────────────────────────
+
+	/**
+	 * Run recognition on the viewer's device and stream the results back.
+	 *
+	 * Headless Chrome ships no speech engine, so `SpeechRecognition` there always
+	 * fails with `not-allowed` no matter what permissions are granted. The
+	 * viewer's browser has both the engine and the microphone, so recognition
+	 * happens there and only the transcripts travel.
+	 */
+	private startSpeechRelay(pending: PendingPermission): boolean {
+		const Recognition =
+			(window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
+
+		if (!Recognition) {
+			throw this.namedError('NotSupportedError', 'This browser has no speech recognition engine');
+		}
+
+		const sessionId = String(pending.payload?.sessionId ?? '');
+		if (!sessionId) {
+			throw this.namedError('DataError', 'Speech session id missing');
+		}
+
+		// Starting a second run for the same id would leave the first orphaned,
+		// holding the microphone open with nothing listening to it.
+		this.stopSpeechSession(sessionId, true);
+
+		const recognition = new Recognition();
+		recognition.lang = pending.payload?.lang || navigator.language;
+		recognition.continuous = !!pending.payload?.continuous;
+		recognition.interimResults = !!pending.payload?.interimResults;
+		recognition.maxAlternatives = pending.payload?.maxAlternatives ?? 1;
+
+		recognition.onresult = (event: any) => {
+			const results = [];
+			for (let i = event.resultIndex; i < event.results.length; i += 1) {
+				const result = event.results[i];
+				const alternatives = [];
+				for (let j = 0; j < result.length; j += 1) {
+					alternatives.push({
+						transcript: result[j].transcript,
+						confidence: result[j].confidence
+					});
+				}
+				results.push({ isFinal: result.isFinal, alternatives });
+			}
+
+			this.sendEvent(pending.tabId, 'speech-result', {
+				sessionId,
+				resultIndex: event.resultIndex,
+				results
+			});
+		};
+
+		recognition.onerror = (event: any) => {
+			this.sendEvent(pending.tabId, 'speech-error', {
+				sessionId,
+				error: event.error,
+				message: event.message
+			});
+		};
+
+		recognition.onend = () => {
+			this.speechSessions.delete(sessionId);
+			this.sendEvent(pending.tabId, 'speech-end', { sessionId });
+		};
+
+		recognition.start();
+		this.speechSessions.set(sessionId, recognition);
+
+		return true;
+	}
+
+	private stopSpeechSession(sessionId: string, abort: boolean): void {
+		const recognition = this.speechSessions.get(sessionId);
+		if (!recognition) return;
+
+		if (abort) this.speechSessions.delete(sessionId);
+
+		try {
+			// `abort()` drops pending audio; `stop()` finishes the current phrase
+			// first, which is what the page asked for when it called stop().
+			if (abort) recognition.abort();
+			else recognition.stop();
+		} catch {
+			// Already finished.
+		}
+	}
+
+	private readPosition(options: PositionOptions | undefined): Promise<Record<string, number | null>> {
+		return new Promise((resolve, reject) => {
+			if (!navigator.geolocation) {
+				reject(this.namedError('PositionUnavailableError', 'This device has no geolocation', 2));
+				return;
+			}
+
+			navigator.geolocation.getCurrentPosition(
+				(position) =>
+					resolve({
+						latitude: position.coords.latitude,
+						longitude: position.coords.longitude,
+						accuracy: position.coords.accuracy,
+						altitude: position.coords.altitude,
+						altitudeAccuracy: position.coords.altitudeAccuracy,
+						heading: position.coords.heading,
+						speed: position.coords.speed,
+						timestamp: position.timestamp
+					}),
+				(error) => reject(this.namedError('NotAllowedError', error.message, error.code)),
+				{
+					enableHighAccuracy: !!options?.enableHighAccuracy,
+					timeout: options?.timeout ?? 20000,
+					maximumAge: options?.maximumAge ?? 0
+				}
+			);
+		});
+	}
+
+	// ── Camera / microphone relay ───────────────────────────────────────────
+
+	/**
+	 * Capture from the viewer's device and answer the page's offer with those
+	 * tracks. The page opened a recvonly connection, so all that is needed here
+	 * is to attach the real tracks and reply — no renegotiation.
+	 */
+	private async startMediaRelay(pending: PendingPermission): Promise<{ sdp: string; sessionId: string }> {
+		const wantsVideo = !!pending.payload?.video;
+		const wantsAudio = !!pending.payload?.audio;
+
+		// A display request opens the viewer's own screen picker; a camera request
+		// opens their device. Both end up as tracks on the same relay.
+		const stream = pending.payload?.display
+			? await navigator.mediaDevices.getDisplayMedia({
+					video: pending.payload?.constraints?.video ?? true,
+					audio: wantsAudio
+				})
+			: await navigator.mediaDevices.getUserMedia({
+					video: wantsVideo ? (pending.payload?.constraints?.video ?? true) : false,
+					audio: wantsAudio ? (pending.payload?.constraints?.audio ?? true) : false
+				});
+
+		const pc = new RTCPeerConnection({ iceServers: this.iceServers });
+
+		try {
+			// Remote description first, tracks second. The page offered specific
+			// recvonly transceivers; adding tracks beforehand would create fresh
+			// ones and the answer would come back with mismatched m-lines.
+			await pc.setRemoteDescription({ type: 'offer', sdp: String(pending.payload?.sdp ?? '') });
+
+			for (const track of stream.getTracks()) {
+				const transceiver = pc
+					.getTransceivers()
+					.find((candidate) => candidate.receiver.track?.kind === track.kind && !candidate.sender.track);
+
+				if (transceiver) {
+					await transceiver.sender.replaceTrack(track);
+					transceiver.direction = 'sendonly';
+				} else {
+					pc.addTrack(track, stream);
+				}
+			}
+
+			const answer = await pc.createAnswer();
+			await pc.setLocalDescription(answer);
+			await this.waitForIce(pc);
+		} catch (error) {
+			this.closeMediaSession({ pc, stream });
+			throw error;
+		}
+
+		const sessionId = `${pending.tabId}:${pending.requestId}`;
+		this.mediaSessions.set(sessionId, { pc, stream });
+
+		// The page can navigate away without ever calling stop(); dropping the
+		// relay when the connection dies releases the camera light either way.
+		pc.addEventListener('connectionstatechange', () => {
+			if (pc.connectionState === 'failed' || pc.connectionState === 'closed') {
+				this.stopMediaSession(sessionId);
+			}
+		});
+
+		return { sdp: pc.localDescription?.sdp ?? '', sessionId };
+	}
+
+	private waitForIce(pc: RTCPeerConnection): Promise<void> {
+		if (pc.iceGatheringState === 'complete') return Promise.resolve();
+
+		return new Promise((resolve) => {
+			let settled = false;
+			const finish = () => {
+				if (settled) return;
+				settled = true;
+				pc.removeEventListener('icegatheringstatechange', onChange);
+				resolve();
+			};
+			const onChange = () => {
+				if (pc.iceGatheringState === 'complete') finish();
+			};
+			pc.addEventListener('icegatheringstatechange', onChange);
+			// Signalling is non-trickle, so an unreachable STUN server must not
+			// hold the answer back past what host candidates alone can carry.
+			setTimeout(finish, 2500);
+		});
+	}
+
+	private stopMediaSession(sessionId: string): void {
+		const session = this.mediaSessions.get(sessionId);
+		if (!session) return;
+		this.mediaSessions.delete(sessionId);
+		this.closeMediaSession(session);
+	}
+
+	private closeMediaSession(session: { pc: RTCPeerConnection; stream: MediaStream }): void {
+		for (const track of session.stream.getTracks()) {
+			try {
+				track.stop();
+			} catch {
+				// Already stopped.
+			}
+		}
+		try {
+			session.pc.close();
+		} catch {
+			// Already closed.
+		}
+	}
+
+	// ── Downloads ───────────────────────────────────────────────────────────
+
+	/**
+	 * Save a file the previewed page downloaded onto the viewer's machine, which
+	 * is the only place a download is any use.
+	 */
+	private handleDownload(event: BrowserDownloadEvent): void {
+		this.callbacks?.onDownload?.(event);
+
+		if (event.state !== 'completed' || !event.data) return;
+
+		try {
+			const binary = atob(event.data);
+			const bytes = new Uint8Array(binary.length);
+			for (let i = 0; i < binary.length; i += 1) {
+				bytes[i] = binary.charCodeAt(i);
+			}
+
+			const url = URL.createObjectURL(new Blob([bytes]));
+			const anchor = document.createElement('a');
+			anchor.href = url;
+			anchor.download = event.filename || 'download';
+			document.body.appendChild(anchor);
+			anchor.click();
+			anchor.remove();
+			// Revoke on the next tick — Safari cancels the download if the object
+			// URL disappears while the click is still being processed.
+			setTimeout(() => URL.revokeObjectURL(url), 1000);
+		} catch (error) {
+			debug.error('preview', 'Failed to save relayed download:', error);
+		}
+	}
+
+	// ── Plumbing ────────────────────────────────────────────────────────────
+
+	/** Push a streamed result down to the page that is waiting on it. */
+	private sendEvent(tabId: string, kind: string, payload: unknown): void {
+		try {
+			ws.emit('preview:browser-host-event', { tabId, kind, payload });
+		} catch (error) {
+			debug.error('preview', 'Failed to deliver host event:', error);
+		}
+	}
+
+	private respond(
+		requestId: string,
+		response: { ok: boolean; result?: unknown; error?: { name?: string; message?: string; code?: number } }
+	): void {
+		try {
+			ws.emit('preview:browser-host-response', { requestId, ...response });
+		} catch (error) {
+			debug.error('preview', 'Failed to answer host request:', error);
+		}
+	}
+
+	private toWireError(error: unknown): { name?: string; message?: string; code?: number } {
+		if (error instanceof Error) {
+			return {
+				name: error.name,
+				message: error.message,
+				code: (error as Error & { code?: number }).code
+			};
+		}
+		return { name: 'UnknownError', message: String(error) };
+	}
+
+	private namedError(name: string, message: string, code?: number): Error {
+		const error = new Error(message);
+		error.name = name;
+		if (typeof code === 'number') (error as Error & { code?: number }).code = code;
+		return error;
+	}
+
+	private toBase64(file: File): Promise<string> {
+		return new Promise((resolve, reject) => {
+			const reader = new FileReader();
+			reader.onload = () => {
+				const result = String(reader.result ?? '');
+				resolve(result.slice(result.indexOf(',') + 1));
+			};
+			reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'));
+			reader.readAsDataURL(file);
+		});
+	}
+}
+
+export const previewHostBridge = new PreviewHostBridge();

--- a/frontend/services/preview/index.ts
+++ b/frontend/services/preview/index.ts
@@ -7,8 +7,9 @@
 // Browser-specific services
 // Note: Session service removed - operations now in browser-tab-operations.svelte.ts module
 export { browserConsoleService } from './browser/browser-console.service';
-export type { ConsoleMessage } from './browser/browser-console.service';
 export { BrowserWebCodecsService } from './browser/browser-webcodecs.service';
+export { previewHostBridge, PreviewHostBridge } from './browser/host-bridge.service';
+export type { HostBridgeCallbacks } from './browser/host-bridge.service';
 
 // MCP Preview Integration
 export {

--- a/frontend/stores/features/preview-tabs-workspace.svelte.ts
+++ b/frontend/stores/features/preview-tabs-workspace.svelte.ts
@@ -93,6 +93,12 @@ function materializeBackendTab(backendTab: ExistingTabInfo): string {
 		},
 		url: backendTab.url,
 		title: backendTab.title || getTabTitle(backendTab.url),
+		// Recovered from the live backend tab, so a page refresh restores the tab
+		// strip as it was instead of dropping to the placeholder until the user
+		// reloads the page itself.
+		favicon: backendTab.favicon,
+		canGoBack: backendTab.canGoBack ?? false,
+		canGoForward: backendTab.canGoForward ?? false,
 		deviceSize: backendTab.deviceSize as DeviceSize,
 		rotation: backendTab.rotation as Rotation,
 		isConnected: true,
@@ -372,6 +378,23 @@ export function initPreviewTabSync(): void {
 
 		const tab = previewTabManager.tabs.find((t) => t.sessionId === data.newTabId);
 		if (tab) previewTabManager.switchTab(tab.id);
+	});
+
+	// Live tab metadata: the page's own title and favicon, plus whether
+	// Back/Forward can go anywhere. Registered here rather than in the panel so
+	// the dock's tab strip stays current even while the panel is unmounted.
+	ws.on('preview:browser-tab-meta' as any, (data: any) => {
+		if (!isEventForActiveProject(data)) return;
+
+		const tab = previewTabManager.tabs.find((t) => t.sessionId === data.tabId);
+		if (!tab) return;
+
+		previewTabManager.updateTab(tab.id, {
+			title: data.title || getTabTitle(data.url),
+			favicon: data.favicon,
+			canGoBack: data.canGoBack,
+			canGoForward: data.canGoForward
+		});
 	});
 
 	ws.on('preview:browser-viewport-changed' as any, (data: any) => {

--- a/frontend/stores/features/terminal.svelte.ts
+++ b/frontend/stores/features/terminal.svelte.ts
@@ -133,6 +133,25 @@ export const terminalStore = {
 		return sessionId;
 	},
 
+	/**
+	 * Move a session so it sits where `targetSessionId` currently is.
+	 *
+	 * Tab order is user-arranged state, so the reorder mutates the session list
+	 * itself rather than being a render-time sort.
+	 */
+	reorderSession(sessionId: string, targetSessionId: string): void {
+		if (sessionId === targetSessionId) return;
+
+		const from = terminalState.sessions.findIndex((session) => session.id === sessionId);
+		const to = terminalState.sessions.findIndex((session) => session.id === targetSessionId);
+		if (from === -1 || to === -1) return;
+
+		const next = [...terminalState.sessions];
+		const [moved] = next.splice(from, 1);
+		next.splice(to, 0, moved);
+		terminalState.sessions = next;
+	},
+
 	switchToSession(sessionId: string): void {
 		// Check for duplicates before switching
 		const uniqueIds = new Set<string>();

--- a/frontend/utils/native-ui.ts
+++ b/frontend/utils/native-ui.ts
@@ -1,6 +1,9 @@
 /**
  * Frontend Native UI Types
- * For dialog, select dropdown, and context menu overlays
+ *
+ * Everything the headless browser hands back for the viewer to render itself:
+ * dialogs, select dropdowns, context menus, console output, and the capability
+ * requests the preview cannot answer without the viewer's own browser.
  */
 
 // Dialog types
@@ -25,6 +28,9 @@ export interface BrowserSelectOption {
 	text: string;
 	selected: boolean;
 	disabled?: boolean;
+	/** `<optgroup>` label this option belongs to, if any. */
+	group?: string;
+	groupDisabled?: boolean;
 }
 
 export interface BrowserSelectInfo {
@@ -53,21 +59,172 @@ export interface BrowserContextMenuItem {
 	submenu?: BrowserContextMenuItem[];
 }
 
+export interface BrowserContextMenuElementInfo {
+	tagName: string;
+	isLink: boolean;
+	isImage: boolean;
+	isInput: boolean;
+	/** Inputs plus contenteditable regions. */
+	isEditable: boolean;
+	isTextSelected: boolean;
+	selectedText?: string;
+	linkUrl?: string;
+	linkText?: string;
+	imageUrl?: string;
+	mediaUrl?: string;
+	mediaType?: string;
+	inputType?: string;
+	pageUrl?: string;
+}
+
 export interface BrowserContextMenuInfo {
 	sessionId: string;
 	menuId: string;
 	x: number;
 	y: number;
 	items: BrowserContextMenuItem[];
-	elementInfo: {
-		tagName: string;
-		isLink: boolean;
-		isImage: boolean;
-		isInput: boolean;
-		isTextSelected: boolean;
-		linkUrl?: string;
-		imageUrl?: string;
-		inputType?: string;
+	elementInfo: BrowserContextMenuElementInfo;
+	timestamp: number;
+}
+
+/**
+ * An input whose picker Chrome renders outside the page.
+ *
+ * Colour swatches and the date/time family open browser-process popups that the
+ * screencast cannot see, so the viewer renders the equivalent control instead.
+ */
+export interface BrowserNativePickerInfo {
+	sessionId: string;
+	pickerId: string;
+	inputType: 'color' | 'date' | 'datetime-local' | 'month' | 'time' | 'week';
+	value: string;
+	min?: string;
+	max?: string;
+	step?: string;
+	boundingBox: {
+		x: number;
+		y: number;
+		width: number;
+		height: number;
 	};
 	timestamp: number;
+}
+
+/**
+ * A console argument, flattened in the page so it can be rendered and expanded
+ * without holding a live reference to the original object.
+ */
+export interface BrowserConsoleValue {
+	type:
+		| 'string'
+		| 'number'
+		| 'boolean'
+		| 'null'
+		| 'undefined'
+		| 'bigint'
+		| 'symbol'
+		| 'function'
+		| 'array'
+		| 'object'
+		| 'error'
+		| 'node'
+		| 'date'
+		| 'regexp'
+		| 'map'
+		| 'set';
+	preview: string;
+	entries?: Array<{ key: string; value: BrowserConsoleValue }>;
+	truncated?: boolean;
+}
+
+export type BrowserConsoleType =
+	| 'log'
+	| 'info'
+	| 'warn'
+	| 'error'
+	| 'debug'
+	| 'trace'
+	| 'clear'
+	| 'input'
+	| 'result';
+
+export interface BrowserConsoleMessage {
+	id: string;
+	type: BrowserConsoleType;
+	text: string;
+	values?: BrowserConsoleValue[];
+	location?: {
+		url: string;
+		lineNumber: number;
+		columnNumber: number;
+	};
+	stackTrace?: string;
+	status?: number;
+	/** Repeat counter for identical consecutive messages. */
+	count?: number;
+	timestamp: number;
+}
+
+/** Live tab metadata pushed after every navigation. */
+export interface BrowserTabMetaEvent {
+	projectId: string;
+	tabId: string;
+	url: string;
+	title: string;
+	favicon?: string;
+	canGoBack: boolean;
+	canGoForward: boolean;
+	timestamp: number;
+}
+
+/**
+ * Capabilities the headless browser routes to the viewer's own browser.
+ * Each one maps to a real Web API call made on the viewer's device.
+ */
+export type HostRequestKind =
+	| 'geolocation'
+	| 'media-request'
+	| 'media-stop'
+	| 'media-devices'
+	| 'clipboard-read'
+	| 'clipboard-write'
+	| 'notification-permission'
+	| 'notification-show'
+	| 'speech-start'
+	| 'speech-stop'
+	| 'file-pick';
+
+export interface BrowserHostRequestEvent {
+	tabId: string;
+	requestId: string;
+	kind: HostRequestKind;
+	payload: any;
+	timestamp: number;
+}
+
+export interface BrowserDownloadEvent {
+	tabId: string;
+	downloadId: string;
+	filename: string;
+	url: string;
+	state: 'started' | 'completed' | 'failed';
+	data?: string;
+	totalBytes?: number;
+	error?: string;
+	timestamp: number;
+}
+
+/**
+ * A capability request waiting on the user's decision.
+ *
+ * Kept separate from the raw event because the prompt outlives it, and because
+ * `Allow` has to run the real Web API call from inside the click handler —
+ * Safari only grants camera and microphone access to a user gesture.
+ */
+export interface PendingPermission {
+	requestId: string;
+	tabId: string;
+	kind: HostRequestKind;
+	payload: any;
+	origin: string;
 }


### PR DESCRIPTION
MCP
- Fix list_tabs always reporting an empty browser: tool handlers are invoked as handler(args), so a positional projectId received {}, passed the falsy guard in getService(), and minted an empty service keyed by that object on every call.
- Reject non-string projectId in getService() so the same shape cannot fail silently again.

Iframes
- Resolve the frame that owns a point before evaluating. page.evaluate only sees the main frame, and elementFromPoint returns the <iframe> element itself — which is why selects, context menus, paste and media controls did nothing inside embedded pages.
- Sweep every frame when resolving a marked select or picker back to its element.
- Relay audio out of iframes: the DataChannel lives on the top frame, so an embedded player's audio encoded correctly and was then dropped.
- Inject the audio tap into every frame rather than the main one.

Navigation
- Add Back/Forward from CDP navigation history rather than history.length, baselined per tab so a fresh tab cannot reverse into its own about:blank.
- Swap Reload for Stop while loading, and make Stop call window.stop().
- Show the page's own title and favicon, restored from the backend so a client refresh keeps them; fall back to the placeholder when the icon fails to load.
- Add a scheme indicator and browser-standard shortcuts.
- Fix "Open Link in New Tab" opening two tabs: createNewTab schedules a launch and setting the URL also trips the URL watcher, so one link created two backend tabs — one unattachable and blank, and closing either took both down.

Fullscreen
- Shim the Fullscreen API to a CSS fullscreen. The real one resizes the renderer to the browser window, discarding the emulated viewport, so the page came back zoomed, off-centre and letterboxed — and stayed that way across a reload because the renderer keeps the state.

Coordinates
- Map against the rect the frame is actually painted into. The canvas is object-contain, so any bitmap/box aspect mismatch letterboxes the image and offsets every point — clicks landed up-and-left of the pointer after a rotation change, and the virtual cursor down-and-right on mobile.
- Derive the device frame's screen size from the same viewport helper the canvas bitmap uses, so the two cannot disagree mid-resize.
- Take the page's coordinate space from the emulated viewport rather than the canvas bitmap. The renderer sizes the backing store to the capture resolution, which follows fit-scale × pixel density and the host's pixel budget, so every point was scaled by capture ÷ viewport: exact whenever that ratio happened to be 1, and off by a few percent — growing toward the bottom-right — whenever it was not.
- Convert overlays back through the same helper, so select popups, context menus, pickers and the agent cursor cannot drift from the element they belong to.
- Keep the canvas API when a tab switch adopts per-tab state. It was copied from the incoming tab, which for a tab with no copy stored yet cleared it — and the canvas publishes its API once, so nothing put it back. Everything positional goes through it, so select popups and pickers silently stopped appearing after a tab switch.
- Report a failed page-to-screen conversion as such instead of the origin, so an overlay is skipped rather than drawn in the corner of the window.

Touch and keyboard
- Send scroll coordinates: CDP dispatches mouse.wheel at the last pointer position and touch scrolling never set one, so scrolls hit the wrong container and stranded hover state elsewhere.
- Drop gestures that begin outside the page. Touch listeners cover the whole panel for trackpad mode, so those arrived with out-of-range coordinates.
- Track the touch identifier so a second finger cannot hijack a gesture, and release on touchcancel.
- Decide the on-screen keyboard from the element under the finger, probed as the tap begins, instead of from focus state afterwards. Focus only settles once the tap has been handled, so the answer always described the previous tap: the first tap on a field did nothing and the second raised the keyboard, while a tap on empty space after typing raised it again. The answer is normally back before touchend, which is also the only moment iOS honours a programmatic focus.
- Leave the keyboard alone during a scroll or a long-press, and set the proxy's input mode from the field's own type.
- Long-press opens the context menu in direct-touch mode, as it does in every mobile browser.
- Start a drag after 4 pixels rather than 10, and let the move that starts one skip the pointer-move throttle. Nothing is dispatched until the threshold is crossed, because the press has to stay a candidate click — so the threshold was also how much of a text selection went missing before it began.

Native UI
- Rewrite the context menu and select popup: both were styled for prefers-color-scheme while the app switches dark mode by class, ignored the preview's fit-scale, clamped to the window instead of the panel, and only dismissed on mouse events.
- Preserve <optgroup> structure and leave inline list boxes to the page.
- Replace the pickers Chrome draws outside the page with an invisible native control laid over the real element, committing as the value changes.
- Draw the colour picker rather than delegating it. showPicker() needs transient activation, which a WebSocket event does not carry, so the invisible native input only opened on a second click — and on macOS what it opens is the system colour panel, which ignores the page's layout and stays up until dismissed on its own terms. Date and time keep the native control, whose popup anchors and closes correctly.
- Surface alert/confirm/prompt in an overlay. They were dead code — the handler was never wired and an auto-dismiss listener won every race — and window.alert would block the main thread and stall the decoder.
- Key dialogs and permission prompts by tab. A single global slot showed tab 1's prompt over tab 2, where answering it granted access to a page the user was not looking at.
- Take a dialog or permission prompt down on every device once anyone answers it. Both belong to the page and are answered once, but each viewer was shown its own copy — so the source now broadcasts when one is settled, including its own auto-dismiss.

Host capabilities
- Route geolocation, camera, microphone, screen capture, speech recognition, clipboard, file pickers and downloads to the viewer's own browser.
- Keep the pre-shim getDisplayMedia reachable for the preview's own capture pipeline, which otherwise asked the viewer for a capture source on every page load.
- Send Page.enable before intercepting file choosers; without it the Page domain emits nothing and file inputs did nothing at all.
- Bridge Ctrl+C/X/V explicitly: forwarded as keystrokes they would use the headless browser's clipboard, which nothing outside the preview can read.

Streaming
- Bind each page's signalling callbacks to its own tab. They resolved a session by taking the first active one in the project, so with several tabs streaming one page's ICE candidates, connection states, cursor and encoder stats were attributed to another tab. The viewer filters those by tab and dropped them, so the connection never completed — and since the first refresh frame is pushed from the connected state, a still page never produced a first frame either.
- Serve every viewer of a tab from one encoder instead of one connection. A second device's handshake used to tear down the first one's channel, whose health check reconnected and tore down the second's, so a preview watched from two places flickered between them and at least one side never left "Loading preview…".
- Carry a viewer id through every signalling message. The emit room is the whole project, so a tab alone does not say which peer a candidate belongs to.
- Pace the shared stream to the slowest viewer, intersect the codecs every viewer can decode, and capture for the sharpest screen watching. Encoded chunks are a delta chain, so they cannot be dropped for one viewer and kept for another.
- Fold viewer feedback into one verdict per window. Each viewer reports on its own timer, so the quality ladder stepped once per viewer and a healthy phone kept cancelling out a struggling laptop.
- Keep capture running until the last viewer detaches, pause it only once every viewer has the preview off screen, and drop a viewer whose socket closes without a stop.
- Buffer remote ICE candidates until there is a remote description to attach them to. The source starts gathering inside the stream-start request, so its host candidates routinely arrive before this side has a peer at all, and dropping them left the connection with nothing to try — the "Loading preview…" that only clears after a reload or two.
- Ask for a refresh frame when a DataChannel opens. The one pushed when the peer reported connected was encoded a moment earlier, with no open channel to send it on, and a still page never encodes anything again.

Console
- Subscribe to console events and render the panel, neither of which existed.
- Wrap output instead of scrolling sideways, keep Copy always visible, and make the prompt the last line of the transcript with multi-line entry.
- Dock to the bottom or the side depending on panel width.
- Flatten values in the page so DOM nodes, class instances and circular graphs survive, where jsonValue() threw and dropped them.

Tabs
- Give the Preview and Terminal strips real horizontal scrolling: the tab buttons compressed instead of overflowing, so the scroller never engaged and tabs became slivers.
- Add drag to reorder and wheel scrolling.
- Pin New Tab beside the last tab rather than at the far edge of the panel, sticking to the right edge only once the tabs overflow.
- Add Close All Tabs next to it. It confirms first, and leaves tabs an agent is driving open — closing one mid-run would fail the automation.