### PR TITLE
fix(preview): keep the stream, the cursor and the way out visible

### DIFF
--- a/backend/chat/stream-manager.ts
+++ b/backend/chat/stream-manager.ts
@@ -243,6 +243,22 @@ class StreamManager extends EventEmitter {
 		super();
 		// Increase max listeners for high concurrency
 		this.setMaxListeners(1000);
+
+		// MCP browser locks are scoped to a chat session, and every release path
+		// runs from this class. Teaching the lock manager how to check liveness
+		// closes the gap those paths can't: a tool call that lands after its
+		// stream ended used to be able to take a lock nothing would release.
+		browserMcpControl.setSessionLivenessProbe((chatSessionId) =>
+			this.isChatSessionStreaming(chatSessionId)
+		);
+	}
+
+	/** Whether any stream for this chat session is still running. */
+	private isChatSessionStreaming(chatSessionId: string): boolean {
+		for (const stream of this.activeStreams.values()) {
+			if (stream.chatSessionId === chatSessionId && stream.status === 'active') return true;
+		}
+		return false;
 	}
 
 	/**
@@ -1302,6 +1318,27 @@ class StreamManager extends EventEmitter {
 			}
 		}
 
+		// Abort first, then release the browser locks, and only then ask the
+		// engine to stop.
+		//
+		// The order matters and used to be the other way round. `engine.cancel()`
+		// is awaited for up to five seconds, and a browser-automation batch that
+		// was mid-flight kept resolving its target tab throughout — re-acquiring
+		// control of a tab moments after (or before) it was handed back, under a
+		// chat session whose release had already run. That is the interrupt that
+		// left the tab locked with nobody to unlock it. Aborting up front makes
+		// the batch stop between actions, and releasing before the wait means
+		// anything that slips through is refused rather than orphaned.
+		if (!streamState.abortController?.signal.aborted) {
+			streamState.abortController?.abort();
+		}
+
+		// Auto-release all MCP-controlled tabs for this chat session
+		if (streamState.chatSessionId) {
+			browserMcpControl.releaseSession(streamState.chatSessionId);
+			debug.log('mcp', `✅ Auto-released MCP tabs for session ${streamState.chatSessionId.slice(0, 8)} on stream cancellation`);
+		}
+
 		// Cancel the per-project engine with a bounded timeout.
 		// engine.cancel() stops the SDK process (Claude Code: close() kills subprocess,
 		// OpenCode: aborts controller + HTTP abort to server). If cancel() hangs
@@ -1320,14 +1357,6 @@ class StreamManager extends EventEmitter {
 			debug.error('chat', 'Error cancelling engine (non-fatal):', error);
 		}
 
-		// Abort the stream-manager's controller as a fallback.
-		// engine.cancel() already aborts the same controller, so this is
-		// typically a no-op but ensures cleanup if the engine timed out
-		// or wasn't active.
-		if (!streamState.abortController?.signal.aborted) {
-			streamState.abortController?.abort();
-		}
-
 		this.emitStreamEvent(streamState, 'cancelled', {
 			processId: streamState.processId,
 			timestamp: streamState.completedAt.toISOString()
@@ -1335,11 +1364,10 @@ class StreamManager extends EventEmitter {
 
 		this.emitStreamLifecycle(streamState, 'cancelled', reason);
 
-		// Auto-release all MCP-controlled tabs for this chat session
-		if (streamState.chatSessionId) {
-			browserMcpControl.releaseSession(streamState.chatSessionId);
-			debug.log('mcp', `✅ Auto-released MCP tabs for session ${streamState.chatSessionId.slice(0, 8)} on stream cancellation`);
-		}
+		// Sweep again after the engine has actually stopped: a tool call still
+		// in flight during the wait above may have taken a lock that its own
+		// release path will never reach.
+		browserMcpControl.releaseOrphans();
 
 		return true;
 	}

--- a/backend/mcp/internal/servers/browser-automation/actions/console.ts
+++ b/backend/mcp/internal/servers/browser-automation/actions/console.ts
@@ -9,6 +9,7 @@ import { commonFields } from './shared';
 export const consoleLogs: ActionDef = {
 	type: 'console_logs',
 	kind: 'control',
+	activity: 'Reading the console',
 	doc: `console_logs {limit?, level?} — the page's console output, oldest first.
   Where to look when an action "worked" but the page did not react: the error is usually here and invisible on screen.`,
 	schema: z.object({
@@ -37,6 +38,7 @@ export const consoleLogs: ActionDef = {
 export const clearConsole: ActionDef = {
 	type: 'clear_console',
 	kind: 'control',
+	activity: 'Clearing the console',
 	doc: `clear_console {} — drop stored console output.
   Put this before the step you are debugging so what follows is only that step's output.`,
 	schema: z.object({ type: z.literal('clear_console'), ...commonFields }),
@@ -49,6 +51,7 @@ export const clearConsole: ActionDef = {
 export const evaluate: ActionDef = {
 	type: 'eval',
 	kind: 'control',
+	activity: 'Running a script',
 	doc: `eval {expression} — run JavaScript in the page and return the result.
   For state that is not in the DOM: computed styles, localStorage, framework internals, window globals. The result must be JSON-serialisable.`,
 	schema: z.object({

--- a/backend/mcp/internal/servers/browser-automation/actions/inspect.ts
+++ b/backend/mcp/internal/servers/browser-automation/actions/inspect.ts
@@ -15,6 +15,7 @@ import { resolveWritePath } from '../paths';
 export const find: ActionDef = {
 	type: 'find',
 	kind: 'control',
+	activity: 'Looking for an element',
 	doc: `find {selector?, text?, role?, limit?} — locate elements and get their positions.
   Returns tag, text, a reusable selector and a centre point for each match, iframes included.
   This is the cheap alternative to a screenshot: to click something you can name, find it and click by selector — no image, no vision, no coordinate guessing.`,
@@ -60,6 +61,7 @@ export const find: ActionDef = {
 export const analyzeDom: ActionDef = {
 	type: 'analyze_dom',
 	kind: 'control',
+	activity: 'Reading the page',
 	doc: `analyze_dom {include?} — the page as text: links, headings, content, forms, metadata.
   The primary tool for reading and exploring. Far cheaper than a screenshot and it sees the whole document, not just the part currently on screen — scrolling to "see more" is never necessary.
   include: navigation | structure | content | forms | summary. Omit for all.
@@ -91,6 +93,7 @@ export const analyzeDom: ActionDef = {
 export const screenshot: ActionDef = {
 	type: 'screenshot',
 	kind: 'control',
+	activity: 'Taking a screenshot',
 	doc: `screenshot {fullPage?, selector?, format?, quality?, saveTo?, return?} — capture the page.
   Needed for what the DOM cannot express: canvases, charts, iframes, captchas, and any visual check of layout or styling.
   saveTo writes a file under the project directory; with return:"file" the image is not sent back at all, which is what makes "capture twenty pages" affordable.

--- a/backend/mcp/internal/servers/browser-automation/actions/navigation.ts
+++ b/backend/mcp/internal/servers/browser-automation/actions/navigation.ts
@@ -13,6 +13,7 @@ import { commonFields } from './shared';
 export const navigate: ActionDef = {
 	type: 'navigate',
 	kind: 'control',
+	activity: 'Navigating',
 	doc: `navigate {url} — load a URL in the current tab.
   Following a link you already have the href for is cheaper and far more reliable than clicking it. Session state (cookies, storage) is kept.`,
 	schema: z.object({
@@ -33,6 +34,7 @@ export const navigate: ActionDef = {
 export const goBack: ActionDef = {
 	type: 'go_back',
 	kind: 'control',
+	activity: 'Going back',
 	doc: `go_back {steps?} — walk back through the tab's history.`,
 	schema: z.object({
 		type: z.literal('go_back'),
@@ -50,6 +52,7 @@ export const goBack: ActionDef = {
 export const goForward: ActionDef = {
 	type: 'go_forward',
 	kind: 'control',
+	activity: 'Going forward',
 	doc: `go_forward {steps?} — walk forward through the tab's history.`,
 	schema: z.object({
 		type: z.literal('go_forward'),
@@ -67,6 +70,7 @@ export const goForward: ActionDef = {
 export const reload: ActionDef = {
 	type: 'reload',
 	kind: 'control',
+	activity: 'Reloading',
 	doc: `reload {hard?} — reload the page. hard bypasses the cache.`,
 	schema: z.object({
 		type: z.literal('reload'),
@@ -87,6 +91,7 @@ export const reload: ActionDef = {
 export const waitFor: ActionDef = {
 	type: 'wait_for',
 	kind: 'control',
+	activity: 'Waiting for the page',
 	doc: `wait_for {selector|text|urlContains|state, timeout?} — wait for the page to catch up.
   Returns the moment the condition holds, so it costs only what it has to.
   state: visible (default, with selector/text) · hidden · navigation · networkIdle.

--- a/backend/mcp/internal/servers/browser-automation/actions/tabs.ts
+++ b/backend/mcp/internal/servers/browser-automation/actions/tabs.ts
@@ -28,6 +28,7 @@ function defaultRotation(deviceSize: string): 'portrait' | 'landscape' {
 export const listTabs: ActionDef = {
 	type: 'list_tabs',
 	kind: 'control',
+	activity: 'Checking tabs',
 	doc: `list_tabs {} — every open tab with its id, URL, viewport and who controls it.
   Use the id, not the position, with switch_tab/close_tab.`,
 	schema: z.object({ type: z.literal('list_tabs'), ...commonFields }),
@@ -53,6 +54,7 @@ export const listTabs: ActionDef = {
 export const openTab: ActionDef = {
 	type: 'open_tab',
 	kind: 'control',
+	activity: 'Opening a tab',
 	doc: `open_tab {url?, deviceSize?, rotation?} — open a tab and make it the target.
   deviceSize: desktop 1920×1080 · laptop 1440×900 (default) · tablet 834×1194 · mobile 402×874.
   rotation defaults to landscape for desktop/laptop, portrait for tablet/mobile.`,
@@ -80,6 +82,7 @@ export const openTab: ActionDef = {
 export const switchTab: ActionDef = {
 	type: 'switch_tab',
 	kind: 'control',
+	activity: 'Switching tab',
 	doc: `switch_tab {tabId} — make another tab the target of following actions.`,
 	schema: z.object({
 		type: z.literal('switch_tab'),
@@ -94,6 +97,9 @@ export const switchTab: ActionDef = {
 		if (tab) {
 			const acquired = browserMcpControl.acquireControl(tab.id, ctx.chatSessionId, ctx.projectId);
 			if (!acquired) {
+				if (!browserMcpControl.isSessionLive(ctx.chatSessionId)) {
+					throw new Error('This chat session is no longer running — the browser was released when it stopped.');
+				}
 				const owner = browserMcpControl.getTabOwner(tab.id);
 				throw new Error(`Tab '${args.tabId}' is controlled by another chat session (${owner?.slice(0, 8)}...)`);
 			}
@@ -109,6 +115,7 @@ export const switchTab: ActionDef = {
 export const closeTab: ActionDef = {
 	type: 'close_tab',
 	kind: 'control',
+	activity: 'Closing a tab',
 	doc: `close_tab {tabId?} — close a tab (default: the current one).`,
 	schema: z.object({
 		type: z.literal('close_tab'),
@@ -135,6 +142,7 @@ export const closeTab: ActionDef = {
 export const setViewport: ActionDef = {
 	type: 'set_viewport',
 	kind: 'control',
+	activity: 'Changing the viewport',
 	doc: `set_viewport {deviceSize?, rotation?} — resize the current tab.
   Changing this re-runs the page's media queries, so it is how responsive layouts get tested.`,
 	schema: z.object({

--- a/backend/mcp/internal/servers/browser-automation/actions/types.ts
+++ b/backend/mcp/internal/servers/browser-automation/actions/types.ts
@@ -72,6 +72,16 @@ export interface ActionDef {
 	 * what stops it from reading a `tab` that may be null.
 	 */
 	needsTab?: boolean;
+	/**
+	 * Two or three words for the caption beside the agent's cursor while this
+	 * runs — "Navigating", "Taking a screenshot".
+	 *
+	 * Only `control` actions carry one. An `input` action's caption is written by
+	 * the interaction handler from the gesture itself, which is the only place
+	 * that knows whether a `type` is text or a keystroke, or a `click` is a right
+	 * click — and the runner has already coalesced the group by then anyway.
+	 */
+	activity?: string;
 	/** `input` actions: translate to the native gesture primitive. */
 	toInput?: (args: any, ctx: ActionContext) => BrowserAutonomousAction | Promise<BrowserAutonomousAction>;
 	/** `control` actions: run directly. */

--- a/backend/mcp/internal/servers/browser-automation/context.ts
+++ b/backend/mcp/internal/servers/browser-automation/context.ts
@@ -84,6 +84,12 @@ export async function getActiveTabSession(
 	if (existing) {
 		const acquired = browserMcpControl.acquireControl(existing.id, chatSessionId, resolvedProjectId);
 		if (!acquired) {
+			// Two very different refusals. Saying "another session" for both sent
+			// an agent looking for a tab conflict that does not exist, when what
+			// actually happened is that its own run was interrupted.
+			if (!browserMcpControl.isSessionLive(chatSessionId)) {
+				throw new Error('This chat session is no longer running — the browser was released when it stopped.');
+			}
 			const owner = browserMcpControl.getTabOwner(existing.id);
 			throw new Error(`Tab '${existing.id}' is controlled by another chat session (${owner?.slice(0, 8)}...). Use a different tab.`);
 		}

--- a/backend/mcp/internal/servers/browser-automation/runner.ts
+++ b/backend/mcp/internal/servers/browser-automation/runner.ts
@@ -23,6 +23,7 @@ import { debug } from '$shared/utils/logger';
 import { ACTIONS_BY_TYPE } from './actions';
 import type { ActionContext, ActionImage, TablessActionContext } from './actions/types';
 import { getActiveTabSession, getPreviewService, peekSessionTab } from './context';
+import { browserMcpControl } from '$backend/preview';
 
 interface ActionArgs {
 	type: string;
@@ -179,10 +180,24 @@ async function runControl(item: { index: number; args: ActionArgs }, deps: RunDe
 		return 1;
 	}
 
+	// Remembered rather than re-read in the `finally`: `close_tab` and
+	// `switch_tab` change what the current tab is, and the caption has to be
+	// taken off the tab it was put on.
+	let labelled: string | null = null;
+
 	try {
 		// The tab actions run on an empty browser — they are how it stops being
 		// empty. Everything else gets a tab opened for it first.
 		const tab = def.needsTab === false ? deps.peekTab() : await deps.resolveTab();
+
+		// Say what is about to happen while it happens. Input gestures label
+		// themselves from inside the engine (see ActionDef.activity); a control
+		// action has no gesture, and is often the longest step in a batch — a
+		// 30-second `wait_for` with a silent cursor on it reads as a hang.
+		if (tab && def.activity) {
+			labelled = tab.id;
+			browserMcpControl.emitActivity(tab.id, def.activity);
+		}
 
 		const output = await def.run(item.args, deps.makeContext(tab));
 		report.steps.push({ index: item.index, type: def.type, ok: true, summary: output.summary, detail: output.detail });
@@ -191,6 +206,11 @@ async function runControl(item: { index: number; args: ActionArgs }, deps: RunDe
 		const message = error instanceof Error ? error.message : 'Unknown error';
 		debug.warn('mcp', `browser action ${item.args.type} failed: ${message}`);
 		report.steps.push({ index: item.index, type: item.args.type, ok: false, error: message });
+	} finally {
+		// Back to a bare "Agent". The pointer stays for as long as the tab is
+		// held; only the caption is tied to a single action, and one left over
+		// from the last step describes a page that has already moved on.
+		if (labelled) browserMcpControl.emitActivity(labelled, null);
 	}
 
 	return 1;

--- a/backend/preview/browser/browser-host-bridge.ts
+++ b/backend/preview/browser/browser-host-bridge.ts
@@ -42,7 +42,11 @@ export type HostRequestKind =
 	// Not a capability and never shown to anyone: the page reporting that Chrome
 	// resized the renderer behind the emulation's back, so the host can put the
 	// viewport it captures from back the way it was. Answered by the service.
-	| 'viewport-restore';
+	| 'viewport-restore'
+	// Also not a capability: the page telling the host it is (or is no longer)
+	// showing something full screen, so the viewer can offer a way out that the
+	// page cannot lose. Answered by the service.
+	| 'fullscreen-state';
 
 export interface HostRequestEvent {
 	tabId: string;
@@ -112,7 +116,9 @@ const REQUEST_TIMEOUT_MS: Record<HostRequestKind, number> = {
 	'file-pick': 300_000,
 	// Nobody is asked anything — this is the host talking to itself, and the page
 	// is blocked on it while a screencast restarts.
-	'viewport-restore': 15_000
+	'viewport-restore': 15_000,
+	// A one-way notification; the page does not wait on the answer.
+	'fullscreen-state': 5_000
 };
 
 /**

--- a/backend/preview/browser/browser-interaction-handler.ts
+++ b/backend/preview/browser/browser-interaction-handler.ts
@@ -78,6 +78,56 @@ export class BrowserInteractionHandler extends EventEmitter {
 		browserMcpControl.emitCursorClick(sessionId, x, y, button);
 	}
 
+	/**
+	 * A few words for the caption beside the agent's pointer.
+	 *
+	 * Written from the watcher's side of the screen, not the agent's: it answers
+	 * "what is happening to my page right now", so it names the gesture rather
+	 * than the action type, and never carries a selector or the text being typed
+	 * — a password would end up on screen, and the caption has room for about
+	 * three words before it stops being a caption.
+	 */
+	private describeActivity(action: BrowserAutonomousAction): string {
+		switch (action.type) {
+			case 'click':
+				return action.button === 'right' ? 'Opening a menu' : 'Clicking';
+			case 'long_press':
+				return 'Holding';
+			case 'move':
+				return 'Moving';
+			case 'drag':
+				return 'Dragging';
+			case 'scroll':
+				return 'Scrolling';
+			case 'type':
+				return action.text !== undefined ? 'Typing' : 'Pressing a key';
+			case 'press':
+				return `Pressing ${action.keys || action.key}`;
+			case 'paste':
+				return 'Pasting';
+			case 'focus':
+				return 'Selecting a field';
+			case 'clear':
+				return 'Clearing a field';
+			case 'select_option':
+				return 'Choosing an option';
+			case 'upload':
+				return 'Attaching a file';
+			case 'tap':
+				return 'Tapping';
+			case 'swipe':
+				return 'Swiping';
+			case 'pinch':
+				return 'Zooming';
+			case 'extract_data':
+				return 'Reading the page';
+			case 'wait':
+				return 'Waiting';
+			default:
+				return 'Working';
+		}
+	}
+
 	// MCP-optimized mouse movement with smooth curves and ease-out easing
 	private async mcpMouseMove(
 		page: Page,
@@ -382,6 +432,25 @@ export class BrowserInteractionHandler extends EventEmitter {
 		isValidSession: () => boolean
 	): Promise<AutonomousRunOutcome> {
 		const results: BrowserActionResult[] = [];
+
+		try {
+			return await this.runBatch(sessionId, session, actions, isValidSession, results);
+		} finally {
+			// The agent keeps the tab between batches, so the pointer stays — but
+			// it is no longer doing the last thing it said it was, and a caption
+			// left reading "Typing" over a page nothing is typing into is worse
+			// than no caption at all.
+			browserMcpControl.emitActivity(sessionId, null);
+		}
+	}
+
+	private async runBatch(
+		sessionId: string,
+		session: BrowserTab,
+		actions: BrowserAutonomousAction[],
+		isValidSession: () => boolean,
+		results: BrowserActionResult[]
+	): Promise<AutonomousRunOutcome> {
 		const page = session.page;
 
 		// Store session ID on page for cursor tracking
@@ -402,6 +471,7 @@ export class BrowserInteractionHandler extends EventEmitter {
 			}
 
 			const action = actions[i];
+			browserMcpControl.emitActivity(sessionId, this.describeActivity(action));
 
 			try {
 				const outcome = await this.runAction(sessionId, session, action);

--- a/backend/preview/browser/browser-mcp-control.ts
+++ b/backend/preview/browser/browser-mcp-control.ts
@@ -41,8 +41,32 @@ export interface McpControlEvent {
 	timestamp: number;
 }
 
+/**
+ * Which of a project's locked tabs the agent is working on right now.
+ *
+ * A session accumulates tabs, and a lock says only "hands off". With several
+ * locked at once that leaves the user unable to tell where the agent actually
+ * is — they can watch any tab freely, but not know which one to watch.
+ * `browserTabId` is null when the project has no focused tab any more.
+ */
+export interface McpFocusEvent {
+	browserTabId: string | null;
+	projectId: string;
+	chatSessionId?: string;
+	timestamp: number;
+}
+
+/** Answers "does this chat session still have a stream running?". */
+export type SessionLivenessProbe = (chatSessionId: string) => boolean;
+
 export interface McpCursorEvent {
 	tabId: string;
+	/**
+	 * Owning project. Tab ids repeat across projects (`tab-1` exists in every
+	 * one), so a cursor broadcast to all of them could be drawn over a
+	 * same-numbered tab in a project the agent has never touched.
+	 */
+	projectId?: string;
 	x: number;
 	y: number;
 	/** Mouse button held down — the difference between a move and a drag. */
@@ -53,11 +77,30 @@ export interface McpCursorEvent {
 
 export interface McpClickEvent {
 	tabId: string;
+	projectId?: string;
 	x: number;
 	y: number;
 	button?: 'left' | 'right' | 'middle';
 	timestamp: number;
 	source: 'mcp';
+}
+
+/**
+ * What the agent is doing on a tab, in the user's words.
+ *
+ * The pointer alone says "something else is driving this" and nothing more,
+ * which is the wrong amount of information for a run that can hold a tab for
+ * minutes: a page changing on its own with a nameless cursor on it reads as a
+ * glitch. `label` is a two-or-three-word gloss of the action about to run —
+ * "Typing", "Clicking", "Navigating" — and rides next to the cursor.
+ *
+ * `null` means the agent still holds the tab but is between actions.
+ */
+export interface McpActivityEvent {
+	tabId: string;
+	projectId?: string;
+	label: string | null;
+	timestamp: number;
 }
 
 export class BrowserMcpControl extends EventEmitter {
@@ -66,6 +109,23 @@ export class BrowserMcpControl extends EventEmitter {
 
 	/** Chat session → set of tab IDs it controls */
 	private sessionTabs = new Map<string, Set<string>>();
+
+	/** Project → the tab its controlling agent is pointed at right now. */
+	private focusedTabs = new Map<string, string>();
+
+	/** Tab → what the agent is doing on it, for the cursor's caption. */
+	private tabActivity = new Map<string, string>();
+
+	/**
+	 * Whether the stream that owns a lock is still running.
+	 *
+	 * Registered by the chat stream manager. Without it a tool call that lands
+	 * after its stream ended — the remote-MCP transports resolve their session
+	 * from "most recent active stream", so a late call can name a session that
+	 * has already been released — filed a lock under an owner nobody would ever
+	 * release, and the tab stayed locked until the server restarted.
+	 */
+	private livenessProbe: SessionLivenessProbe | null = null;
 
 	// Pending tab requests (keyed by request type + timestamp)
 	private pendingTabRequests = new Map<string, PendingTabRequest>();
@@ -91,6 +151,47 @@ export class BrowserMcpControl extends EventEmitter {
 		});
 
 		debug.log('mcp', '🔗 Browser MCP Control initialized with event-based tab tracking');
+	}
+
+	/**
+	 * Teach this manager which chat sessions are still streaming.
+	 *
+	 * Called once by the chat stream manager. Absent, every session reads as
+	 * live — the previous behaviour, which is the safe default for anything
+	 * that constructs this without a chat layer (tests, tooling).
+	 */
+	setSessionLivenessProbe(probe: SessionLivenessProbe): void {
+		this.livenessProbe = probe;
+	}
+
+	/** Whether a chat session is still streaming (true when no probe is set). */
+	isSessionLive(chatSessionId: string): boolean {
+		return this.livenessProbe ? this.livenessProbe(chatSessionId) : true;
+	}
+
+	/**
+	 * Release every tab whose owning session has stopped streaming.
+	 *
+	 * The belt to `releaseSession`'s braces. Release is driven by the stream's
+	 * terminal events, so anything that never reaches one — a lock acquired
+	 * during the teardown window, an interrupt that took an unusual path —
+	 * leaves ownership behind with nothing to collect it. Sweeping is cheap
+	 * (the map holds a handful of entries) and makes a stuck lock recover on
+	 * the next stream event or tab query instead of at the next restart.
+	 */
+	releaseOrphans(): number {
+		if (!this.livenessProbe) return 0;
+
+		const orphans = [...this.tabOwnership.entries()]
+			.filter(([, info]) => !this.isSessionLive(info.chatSessionId))
+			.map(([tabId]) => tabId);
+
+		for (const tabId of orphans) {
+			debug.warn('mcp', `🧹 Releasing orphaned tab ${tabId} — its chat session is no longer streaming`);
+			this.releaseTab(tabId);
+		}
+
+		return orphans.length;
 	}
 
 	/**
@@ -224,6 +325,11 @@ export class BrowserMcpControl extends EventEmitter {
 			sessionSet.delete(browserTabId);
 			sessionSet.add(browserTabId);
 			debug.log('mcp', `🔀 Promoted tab ${browserTabId} to end of session ${chatSessionId.slice(0, 8)} set`);
+
+			// The agent just changed where it is working; the focus marker is
+			// what tells the user that, so it moves with the promotion.
+			const projectId = this.tabOwnership.get(browserTabId)?.projectId;
+			if (projectId) this.focusTab(browserTabId, chatSessionId, projectId);
 		}
 	}
 
@@ -235,12 +341,21 @@ export class BrowserMcpControl extends EventEmitter {
 	 * - If the tab is free → acquire and add to session's controlled set
 	 */
 	acquireControl(browserTabId: string, chatSessionId: string, projectId: string): boolean {
+		// A cancelled stream can still have a tool call in flight. Letting it
+		// take the lock re-locks a tab that was just handed back, and files the
+		// lock under an owner whose release already ran.
+		if (!this.isSessionLive(chatSessionId)) {
+			debug.warn('mcp', `❌ Session ${chatSessionId.slice(0, 8)} is no longer streaming, refusing control of ${browserTabId}`);
+			return false;
+		}
+
 		// Check existing ownership
 		const existingOwner = this.tabOwnership.get(browserTabId);
 
 		if (existingOwner) {
 			// Same session already owns it → idempotent success
 			if (existingOwner.chatSessionId === chatSessionId) {
+				this.focusTab(browserTabId, chatSessionId, projectId);
 				return true;
 			}
 			// Different session owns it → denied
@@ -266,9 +381,63 @@ export class BrowserMcpControl extends EventEmitter {
 
 		// Emit control start event to frontend
 		this.emitControlStart(browserTabId, chatSessionId, projectId);
+		this.focusTab(browserTabId, chatSessionId, projectId);
 
 		debug.log('mcp', `🎮 Session ${chatSessionId.slice(0, 8)} acquired tab: ${browserTabId} (total: ${sessionSet.size} tabs)`);
 		return true;
+	}
+
+	// ============================================================================
+	// Focus
+	// ============================================================================
+
+	/**
+	 * Mark the tab the agent is acting on. Idempotent and quiet when unchanged —
+	 * it is called on every action, and only a change is worth telling the UI.
+	 */
+	focusTab(browserTabId: string, chatSessionId: string, projectId: string): void {
+		if (this.focusedTabs.get(projectId) === browserTabId) return;
+
+		this.focusedTabs.set(projectId, browserTabId);
+		this.emitFocus(browserTabId, projectId, chatSessionId);
+	}
+
+	/** The tab a project's agent is currently pointed at, if any. */
+	getFocusedTab(projectId: string): string | null {
+		return this.focusedTabs.get(projectId) ?? null;
+	}
+
+	/**
+	 * Re-derive a project's focus after ownership changed.
+	 *
+	 * Falls back to another tab the *same* session still holds, so a batch that
+	 * closed the tab it was working on lands the marker where the work went
+	 * rather than nowhere — and never onto a tab a different session owns,
+	 * which would point the user at the wrong agent. Emits nothing when the
+	 * focused tab is still held, so releasing several tabs at once produces one
+	 * update rather than a burst.
+	 */
+	private refreshFocus(projectId: string | undefined): void {
+		if (!projectId) return;
+
+		const focused = this.focusedTabs.get(projectId);
+		if (!focused) return;
+
+		const owner = this.tabOwnership.get(focused);
+		if (owner && owner.projectId === projectId) return; // Still held — nothing to say.
+
+		const successor = [...this.tabOwnership.entries()]
+			.reverse()
+			.find(([, info]) => info.projectId === projectId);
+
+		if (successor) {
+			this.focusedTabs.set(projectId, successor[0]);
+			this.emitFocus(successor[0], projectId, successor[1].chatSessionId);
+			return;
+		}
+
+		this.focusedTabs.delete(projectId);
+		this.emitFocus(null, projectId);
 	}
 
 	// ============================================================================
@@ -295,8 +464,13 @@ export class BrowserMcpControl extends EventEmitter {
 			}
 		}
 
+		// Before the control-end, so the caption cannot outlive the cursor it
+		// belongs to on a viewer that processes the two in order.
+		this.emitActivity(browserTabId, null, ownership.projectId);
+
 		// Emit control end event to frontend
 		this.emitControlEnd(browserTabId, ownership.projectId);
+		this.refreshFocus(ownership.projectId);
 
 		debug.log('mcp', `🎮 Released tab: ${browserTabId} (was owned by session ${ownership.chatSessionId.slice(0, 8)})`);
 	}
@@ -307,23 +481,31 @@ export class BrowserMcpControl extends EventEmitter {
 	 */
 	releaseSession(chatSessionId: string): void {
 		const sessionSet = this.sessionTabs.get(chatSessionId);
-		if (!sessionSet || sessionSet.size === 0) {
-			this.sessionTabs.delete(chatSessionId);
-			return;
-		}
-
-		const tabIds = Array.from(sessionSet);
-		debug.log('mcp', `🎮 Releasing ${tabIds.length} tabs for session ${chatSessionId.slice(0, 8)}`);
-
-		for (const tabId of tabIds) {
-			const ownership = this.tabOwnership.get(tabId);
-			this.tabOwnership.delete(tabId);
-			this.emitControlEnd(tabId, ownership?.projectId);
-		}
-
 		this.sessionTabs.delete(chatSessionId);
 
-		debug.log('mcp', `🎮 Session ${chatSessionId.slice(0, 8)} fully released`);
+		const tabIds = Array.from(sessionSet ?? []);
+		if (tabIds.length > 0) {
+			debug.log('mcp', `🎮 Releasing ${tabIds.length} tabs for session ${chatSessionId.slice(0, 8)}`);
+
+			const projects = new Set<string>();
+			for (const tabId of tabIds) {
+				const ownership = this.tabOwnership.get(tabId);
+				this.tabOwnership.delete(tabId);
+				this.emitActivity(tabId, null, ownership?.projectId);
+				this.emitControlEnd(tabId, ownership?.projectId);
+				if (ownership?.projectId) projects.add(ownership.projectId);
+			}
+
+			// After every deletion, so the successor search sees the final state
+			// rather than tabs that are about to go too.
+			for (const projectId of projects) this.refreshFocus(projectId);
+
+			debug.log('mcp', `🎮 Session ${chatSessionId.slice(0, 8)} fully released`);
+		}
+
+		// A tool call that acquired during this session's teardown is filed
+		// under an owner that is already gone; nothing else would collect it.
+		this.releaseOrphans();
 	}
 
 	/**
@@ -344,11 +526,18 @@ export class BrowserMcpControl extends EventEmitter {
 	forceReleaseAll(): void {
 		// Emit control-end for all controlled tabs
 		for (const [tabId, info] of this.tabOwnership) {
+			this.emitActivity(tabId, null, info.projectId);
 			this.emitControlEnd(tabId, info.projectId);
+		}
+
+		for (const projectId of this.focusedTabs.keys()) {
+			this.emitFocus(null, projectId);
 		}
 
 		this.tabOwnership.clear();
 		this.sessionTabs.clear();
+		this.focusedTabs.clear();
+		this.tabActivity.clear();
 
 		debug.log('mcp', '🧹 Force released all MCP control');
 	}
@@ -363,6 +552,7 @@ export class BrowserMcpControl extends EventEmitter {
 	emitCursorPosition(tabId: string, x: number, y: number, pressed = false): void {
 		const event: McpCursorEvent = {
 			tabId,
+			projectId: this.tabOwnership.get(tabId)?.projectId,
 			x,
 			y,
 			pressed,
@@ -379,6 +569,7 @@ export class BrowserMcpControl extends EventEmitter {
 	emitCursorClick(tabId: string, x: number, y: number, button: 'left' | 'right' | 'middle' = 'left'): void {
 		const event: McpClickEvent = {
 			tabId,
+			projectId: this.tabOwnership.get(tabId)?.projectId,
 			x,
 			y,
 			button,
@@ -387,6 +578,36 @@ export class BrowserMcpControl extends EventEmitter {
 		};
 
 		this.emit('cursor-click', event);
+	}
+
+	/**
+	 * Say what the agent is doing on a tab.
+	 *
+	 * Repeats are dropped: a batch of eight `type` actions would otherwise
+	 * relabel the cursor eight times with the same word, and every one of those
+	 * is a re-render on every viewer.
+	 */
+	emitActivity(tabId: string, label: string | null, projectId?: string): void {
+		if ((this.tabActivity.get(tabId) ?? null) === label) return;
+
+		if (label === null) this.tabActivity.delete(tabId);
+		else this.tabActivity.set(tabId, label);
+
+		const event: McpActivityEvent = {
+			tabId,
+			// Explicit on release, where ownership has already been dropped and
+			// there is nothing left to look the project up in.
+			projectId: projectId ?? this.tabOwnership.get(tabId)?.projectId,
+			label,
+			timestamp: Date.now()
+		};
+
+		this.emit('activity', event);
+	}
+
+	/** What the agent last said it was doing on a tab, for a late-joining viewer. */
+	getActivity(tabId: string): string | null {
+		return this.tabActivity.get(tabId) ?? null;
 	}
 
 	/**
@@ -429,6 +650,19 @@ export class BrowserMcpControl extends EventEmitter {
 		this.emit('control-end', event);
 
 		debug.log('mcp', `📢 Emitted mcp:control-end for tab: ${browserTabId}`);
+	}
+
+	private emitFocus(browserTabId: string | null, projectId: string, chatSessionId?: string): void {
+		const event: McpFocusEvent = {
+			browserTabId,
+			projectId,
+			chatSessionId,
+			timestamp: Date.now()
+		};
+
+		this.emit('control-focus', event);
+
+		debug.log('mcp', `📢 Emitted mcp:control-focus for ${projectId}: ${browserTabId ?? 'none'}`);
 	}
 }
 

--- a/backend/preview/browser/browser-preview-service.ts
+++ b/backend/preview/browser/browser-preview-service.ts
@@ -56,6 +56,9 @@ export class BrowserPreviewService extends EventEmitter {
 	// Store context menu info for later action execution
 	private contextMenus = new Map<string, BrowserContextMenuInfo>();
 
+	/** Tabs whose page is showing something full screen — see applyFullscreenState. */
+	private fullscreenTabs = new Set<string>();
+
 	// Project ID for isolation (REQUIRED)
 	private projectId: string;
 
@@ -105,6 +108,13 @@ export class BrowserPreviewService extends EventEmitter {
 		this.navigationTracker.on('navigation', async (data) => {
 			this.emit('preview:browser-navigation', data);
 
+			// A new document cannot still be full screen: the element that was
+			// went with the old one. Left set, the viewer would keep offering an
+			// exit for a state that no longer exists.
+			if (this.fullscreenTabs.delete(data.sessionId)) {
+				this.emit('preview:browser-fullscreen-state', { tabId: data.sessionId, active: false });
+			}
+
 			// After navigation completes, restart video streaming for the tab
 			// This re-injects the peer script and restarts CDP screencast
 			const { sessionId } = data;
@@ -115,14 +125,21 @@ export class BrowserPreviewService extends EventEmitter {
 			if (this.videoCapture.isStreaming(sessionId)) {
 				const tab = this.getTab(sessionId);
 				if (tab) {
-					// Restart streaming immediately — page is already navigated
+					// Restart streaming immediately — page is already navigated.
+					// A failure here is logged rather than swallowed: it used to
+					// leave the session marked active over a page that could no
+					// longer encode, and the only visible symptom was a preview
+					// stuck loading. handleNavigation now clears `isActive` on
+					// failure so the next handshake rebuilds from scratch.
 					try {
 						const success = await this.videoCapture.handleNavigation(sessionId, tab);
 						if (success) {
 							this.emit('preview:browser-navigation-streaming-ready', { sessionId });
+						} else {
+							debug.warn('preview', `Streaming restore failed after navigation on ${sessionId}`);
 						}
 					} catch (error) {
-						// Silently fail - frontend will request refresh if needed
+						debug.warn('preview', `Streaming restore threw after navigation on ${sessionId}:`, error);
 					}
 				}
 			}
@@ -152,6 +169,15 @@ export class BrowserPreviewService extends EventEmitter {
 			this.emit('preview:browser-tab-opened', data);
 		});
 		this.tabManager.on('preview:browser-tab-closed', (data) => {
+			// Hooked to the event rather than to closeTab(): the tab manager
+			// closes tabs on its own too (browser disconnect, pool teardown, a
+			// window the page closed), and those paths never pass through the
+			// service. The page is gone either way, and with it the bindings and
+			// on-new-document scripts this bookkeeping describes.
+			if (data?.tabId) {
+				this.videoCapture.disposeTab(data.tabId);
+				this.fullscreenTabs.delete(data.tabId);
+			}
 			this.emit('preview:browser-tab-closed', data);
 		});
 		this.tabManager.on('preview:browser-tab-switched', (data) => {
@@ -197,6 +223,10 @@ export class BrowserPreviewService extends EventEmitter {
 			// it would put an unanswerable dialog on every screen watching the tab.
 			if (data.kind === 'viewport-restore') {
 				void this.restoreEmulatedViewport(data.tabId, data.requestId);
+				return;
+			}
+			if (data.kind === 'fullscreen-state') {
+				this.applyFullscreenState(data.tabId, data.requestId, data.payload);
 				return;
 			}
 			this.emit('preview:browser-host-request', data);
@@ -679,6 +709,68 @@ export class BrowserPreviewService extends EventEmitter {
 		}
 	}
 
+	/**
+	 * Record that a tab's page went full screen (or left it) and tell viewers.
+	 *
+	 * The state matters to the viewer because the way out cannot live only in
+	 * the page: the hint the shim draws is a DOM node the page is free to
+	 * destroy, and a fullscreen Chrome granted from its own C++ leaves no hint
+	 * at all. Knowing lets the viewer render an exit control of its own, which
+	 * nothing in the page can reach.
+	 */
+	private applyFullscreenState(tabId: string, requestId: string, payload: unknown): void {
+		const active = !!(payload as { active?: boolean } | null)?.active;
+
+		if (active) this.fullscreenTabs.add(tabId);
+		else this.fullscreenTabs.delete(tabId);
+
+		debug.log('preview', `🖥️ Tab ${tabId} full screen: ${active}`);
+		this.emit('preview:browser-fullscreen-state', { tabId, active });
+		this.hostBridge.respond(requestId, { ok: true });
+	}
+
+	/** Whether a tab's page currently has something full screen. */
+	isPageFullscreen(tabId: string): boolean {
+		return this.fullscreenTabs.has(tabId);
+	}
+
+	/**
+	 * Force a tab out of full screen, from outside the page.
+	 *
+	 * Every frame is asked, not just the main one: a video in an embed goes
+	 * full screen inside its own document, and that frame is the only one that
+	 * holds the state. The emulated viewport is re-asserted afterwards because
+	 * a fullscreen Chrome granted itself collapses the composited surface and
+	 * leaves it collapsed — the zoomed, cropped preview that looked like the
+	 * fullscreen had never ended.
+	 */
+	async exitPageFullscreen(tabId: string): Promise<boolean> {
+		const tab = this.getTab(tabId);
+		if (!tab?.page || tab.page.isClosed()) return false;
+
+		await Promise.all(
+			tab.page.frames().map((frame) =>
+				frame
+					.evaluate(() => {
+						(window as any).__clopenFullscreen?.forceExit();
+					})
+					.catch(() => {
+						// Detached or navigating — nothing of ours is left in it.
+					})
+			)
+		);
+
+		this.fullscreenTabs.delete(tabId);
+		this.emit('preview:browser-fullscreen-state', { tabId, active: false });
+
+		const { width, height } = getViewportDimensions(tab.deviceSize, tab.rotation);
+		const restored = await this.videoCapture.updateViewport(tabId, tab, width, height);
+		if (!restored) await tab.page.setViewport({ width, height }).catch(() => {});
+
+		debug.log('preview', `🖥️ Forced tab ${tabId} out of full screen`);
+		return true;
+	}
+
 	async updateWebCodecsViewport(tabId: string, width: number, height: number): Promise<boolean> {
 		const tab = this.getTab(tabId);
 		if (!tab) {
@@ -1056,6 +1148,10 @@ class BrowserPreviewServiceManager {
 			ws.emit.project(projectId, 'preview:browser-viewport-changed', { ...data, projectId });
 		});
 
+		service.on('preview:browser-fullscreen-state', (data) => {
+			ws.emit.project(projectId, 'preview:browser-fullscreen-state', { ...data, projectId });
+		});
+
 		// Forward live tab metadata (title, favicon, back/forward availability)
 		service.on('preview:browser-tab-meta', (data) => {
 			ws.emit.project(projectId, 'preview:browser-tab-meta', { ...data, projectId });
@@ -1202,26 +1298,68 @@ class BrowserPreviewServiceManager {
 			});
 		});
 
+		browserMcpControl.on('control-focus', (data) => {
+			ws.emit.project(data.projectId, 'preview:browser-mcp-control-focus', {
+				browserTabId: data.browserTabId,
+				projectId: data.projectId,
+				timestamp: data.timestamp
+			});
+		});
+
+		// Cursor events go to the owning project when it is known. Tab ids repeat
+		// across projects, so a broadcast could draw the agent's pointer over a
+		// same-numbered tab somewhere the agent has never been. The broadcast is
+		// kept only for the case where ownership can't be resolved.
 		browserMcpControl.on('cursor-position', (data) => {
-			emitToActiveProjects('preview:browser-mcp-cursor-position', {
+			const payload = {
 				sessionId: data.tabId,
 				x: data.x,
 				y: data.y,
 				pressed: data.pressed ?? false,
 				timestamp: data.timestamp,
-				source: 'mcp'
-			});
+				source: 'mcp' as const
+			};
+
+			if (data.projectId) {
+				ws.emit.project(data.projectId, 'preview:browser-mcp-cursor-position', payload);
+				return;
+			}
+			emitToActiveProjects('preview:browser-mcp-cursor-position', payload);
 		});
 
 		browserMcpControl.on('cursor-click', (data) => {
-			emitToActiveProjects('preview:browser-mcp-cursor-click', {
+			const payload = {
 				sessionId: data.tabId,
 				x: data.x,
 				y: data.y,
 				button: data.button ?? 'left',
 				timestamp: data.timestamp,
-				source: 'mcp'
-			});
+				source: 'mcp' as const
+			};
+
+			if (data.projectId) {
+				ws.emit.project(data.projectId, 'preview:browser-mcp-cursor-click', payload);
+				return;
+			}
+			emitToActiveProjects('preview:browser-mcp-cursor-click', payload);
+		});
+
+		// What the agent is doing, for the caption beside its cursor. Same
+		// project-scoping rule as the cursor itself, and the same fallback: an
+		// event nobody can attribute is better broadcast than dropped, since the
+		// alternative is a pointer left describing an action that has finished.
+		browserMcpControl.on('activity', (data) => {
+			const payload = {
+				sessionId: data.tabId,
+				label: data.label,
+				timestamp: data.timestamp
+			};
+
+			if (data.projectId) {
+				ws.emit.project(data.projectId, 'preview:browser-mcp-activity', payload);
+				return;
+			}
+			emitToActiveProjects('preview:browser-mcp-activity', payload);
 		});
 
 		browserMcpControl.on('test-completed', (data) => {

--- a/backend/preview/browser/browser-video-capture.ts
+++ b/backend/preview/browser/browser-video-capture.ts
@@ -35,6 +35,7 @@ import type {
 	ClientCodecSupport,
 	ClientDisplayMetrics,
 	ClientStreamFeedback,
+	PeerHealth,
 	StreamingConfig
 } from './types';
 import { DEFAULT_STREAMING_CONFIG, resolveCodecCandidates } from './types';
@@ -117,6 +118,39 @@ interface StreamViewer {
 	visible: boolean;
 	/** Latest decoder verdict — the ladder follows the worst viewer. */
 	decoderSaturated: boolean;
+	/**
+	 * When this viewer last handshook. A viewer that never reaches `connected`
+	 * has to expire: entries only ever left this table on an explicit stop, a
+	 * `closed`/`failed` state or a socket teardown, so a handshake that simply
+	 * never completed — a host browser refreshed hard, a laptop closed
+	 * mid-negotiation — stayed forever and made the session look watched.
+	 */
+	attachedAt: number;
+}
+
+/**
+ * Per-tab injection bookkeeping.
+ *
+ * Deliberately *not* on the stream session: `stopStreaming` deletes that
+ * record, so every stop/start cycle — i.e. every switch away from a preview
+ * tab and back — believed it had never injected anything. Puppeteer's
+ * `exposeFunction` then threw ("already exists") and the whole handshake
+ * failed, while `evaluateOnNewDocument` happily registered another copy of
+ * the audio tap that nothing ever removed. This lives as long as the tab.
+ */
+interface TabInjectionState {
+	/** Signalling bindings installed on the page (survive navigation). */
+	bindingsExposed: boolean;
+	/** Identifier of the registered on-new-document audio script, if any. */
+	audioScriptId: string | null;
+	/** Id stamped on the most recent peer injection — compared to PeerHealth. */
+	epoch: string;
+	/**
+	 * Codec order the injected encoder was built with. The page decides its
+	 * codec once, at injection, so a viewer arriving with different decode
+	 * capabilities needs a rebuild rather than a reconfigure.
+	 */
+	codecSignature: string;
 }
 
 interface VideoStreamSession {
@@ -127,7 +161,14 @@ interface VideoStreamSession {
 	viewers: Map<string, StreamViewer>;
 	scriptInjected: boolean; // Track if persistent script was injected
 	scriptsPreInjected: boolean; // Track if scripts were pre-injected during tab creation
-	audioOnNewDocumentInjected: boolean; // Track if evaluateOnNewDocument was registered for audio
+	/**
+	 * When the page last reported frames reaching its encoder. A connected
+	 * viewer while this stands still is watching a stream that has stopped
+	 * producing — which looks identical, from the client, to a slow page.
+	 */
+	lastEncodedAt: number;
+	/** Guards the watchdog against re-entering while a repair is in flight. */
+	repairing: boolean;
 	/** Codecs every viewer can decode — one encoder serves them all. */
 	codecSupport: ClientCodecSupport;
 	/** Display metrics of the most demanding viewer. */
@@ -196,8 +237,12 @@ const DEFAULT_CODEC_SUPPORT: ClientCodecSupport = {
  * saves work: before the frame is produced.
  */
 class ScreencastFeeder {
+	/** Attempts to re-deliver a still-page refresh frame before giving up. */
+	private static readonly MAX_TOP_OFF_RETRIES = 3;
+
 	private ackTimer: ReturnType<typeof setTimeout> | null = null;
 	private topOffTimer: ReturnType<typeof setTimeout> | null = null;
+	private topOffRetries = 0;
 	private peerObjectId: string | null = null;
 	private acquiringPeer = false;
 	private capturingTopOff = false;
@@ -290,12 +335,12 @@ class ScreencastFeeder {
 	 * single frame — hundreds of kilobytes of compilation per frame, for a
 	 * call that never changes.
 	 */
-	private dispatch(data: string, isTopOff: boolean, mimeType: string): void {
-		if (this.destroyed) return;
+	private dispatch(data: string, isTopOff: boolean, mimeType: string): boolean {
+		if (this.destroyed) return false;
 
 		if (!this.peerObjectId) {
 			void this.acquirePeerHandle();
-			return;
+			return false;
 		}
 
 		this.cdp
@@ -311,6 +356,8 @@ class ScreencastFeeder {
 				// Stale handle (navigation) — the next frame re-acquires it.
 				this.peerObjectId = null;
 			});
+
+		return true;
 	}
 
 	private ack(cdpSessionId: number): void {
@@ -362,7 +409,7 @@ class ScreencastFeeder {
 			}
 
 			this.lastDispatchAt = now;
-			this.dispatch(event.data, false, 'image/jpeg');
+			if (this.dispatch(event.data, false, 'image/jpeg')) this.topOffRetries = 0;
 			this.scheduleTopOff();
 		} finally {
 			// Self-calibrating hold. The period the viewer actually sees is
@@ -454,11 +501,26 @@ class ScreencastFeeder {
 				// screencast frames already rescheduled the top-off.
 				if (this.frameSeq !== seqAtCapture || this.destroyed) return;
 
-				this.dispatch(
+				const sent = this.dispatch(
 					screenshot.data,
 					true,
 					profile.topOffFormat === 'jpeg' ? 'image/jpeg' : 'image/png'
 				);
+
+				// A dropped top-off used to be the end of the line. The encoder
+				// handle goes stale on every navigation and re-injection, and the
+				// screencast only fires on damage — so on a page that is not
+				// moving (a preview the user has just come back to) the one frame
+				// that would have cleared "Loading preview…" was lost and nothing
+				// would ever produce another. Retry while the handle is being
+				// re-acquired, then give up rather than spin.
+				if (!sent && this.topOffRetries < ScreencastFeeder.MAX_TOP_OFF_RETRIES) {
+					this.topOffRetries++;
+					this.capturingTopOff = false;
+					this.scheduleTopOff();
+					return;
+				}
+				this.topOffRetries = 0;
 			} catch {
 				// Page may be navigating/closing — top-off is best-effort
 			} finally {
@@ -474,6 +536,7 @@ class ScreencastFeeder {
 		this.flushPendingAck();
 		this.lastDispatchAt = 0;
 		this.lastAckAt = 0;
+		this.topOffRetries = 0;
 
 		if (this.topOffTimer) {
 			clearTimeout(this.topOffTimer);
@@ -509,13 +572,54 @@ export class BrowserVideoCapture extends EventEmitter {
 	 */
 	private static readonly CLIENT_ADAPT_INTERVAL_MS = 1500;
 
+	/**
+	 * How long a viewer may sit in the table without ever connecting.
+	 * Generous — a slow network can take seconds to finish ICE — but finite,
+	 * which is the point: a viewer that never completes must not keep the
+	 * session looking watched forever.
+	 */
+	private static readonly VIEWER_HANDSHAKE_TTL_MS = 45_000;
+
+	/**
+	 * Silence tolerated from a connected viewer's stream before the watchdog
+	 * repairs it. Two encoder-stat windows plus slack — long enough that a
+	 * genuinely idle page (which still tops off) never trips it.
+	 */
+	private static readonly STREAM_STALL_MS = 6_000;
+
 	private sessions = new Map<string, VideoStreamSession>();
 	private feeders = new Map<string, ScreencastFeeder>();
 	private preInjectPromises = new Map<string, Promise<boolean>>();
 	private displayMetricsTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	/** Injection bookkeeping, per tab — outlives the stream session. */
+	private tabInjection = new Map<string, TabInjectionState>();
+	private epochCounter = 0;
+	private watchdogTimer: ReturnType<typeof setInterval> | null = null;
 
 	constructor() {
 		super();
+	}
+
+	/** Injection bookkeeping for a tab, created on first use. */
+	private injectionState(sessionId: string): TabInjectionState {
+		let state = this.tabInjection.get(sessionId);
+		if (!state) {
+			state = { bindingsExposed: false, audioScriptId: null, epoch: '', codecSignature: '' };
+			this.tabInjection.set(sessionId, state);
+		}
+		return state;
+	}
+
+	private nextEpoch(sessionId: string): string {
+		return `${sessionId}:${++this.epochCounter}:${Date.now().toString(36)}`;
+	}
+
+	/**
+	 * Forget everything remembered about a tab. Called when the tab is closed —
+	 * its page is gone, so the bindings and on-new-document scripts go with it.
+	 */
+	disposeTab(sessionId: string): void {
+		this.tabInjection.delete(sessionId);
 	}
 
 	// ------------------------------------------------------------------
@@ -550,6 +654,7 @@ export class BrowserVideoCapture extends EventEmitter {
 
 		return {
 			...DEFAULT_STREAMING_CONFIG.video,
+			epoch: this.injectionState(videoSession.sessionId).epoch,
 			width,
 			height,
 			framerate: videoSession.targetFramerate,
@@ -622,7 +727,8 @@ export class BrowserVideoCapture extends EventEmitter {
 			viewers: new Map(),
 			scriptInjected: false,
 			scriptsPreInjected: false,
-			audioOnNewDocumentInjected: false,
+			lastEncodedAt: 0,
+			repairing: false,
 			codecSupport: { ...DEFAULT_CODEC_SUPPORT },
 			display: {},
 			profile,
@@ -669,7 +775,7 @@ export class BrowserVideoCapture extends EventEmitter {
 			videoSession.scriptInjected = true;
 			this.sessions.set(sessionId, videoSession);
 
-			await this.injectScripts(sessionId, page, this.buildVideoConfig(videoSession, viewport), this.buildAudioConfig(videoSession));
+			await this.injectScripts(sessionId, page, videoSession, viewport);
 
 			// Mark as pre-injected only after successful completion
 			videoSession.scriptsPreInjected = true;
@@ -687,85 +793,299 @@ export class BrowserVideoCapture extends EventEmitter {
 	}
 
 	/**
-	 * Inject signaling bindings + encoder scripts into page
+	 * Expose the signalling bindings, once per tab.
+	 *
+	 * Every one of these is bound to the tab whose page it was injected into.
+	 * They used to resolve their session by picking the first active one in
+	 * the whole project, which is correct only while exactly one tab streams:
+	 * with several open, one page's ICE candidates, connection states, cursor
+	 * and encoder stats were all attributed to a different tab.
+	 *
+	 * Whether they are already installed is remembered here rather than probed
+	 * from the page. `typeof window.__sendIceCandidate === 'function'` describes
+	 * the *current document*, and Puppeteer re-installs bindings on each new
+	 * one — so mid-navigation the probe says "absent" while Puppeteer's own
+	 * registry says "present", and `exposeFunction` throws. That threw out of
+	 * the whole handshake, and every client retry hit the same window: the
+	 * preview sat on "Loading preview…" until something else moved the page.
+	 */
+	private async exposeBindings(sessionId: string, page: Page): Promise<void> {
+		const state = this.injectionState(sessionId);
+		if (state.bindingsExposed) return;
+
+		/** Already-registered is success, not failure — see above. */
+		const expose = async (name: string, fn: (...args: any[]) => void) => {
+			try {
+				await page.exposeFunction(name, fn);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				if (!message.includes('already exists')) throw error;
+			}
+		};
+
+		await expose('__sendIceCandidate', (viewerId: string, candidate: RTCIceCandidateInit) => {
+			this.emit('ice-candidate', { sessionId, viewerId, candidate, from: 'headless' });
+		});
+
+		await expose('__sendConnectionState', (viewerId: string, state: string) => {
+			const videoSession = this.sessions.get(sessionId);
+			if (!videoSession) return;
+
+			videoSession.stats.connectionState = state;
+			this.emit('connection-state', { sessionId, viewerId, state });
+
+			const viewer = videoSession.viewers.get(viewerId);
+			if (viewer && state === 'connected') viewer.connected = true;
+
+			// Capture sources only produce frames on damage, so a viewer
+			// that connects to an already-still page would otherwise wait
+			// for the first mouse move to see anything. Push one refresh
+			// frame as soon as the peer is up.
+			if (state === 'connected' && videoSession.tab) {
+				videoSession.lastEncodedAt = Date.now();
+				void this.requestKeyframe(sessionId, videoSession.tab);
+			}
+
+			if (state === 'closed' || state === 'failed') {
+				videoSession.viewers.delete(viewerId);
+			}
+		});
+
+		// A channel that has just opened has no frame to show yet on a still
+		// page — see the matching comment in video-stream.ts.
+		await expose('__requestRefreshFrame', (viewerId: string) => {
+			const videoSession = this.sessions.get(sessionId);
+			if (!videoSession?.tab) return;
+			debug.log('webcodecs', `Refresh frame requested by viewer ${viewerId} on ${sessionId}`);
+			void this.requestKeyframe(sessionId, videoSession.tab);
+		});
+
+		await expose('__sendCursorChange', (cursor: string) => {
+			this.emit('cursor-change', { sessionId, cursor });
+		});
+
+		await expose('__sendEncoderStats', (stats: EncoderStats) => {
+			this.applyEncoderStats(sessionId, stats);
+		});
+
+		state.bindingsExposed = true;
+	}
+
+	/**
+	 * Inject signalling bindings + encoder scripts into the page.
+	 *
+	 * Mints a fresh epoch for the peer object it creates, so a later health
+	 * check can tell this injection apart from one left behind by a document
+	 * the page has since navigated away from.
 	 */
 	private async injectScripts(
 		sessionId: string,
 		page: Page,
-		videoConfig: StreamingConfig['video'],
-		audioConfig: StreamingConfig['audio']
+		videoSession: VideoStreamSession,
+		viewport: { width: number; height: number }
 	): Promise<void> {
-		// Check if bindings exist
-		const bindingsExist = await page.evaluate(() => {
-			return typeof (window as any).__sendIceCandidate === 'function';
-		});
+		await this.exposeBindings(sessionId, page);
 
-		// Expose signaling functions (persists across navigations).
+		const state = this.injectionState(sessionId);
+		const audioConfig = this.buildAudioConfig(videoSession);
+
+		// Register audio capture as a startup script — runs before page scripts on
+		// every new document load. Critical for SPAs that create AudioContext
+		// during initialization (before page.evaluate runs).
 		//
-		// Every one of these is bound to the tab whose page it was injected into.
-		// They used to resolve their session by picking the first active one in
-		// the whole project, which is correct only while exactly one tab streams:
-		// with several open, one page's ICE candidates, connection states, cursor
-		// and encoder stats were all attributed to a different tab. The viewer
-		// filters those by tab, so its candidates were silently discarded and the
-		// connection never completed — and because the first refresh frame is
-		// pushed from the `connected` state, a still page also never produced a
-		// first frame. That is the "Loading preview…" that never resolves.
-		if (!bindingsExist) {
-			await page.exposeFunction('__sendIceCandidate', (viewerId: string, candidate: RTCIceCandidateInit) => {
-				this.emit('ice-candidate', { sessionId, viewerId, candidate, from: 'headless' });
-			});
-
-			await page.exposeFunction('__sendConnectionState', (viewerId: string, state: string) => {
-				const videoSession = this.sessions.get(sessionId);
-				if (!videoSession) return;
-
-				videoSession.stats.connectionState = state;
-				this.emit('connection-state', { sessionId, viewerId, state });
-
-				// Capture sources only produce frames on damage, so a viewer
-				// that connects to an already-still page would otherwise wait
-				// for the first mouse move to see anything. Push one refresh
-				// frame as soon as the peer is up.
-				if (state === 'connected' && videoSession.tab) {
-					void this.requestKeyframe(sessionId, videoSession.tab);
-				}
-
-				if (state === 'closed' || state === 'failed') {
-					videoSession.viewers.delete(viewerId);
-				}
-			});
-
-			// A channel that has just opened has no frame to show yet on a still
-			// page — see the matching comment in video-stream.ts.
-			await page.exposeFunction('__requestRefreshFrame', (viewerId: string) => {
-				const videoSession = this.sessions.get(sessionId);
-				if (!videoSession?.tab) return;
-				debug.log('webcodecs', `Refresh frame requested by viewer ${viewerId} on ${sessionId}`);
-				void this.requestKeyframe(sessionId, videoSession.tab);
-			});
-
-			await page.exposeFunction('__sendCursorChange', (cursor: string) => {
-				this.emit('cursor-change', { sessionId, cursor });
-			});
-
-			await page.exposeFunction('__sendEncoderStats', (stats: EncoderStats) => {
-				this.applyEncoderStats(sessionId, stats);
-			});
+		// Registered exactly once for the tab. This used to be tracked on the
+		// stream session, which `stopStreaming` deletes, so every switch away
+		// from a preview tab and back added another copy that nothing removed —
+		// after enough switches each page load ran a stack of them, and the only
+		// cure was restarting the server.
+		if (!state.audioScriptId) {
+			const registered = await page.evaluateOnNewDocument(audioCaptureScript, audioConfig);
+			state.audioScriptId = (registered as { identifier?: string })?.identifier ?? 'registered';
 		}
 
-		// Register audio capture as a startup script — runs before page scripts on every new document load.
-		// Critical for SPAs that create AudioContext during initialization (before page.evaluate runs).
-		// The idempotency guard in audioCaptureScript prevents double-injection.
-		const session = this.sessions.get(sessionId);
-		if (session && !session.audioOnNewDocumentInjected) {
-			await page.evaluateOnNewDocument(audioCaptureScript, audioConfig);
-			session.audioOnNewDocumentInjected = true;
-		}
+		state.epoch = this.nextEpoch(sessionId);
 
 		// Inject video encoder + audio capture scripts into the current page context
+		const videoConfig = this.buildVideoConfig(videoSession, viewport);
+		state.codecSignature = this.codecSignature(videoSession);
+
 		await page.evaluate(videoEncoderScript, videoConfig);
 		await injectAudioCaptureIntoAllFrames(page, audioConfig);
+	}
+
+	/** Which encoder candidates the current viewer set implies. */
+	private codecSignature(videoSession: VideoStreamSession): string {
+		return resolveCodecCandidates(videoSession.codecSupport)
+			.map((candidate) => candidate.name)
+			.join(',');
+	}
+
+	// ------------------------------------------------------------------
+	// Liveness
+	// ------------------------------------------------------------------
+
+	/** What the page says about its own peer, or null when it has none. */
+	private async readPeerHealth(page: Page): Promise<PeerHealth | null> {
+		if (page.isClosed()) return null;
+		try {
+			return await page.evaluate(() => {
+				const peer = (window as any).__webCodecsPeer;
+				return typeof peer?.health === 'function' ? peer.health() : null;
+			});
+		} catch {
+			// Execution context torn down mid-navigation — treat as "no peer",
+			// which is exactly what it will be a moment from now.
+			return null;
+		}
+	}
+
+	/**
+	 * Bring the page's capture in line with what the backend believes.
+	 *
+	 * This replaces the old fork in `startStreaming`, which chose between a
+	 * clean restart and a bare attach purely on how many *other* viewers were
+	 * registered. That choice was made from the backend's own record, and the
+	 * record is exactly the thing that goes stale: with another viewer present
+	 * the attach path never re-injected the peer script, so a page whose peer
+	 * had died with a navigation stayed dead, `createOffer` returned null
+	 * forever, and every client retry took the same doomed branch. Reloading
+	 * the page was the only way out, because that re-injected by another route.
+	 *
+	 * Asking the page instead makes both cases converge: cheap when it is
+	 * healthy (one evaluate), correct when it is not.
+	 */
+	private async ensureLive(
+		sessionId: string,
+		session: BrowserTab,
+		isValidSession: () => boolean,
+		options: { force?: boolean } = {}
+	): Promise<boolean> {
+		const videoSession = this.sessions.get(sessionId);
+		if (!videoSession) return false;
+		if (!session.page || session.page.isClosed()) return false;
+
+		const page = session.page;
+		const viewport = page.viewport()!;
+		videoSession.tab = session;
+
+		const health = options.force ? null : await this.readPeerHealth(page);
+		const injection = this.injectionState(sessionId);
+
+		// A peer from a different injection answers every call and encodes into
+		// a page that is no longer on screen — indistinguishable from a healthy
+		// one without the epoch.
+		const epochMismatch = !health || !health.epoch || health.epoch !== injection.epoch;
+		const codecChanged = injection.codecSignature !== this.codecSignature(videoSession);
+		const needsInjection = epochMismatch || codecChanged;
+
+		if (needsInjection) {
+			const reason = options.force
+				? 'forced'
+				: !health
+					? 'no peer in page'
+					: epochMismatch
+						? 'epoch mismatch'
+						: 'codec set changed';
+			debug.log('webcodecs', `Rebuilding peer for ${sessionId} (${reason})`);
+			await this.injectScripts(sessionId, page, videoSession, viewport);
+			videoSession.scriptInjected = true;
+			// The old page's encoder handle died with its execution context.
+			this.feeders.get(sessionId)?.invalidatePeerHandle();
+		}
+
+		if (needsInjection || !health?.capturing) {
+			const started = await this.startPageCapture(page);
+			if (!started) {
+				debug.error('webcodecs', `Page refused to start capturing for ${sessionId}`);
+				return false;
+			}
+			videoSession.isActive = true;
+			videoSession.headlessReady = true;
+			videoSession.paused = false;
+			videoSession.captureMode = 'push';
+			videoSession.healthyWindows = 0;
+			await this.setupCapture(sessionId, session, isValidSession);
+		} else {
+			// Healthy: keep the backend's view of the page honest anyway, since
+			// the page may have switched capture source on its own.
+			videoSession.isActive = true;
+			videoSession.headlessReady = true;
+			videoSession.captureMode = health.captureMode;
+			this.reconcileViewers(videoSession, health);
+		}
+
+		videoSession.lastEncodedAt = Date.now();
+		this.ensureWatchdog();
+		return true;
+	}
+
+	/**
+	 * Start (or confirm) the page-side encoder and audio tap in one round-trip.
+	 */
+	private async startPageCapture(page: Page): Promise<boolean> {
+		const initResult = await page.evaluate(async () => {
+			const peer = (window as any).__webCodecsPeer;
+			if (typeof peer?.startStreaming !== 'function') {
+				return { peerExists: false, started: false, audioInitialized: false };
+			}
+
+			const started = await peer.startStreaming();
+			if (!started) {
+				return { peerExists: true, started: false, audioInitialized: false };
+			}
+
+			// Initialize audio encoder if available
+			let audioInitialized = false;
+			const encoder = (window as any).__audioEncoder;
+			if (typeof encoder?.init === 'function') {
+				try {
+					const initiated = await encoder.init();
+					if (initiated) {
+						audioInitialized = !!encoder.start();
+					}
+				} catch {}
+			}
+
+			return { peerExists: true, started: true, audioInitialized };
+		});
+
+		if (!initResult.peerExists || !initResult.started) return false;
+
+		if (!initResult.audioInitialized) {
+			debug.warn('webcodecs', 'Audio not available, continuing with video only');
+		}
+
+		return true;
+	}
+
+	/**
+	 * Drop viewers the page has never heard of and handshakes that never
+	 * completed. Without this a viewer that vanished mid-negotiation — a host
+	 * browser refreshed, a laptop closed — stayed in the table forever, and the
+	 * session went on looking watched by an audience of nobody.
+	 */
+	private reconcileViewers(videoSession: VideoStreamSession, health: PeerHealth): void {
+		const livePeers = new Set(health.viewers);
+		const now = Date.now();
+		let dropped = 0;
+
+		for (const [viewerId, viewer] of videoSession.viewers) {
+			if (livePeers.has(viewerId)) continue;
+			// Still negotiating — its peer is created by createOffer, which may
+			// not have run yet.
+			if (now - viewer.attachedAt < BrowserVideoCapture.VIEWER_HANDSHAKE_TTL_MS) continue;
+
+			videoSession.viewers.delete(viewerId);
+			dropped++;
+		}
+
+		if (dropped > 0) {
+			debug.log(
+				'webcodecs',
+				`Dropped ${dropped} stale viewer(s) from ${videoSession.sessionId}, ${videoSession.viewers.size} left`
+			);
+			this.refreshViewerConfig(videoSession);
+		}
 	}
 
 	// ------------------------------------------------------------------
@@ -792,7 +1112,8 @@ export class BrowserVideoCapture extends EventEmitter {
 			connected: false,
 			pendingCandidates: [],
 			visible: true,
-			decoderSaturated: false
+			decoderSaturated: false,
+			attachedAt: Date.now()
 		};
 
 		if (options.codecSupport) viewer.codecSupport = options.codecSupport;
@@ -802,40 +1123,12 @@ export class BrowserVideoCapture extends EventEmitter {
 		viewer.connected = false;
 		viewer.pendingCandidates = [];
 		viewer.visible = true;
+		viewer.attachedAt = Date.now();
 
 		videoSession.viewers.set(viewer.id, viewer);
 		this.refreshViewerConfig(videoSession);
 
 		return viewer;
-	}
-
-	/**
-	 * Add a viewer to a stream that is already running.
-	 *
-	 * Nothing about the capture is disturbed — the existing viewers keep their
-	 * channels. Only the shared geometry is re-derived, in case the newcomer has
-	 * a sharper screen than anyone already watching.
-	 */
-	private async attachViewer(
-		sessionId: string,
-		session: BrowserTab,
-		options: {
-			viewerId: string;
-			codecSupport?: ClientCodecSupport;
-			display?: ClientDisplayMetrics;
-		}
-	): Promise<boolean> {
-		const videoSession = this.sessions.get(sessionId);
-		if (!videoSession?.isActive) return false;
-
-		this.registerViewer(videoSession, options);
-		videoSession.tab = session;
-
-		// The stream may have been paused because everyone watching had it off
-		// screen; someone is watching again.
-		await this.setPaused(sessionId, session, false);
-		await this.applyCaptureGeometry(sessionId, session);
-		return true;
 	}
 
 	/**
@@ -878,7 +1171,14 @@ export class BrowserVideoCapture extends EventEmitter {
 	// ------------------------------------------------------------------
 
 	/**
-	 * Start video streaming for a session
+	 * Attach a viewer to a tab's stream, bringing the stream up if it isn't.
+	 *
+	 * One path for both cases. The old code chose between "restart everything"
+	 * and "just attach" from its own viewer count, which meant a stale entry
+	 * could route a perfectly ordinary reconnect into the attach branch and
+	 * leave a dead page untouched. Here the page decides (see `ensureLive`),
+	 * and the difference between a first viewer and a fifth is only how much
+	 * work that check turns out to imply.
 	 */
 	async startStreaming(
 		sessionId: string,
@@ -900,37 +1200,12 @@ export class BrowserVideoCapture extends EventEmitter {
 			await pendingPreInject.catch(() => {});
 		}
 
-		// A viewer re-handshaking (its own recovery path) gets a clean restart
-		// only when it is the sole viewer — that is the case the recovery logic
-		// was written for. Tearing the capture down because a *second* viewer
-		// arrived is what made two devices fight over one tab: each new
-		// handshake killed the other side's channel, whose health check
-		// reconnected and killed this one straight back.
-		const existingSession = this.sessions.get(sessionId);
-		if (existingSession?.isActive) {
-			const others = Array.from(existingSession.viewers.keys()).filter((id) => id !== viewerId);
-			if (others.length === 0) {
-				debug.log('webcodecs', `Session ${sessionId} already active for its only viewer, restarting clean`);
-				await this.stopStreaming(sessionId, session);
-			} else {
-				debug.log(
-					'webcodecs',
-					`Session ${sessionId} already streaming to ${others.length} other viewer(s), attaching ${viewerId}`
-				);
-				return this.attachViewer(sessionId, session, options);
-			}
-		}
-
 		if (!session.page || session.page.isClosed()) {
 			debug.error('webcodecs', `Cannot start: page is closed`);
 			return false;
 		}
 
 		try {
-			const page = session.page;
-			const viewport = page.viewport()!;
-
-			// Get or create session tracking
 			let videoSession = this.sessions.get(sessionId);
 			if (!videoSession) {
 				videoSession = this.createSessionState(sessionId);
@@ -939,80 +1214,28 @@ export class BrowserVideoCapture extends EventEmitter {
 
 			videoSession.tab = session;
 			this.registerViewer(videoSession, options);
-			videoSession.paused = false;
-			videoSession.captureMode = 'push';
-			videoSession.healthyWindows = 0;
 
-			const videoConfig = this.buildVideoConfig(videoSession, viewport);
-			const audioConfig = this.buildAudioConfig(videoSession);
+			// The pre-injected peer was built before any viewer's capabilities
+			// were known; `ensureLive` re-injects if this one needs a different
+			// codec set, and reuses it otherwise. Display metrics never need a
+			// rebuild — `applyCaptureGeometry` reconfigures the live encoder.
+			const live = await this.ensureLive(sessionId, session, isValidSession);
 
-			// The pre-injected script was configured before the viewer's codec
-			// support and display metrics were known, so re-inject whenever the
-			// handshake carried either.
-			const mustReinject = !videoSession.scriptsPreInjected || !!options?.codecSupport || !!options?.display;
-			if (mustReinject) {
-				await this.injectScripts(sessionId, page, videoConfig, audioConfig);
-				videoSession.scriptInjected = true;
-			} else {
-				debug.log('webcodecs', `Scripts already pre-injected for ${sessionId}, skipping injection`);
-			}
-
-			// Single batched call: verify peer + start streaming + init audio
-			// (saves ~60ms of IPC overhead vs 4 separate page.evaluate calls)
-			const initResult = await page.evaluate(async () => {
-				const peer = (window as any).__webCodecsPeer;
-				if (typeof peer?.startStreaming !== 'function') {
-					return { peerExists: false, started: false, audioInitialized: false };
-				}
-
-				const started = await peer.startStreaming();
-				if (!started) {
-					return { peerExists: true, started: false, audioInitialized: false };
-				}
-
-				// Initialize audio encoder if available
-				let audioInitialized = false;
-				const encoder = (window as any).__audioEncoder;
-				if (typeof encoder?.init === 'function') {
-					try {
-						const initiated = await encoder.init();
-						if (initiated) {
-							audioInitialized = !!encoder.start();
-						}
-					} catch {}
-				}
-
-				return { peerExists: true, started: true, audioInitialized };
-			});
-
-			if (!initResult.peerExists) {
-				debug.error('webcodecs', `Peer script injected but __webCodecsPeer not available`);
-				this.sessions.delete(sessionId);
+			if (!live) {
+				debug.error('webcodecs', `Failed to bring up capture for ${sessionId}`);
 				return false;
 			}
 
-			if (!initResult.started) {
-				debug.error('webcodecs', `startStreaming returned false`);
-				this.sessions.delete(sessionId);
-				return false;
-			}
-
-			videoSession.isActive = true;
-
-			if (initResult.audioInitialized) {
-				debug.log('webcodecs', 'Audio encoder initialized and started');
-			} else {
-				debug.warn('webcodecs', 'Audio not available, continuing with video only');
-			}
-
-			videoSession.headlessReady = true;
-
-			await this.setupCapture(sessionId, session, isValidSession);
+			// Someone is watching again — the stream may have been paused because
+			// everyone who had it open put it off screen.
+			await this.setPaused(sessionId, session, false);
+			await this.applyCaptureGeometry(sessionId, session);
 
 			debug.log(
 				'webcodecs',
-				`Streaming started for ${sessionId} — ${videoSession.capture.width}x${videoSession.capture.height} ` +
-					`@${videoSession.targetFramerate}fps (${videoSession.captureMode}, ${videoSession.profile.tier})`
+				`Streaming ready for ${sessionId} — ${videoSession.capture.width}x${videoSession.capture.height} ` +
+					`@${videoSession.targetFramerate}fps (${videoSession.captureMode}, ${videoSession.profile.tier}, ` +
+					`${videoSession.viewers.size} viewer(s))`
 			);
 			return true;
 		} catch (error) {
@@ -1284,6 +1507,107 @@ export class BrowserVideoCapture extends EventEmitter {
 	}
 
 	/**
+	 * Watch every live session for a stream that has stopped producing.
+	 *
+	 * On a timer rather than driven by encoder stats, because the failures that
+	 * matter are the ones where the page stops reporting altogether — a peer
+	 * that died with a navigation sends nothing, so anything event-driven would
+	 * wait forever for a signal that is never coming. Runs only while sessions
+	 * exist, and does nothing at all unless one has actually gone quiet.
+	 */
+	private ensureWatchdog(): void {
+		if (this.watchdogTimer || this.sessions.size === 0) return;
+
+		this.watchdogTimer = setInterval(() => {
+			if (this.sessions.size === 0) {
+				clearInterval(this.watchdogTimer!);
+				this.watchdogTimer = null;
+				return;
+			}
+
+			for (const videoSession of [...this.sessions.values()]) {
+				if (!videoSession.isActive) continue;
+				if (this.reapStaleViewers(videoSession)) continue;
+				this.checkForStall(videoSession);
+			}
+		}, BrowserVideoCapture.STREAM_STALL_MS);
+
+		// Nothing here should hold the process open on its own.
+		this.watchdogTimer.unref?.();
+	}
+
+	/**
+	 * Drop viewers that handshook and never connected, and tear the capture
+	 * down if that leaves nobody watching. Returns whether the session ended.
+	 *
+	 * The page-informed pass in `reconcileViewers` only runs when someone
+	 * handshakes, which is precisely what a tab nobody is watching any more
+	 * never gets — so without this a viewer that vanished mid-negotiation kept
+	 * a headless renderer and an encoder busy for an audience of nobody.
+	 */
+	private reapStaleViewers(videoSession: VideoStreamSession): boolean {
+		const now = Date.now();
+		let dropped = 0;
+
+		for (const [viewerId, viewer] of videoSession.viewers) {
+			if (viewer.connected) continue;
+			if (now - viewer.attachedAt < BrowserVideoCapture.VIEWER_HANDSHAKE_TTL_MS) continue;
+
+			videoSession.viewers.delete(viewerId);
+			dropped++;
+		}
+
+		if (dropped === 0) return false;
+
+		debug.log(
+			'webcodecs',
+			`Reaped ${dropped} viewer(s) that never connected on ${videoSession.sessionId}, ` +
+				`${videoSession.viewers.size} left`
+		);
+
+		if (videoSession.viewers.size > 0) {
+			this.refreshViewerConfig(videoSession);
+			return false;
+		}
+
+		void this.stopStreaming(videoSession.sessionId, videoSession.tab);
+		return true;
+	}
+
+	/**
+	 * Repair a stream that has stopped producing while someone is watching it.
+	 *
+	 * Recovery used to live entirely in the viewer: it noticed no first frame,
+	 * asked for a screencast refresh, then re-handshook. That only works while
+	 * the *client's* view of the problem is right — and the failures that stuck
+	 * were the ones where the client did everything correctly and the source
+	 * was the broken half. Repairing from here closes that gap, and costs
+	 * nothing on a healthy stream because even an idle page still tops off.
+	 */
+	private checkForStall(videoSession: VideoStreamSession): void {
+		if (videoSession.paused || videoSession.repairing || !videoSession.tab) return;
+		if (videoSession.viewers.size === 0) return;
+		if (!Array.from(videoSession.viewers.values()).some((viewer) => viewer.connected)) return;
+
+		const silentFor = Date.now() - videoSession.lastEncodedAt;
+		if (videoSession.lastEncodedAt === 0 || silentFor < BrowserVideoCapture.STREAM_STALL_MS) return;
+
+		const { sessionId, tab } = videoSession;
+		debug.warn('webcodecs', `Stream for ${sessionId} produced nothing for ${silentFor}ms — repairing`);
+
+		videoSession.repairing = true;
+		void this.ensureLive(sessionId, tab, () => !tab.isDestroyed)
+			.then((live) => {
+				if (live) return this.requestKeyframe(sessionId, tab);
+			})
+			.catch((error) => debug.warn('webcodecs', `Stall repair failed for ${sessionId}:`, error))
+			.finally(() => {
+				videoSession.repairing = false;
+				videoSession.lastEncodedAt = Date.now();
+			});
+	}
+
+	/**
 	 * Encoder health from the page. Saturation here means this host cannot
 	 * produce frames fast enough, which no amount of network headroom fixes.
 	 */
@@ -1292,6 +1616,11 @@ export class BrowserVideoCapture extends EventEmitter {
 		if (!videoSession?.isActive) return;
 
 		videoSession.captureMode = stats.captureMode || videoSession.captureMode;
+
+		// Frames reaching the encoder is the one signal that means the pipeline
+		// is genuinely alive end to end. The counter is per-window, so any
+		// non-zero report is proof of life for this window.
+		if (stats.framesAttempted > 0) videoSession.lastEncodedAt = Date.now();
 
 		// In-page capture can end on its own — the captured surface goes away
 		// on some navigations — and the page has no way to start a screencast.
@@ -1421,8 +1750,14 @@ export class BrowserVideoCapture extends EventEmitter {
 		visible: boolean
 	): Promise<boolean> {
 		const videoSession = this.sessions.get(sessionId);
-		const viewer = videoSession?.viewers.get(viewerId);
-		if (!videoSession || !viewer) return false;
+		if (!videoSession) return false;
+
+		// Registered on demand rather than refused. A viewer whose peer failed
+		// while it was suspended loses its entry, and coming back is exactly
+		// when it needs one: refusing left the tab paused with `isActive` true
+		// and nobody in the table, and nothing else ever re-evaluated that.
+		const viewer =
+			videoSession.viewers.get(viewerId) ?? this.registerViewer(videoSession, { viewerId });
 
 		viewer.visible = visible;
 		return this.setPaused(sessionId, session, this.allViewersHidden(videoSession));
@@ -1697,8 +2032,14 @@ export class BrowserVideoCapture extends EventEmitter {
 	}
 
 	/**
-	 * Handle navigation - re-inject peer script and restart capture
-	 * Called after page navigation to restore video streaming without full reconnection
+	 * Re-establish capture after the page swapped documents.
+	 *
+	 * The peer object lived in the old execution context, so it is gone; only
+	 * the exposed bindings survive. `ensureLive` already knows how to notice
+	 * that and rebuild, and routing through it means a navigation and a stalled
+	 * stream heal by the same code — a failure here no longer leaves the
+	 * session marked active with a dead page behind it, which is the state that
+	 * used to be unrecoverable without reloading by hand.
 	 */
 	async handleNavigation(sessionId: string, session: BrowserTab): Promise<boolean> {
 		const videoSession = this.sessions.get(sessionId);
@@ -1707,70 +2048,27 @@ export class BrowserVideoCapture extends EventEmitter {
 			return false;
 		}
 
+		debug.log('webcodecs', `🔄 Handling navigation for ${sessionId} — rebuilding page capture`);
+
 		try {
-			const page = session.page;
-			const viewport = page.viewport()!;
-
-			debug.log('webcodecs', `🔄 Handling navigation for ${sessionId} - re-injecting peer script and restarting capture`);
-
-			const videoConfig = this.buildVideoConfig(videoSession, viewport);
-			const audioConfig = this.buildAudioConfig(videoSession);
-
-			// Re-inject video encoder and audio capture scripts to new page context
-			await page.evaluate(videoEncoderScript, videoConfig);
-			await injectAudioCaptureIntoAllFrames(page, audioConfig);
-
-			// Single batched call: verify peer + start streaming + init audio
-			const initResult = await page.evaluate(async () => {
-				const peer = (window as any).__webCodecsPeer;
-				if (typeof peer?.startStreaming !== 'function') {
-					return { peerExists: false, started: false, audioInitialized: false };
-				}
-
-				const started = await peer.startStreaming();
-				if (!started) {
-					return { peerExists: true, started: false, audioInitialized: false };
-				}
-
-				let audioInitialized = false;
-				const encoder = (window as any).__audioEncoder;
-				if (typeof encoder?.init === 'function') {
-					try {
-						const initiated = await encoder.init();
-						if (initiated) {
-							audioInitialized = !!encoder.start();
-						}
-					} catch {}
-				}
-
-				return { peerExists: true, started: true, audioInitialized };
+			const live = await this.ensureLive(sessionId, session, () => !session.isDestroyed, {
+				force: true
 			});
 
-			if (!initResult.peerExists) {
-				debug.error('webcodecs', `Peer script re-injection failed - peer not available`);
+			if (!live) {
+				// Leave the session marked inactive so the next handshake starts
+				// from scratch instead of attaching to a page that cannot encode.
+				videoSession.isActive = false;
+				debug.error('webcodecs', `Failed to restore streaming after navigation for ${sessionId}`);
 				return false;
 			}
-
-			if (!initResult.started) {
-				debug.error('webcodecs', `Failed to start streaming on new page`);
-				return false;
-			}
-
-			if (initResult.audioInitialized) {
-				debug.log('webcodecs', 'Audio re-initialized after navigation');
-			} else {
-				debug.warn('webcodecs', 'Audio not available after navigation, continuing with video only');
-			}
-
-			// The old page's encoder handle died with its execution context.
-			videoSession.captureMode = 'push';
-			await this.setupCapture(sessionId, session, () => !session.isDestroyed);
 
 			// Emit event to notify frontend that streaming is ready
 			this.emit('navigation-streaming-ready', { sessionId });
 
 			return true;
 		} catch (error) {
+			videoSession.isActive = false;
 			debug.error('webcodecs', `Failed to handle navigation:`, error);
 			return false;
 		}
@@ -1846,10 +2144,16 @@ export class BrowserVideoCapture extends EventEmitter {
 	async cleanup(): Promise<void> {
 		debug.log('webcodecs', 'Cleaning up all sessions');
 
+		if (this.watchdogTimer) {
+			clearInterval(this.watchdogTimer);
+			this.watchdogTimer = null;
+		}
+
 		const sessionIds = Array.from(this.sessions.keys());
 		await Promise.all(sessionIds.map((id) => this.stopStreaming(id)));
 
 		this.sessions.clear();
+		this.tabInjection.clear();
 	}
 }
 

--- a/backend/preview/browser/scripts/host-bridge.ts
+++ b/backend/preview/browser/scripts/host-bridge.ts
@@ -665,14 +665,8 @@ export function hostBridgeScript(bindingName: string) {
 	{
 		const STYLE_ID = '__clopen-fullscreen-style';
 		const MAX_Z = 2147483647;
-		/** How long the exit hint stays up before fading, as in Chrome itself. */
-		const EXIT_HINT_MS = 3200;
-		/** What counts as "the user is still there" and brings the hint back. */
-		const ACTIVITY_EVENTS = ['mousemove', 'touchstart', 'keydown'];
 
 		let fullscreenElement: Element | null = null;
-		let exitButton: HTMLElement | null = null;
-		let hideHintTimer: ReturnType<typeof setTimeout> | undefined;
 
 		// Captured before the patches further down shadow them. Every replacement
 		// below is installed as an *own* property of `document`, while the real
@@ -731,87 +725,14 @@ export function hostBridgeScript(bindingName: string) {
 			(document.head || document.documentElement).appendChild(style);
 		};
 
-		/**
-		 * Bring the hint back and start its countdown again.
-		 *
-		 * It stays clickable while faded — the fade is there so the corner of a
-		 * video is not permanently covered, not to withdraw the way out. A phone
-		 * has no pointer to move, so a tap has to land on something.
-		 */
-		const revealExitButton = () => {
-			if (!exitButton) return;
-			exitButton.style.opacity = '1';
-			clearTimeout(hideHintTimer);
-			hideHintTimer = setTimeout(() => {
-				if (exitButton) exitButton.style.opacity = '0.12';
-			}, EXIT_HINT_MS);
-		};
-
-		/**
-		 * The exit affordance.
-		 *
-		 * Rendered inside the page on purpose: it is then part of the captured
-		 * frame and answers a normal click or tap, so it works on a phone and on
-		 * a second viewer's screen. Anything app-side would need a channel of its
-		 * own and would still miss the pages that swallow Escape.
-		 *
-		 * It fades the way Chrome's own "Press Esc to exit full screen" notice
-		 * does and returns on the next sign of life. A badge pinned over the
-		 * corner of a video for the whole of playback is not what full screen
-		 * looks like anywhere else.
-		 */
-		const showExitButton = () => {
-			if (exitButton) {
-				revealExitButton();
-				return;
-			}
-
-			const button = document.createElement('button');
-			button.type = 'button';
-			button.setAttribute('data-clopen-fullscreen-ui', '');
-			button.textContent = 'Exit full screen (Esc)';
-			button.style.cssText = [
-				'position:fixed',
-				'top:12px',
-				'right:12px',
-				`z-index:${MAX_Z}`,
-				'margin:0',
-				'padding:6px 12px',
-				'border:0',
-				'border-radius:9999px',
-				'font:500 12px/1.4 system-ui,-apple-system,Segoe UI,sans-serif',
-				'color:#fff',
-				'background:rgba(15,23,42,0.82)',
-				'box-shadow:0 2px 10px rgba(0,0,0,0.45)',
-				'cursor:pointer',
-				'opacity:1',
-				'transition:opacity 220ms ease'
-			].join(';');
-			button.addEventListener('click', (event) => {
-				event.preventDefault();
-				event.stopPropagation();
-				void exit();
-			});
-			(document.body || document.documentElement).appendChild(button);
-			exitButton = button;
-
-			// Capture phase: a player that swallows pointer events over its own
-			// surface would otherwise keep the hint from ever coming back.
-			for (const type of ACTIVITY_EVENTS) {
-				document.addEventListener(type, revealExitButton, true);
-			}
-			revealExitButton();
-		};
-
-		const removeChrome = () => {
-			clearTimeout(hideHintTimer);
-			hideHintTimer = undefined;
-			for (const type of ACTIVITY_EVENTS) {
-				document.removeEventListener(type, revealExitButton, true);
-			}
-			exitButton?.remove();
-			exitButton = null;
-		};
+		// No in-page exit affordance is drawn any more. There used to be an
+		// "Exit full screen (Esc)" badge here, which put two buttons saying the
+		// same thing over the same frame — the page's, painted into the captured
+		// picture, and the app's, drawn over it. Only one can be the way out, and
+		// the app-side control is the one that survives a page re-render, reaches
+		// every viewer, and still works when Chrome granted a fullscreen from its
+		// own C++ that this shim never saw. All the page draws now is the style
+		// rule that fakes the fullscreen in the first place.
 
 		/**
 		 * Chrome fires this *on the element*; listeners on `document` only see it
@@ -832,10 +753,25 @@ export function hostBridgeScript(bindingName: string) {
 			element.removeAttribute('data-clopen-fullscreen');
 		};
 
+		/**
+		 * Tell the host whether this page is showing something full screen.
+		 *
+		 * The in-page exit affordance is drawn by the page, which means the page
+		 * can lose it — a re-render that empties the body, a stacking context
+		 * that buries it, a fullscreen Chrome granted from C++ that this shim
+		 * never saw. The viewer needs its own way out, and it can only offer one
+		 * if it knows. Fire-and-forget: a frame with no route to the host still
+		 * has a working CSS fullscreen, it just cannot be rescued from outside.
+		 */
+		const reportState = (active: boolean) => {
+			void call('fullscreen-state', { active }).catch(() => {});
+		};
+
 		const enter = (element: Element) => {
 			ensureStyle();
 			if (fullscreenElement && fullscreenElement !== element) clearMarks(fullscreenElement);
 
+			const wasActive = fullscreenElement !== null;
 			fullscreenElement = element;
 			// The root and the body already fill the viewport; pinning them as
 			// fixed boxes only breaks their own layout.
@@ -844,8 +780,8 @@ export function hostBridgeScript(bindingName: string) {
 			}
 			document.documentElement.classList.add('clopen-fullscreen-active');
 			document.body?.classList.add('clopen-fullscreen-active');
-			showExitButton();
 			notify(element);
+			if (!wasActive) reportState(true);
 			return Promise.resolve();
 		};
 
@@ -857,9 +793,45 @@ export function hostBridgeScript(bindingName: string) {
 			fullscreenElement = null;
 			document.documentElement.classList.remove('clopen-fullscreen-active');
 			document.body?.classList.remove('clopen-fullscreen-active');
-			removeChrome();
 			notify(previous);
+			reportState(false);
 			return Promise.resolve();
+		};
+
+		/**
+		 * Leave full screen no matter how the page got there.
+		 *
+		 * `exit()` alone is not enough as a rescue: it returns immediately when
+		 * this shim holds no element, which is exactly the case that strands the
+		 * preview — Chrome granted a fullscreen from its own C++ (a `<video>`
+		 * control bar, a double-click) and the conversion did not take, so the
+		 * composited surface is collapsed with nothing in the page marked. This
+		 * clears every trace unconditionally: the shim's state, any stray marks
+		 * left by a document that changed underneath it, the scroll lock, and
+		 * Chrome's own fullscreen.
+		 */
+		const forceExit = () => {
+			void exit();
+
+			for (const marked of Array.from(document.querySelectorAll('[data-clopen-fullscreen]'))) {
+				marked.removeAttribute('data-clopen-fullscreen');
+			}
+			document.documentElement.classList.remove('clopen-fullscreen-active');
+			document.body?.classList.remove('clopen-fullscreen-active');
+
+			try {
+				if (readNativeElement()) nativeExit?.();
+			} catch {
+				// Already leaving, or never was.
+			}
+
+			reportState(false);
+		};
+
+		// The viewer's own escape hatch, reachable from the host in every frame.
+		scope.__clopenFullscreen = {
+			active: () => fullscreenElement !== null || readNativeElement() !== null,
+			forceExit
 		};
 
 		/**

--- a/backend/preview/browser/scripts/video-stream.ts
+++ b/backend/preview/browser/scripts/video-stream.ts
@@ -58,6 +58,19 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 	const viewers = new Map<string, ViewerPeer>();
 	let videoEncoder: VideoEncoder | null = null;
 	let isCapturing = false;
+
+	/**
+	 * Which injection this object came from.
+	 *
+	 * The backend stamps every injection with an id and keeps the last one it
+	 * issued. Anything else — a peer left over from a document the page has
+	 * since navigated away from, or one injected by a different backend session
+	 * — reads as a mismatch, and the backend rebuilds rather than talking to an
+	 * object whose encoder and viewers belong to a page that no longer exists.
+	 * That mismatch is invisible from the outside: `window.__webCodecsPeer` is
+	 * present and every method answers, they just answer for the wrong page.
+	 */
+	const epoch = config.epoch || '';
 	let videoFrameCount = 0;
 	let audioFrameCount = 0;
 	let lastKeyframeTime = 0;
@@ -1240,8 +1253,27 @@ export function videoEncoderScript(config: StreamingConfig['video']) {
 		}
 	}
 
+	/**
+	 * Everything the backend needs to decide "is this page actually streaming?".
+	 *
+	 * Cheap on purpose — it is read on every handshake. `viewers` is the list
+	 * of peers that genuinely exist here, which is the only way the backend can
+	 * tell its own viewer table from wishful thinking: an entry it holds that
+	 * this page has never heard of is a viewer that will never receive a frame.
+	 */
+	function health() {
+		return {
+			epoch,
+			capturing: isCapturing,
+			encoderReady: !!videoEncoder,
+			captureMode,
+			viewers: Array.from(viewers.keys())
+		};
+	}
+
 	// Expose API
 	(window as any).__webCodecsPeer = {
+		health,
 		startStreaming,
 		stopStreaming,
 		createOffer,

--- a/backend/preview/browser/types.ts
+++ b/backend/preview/browser/types.ts
@@ -462,8 +462,29 @@ export interface ClientStreamFeedback {
  *
  * Single source of truth for all codec settings.
  */
+/**
+ * What the in-page peer reports about itself.
+ *
+ * The backend's session record and the page's encoder are two independent
+ * state machines — a navigation, a self-reload or a failed re-injection moves
+ * one without the other — and every "Loading preview…" that never resolved
+ * traced back to trusting the backend's copy. This is the page's own answer,
+ * read at every handshake so a mismatch is repaired instead of inherited.
+ */
+export interface PeerHealth {
+	/** Injection id. A mismatch means this peer belongs to a different document. */
+	epoch: string;
+	capturing: boolean;
+	encoderReady: boolean;
+	captureMode: 'push' | 'native';
+	/** Viewer ids with a live peer here — the ground truth for the viewer table. */
+	viewers: string[];
+}
+
 export interface StreamingConfig {
 	video: {
+		/** Stamped onto the injected peer so the backend can recognise its own. */
+		epoch: string;
 		codec: string; // Fallback codec (VP8, fixed-bitrate mode) when nothing better is negotiated
         width: number;
         height: number;
@@ -518,6 +539,7 @@ export interface StreamingConfig {
  */
 export const DEFAULT_STREAMING_CONFIG: StreamingConfig = {
 	video: {
+		epoch: '',
 		codec: 'vp8',
 		width: 0,
 		height: 0,

--- a/backend/preview/index.ts
+++ b/backend/preview/index.ts
@@ -2,7 +2,12 @@
 export * from './browser/types';
 
 // Export MCP control types
-export type { McpControlEvent, McpCursorEvent, McpClickEvent } from './browser/browser-mcp-control';
+export type {
+	McpControlEvent,
+	McpCursorEvent,
+	McpClickEvent,
+	McpFocusEvent
+} from './browser/browser-mcp-control';
 
 // Export the main preview service class and manager
 export {

--- a/backend/ws/preview/browser/interact.ts
+++ b/backend/ws/preview/browser/interact.ts
@@ -540,8 +540,22 @@ export const interactPreviewHandler = createRouter()
 						// Handle viewport change (device/rotation) without reconnection
 						if (action.width && action.height && action.scale && action.scale > 0 && action.scale <= 1) {
 							session.scale = action.scale;
-							if (action.deviceSize) session.deviceSize = action.deviceSize as any;
-							if (action.rotation) session.rotation = action.rotation as any;
+
+							// Routed through the service rather than assigned here.
+							// Writing the fields directly left every *other* viewer of
+							// this tab out of the loop: their picture resized, because
+							// capture geometry follows the page, but their device
+							// selector and the mockup drawn around the canvas both read
+							// the tab's metadata — which nothing told them had changed.
+							// So a phone switched to Tablet from a laptop went on
+							// drawing a laptop frame around a tablet-shaped picture.
+							if (action.deviceSize || action.rotation) {
+								await previewService.setViewport(
+									session.id,
+									(action.deviceSize as any) ?? session.deviceSize,
+									(action.rotation as any) ?? session.rotation
+								);
+							}
 
 							debug.log('preview', `📱 Viewport updated for tab ${tabId}: ${action.width}x${action.height}`);
 

--- a/backend/ws/preview/browser/native-ui.ts
+++ b/backend/ws/preview/browser/native-ui.ts
@@ -10,12 +10,33 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { debug } from '$shared/utils/logger';
-import { requireBrowserPreviewAccess } from '../access';
+import { requireBrowserPreviewAccess, requireBrowserTabAccess } from '../access';
 
 // Event forwarding is now handled automatically by BrowserPreviewServiceManager
 // when service instances are created, ensuring proper project isolation.
 
 export const nativeUIPreviewHandler = createRouter()
+	/**
+	 * Take the page out of full screen on the viewer's behalf.
+	 *
+	 * The page draws its own exit hint, but it is a DOM node the page is free
+	 * to destroy — and a fullscreen Chrome granted from its own C++ leaves no
+	 * hint at all, just a collapsed capture surface that reads as a preview
+	 * stuck full screen. This route is the way out that the page cannot lose.
+	 */
+	.http('preview:browser-exit-fullscreen', {
+		data: t.Object({
+			tabId: t.Optional(t.String())
+		}),
+		response: t.Object({
+			success: t.Boolean()
+		})
+	}, async ({ data, conn }) => {
+		const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
+		const success = await previewService.exitPageFullscreen(tab.id);
+		return { success };
+	})
+
 	// Action: Client responds to a dialog (alert, confirm, prompt)
 	.on('preview:browser-dialog-input', {
 		data: t.Object({

--- a/backend/ws/preview/browser/tab-info.ts
+++ b/backend/ws/preview/browser/tab-info.ts
@@ -63,7 +63,16 @@ export const tabInfoPreviewHandler = createRouter()
 				isActive: t.Boolean(),
 				canGoBack: t.Boolean(),
 				canGoForward: t.Boolean(),
-				isMcpControlled: t.Boolean()
+				isMcpControlled: t.Boolean(),
+				/** The tab this project's agent is acting on right now. */
+				isMcpFocused: t.Boolean(),
+				/**
+				 * What the agent is doing on this tab, for the caption beside its
+				 * cursor. Recovered with the lock: a run holds a tab for minutes,
+				 * so a panel opened in the middle of one must not have to wait for
+				 * the next action before it can say anything.
+				 */
+				mcpActivity: t.Optional(t.String())
 			})),
 			activeTabId: t.Union([t.String(), t.Null()]),
 			count: t.Number()
@@ -73,8 +82,15 @@ export const tabInfoPreviewHandler = createRouter()
 			? requireBrowserPreviewAccessFor(conn, data.projectId)
 			: requireBrowserPreviewAccess(conn);
 
+		// This is where the frontend rebuilds its lock state from scratch — a
+		// project switch, a page reload — so it is the natural point to collect
+		// locks whose chat session died without reaching a release path. Without
+		// it, a stuck lock would survive every reload until the server restarted.
+		browserMcpControl.releaseOrphans();
+
 		const allTabsInfo = previewService.getAllTabsInfo();
 		const activeTab = previewService.getActiveTab();
+		const focusedTabId = browserMcpControl.getFocusedTab(projectId);
 
 		debug.log('preview', `📋 Listing ${allTabsInfo.length} active browser tabs for session recovery (project: ${projectId})`);
 
@@ -91,7 +107,9 @@ export const tabInfoPreviewHandler = createRouter()
 				isActive: tab.isActive,
 				canGoBack: tab.canGoBack,
 				canGoForward: tab.canGoForward,
-				isMcpControlled: browserMcpControl.isTabControlled(tab.id, projectId)
+				isMcpControlled: browserMcpControl.isTabControlled(tab.id, projectId),
+				isMcpFocused: tab.id === focusedTabId,
+				mcpActivity: browserMcpControl.getActivity(tab.id) ?? undefined
 			})),
 			activeTabId: activeTab?.id || null,
 			count: allTabsInfo.length

--- a/backend/ws/preview/browser/webcodecs.ts
+++ b/backend/ws/preview/browser/webcodecs.ts
@@ -342,9 +342,14 @@ export const streamPreviewHandler = createRouter()
 			})
 		},
 		async ({ data, conn }) => {
-			const { previewService, tab } = requireBrowserTabAccess(conn, data.tabId);
+			const { previewService, projectId, tab } = requireBrowserTabAccess(conn, data.tabId);
 
 			await previewService.stopWebCodecsStreaming(tab.id, data.viewerId);
+
+			// The disconnect cleanup for this pair has nothing left to do.
+			// Dropping the key lets a later re-handshake register a fresh one
+			// instead of relying on a closure whose stop has already run.
+			registeredViewerCleanups.delete(`${projectId}:${tab.id}:${data.viewerId}`);
 
 			return { success: true };
 		}

--- a/backend/ws/preview/index.ts
+++ b/backend/ws/preview/index.ts
@@ -146,6 +146,14 @@ export const previewRouter = createRouter()
 		projectId: t.Optional(t.String()),
 		timestamp: t.Number()
 	}))
+	// Which controlled tab the agent is acting on right now. A lock says the
+	// user must not touch a tab; this says where the agent actually is, so
+	// several locked tabs stop being indistinguishable. Null = none.
+	.emit('preview:browser-mcp-control-focus', t.Object({
+		browserTabId: t.Union([t.String(), t.Null()]),
+		projectId: t.String(),
+		timestamp: t.Number()
+	}))
 	.emit('preview:browser-mcp-cursor-position', t.Object({
 		sessionId: t.String(),
 		x: t.Number(),
@@ -168,6 +176,20 @@ export const previewRouter = createRouter()
 		sessionId: t.String(),
 		timestamp: t.Number(),
 		source: t.Literal('mcp')
+	}))
+	// What the agent is doing on a tab, in a few words, for the caption beside
+	// its cursor. Null means it still holds the tab but is between actions.
+	.emit('preview:browser-mcp-activity', t.Object({
+		sessionId: t.String(),
+		label: t.Union([t.String(), t.Null()]),
+		timestamp: t.Number()
+	}))
+	// The page put something full screen (or left it). The viewer's exit control
+	// is drawn from this, and is the only one there is — the page draws none.
+	.emit('preview:browser-fullscreen-state', t.Object({
+		projectId: t.String(),
+		tabId: t.String(),
+		active: t.Boolean()
 	}))
 	.emit('preview:browser-viewport-changed', t.Object({
 		projectId: t.String(),

--- a/frontend/components/preview/browser/BrowserPreview.svelte
+++ b/frontend/components/preview/browser/BrowserPreview.svelte
@@ -26,6 +26,11 @@
 	import { previewHostBridge } from '$frontend/services/preview/browser/host-bridge.service';
 	import { browserConsoleService } from '$frontend/services/preview/browser/browser-console.service';
 	import { addNotification } from '$frontend/stores/ui/notification.svelte';
+	import {
+		getMcpActivity,
+		isBackendTabFullscreen
+	} from '$frontend/stores/features/preview-tabs-workspace.svelte';
+	import ws from '$frontend/utils/ws';
 	import { projectState } from '$frontend/stores/core/projects.svelte';
 	import { appState } from '$frontend/stores/core/app.svelte';
 
@@ -122,6 +127,12 @@
 	 * Kept in page space all the way down to the Container, which owns the
 	 * projection. Converting on arrival meant the event was dropped whenever the
 	 * canvas had not painted yet — and a dropped cursor event never comes back.
+	 *
+	 * `visible` says only "a gesture has placed this", never "draw it": whether
+	 * the pointer is on screen follows from the agent holding the tab, which the
+	 * Container reads directly. Half the actions in a batch carry no
+	 * coordinates, so anything that gated drawing on an incoming event spent
+	 * most of a run showing nothing.
 	 */
 	let mcpCursorPage = $state<{x: number, y: number, visible: boolean, clicking?: boolean, pressed?: boolean}>({
 		x: 0, y: 0, visible: false, clicking: false, pressed: false
@@ -802,8 +813,6 @@
 	function handleCanvasInteraction(action: any) {
 		const tab = activeTab;
 		if (tab && tab.sessionId) {
-			// Hide the AI cursor instantly if the human explicitly interacts
-			mcpCursorPage = { ...mcpCursorPage, visible: false };
 			coordinator.sendInteraction(action);
 		}
 	}
@@ -848,7 +857,26 @@
 	}
 
 	/**
-	 * Drop the agent's cursor when the panel starts showing a different tab.
+	 * Leave a page full screen from outside the page.
+	 *
+	 * The only way out, now that the shim no longer draws one of its own inside
+	 * the page. It is also the one that works in the case the in-page hint never
+	 * could: a fullscreen Chrome granted from its own C++ that the shim never
+	 * saw, which used to leave the preview zoomed and cropped with nothing to
+	 * press.
+	 */
+	async function exitPageFullscreen() {
+		const tab = activeTab;
+		if (!tab?.sessionId) return;
+		try {
+			await ws.http('preview:browser-exit-fullscreen', { tabId: tab.sessionId }, 10000);
+		} catch (error) {
+			debug.warn('preview', 'Failed to exit page full screen:', error);
+		}
+	}
+
+	/**
+	 * Re-point the agent's cursor at whichever tab the panel is now showing.
 	 *
 	 * Keyed on the tab alone, deliberately. Gating this on "is the tab still in
 	 * the controlled set" instead re-ran it on *every* tab mutation — a console
@@ -856,14 +884,23 @@
 	 * message, which can land after the first gestures. So the opening moves of
 	 * a run were cleared before they were ever drawn, which is the one stretch
 	 * where seeing the pointer matters most.
+	 *
+	 * It restores rather than only clears. An agent that has stopped moving
+	 * sends nothing further, so a switch away and back used to lose the pointer
+	 * for the rest of the run — the tab was still being driven, it just looked
+	 * like it wasn't.
 	 */
 	let lastCursorTabId: string | null = null;
 	$effect(() => {
 		const tabId = activeTabId;
 		if (tabId === lastCursorTabId) return;
 		lastCursorTabId = tabId;
+
+		const restored = mcpHandler.getCursorFor(tabManager.getTab(tabId ?? '')?.sessionId ?? null);
 		untrack(() => {
-			mcpCursorPage = { x: 0, y: 0, visible: false, clicking: false, pressed: false };
+			mcpCursorPage = restored
+				? { x: restored.x, y: restored.y, visible: true, clicking: false, pressed: restored.pressed }
+				: { x: 0, y: 0, visible: false, clicking: false, pressed: false };
 		});
 	});
 
@@ -923,6 +960,7 @@
 			{tabs}
 			{activeTabId}
 			mcpControlledTabIds={mcpHandler.getControlledTabIds()}
+			mcpFocusedTabId={mcpHandler.getFocusedTabId()}
 			onGoClick={handleGoClick}
 			onRefresh={refreshPreview}
 			onStop={stopLoading}
@@ -971,6 +1009,10 @@
 				bind:lastFrameData={currentTabLastFrameData}
 				bind:touchMode
 				isMcpControlled={isCurrentTabMcpControlled()}
+				isMcpFocused={mcpHandler.isCurrentTabMcpFocused()}
+				mcpActivity={getMcpActivity(sessionId) ?? ''}
+				isPageFullscreen={isBackendTabFullscreen(sessionId)}
+				onExitFullscreen={exitPageFullscreen}
 				onInteraction={handleCanvasInteraction}
 				onRetry={handleGoClick}
 			/>

--- a/frontend/components/preview/browser/components/Canvas.svelte
+++ b/frontend/components/preview/browser/components/Canvas.svelte
@@ -36,7 +36,7 @@
 		onRequestScreencastRefresh = $bindable<() => void>(() => {}), // Called when stream is stuck
 		touchMode = $bindable<'scroll' | 'cursor'>('scroll'),
 		touchTarget = undefined as HTMLElement | undefined, // Container element for touch events
-		onTouchCursorUpdate = $bindable<(pos: { x: number; y: number; visible: boolean; clicking?: boolean }) => void>(() => {})
+		onTouchCursorUpdate = $bindable<(pos: { x: number; y: number; visible: boolean; clicking?: boolean; pressed?: boolean }) => void>(() => {})
 	} = $props();
 
 	/**
@@ -88,21 +88,57 @@
 	let screencastRefreshCount = 0; // Track retry count for stuck detection
 	let navigationJustCompleted = false; // Track if navigation just completed (for fast refresh)
 
+	// Watchdog bookkeeping — see WATCHDOG_* above. Plain locals: nothing renders
+	// from them, and making them reactive would re-run effects once a second.
+	let blankSince = 0;
+	let watchdogRound = 0;
+
 	// Canvas snapshot storage for instant tab switching
 	// Stores a clone of the canvas per sessionId so switching back shows content immediately
 	const canvasSnapshots = new Map<string, HTMLCanvasElement>();
 	const MAX_SNAPSHOTS = 10;
 	let hasRestoredSnapshot = false; // Prevents canvas clear/reset during streaming start
 
-	// Recovery is only triggered by ACTUAL failures, not timeouts
-	// - ICE connection failed
-	// - WebCodecs connection closed unexpectedly
-	// - Explicit errors
+	// Recovery is triggered by ACTUAL failures — ICE failed, the WebCodecs
+	// connection closed unexpectedly, an explicit error — and, as a last resort,
+	// by the watchdog below when none of those fired but there is still no
+	// picture. This bounds how many attempts one *round* makes before backing
+	// off; the watchdog opens the next round.
 	const MAX_CONSECUTIVE_FAILURES = 2;
 	const HEALTH_CHECK_INTERVAL = 2000; // Check every 2 seconds for connection health
 	const FRAME_CHECK_INTERVAL = 100; // Fallback poll for first frame (primary path is onFirstFrame callback)
 	const STUCK_STREAM_TIMEOUT = 3000; // Fallback: Request screencast refresh after 3 seconds of connected but no frame
 	const NAVIGATION_FAST_REFRESH_DELAY = 300; // Fast refresh after navigation: 300ms
+
+	/**
+	 * Last-resort watchdog: how long a session may show nothing before this
+	 * component starts the whole handshake again, and how much longer it waits
+	 * on each further attempt.
+	 *
+	 * Everything above only recovers from a failure it was told about — an ICE
+	 * `failed`, a DataChannel close, a stream that connected and then produced
+	 * no frame. Three ways to end up with no picture and no recovery at all were
+	 * left over, and all three ended in a permanent "Loading preview…":
+	 *
+	 * - `startStreaming()` exhausting its retries. Nothing re-runs it: the
+	 *   streaming effect's dependencies have not changed, so it never fires again.
+	 * - A peer that never reaches `connected`. The stuck-stream ladder is gated
+	 *   on `isConnected`, and ICE can sit in `checking` indefinitely without ever
+	 *   declaring `failed` — much likelier over a Remote Access link than on the
+	 *   host, which is exactly where it was seen to hang forever.
+	 * - `attemptRecovery()` giving up after two tries and stopping the stream for
+	 *   good.
+	 *
+	 * This is deliberately outside all of that: it looks only at whether a frame
+	 * has ever arrived, so it cannot be defeated by a wrong diagnosis. The delay
+	 * grows a little per round to stay out of the way of a link that is merely
+	 * slow, and is capped — a viewer that is looking at a spinner must never be
+	 * left waiting minutes for the next attempt.
+	 */
+	const WATCHDOG_TICK_MS = 1000;
+	const WATCHDOG_FIRST_ESCALATION_MS = 8000;
+	const WATCHDOG_ESCALATION_STEP_MS = 3000;
+	const WATCHDOG_MAX_WAIT_MS = 15000;
 
 	// Sync isStreamReady with hasReceivedFirstFrame for parent component
 	$effect(() => {
@@ -157,6 +193,10 @@
 				lastStartRequestId = null; // Allow new start request for new session
 			}
 			lastTrackedSessionId = currentSessionId;
+			// A new tab starts its own patience: carrying the previous one's
+			// stopwatch over would fire the watchdog on its very first tick.
+			blankSince = 0;
+			watchdogRound = 0;
 		}
 	});
 
@@ -534,6 +574,52 @@
 	let trackpadTwoFingerLastCenterX = 0;
 	let trackpadTwoFingerLastCenterY = 0;
 	let trackpadTwoFingerTotalDist = 0;
+	/**
+	 * A two-finger gesture has happened and not every finger is off the glass.
+	 *
+	 * Fingers never leave together. Whichever one lifts first used to be read as
+	 * the end of the two-finger gesture and the *start* of a single-finger tap,
+	 * so ending a two-finger scroll fired a click wherever the cursor happened
+	 * to be — and the two-finger tap that should have opened a context menu was
+	 * consumed by that same transition before it could be recognised. The
+	 * gesture is now decided the moment the count drops below two, and nothing
+	 * else is read from the remaining fingers until the glass is clear.
+	 */
+	let trackpadGestureSettled = false;
+
+	/**
+	 * Double-tap-and-drag, the trackpad idiom for "press and hold while moving".
+	 *
+	 * Long-press was the only way to start a drag, which costs 600ms before
+	 * anything happens and is unusable for selecting text. A second tap that
+	 * lands quickly and then moves means the same thing and starts immediately;
+	 * one that lands and lifts again is just a double-click.
+	 */
+	let trackpadLastTapAt = 0;
+	let trackpadDoubleTapArmed = false;
+	/** Longest gap between the two taps that still reads as one gesture. */
+	const DOUBLE_TAP_WINDOW_MS = 320;
+
+	/** Show the touch cursor at its current spot, optionally mid-gesture. */
+	function publishTouchCursor(state: { clicking?: boolean; pressed?: boolean } = {}) {
+		if (!canvasElement) return;
+		const pos = canvasToScreen(trackpadCursorX, trackpadCursorY);
+		onTouchCursorUpdate({ x: pos.x, y: pos.y, visible: true, ...state });
+	}
+
+	/**
+	 * Flash the click ripple, then settle back.
+	 *
+	 * A tap on a trackpad surface lands somewhere the finger is not, so without
+	 * a mark on the cursor there is nothing to confirm the tap registered —
+	 * the same reason the agent's pointer draws one.
+	 */
+	function pulseTouchCursor(pressed = false) {
+		publishTouchCursor({ clicking: true, pressed });
+		setTimeout(() => {
+			if (touchMode === 'cursor') publishTouchCursor({ pressed });
+		}, 220);
+	}
 
 	function handleCanvasMouseDown(event: MouseEvent, canvas: HTMLCanvasElement) {
 		if (!sessionId) return;
@@ -1016,8 +1102,12 @@
 		consecutiveFailures++;
 		debug.log('webcodecs', `Recovery attempt ${consecutiveFailures}/${MAX_CONSECUTIVE_FAILURES} for session ${sessionId}`);
 
+		// A burst of failures is a bad moment, not a verdict: back off and let the
+		// watchdog re-arm this counter and try again. Returning here used to be
+		// terminal — the stream stopped and nothing ever restarted it, which is
+		// one of the ways a preview ended up on "Loading preview…" for good.
 		if (consecutiveFailures > MAX_CONSECUTIVE_FAILURES) {
-			debug.error('webcodecs', 'Max recovery attempts reached, giving up');
+			debug.warn('webcodecs', 'Recovery attempts exhausted for now, backing off to the watchdog');
 			isRecovering = false;
 			await stopStreaming();
 			return;
@@ -1097,6 +1187,79 @@
 			isStartingStream = false;
 		}
 	}
+
+	/**
+	 * One watchdog tick. Sees only "is there a picture yet"; see WATCHDOG_* above
+	 * for why it deliberately knows nothing about *why* there isn't one.
+	 */
+	async function watchdogTick() {
+		if (!sessionId || !sessionInfo || !canvasElement) return;
+
+		if (hasReceivedFirstFrame) {
+			blankSince = 0;
+			watchdogRound = 0;
+			return;
+		}
+
+		// Something is already on its way to a frame — starting a second attempt
+		// on top of it is how two streams end up fighting over one canvas. Only
+		// these two, and deliberately not `isNavigating`/`isReconnecting`: those
+		// are set by the page and can stay true indefinitely, which would hand
+		// the stuck state a way to switch the watchdog off.
+		if (isStartingStream || isRecovering) {
+			blankSince = 0;
+			return;
+		}
+
+		const now = Date.now();
+		if (blankSince === 0) {
+			blankSince = now;
+			return;
+		}
+
+		const patience = Math.min(
+			WATCHDOG_FIRST_ESCALATION_MS + watchdogRound * WATCHDOG_ESCALATION_STEP_MS,
+			WATCHDOG_MAX_WAIT_MS
+		);
+		if (now - blankSince < patience) return;
+
+		blankSince = now;
+		watchdogRound++;
+		// A fresh round gets a fresh allowance, so `attemptRecovery` can never be
+		// permanently spent — that is the whole point of the back-off above.
+		consecutiveFailures = 0;
+		connectionFailed = false;
+
+		const stats = webCodecsService?.getStats();
+
+		// Connected, decoding nothing: the source half is the broken one, and
+		// restarting its capture is both cheaper and likelier to work than
+		// re-negotiating a connection that is demonstrably fine.
+		if (isWebCodecsActive && stats?.isConnected) {
+			debug.warn('webcodecs', `Watchdog: connected but blank for ${patience}ms, refreshing capture (round ${watchdogRound})`);
+			onRequestScreencastRefresh();
+			return;
+		}
+
+		debug.warn(
+			'webcodecs',
+			`Watchdog: no frame after ${patience}ms (connection=${stats?.connectionState ?? 'none'}), re-handshaking (round ${watchdogRound})`
+		);
+		await attemptRecovery();
+	}
+
+	// Runs for as long as a tab has a session, independently of whether a stream
+	// was ever successfully started — a failed start is one of the cases this
+	// exists to catch.
+	$effect(() => {
+		if (!sessionId || !sessionInfo) return;
+
+		const timer = setInterval(() => {
+			void watchdogTick();
+		}, WATCHDOG_TICK_MS);
+
+		return () => clearInterval(timer);
+	});
 
 	// Stop WebCodecs streaming
 	async function stopStreaming() {
@@ -1414,8 +1577,10 @@
 				isMouseDown = false;
 				dragStarted = false;
 				touchLongPressed = false;
+				publishTouchCursor();
 			}
 			trackpadTwoFingerActive = true;
+			trackpadGestureSettled = false;
 			trackpadTwoFingerStartTime = Date.now();
 			trackpadTwoFingerTotalDist = 0;
 			const t1 = event.touches[0];
@@ -1425,7 +1590,10 @@
 			return;
 		}
 
-		if (trackpadTwoFingerActive) return; // Ignore until two-finger gesture fully ends
+		// Ignore anything that arrives before the glass is clear: a finger put
+		// back down while the tail of a two-finger gesture is still lifting is
+		// part of that gesture, not the start of a tap.
+		if (trackpadTwoFingerActive || trackpadGestureSettled) return;
 
 		// Single finger
 		const touch = event.touches[0];
@@ -1437,6 +1605,7 @@
 		mouseDownTime = Date.now();
 		dragStarted = false;
 		touchLongPressed = false;
+		trackpadDoubleTapArmed = mouseDownTime - trackpadLastTapAt < DOUBLE_TAP_WINDOW_MS;
 
 		// The tap lands at the virtual cursor, not the finger — probe there.
 		beginKeyboardProbe({ x: Math.round(trackpadCursorX), y: Math.round(trackpadCursorY) });
@@ -1453,6 +1622,9 @@
 				dragStarted = true;
 				cancelKeyboardProbe();
 				sendInteraction({ type: 'mousedown', x: Math.round(trackpadCursorX), y: Math.round(trackpadCursorY), button: 'left' });
+				// Held, not tapped: the cursor shows the button down for as long
+				// as the drag lasts, the way the agent's does.
+				publishTouchCursor({ pressed: true });
 			}
 		}, 600);
 	}
@@ -1486,7 +1658,7 @@
 			return;
 		}
 
-		if (event.touches.length !== 1 || !isMouseDown || trackpadTwoFingerActive) return;
+		if (event.touches.length !== 1 || !isMouseDown || trackpadTwoFingerActive || trackpadGestureSettled) return;
 
 		const touch = event.touches[0];
 		const deltaClientX = touch.clientX - trackpadLastClientX;
@@ -1507,6 +1679,15 @@
 			// Moving the cursor is not a tap; the probed point is no longer where
 			// the gesture will land.
 			cancelKeyboardProbe();
+
+			// The second tap of a double-tap moved: that is a drag, and it starts
+			// from where the cursor already is rather than waiting out a press.
+			if (trackpadDoubleTapArmed && !dragStarted) {
+				trackpadDoubleTapArmed = false;
+				touchLongPressed = true;
+				dragStarted = true;
+				sendInteraction({ type: 'mousedown', x: Math.round(trackpadCursorX), y: Math.round(trackpadCursorY), button: 'left' });
+			}
 		}
 
 		// Convert screen delta → page delta and move cursor
@@ -1517,35 +1698,40 @@
 		// Send mousemove so the browser sees hover state changes
 		sendInteraction({ type: 'mousemove', x: Math.round(trackpadCursorX), y: Math.round(trackpadCursorY) });
 
-		// Update virtual cursor display
-		const pos = canvasToScreen(trackpadCursorX, trackpadCursorY);
-		onTouchCursorUpdate({ x: pos.x, y: pos.y, visible: true });
+		// Update virtual cursor display — held while a long-press drag is running.
+		publishTouchCursor({ pressed: dragStarted });
 	}
 
 	function handleTrackpadTouchEnd(event: TouchEvent) {
 		if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
 
 		const remainingTouches = event.touches.length;
+		// The OS took the gesture away — it was never completed, so nothing it
+		// might have meant should be dispatched.
+		const cancelled = event.type === 'touchcancel';
 
 		if (trackpadTwoFingerActive) {
-			if (remainingTouches === 0) {
-				// All fingers lifted: check for two-finger tap → right click
-				const duration = Date.now() - trackpadTwoFingerStartTime;
-				if (duration < 300 && trackpadTwoFingerTotalDist < 20) {
-					sendInteraction({ type: 'rightclick', x: Math.round(trackpadCursorX), y: Math.round(trackpadCursorY) });
-				}
-				trackpadTwoFingerActive = false;
-			} else if (remainingTouches === 1) {
-				// One finger remains: transition back to single-finger tracking
-				const touch = event.touches[0];
-				trackpadLastClientX = touch.clientX;
-				trackpadLastClientY = touch.clientY;
-				trackpadTouchStartClientX = touch.clientX;
-				trackpadTouchStartClientY = touch.clientY;
-				isMouseDown = true;
-				mouseDownTime = Date.now();
-				trackpadTwoFingerActive = false;
+			// Decided here, on the *first* lift, because that is the last moment
+			// the gesture is still recognisable — a two-finger tap only ever
+			// reaches this branch, never the all-fingers-up one.
+			const duration = Date.now() - trackpadTwoFingerStartTime;
+			if (!cancelled && duration < 400 && trackpadTwoFingerTotalDist < 24) {
+				sendInteraction({ type: 'rightclick', x: Math.round(trackpadCursorX), y: Math.round(trackpadCursorY) });
+				pulseTouchCursor();
 			}
+
+			trackpadTwoFingerActive = false;
+			// Whatever is still touching belongs to the gesture just finished.
+			trackpadGestureSettled = remainingTouches > 0;
+			isMouseDown = false;
+			dragStarted = false;
+			touchLongPressed = false;
+			return;
+		}
+
+		if (trackpadGestureSettled) {
+			// Tail of a two-finger gesture. Clear once the glass is.
+			if (remainingTouches === 0) trackpadGestureSettled = false;
 			return;
 		}
 
@@ -1553,6 +1739,7 @@
 
 		if (touchLongPressed && dragStarted) {
 			sendInteraction({ type: 'mouseup', x: Math.round(trackpadCursorX), y: Math.round(trackpadCursorY), button: 'left' });
+			pulseTouchCursor();
 		} else {
 			// Tap: short + minimal movement → left click at cursor position
 			const duration = Date.now() - mouseDownTime;
@@ -1560,18 +1747,31 @@
 				Math.pow(trackpadLastClientX - trackpadTouchStartClientX, 2) +
 				Math.pow(trackpadLastClientY - trackpadTouchStartClientY, 2)
 			);
-			if (duration < 250 && moveDist < 10) {
+			if (!cancelled && duration < 250 && moveDist < 10) {
 				const anchor = { x: Math.round(trackpadCursorX), y: Math.round(trackpadCursorY) };
-				sendInteraction({ type: 'click', x: anchor.x, y: anchor.y });
+				// A second tap that never moved is a double-click, not two clicks:
+				// sending a bare click again would not select a word or open what
+				// a double-click opens.
+				sendInteraction({
+					type: trackpadDoubleTapArmed ? 'doubleclick' : 'click',
+					x: anchor.x,
+					y: anchor.y
+				});
 				settleKeyboard(anchor);
+				pulseTouchCursor();
+				// A completed double-click closes the sequence; a third tap in a
+				// row should start over rather than count as another pair.
+				trackpadLastTapAt = trackpadDoubleTapArmed ? 0 : Date.now();
 			} else {
 				cancelKeyboardProbe();
+				publishTouchCursor();
 			}
 		}
 
 		isMouseDown = false;
 		dragStarted = false;
 		touchLongPressed = false;
+		trackpadDoubleTapArmed = false;
 	}
 
 	// ── Touch event handlers (dispatch to scroll or trackpad mode) ────────────

--- a/frontend/components/preview/browser/components/Container.svelte
+++ b/frontend/components/preview/browser/components/Container.svelte
@@ -54,6 +54,30 @@
 
 		// MCP Control State
 		isMcpControlled = $bindable(false),
+		/**
+		 * Whether the agent is acting on *this* tab right now, as opposed to
+		 * merely holding it. Only the tab being worked on pulses — with several
+		 * locked at once, a border that pulses on all of them says nothing.
+		 */
+		isMcpFocused = false,
+		/**
+		 * What the agent is doing right now, from the backend. Empty while it
+		 * holds the tab without acting, which reads as a bare "Agent".
+		 */
+		mcpActivity = '' as string,
+
+		/**
+		 * The page has something full screen.
+		 *
+		 * The only way out. The shim used to draw a hint inside the page as well,
+		 * which meant two buttons saying the same thing over one frame — and the
+		 * in-page one was the weaker of the two: a node the page can destroy on a
+		 * re-render, and never drawn at all for a fullscreen Chrome granted from
+		 * its own C++. This control lives outside the page, so nothing in the
+		 * page can take it away.
+		 */
+		isPageFullscreen = false,
+		onExitFullscreen = (() => {}) as () => void,
 
 		// Canvas API
 		canvasAPI = $bindable<any>(null),
@@ -70,7 +94,7 @@
 	} = $props();
 
 	let previewContainer = $state<HTMLDivElement | undefined>();
-	let touchCursorPos = $state<{ x: number; y: number; visible: boolean; clicking?: boolean }>({ x: 0, y: 0, visible: false });
+	let touchCursorPos = $state<{ x: number; y: number; visible: boolean; clicking?: boolean; pressed?: boolean }>({ x: 0, y: 0, visible: false });
 
 	type OverlayCursor = { x: number; y: number; visible: boolean; clicking?: boolean; pressed?: boolean };
 
@@ -97,7 +121,17 @@
 		};
 	}
 
-	/** The agent's pointer, page coordinates → where to draw it. */
+	/**
+	 * The agent's pointer, page coordinates → where to draw it.
+	 *
+	 * Drawn for as long as the agent *holds* the tab, not only while cursor
+	 * events are arriving. Those two are not the same thing, and the difference
+	 * is most of a run: a batch of `type` actions against named selectors, a
+	 * `navigate`, a `screenshot`, a long `wait_for` — none of them necessarily
+	 * moves a pointer, so a lock could be taken and worked with for a minute
+	 * while the preview showed a page changing by itself with nothing on it to
+	 * say why. The lock is the honest signal, so the lock is what decides.
+	 */
 	const mcpCursor = $derived.by((): OverlayCursor => {
 		const page = mcpCursorPage;
 		// Geometry dependencies: any of these moves where a page point lands, so
@@ -106,13 +140,35 @@
 		void previewDimensions;
 		void deviceSize;
 		void rotation;
+		// Readiness dependencies. `pageToScreen` refuses to answer until the
+		// canvas has a bitmap, which is exactly the window an agent starts
+		// working in — it opens a tab and moves immediately, while the first
+		// frame is still in flight. Those early positions were projected to
+		// nothing and, because a parked pointer sends no further updates, the
+		// cursor stayed invisible for the rest of the run. Depending on the
+		// signals that mark the canvas ready re-runs the projection once it can
+		// actually succeed.
+		void isStreamReady;
+		void lastFrameData;
+		void sessionId;
 
-		if (!page?.visible) return HIDDEN_CURSOR;
+		// Read unconditionally: `!page.visible && !controlled` would short-circuit
+		// past it whenever a position is known, and the derived would then not
+		// re-run when the lock is released.
+		const controlled = isMcpControlled;
+		if (!page?.visible && !controlled) return HIDDEN_CURSOR;
 
-		const screen = canvasAPI?.pageToScreen?.(page.x, page.y);
+		// No gesture has placed it yet: park it in the middle of the page rather
+		// than at the origin, which reads as a pointer that got lost in the
+		// corner. The first real event moves it, and it glides there.
+		const size = canvasAPI?.getPageSize?.();
+		const x = page?.visible ? page.x : (size?.width ?? 0) / 2;
+		const y = page?.visible ? page.y : (size?.height ?? 0) / 2;
+
+		const screen = canvasAPI?.pageToScreen?.(x, y);
 		if (!screen) return HIDDEN_CURSOR;
 
-		return toLocalCursor({ ...page, ...screen });
+		return toLocalCursor({ ...page, visible: true, ...screen });
 	});
 
 	const localVirtualCursor = $derived(toLocalCursor(virtualCursor));
@@ -177,8 +233,8 @@
 		}
 	});
 
-	function handleTouchCursorUpdate(pos: { x: number; y: number; visible: boolean; clicking?: boolean }) {
-		touchCursorPos = { x: pos.x, y: pos.y, visible: pos.visible, clicking: pos.clicking };
+	function handleTouchCursorUpdate(pos: { x: number; y: number; visible: boolean; clicking?: boolean; pressed?: boolean }) {
+		touchCursorPos = { x: pos.x, y: pos.y, visible: pos.visible, clicking: pos.clicking, pressed: pos.pressed };
 	}
 
 	onDestroy(() => {
@@ -461,8 +517,10 @@
 	{:else if url}
 		<!-- Scaled container for proper viewport simulation -->
 		<div
-			class="relative flex-shrink-0 {isMcpControlled ? 'ring-2 ring-amber-500 ring-offset-2 ring-offset-slate-900 rounded-xl' : ''}"
-			class:mcp-control-border={isMcpControlled}
+			class="relative flex-shrink-0 {isMcpControlled
+				? `ring-2 ring-offset-2 ring-offset-slate-900 rounded-xl ${isMcpFocused ? 'ring-amber-500' : 'ring-amber-500/40'}`
+				: ''}"
+			class:mcp-control-border={isMcpControlled && isMcpFocused}
 			style="width: {previewDimensions.width}; height: {previewDimensions.height};"
 			in:scale={{ duration: 250, easing: cubicOut, start: 0.95 }}
 			out:scale={{ duration: 200, easing: cubicOut, start: 0.95 }}
@@ -546,6 +604,40 @@
 				</div>
 			{/if}
 
+			<!--
+				App-side way out of a page full screen. Anchored to the screen rect
+				so it sits inside the device frame, above everything the page can
+				draw, and clickable even while an agent holds the tab — being stuck
+				full screen is not something the user should have to wait out.
+			-->
+			{#if isPageFullscreen}
+				<!--
+					Laid out as a right-aligned row over the screen rect rather than
+					offset by hand: the button's own width is not knowable here, and
+					a percentage in `left` would resolve against the frame, not the
+					button. The row ignores pointer events so only the button itself
+					takes them.
+				-->
+				<div
+					class="pointer-events-none absolute z-30 flex justify-end p-3"
+					style="
+						left: {previewDimensions.screenOffsetLeft};
+						top: {previewDimensions.screenOffsetTop};
+						width: {previewDimensions.screenWidth};
+					"
+				>
+					<button
+						type="button"
+						onclick={onExitFullscreen}
+						class="pointer-events-auto flex items-center gap-1.5 rounded-full bg-slate-900/85 px-3 py-1.5 text-xs font-medium text-white shadow-lg backdrop-blur-sm transition-colors hover:bg-slate-900"
+						title="Exit full screen"
+					>
+						<Icon name="lucide:minimize-2" class="h-3.5 w-3.5" />
+						<span>Exit full screen</span>
+					</button>
+				</div>
+			{/if}
+
 			<!-- MCP Control Overlay - blocks user interaction (screen only) -->
 			{#if isMcpControlled && isStreamReady}
 				<div
@@ -587,12 +679,23 @@
 
 	<!-- Touch Cursor - shown in cursor simulation mode -->
 	{#if touchMode === 'cursor' && localTouchCursor.visible}
-		<VirtualCursor cursor={localTouchCursor} variant="user" />
+		<VirtualCursor cursor={localTouchCursor} variant="touch" />
 	{/if}
 
-	<!-- Agent cursor. Amber, labelled, and always on top of the user's own. -->
+	<!--
+		Agent cursor. Amber, labelled, and always on top of the user's own.
+
+		The caption names what the agent is doing when the backend has told us —
+		"Agent · Typing". A bare "Agent" was accurate and useless: it is on screen
+		for whole minutes now, and for that long the interesting question is not
+		who is driving but what they are about to do to the page.
+	-->
 	{#if mcpCursor.visible}
-		<VirtualCursor cursor={mcpCursor} variant="mcp" label="Agent" />
+		<VirtualCursor
+			cursor={mcpCursor}
+			variant="mcp"
+			label={mcpActivity ? `Agent · ${mcpActivity}` : 'Agent'}
+		/>
 	{/if}
 </div>
 

--- a/frontend/components/preview/browser/components/Toolbar.svelte
+++ b/frontend/components/preview/browser/components/Toolbar.svelte
@@ -37,6 +37,14 @@
 		tabs = [] as any[],
 		activeTabId = null as string | null,
 		mcpControlledTabIds = new Set<string>(),
+		/**
+		 * The controlled tab the agent is acting on right now.
+		 *
+		 * Distinct from being locked: an agent working across several tabs locks
+		 * all of them, and the user — free to look wherever they like — otherwise
+		 * has no way to tell which one is live.
+		 */
+		mcpFocusedTabId = null as string | null,
 
 		// Callbacks
 		onGoClick = () => {},
@@ -297,6 +305,7 @@
 			{#each tabs as tab (tab.id)}
 				{@const isActive = tab.id === activeTabId}
 				{@const isControlled = mcpControlledTabIds.has(tab.id)}
+				{@const isAgentHere = isControlled && tab.id === mcpFocusedTabId}
 				<button
 					type="button"
 					data-tab-id={tab.id}
@@ -333,7 +342,8 @@
 						? 'text-violet-600 dark:text-violet-400'
 						: 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'}
 						{draggingTabId === tab.id ? 'opacity-40' : ''}
-						{dragOverTabId === tab.id ? 'bg-violet-500/10' : ''}"
+						{dragOverTabId === tab.id ? 'bg-violet-500/10' : ''}
+						{isAgentHere ? 'bg-amber-500/10' : ''}"
 					onclick={() => onSwitchTab(tab.id)}
 					onauxclick={(event) => {
 						// Middle-click closes, as in every browser.
@@ -370,8 +380,24 @@
 					<span class="truncate max-w-28">{tab.title || 'New Tab'}</span>
 
 					{#if isControlled}
-						<span title="Controlled by an AI agent" class="flex">
-							<Icon name="lucide:lock" class="h-3 w-3 shrink-0 text-amber-500" />
+						<!--
+							Two states, not one. The static lock means "an agent holds
+							this tab"; the pulse means "an agent is working in it right
+							now". Told apart, the strip answers the question the lock
+							alone could not — which tab to actually watch.
+						-->
+						<span
+							title={isAgentHere
+								? 'An AI agent is working in this tab'
+								: 'Held by an AI agent'}
+							class="flex"
+						>
+							<Icon
+								name="lucide:lock"
+								class="h-3 w-3 shrink-0 {isAgentHere
+									? 'animate-pulse text-amber-500'
+									: 'text-amber-500/60'}"
+							/>
 						</span>
 					{:else}
 						<span
@@ -396,6 +422,11 @@
 
 					{#if isActive}
 						<span class="absolute inset-x-0 bottom-0 h-px bg-violet-600 dark:bg-violet-400"></span>
+					{:else if isAgentHere}
+						<!-- The agent's tab is findable without being the one on screen:
+						     the point is that the user can look elsewhere and still know
+						     where the work is happening. -->
+						<span class="absolute inset-x-0 bottom-0 h-px animate-pulse bg-amber-500"></span>
 					{/if}
 				</button>
 			{/each}

--- a/frontend/components/preview/browser/components/VirtualCursor.svelte
+++ b/frontend/components/preview/browser/components/VirtualCursor.svelte
@@ -9,12 +9,17 @@
 	 * offset away and outside the panel's `overflow: hidden` box. Anchoring to the
 	 * container the frame is painted in cannot drift that way.
 	 *
-	 * `variant` is what tells the two apart on screen: the agent's cursor stays
-	 * amber, the local one is sky blue. Drawn in the same colour, there was no
-	 * way to tell whether the browser was moving on its own.
+	 * `variant` is what tells them apart on screen: the agent's cursor stays
+	 * amber, the local one is sky blue, and the touch trackpad's is white.
+	 * Drawn in the same colour, there was no way to tell whether the browser
+	 * was moving on its own.
+	 *
+	 * White for touch because that pointer is the one the finger is steering:
+	 * it has to read against a page of any colour, and the blue was too close
+	 * to the links and controls it spends its time hovering.
 	 *
 	 * `pressed` renders the button as held — the only visible difference
-	 * between the agent moving and the agent dragging.
+	 * between moving and dragging.
 	 */
 	let {
 		cursor = $bindable<{ x: number; y: number; visible: boolean; clicking?: boolean; pressed?: boolean }>({
@@ -23,17 +28,23 @@
 			visible: false,
 			clicking: false
 		}),
-		variant = 'user' as 'user' | 'mcp',
+		variant = 'user' as 'user' | 'mcp' | 'touch',
 		/** Caption trailing the pointer. Only the agent gets one, so an unattended
 		 *  run reads as "something else is driving this", not as a stray cursor. */
 		label = ''
 	} = $props();
 
-	const palette = $derived(
-		variant === 'mcp'
-			? { idle: '#FFD700', active: '#FFA500', highlight: '#FFF59D', activeHighlight: '#FFE5B4', ring: 'border-orange-500' }
-			: { idle: '#38BDF8', active: '#0284C7', highlight: '#BAE6FD', activeHighlight: '#E0F2FE', ring: 'border-sky-500' }
-	);
+	const palette = $derived.by(() => {
+		if (variant === 'mcp') {
+			return { idle: '#FFD700', active: '#FFA500', highlight: '#FFF59D', activeHighlight: '#FFE5B4', ring: 'border-orange-500' };
+		}
+		if (variant === 'touch') {
+			// The dark outline is what keeps a white pointer visible on a white
+			// page; the "active" shade only dims it, so a press still reads.
+			return { idle: '#FFFFFF', active: '#D4D4D8', highlight: '#F4F4F5', activeHighlight: '#E4E4E7', ring: 'border-white' };
+		}
+		return { idle: '#38BDF8', active: '#0284C7', highlight: '#BAE6FD', activeHighlight: '#E0F2FE', ring: 'border-sky-500' };
+	});
 
 	const engaged = $derived(!!cursor.clicking || !!cursor.pressed);
 </script>

--- a/frontend/components/preview/browser/core/mcp-handlers.svelte.ts
+++ b/frontend/components/preview/browser/core/mcp-handlers.svelte.ts
@@ -8,7 +8,10 @@
 
 import { debug } from '$shared/utils/logger';
 import ws from '$frontend/utils/ws';
-import { getMcpControlledBackendIds } from '$frontend/stores/features/preview-tabs-workspace.svelte';
+import {
+	getMcpControlledBackendIds,
+	getMcpFocusedBackendId
+} from '$frontend/stores/features/preview-tabs-workspace.svelte';
 import type { TabManager } from './tab-manager.svelte';
 
 export interface McpHandlerConfig {
@@ -65,22 +68,22 @@ export function createMcpHandler(config: McpHandlerConfig) {
 				handleTestCompleted(data);
 			}),
 
-			// The precise end-of-control signal: the tab is handed back the moment
-			// the owning chat session releases it, which is when the pointer stops
-			// meaning anything. `chat:complete` below is the backstop for a stream
-			// that ends without ever reaching the release path.
+			// The end-of-control signal, and now the only one: the tab is handed
+			// back the moment the owning chat session releases it, which is when
+			// the pointer stops meaning anything.
+			//
+			// `chat:complete`/`chat:cancelled` used to hide the pointer here too,
+			// as a backstop. They are worse than redundant now that the pointer is
+			// drawn from the lock itself: a stream ends by releasing its tabs, so
+			// the backstop only ever fired *before* the release it was covering
+			// for — and took the pointer off a tab the agent still held. A release
+			// that genuinely never happens leaves the tab locked as well, which is
+			// the orphan sweep's job on the backend, not something to paper over
+			// by drawing a lock that is real as though it were not.
 			ws.on('preview:browser-mcp-control-end', (data) => {
+				forgetCursor(data.browserTabId);
 				const activeTab = tabManager.tabs.find(t => t.id === tabManager.activeTabId);
 				if (activeTab?.sessionId === data.browserTabId) onCursorHide?.();
-			}),
-
-			// Hide cursor when the entire Claude request finishes or is stopped
-			ws.on('chat:complete', () => {
-				if (onCursorHide) onCursorHide();
-			}),
-
-			ws.on('chat:cancelled', () => {
-				if (onCursorHide) onCursorHide();
 			})
 		];
 
@@ -133,7 +136,43 @@ export function createMcpHandler(config: McpHandlerConfig) {
 		return result;
 	}
 
+	/** The frontend tab the agent is acting on right now, if it is on screen. */
+	function getFocusedTabId(): string | null {
+		const focused = getMcpFocusedBackendId();
+		if (!focused) return null;
+		return tabManager.tabs.find((tab) => tab.sessionId === focused)?.id ?? null;
+	}
+
+	/** Whether the panel is currently showing the tab the agent is working on. */
+	function isCurrentTabMcpFocused(): boolean {
+		const activeTab = tabManager.tabs.find((t) => t.id === tabManager.activeTabId);
+		return !!activeTab?.sessionId && activeTab.sessionId === getMcpFocusedBackendId();
+	}
+
 	// Private handlers
+
+	/**
+	 * Where the agent's pointer was last seen on each tab.
+	 *
+	 * An agent that has finished moving sends nothing more, so a pointer parked
+	 * on a tab the user was not watching had no way to reappear when they
+	 * switched to it — the panel cleared its cursor on every tab change and
+	 * nothing would ever redraw it. Remembering the last position is what makes
+	 * "look at whichever tab you like" work with the agent still holding one.
+	 */
+	const lastCursorBySession = new Map<string, { x: number; y: number; pressed: boolean }>();
+
+	/**
+	 * The agent's last known pointer on a tab, for restoring after a switch.
+	 *
+	 * Gated on the tab still being controlled: a release that happened while
+	 * this panel was unmounted never reached `forgetCursor`, and drawing a
+	 * pointer for an agent that has already left is worse than drawing none.
+	 */
+	function getCursorFor(sessionId: string | null): { x: number; y: number; pressed: boolean } | null {
+		if (!sessionId || !controlledSessionIds().has(sessionId)) return null;
+		return lastCursorBySession.get(sessionId) ?? null;
+	}
 
 	/**
 	 * Hand an agent cursor event up to the panel.
@@ -148,19 +187,32 @@ export function createMcpHandler(config: McpHandlerConfig) {
 		data: { sessionId: string; x: number; y: number; pressed?: boolean },
 		clicking: boolean
 	) {
+		// Recorded before the gate: the position matters even — especially —
+		// while the user is looking somewhere else.
+		lastCursorBySession.set(data.sessionId, {
+			x: data.x,
+			y: data.y,
+			pressed: !!data.pressed
+		});
+
 		const activeTab = tabManager.tabs.find(t => t.id === tabManager.activeTabId);
 
 		if (!activeTab?.sessionId) {
-			debug.log('preview', `🖱️ [mcp-cursor] dropped: no session on the active tab (event for ${data.sessionId})`);
+			debug.log('preview', `🖱️ [mcp-cursor] deferred: no session on the active tab (event for ${data.sessionId})`);
 			return;
 		}
 
 		if (activeTab.sessionId !== data.sessionId) {
-			debug.log('preview', `🖱️ [mcp-cursor] dropped: event for ${data.sessionId}, viewing ${activeTab.sessionId}`);
+			debug.log('preview', `🖱️ [mcp-cursor] deferred: event for ${data.sessionId}, viewing ${activeTab.sessionId}`);
 			return;
 		}
 
 		onCursorUpdate?.(data.x, data.y, clicking, data.pressed);
+	}
+
+	/** Forget a tab's pointer once the agent has handed the tab back. */
+	function forgetCursor(sessionId: string): void {
+		lastCursorBySession.delete(sessionId);
 	}
 
 	function handleCursorPosition(data: { sessionId: string; x: number; y: number; pressed?: boolean; timestamp: number; source: 'mcp' }) {
@@ -304,8 +356,11 @@ export function createMcpHandler(config: McpHandlerConfig) {
 	return {
 		setupEventListeners,
 		isCurrentTabMcpControlled,
+		isCurrentTabMcpFocused,
 		isSessionControlled,
 		getControlledTabIds,
+		getFocusedTabId,
+		getCursorFor,
 		get controlledSessionIds() { return controlledSessionIds(); }
 	};
 }

--- a/frontend/components/preview/browser/core/native-ui-handlers.svelte.ts
+++ b/frontend/components/preview/browser/core/native-ui-handlers.svelte.ts
@@ -53,6 +53,40 @@ export function createNativeUIHandler(config: NativeUIHandlerConfig) {
 	} = config;
 
 	/**
+	 * Longest we keep re-attempting to place a page-anchored overlay before
+	 * giving up. Comfortably past a first frame; short enough that a genuinely
+	 * dead tab does not keep a timer alive.
+	 */
+	const PLACEMENT_RETRY_MS = 2000;
+
+	/**
+	 * Run `place` once the canvas can answer where a page point is on screen.
+	 *
+	 * These overlays are anchored to an element inside the page, so they cannot
+	 * be drawn until the canvas has a bitmap to measure against — and the moment
+	 * they arrive is often exactly when it does not: the page opened a select on
+	 * load, or the panel has just switched tabs. Dropping the event there was
+	 * silent and final. The page believes its dropdown is open and waits for an
+	 * answer that can no longer come, so the control simply stops responding.
+	 *
+	 * Retrying per frame turns that into a delay of a frame or two instead.
+	 */
+	function placeWhenReady(place: () => boolean, label: string): void {
+		if (place()) return;
+
+		const deadline = Date.now() + PLACEMENT_RETRY_MS;
+		const attempt = () => {
+			if (place()) return;
+			if (Date.now() >= deadline) {
+				debug.warn('preview', `${label} skipped — canvas never became measurable`);
+				return;
+			}
+			requestAnimationFrame(attempt);
+		};
+		requestAnimationFrame(attempt);
+	}
+
+	/**
 	 * Setup WebSocket event listeners for native UI events.
 	 * Returns a teardown that removes every listener — the coordinator calls it
 	 * on unmount so listeners don't accumulate across BrowserPreview re-mounts.
@@ -188,36 +222,33 @@ export function createNativeUIHandler(config: NativeUIHandlerConfig) {
 			return;
 		}
 
-		// Transform coordinates from browser (Puppeteer) to display coordinates
-		// The transformation function will handle cases where canvas is not ready (returns null)
-		const topLeft = transformBrowserToDisplayCoordinates(data.boundingBox.x, data.boundingBox.y);
-		const bottomRight = transformBrowserToDisplayCoordinates(
-			data.boundingBox.x + data.boundingBox.width,
-			data.boundingBox.y + data.boundingBox.height
-		);
+		// Transform coordinates from browser (Puppeteer) to display coordinates.
+		// Retried rather than dropped — see placeWhenReady.
+		placeWhenReady(() => {
+			const topLeft = transformBrowserToDisplayCoordinates(data.boundingBox.x, data.boundingBox.y);
+			const bottomRight = transformBrowserToDisplayCoordinates(
+				data.boundingBox.x + data.boundingBox.width,
+				data.boundingBox.y + data.boundingBox.height
+			);
+			if (!topLeft || !bottomRight) return false;
 
-		if (!topLeft || !bottomRight) {
-			debug.warn('preview', `Select dropdown skipped - coordinate transformation failed (${data.boundingBox.x}, ${data.boundingBox.y})`);
-			return;
-		}
+			// Create transformed select info with display coordinates
+			const transformedSelectInfo: BrowserSelectInfo = {
+				...data,
+				boundingBox: {
+					x: topLeft.x,
+					y: topLeft.y,
+					width: bottomRight.x - topLeft.x,
+					height: bottomRight.y - topLeft.y
+				}
+			};
 
-		// Create transformed select info with display coordinates
-		const transformedSelectInfo: BrowserSelectInfo = {
-			...data,
-			boundingBox: {
-				x: topLeft.x,
-				y: topLeft.y,
-				width: bottomRight.x - topLeft.x,
-				height: bottomRight.y - topLeft.y
-			}
-		};
+			debug.log('preview', `📋 Transformed select position: (${transformedSelectInfo.boundingBox.x}, ${transformedSelectInfo.boundingBox.y})`);
 
-		debug.log('preview', `📋 Transformed select position: (${transformedSelectInfo.boundingBox.x}, ${transformedSelectInfo.boundingBox.y})`);
-
-		// Show select dropdown overlay
-		if (onSelectOpen) {
-			onSelectOpen(transformedSelectInfo);
-		}
+			// Show select dropdown overlay
+			onSelectOpen?.(transformedSelectInfo);
+			return true;
+		}, 'Select dropdown');
 	}
 
 	/**
@@ -256,28 +287,25 @@ export function createNativeUIHandler(config: NativeUIHandlerConfig) {
 			return;
 		}
 
-		// Transform coordinates from browser (Puppeteer) to display coordinates
-		// The transformation function will handle cases where canvas is not ready (returns null)
-		const position = transformBrowserToDisplayCoordinates(data.x, data.y);
+		// Transform coordinates from browser (Puppeteer) to display coordinates.
+		// Retried rather than dropped — see placeWhenReady.
+		placeWhenReady(() => {
+			const position = transformBrowserToDisplayCoordinates(data.x, data.y);
+			if (!position) return false;
 
-		if (!position) {
-			debug.warn('preview', `Context menu skipped - coordinate transformation failed (${data.x}, ${data.y})`);
-			return;
-		}
+			// Create transformed context menu info with display coordinates
+			const transformedMenuInfo: BrowserContextMenuInfo = {
+				...data,
+				x: position.x,
+				y: position.y
+			};
 
-		// Create transformed context menu info with display coordinates
-		const transformedMenuInfo: BrowserContextMenuInfo = {
-			...data,
-			x: position.x,
-			y: position.y
-		};
+			debug.log('preview', `📜 Transformed context menu position: (${transformedMenuInfo.x}, ${transformedMenuInfo.y})`);
 
-		debug.log('preview', `📜 Transformed context menu position: (${transformedMenuInfo.x}, ${transformedMenuInfo.y})`);
-
-		// Show context menu overlay
-		if (onContextMenuOpen) {
-			onContextMenuOpen(transformedMenuInfo);
-		}
+			// Show context menu overlay
+			onContextMenuOpen?.(transformedMenuInfo);
+			return true;
+		}, 'Context menu');
 	}
 
 	/**
@@ -289,22 +317,25 @@ export function createNativeUIHandler(config: NativeUIHandlerConfig) {
 
 		if (!transformBrowserToDisplayCoordinates) return;
 
-		const topLeft = transformBrowserToDisplayCoordinates(data.boundingBox.x, data.boundingBox.y);
-		const bottomRight = transformBrowserToDisplayCoordinates(
-			data.boundingBox.x + data.boundingBox.width,
-			data.boundingBox.y + data.boundingBox.height
-		);
-		if (!topLeft || !bottomRight) return;
+		placeWhenReady(() => {
+			const topLeft = transformBrowserToDisplayCoordinates(data.boundingBox.x, data.boundingBox.y);
+			const bottomRight = transformBrowserToDisplayCoordinates(
+				data.boundingBox.x + data.boundingBox.width,
+				data.boundingBox.y + data.boundingBox.height
+			);
+			if (!topLeft || !bottomRight) return false;
 
-		onNativePickerOpen?.({
-			...data,
-			boundingBox: {
-				x: topLeft.x,
-				y: topLeft.y,
-				width: bottomRight.x - topLeft.x,
-				height: bottomRight.y - topLeft.y
-			}
-		});
+			onNativePickerOpen?.({
+				...data,
+				boundingBox: {
+					x: topLeft.x,
+					y: topLeft.y,
+					width: bottomRight.x - topLeft.x,
+					height: bottomRight.y - topLeft.y
+				}
+			});
+			return true;
+		}, 'Native picker');
 	}
 
 	/**

--- a/frontend/components/preview/browser/core/tab-operations.svelte.ts
+++ b/frontend/components/preview/browser/core/tab-operations.svelte.ts
@@ -48,6 +48,10 @@ export interface ExistingTabInfo {
 	canGoBack?: boolean;
 	canGoForward?: boolean;
 	isMcpControlled?: boolean;
+	/** The controlled tab the agent is acting on right now. */
+	isMcpFocused?: boolean;
+	/** What the agent is doing on it, for the caption beside its cursor. */
+	mcpActivity?: string;
 }
 
 export interface ExistingTabsResult {

--- a/frontend/services/preview/browser/browser-webcodecs.service.ts
+++ b/frontend/services/preview/browser/browser-webcodecs.service.ts
@@ -32,11 +32,52 @@ const CODEC_NAMES: Record<number, 'vp8' | 'vp9' | 'avc'> = {
 };
 
 /** `randomUUID` needs a secure context, which a LAN preview over http is not. */
-function createViewerId(): string {
+function randomId(): string {
 	if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
 		return crypto.randomUUID();
 	}
 	return `viewer-${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+}
+
+const VIEWER_ID_STORAGE_KEY = 'clopen.preview.viewerId';
+
+/** Viewer ids currently held by a live service in this document. */
+const activeViewerIds = new Set<string>();
+
+/**
+ * A durable identity for "this browser tab, watching previews".
+ *
+ * Minting a fresh id per service instance made every panel re-mount, project
+ * switch and page refresh look like a brand-new audience member arriving while
+ * the previous one was still registered — the source saw two viewers where
+ * there was one person, and the entry left behind kept the tab looking watched
+ * long after nobody was. Keyed in `sessionStorage`, so a refresh is recognised
+ * as the same viewer returning and its peer is replaced rather than added to.
+ * The suffix only comes into play when two panels genuinely watch at once.
+ */
+function acquireViewerId(): string {
+	let base: string;
+
+	try {
+		const stored = sessionStorage.getItem(VIEWER_ID_STORAGE_KEY);
+		base = stored ?? randomId();
+		if (!stored) sessionStorage.setItem(VIEWER_ID_STORAGE_KEY, base);
+	} catch {
+		// Private mode / storage disabled — fall back to a per-instance id.
+		base = randomId();
+	}
+
+	if (!activeViewerIds.has(base)) {
+		activeViewerIds.add(base);
+		return base;
+	}
+
+	for (let suffix = 2; ; suffix++) {
+		const candidate = `${base}-${suffix}`;
+		if (activeViewerIds.has(candidate)) continue;
+		activeViewerIds.add(candidate);
+		return candidate;
+	}
 }
 
 export interface ClientCodecSupportPayload {
@@ -251,7 +292,7 @@ export class BrowserWebCodecsService {
 	 * per-connection: it survives reconnects, so the backend can recognise a
 	 * recovering viewer as the same one rather than a second audience member.
 	 */
-	private readonly viewerId: string = createViewerId();
+	private readonly viewerId: string = acquireViewerId();
 
 	/**
 	 * Remote ICE candidates that arrived before this side could take them.
@@ -2266,6 +2307,12 @@ export class BrowserWebCodecsService {
 	 */
 	destroy(): void {
 		this.cleanup();
+
+		// Release the identity so a later service in this document can reuse it
+		// instead of being pushed onto a suffix — otherwise a panel that
+		// mounts and unmounts a few times walks the id upward and the source
+		// sees a stranger every time.
+		activeViewerIds.delete(this.viewerId);
 
 		this.terminateVideoWorker();
 

--- a/frontend/stores/features/preview-tabs-workspace.svelte.ts
+++ b/frontend/stores/features/preview-tabs-workspace.svelte.ts
@@ -49,8 +49,67 @@ export const previewTabManager: TabManager = createTabManager();
  */
 let mcpControlledBackendIds = $state(new Set<string>());
 
+/**
+ * The one controlled tab the agent is acting on right now, if any.
+ *
+ * A lock only says "hands off". Once an agent is working across several tabs
+ * that leaves every one of them looking identical, and the user cannot tell
+ * where to look — they can still browse freely, they just had no way of
+ * knowing which tab was live. Seeded from the backend in load() and kept
+ * current by the focus listener below.
+ */
+let mcpFocusedBackendId = $state<string | null>(null);
+
 export function getMcpControlledBackendIds(): ReadonlySet<string> {
 	return mcpControlledBackendIds;
+}
+
+export function getMcpFocusedBackendId(): string | null {
+	return mcpFocusedBackendId;
+}
+
+/**
+ * What the agent is doing on each controlled tab, in a few words.
+ *
+ * Held next to the control set rather than in the panel, and for the same
+ * reason: the run carries on while the preview is closed, so the caption has to
+ * be right the moment the user looks — not from the next action onwards.
+ */
+let mcpActivityByBackendId = $state<Record<string, string>>({});
+
+export function getMcpActivity(backendTabId: string | null): string | null {
+	return backendTabId ? (mcpActivityByBackendId[backendTabId] ?? null) : null;
+}
+
+function setMcpActivity(backendTabId: string, label: string | null): void {
+	if ((mcpActivityByBackendId[backendTabId] ?? null) === label) return;
+
+	const next = { ...mcpActivityByBackendId };
+	if (label === null) delete next[backendTabId];
+	else next[backendTabId] = label;
+	mcpActivityByBackendId = next;
+}
+
+/**
+ * Backend tab ids whose page is showing something full screen.
+ *
+ * Held here, not in the panel, for the same reason as the lock state: the
+ * event can land while the preview is hidden, and the way out of a full screen
+ * has to be on screen the moment the user looks — not only if they happened to
+ * be watching when it started.
+ */
+let fullscreenBackendIds = $state(new Set<string>());
+
+export function isBackendTabFullscreen(backendTabId: string | null): boolean {
+	return !!backendTabId && fullscreenBackendIds.has(backendTabId);
+}
+
+function setBackendTabFullscreen(backendTabId: string, active: boolean): void {
+	if (active === fullscreenBackendIds.has(backendTabId)) return;
+	const next = new Set(fullscreenBackendIds);
+	if (active) next.add(backendTabId);
+	else next.delete(backendTabId);
+	fullscreenBackendIds = next;
 }
 
 /** Add/remove a backend tab id from the controlled set (reassign for reactivity). */
@@ -113,6 +172,10 @@ function materializeBackendTab(backendTab: ExistingTabInfo): string {
 
 	if (backendTab.isMcpControlled) {
 		setMcpControlled(backendTab.tabId, true);
+		setMcpActivity(backendTab.tabId, backendTab.mcpActivity ?? null);
+	}
+	if (backendTab.isMcpFocused) {
+		mcpFocusedBackendId = backendTab.tabId;
 	}
 
 	return frontendId;
@@ -203,6 +266,9 @@ registerDock({
 		previewTabManager.clearAllTabs();
 		browserCleanup.clearAll();
 		mcpControlledBackendIds = new Set();
+		mcpFocusedBackendId = null;
+		mcpActivityByBackendId = {};
+		fullscreenBackendIds = new Set();
 		restoredSnapshot = null;
 	},
 	snapshot(): TabSnapshotSlot[] {
@@ -362,6 +428,9 @@ export function initPreviewTabSync(): void {
 		previewTabManager.closeTab(tab.id);
 		browserCleanup.unregisterSession(data.tabId);
 		setMcpControlled(data.tabId, false);
+		setMcpActivity(data.tabId, null);
+		setBackendTabFullscreen(data.tabId, false);
+		if (mcpFocusedBackendId === data.tabId) mcpFocusedBackendId = null;
 
 		// Backend-driven close (e.g. MCP) left zero tabs → reseed an empty one so
 		// the panel doesn't render as a void.
@@ -435,6 +504,8 @@ export function initPreviewTabSync(): void {
 		if (!isEventForActiveProject(data)) return;
 
 		setMcpControlled(data.browserTabId, false);
+		setMcpActivity(data.browserTabId, null);
+		if (mcpFocusedBackendId === data.browserTabId) mcpFocusedBackendId = null;
 
 		// Toast when all tabs released.
 		if (mcpControlledBackendIds.size === 0) {
@@ -444,5 +515,25 @@ export function initPreviewTabSync(): void {
 				4000
 			);
 		}
+	});
+
+	// Which locked tab the agent is working on right now. Registered here rather
+	// than in the panel so the tab strip stays truthful even while the preview is
+	// hidden — the marker has to be right the moment the user looks at it.
+	ws.on('preview:browser-mcp-control-focus' as any, (data: any) => {
+		if (!isEventForActiveProject(data)) return;
+		mcpFocusedBackendId = data.browserTabId ?? null;
+	});
+
+	// The caption for the agent's cursor. Unstamped by project on purpose — see
+	// the cursor forwarding in browser-preview-service; `sessionId` is a backend
+	// tab id, and only tabs this project actually holds are ever read from here.
+	ws.on('preview:browser-mcp-activity' as any, (data: any) => {
+		setMcpActivity(data.sessionId, data.label ?? null);
+	});
+
+	ws.on('preview:browser-fullscreen-state' as any, (data: any) => {
+		if (!isEventForActiveProject(data)) return;
+		setBackendTabFullscreen(data.tabId, !!data.active);
 	});
 }


### PR DESCRIPTION
- Give the viewer its own way out of a page full screen: the page reports the state over the host bridge, and an app-side control calls a force-exit that clears the shim's marks, the scroll lock and Chrome's own fullscreen in every frame, then re-asserts the emulated viewport
- Stop the page drawing an exit hint of its own, which put two buttons saying the same thing over one frame; the app-side control is the one that survives a re-render and covers a fullscreen Chrome granted without the shim seeing it
- Recover a preview that never paints, whatever the reason: a watchdog that keys only on whether a frame has ever arrived now re-handshakes a stream whose start ran out of retries, whose peer never left ICE checking, or whose recovery had spent itself and stopped for good
- Draw the agent's pointer from the lock rather than from cursor events, so a run spent typing into named fields, navigating or waiting is no longer a page changing by itself with nothing on screen to say why
- Caption that pointer with what the agent is doing, taken from the gesture for input and from the action registry for everything else, and never carrying a selector or the text being typed
- Decide a two-finger trackpad gesture on the first finger lift rather than the last, which is what let a finished scroll register a phantom click and stopped a two-finger tap from ever reaching the context-menu branch
- Ignore leftover fingers until the glass is clear, and drop a gesture the OS cancelled instead of dispatching what it might have meant
- Render the touch cursor in white and give it the same click, double-click and press feedback the agent's cursor has
- Add double-tap-and-drag so a drag no longer costs a 600ms long press, and send a real double-click when the second tap does not move
- Route viewport changes through the tab manager so every Remote Access device syncs its device selector and mockup frame, not just the picture inside it
- Retry placing select dropdowns, colour pickers and context menus until the canvas can be measured, instead of discarding them and leaving the page waiting on an answer that never comes