### PR TITLE
feat(chat): allow engine switch mid-session without new chat

### DIFF
--- a/backend/chat/engine-handoff.test.ts
+++ b/backend/chat/engine-handoff.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test } from 'bun:test';
+
+import { renderHandoff, withHandoff } from './engine-handoff';
+import type {
+	AssistantMessage,
+	MessageEngine,
+	ReasoningMessage,
+	UnifiedMessage,
+	UserMessage,
+} from '$shared/types/unified';
+
+// The handoff is the only thing standing between "switch engine" and "the new
+// engine has no idea what we were doing", and it runs invisibly — a user never
+// sees the transcript, so a regression here is silent. Each case below is a
+// property the design depends on rather than an incidental detail of the
+// current wording.
+
+const ALL: { image: boolean; document: boolean } = { image: true, document: true };
+const TEXT_ONLY: { image: boolean; document: boolean } = { image: false, document: false };
+
+function engine(type: MessageEngine['type'] = 'claude-code'): MessageEngine {
+	return { type, provider: 'anthropic', model: { id: 'm', name: 'M' }, account: { id: 0, name: '' } };
+}
+
+function base(id: string) {
+	return {
+		createdAt: '2026-01-01T00:00:00.000Z',
+		messageId: id,
+		sessionId: 'sdk-1',
+		parent: { messageId: null, sessionId: null, toolUseId: null },
+		engine: engine(),
+	};
+}
+
+function user(id: string, text: string, extra: Partial<UserMessage> = {}): UserMessage {
+	return {
+		...base(id),
+		type: 'user',
+		sender: { id: 'u', name: 'U' },
+		content: [{ type: 'text', text }],
+		synthetic: false,
+		...extra,
+	};
+}
+
+function assistant(id: string, text: string, extra: Partial<AssistantMessage> = {}): AssistantMessage {
+	return {
+		...base(id),
+		type: 'assistant',
+		content: [{ type: 'text', text }],
+		stopReason: null,
+		usage: null,
+		...extra,
+	};
+}
+
+function toolCall(id: string, toolUseId: string, name: string, input: unknown): AssistantMessage {
+	return {
+		...base(id),
+		type: 'assistant',
+		content: [{
+			type: 'tool_use',
+			id: toolUseId,
+			name,
+			input,
+			result: null,
+			subActivities: [],
+			skillPrompt: null,
+			interrupted: false,
+		} as AssistantMessage['content'][number]],
+		stopReason: 'tool_use',
+		usage: null,
+	};
+}
+
+function toolResult(id: string, toolUseId: string, content: string): UserMessage {
+	return {
+		...base(id),
+		type: 'user',
+		sender: { id: '', name: '' },
+		content: [{ type: 'tool_result', toolUseId, content, isError: false }],
+		synthetic: true,
+	};
+}
+
+/** The single text block of a handoff result. */
+function transcriptOf(messages: UnifiedMessage[], support = ALL, previous: MessageEngine['type'] | null = 'claude-code') {
+	const result = renderHandoff(messages, support, previous);
+	expect(result).not.toBeNull();
+	const first = result!.blocks[0];
+	expect(first.type).toBe('text');
+	return { text: (first as { type: 'text'; text: string }).text, result: result! };
+}
+
+describe('renderHandoff', () => {
+	test('returns null when there is nothing to replay', () => {
+		expect(renderHandoff([], ALL, null)).toBeNull();
+	});
+
+	test('replays the conversation in order and names the previous engine', () => {
+		const { text } = transcriptOf([
+			user('1', 'add a login page'),
+			assistant('2', 'done, added Login.svelte'),
+		]);
+
+		expect(text).toContain('claude-code');
+		expect(text.indexOf('add a login page')).toBeLessThan(text.indexOf('done, added Login.svelte'));
+	});
+
+	test('carries tool calls with their inputs and results verbatim under the trigger', () => {
+		const { text, result } = transcriptOf([
+			user('1', 'what is in config.ts?'),
+			toolCall('2', 't1', 'Read', { filePath: '/app/config.ts' }),
+			toolResult('3', 't1', 'export const PORT = 3000'),
+		]);
+
+		expect(text).toContain('Read');
+		expect(text).toContain('/app/config.ts');
+		expect(text).toContain('export const PORT = 3000');
+		expect(result.stats.clearedToolResults).toBe(0);
+	});
+
+	test('keeps reasoning blocks', () => {
+		const reasoning: ReasoningMessage = { ...base('2'), type: 'reasoning', text: 'the user wants X' };
+		const { text } = transcriptOf([user('1', 'hi'), reasoning]);
+		expect(text).toContain('the user wants X');
+	});
+
+	// Sub-agent traffic is already summarised by its parent tool result; replaying
+	// it would duplicate the same work far more verbosely.
+	test('drops sub-agent messages but keeps root-level ones', () => {
+		const nested = assistant('2', 'inner sub-agent chatter');
+		nested.parent = { messageId: null, sessionId: null, toolUseId: 't1' };
+
+		const { text } = transcriptOf([user('1', 'root question'), nested, assistant('3', 'root answer')]);
+
+		expect(text).toContain('root question');
+		expect(text).toContain('root answer');
+		expect(text).not.toContain('inner sub-agent chatter');
+	});
+
+	// The compaction summary is the previous engine's own compression of
+	// everything before it — the single most valuable message to carry over.
+	test('keeps the synthetic post-compaction summary', () => {
+		const summary = user('2', 'Summary: we refactored the auth module', { synthetic: true });
+		const { text } = transcriptOf([user('1', 'start'), summary]);
+		expect(text).toContain('we refactored the auth module');
+	});
+
+	describe('tool-result clearing past the trigger', () => {
+		// >100k estimated tokens means >400k characters at 4 chars/token.
+		const HUGE = 'x'.repeat(120_000);
+
+		const longRun: UnifiedMessage[] = [
+			user('1', 'go'),
+			toolCall('2', 't1', 'Read', { filePath: '/a' }),
+			toolResult('3', 't1', `oldest ${HUGE}`),
+			toolCall('4', 't2', 'Read', { filePath: '/b' }),
+			toolResult('5', 't2', `second ${HUGE}`),
+			toolCall('6', 't3', 'Read', { filePath: '/c' }),
+			toolResult('7', 't3', `third ${HUGE}`),
+			toolCall('8', 't4', 'Read', { filePath: '/d' }),
+			toolResult('9', 't4', `fourth ${HUGE}`),
+			toolCall('10', 't5', 'Read', { filePath: '/e' }),
+			toolResult('11', 't5', `newest ${HUGE}`),
+		];
+
+		test('clears the oldest results and keeps the last three', () => {
+			const { text, result } = transcriptOf(longRun);
+
+			// 5 tool uses, keep 3 → the 2 oldest results are cleared.
+			expect(result.stats.clearedToolResults).toBe(2);
+			expect(text).not.toContain('oldest x');
+			expect(text).not.toContain('second x');
+			expect(text).toContain('third x');
+			expect(text).toContain('fourth x');
+			expect(text).toContain('newest x');
+		});
+
+		test('keeps every tool input even when its result is cleared', () => {
+			const { text } = transcriptOf(longRun);
+			for (const path of ['/a', '/b', '/c', '/d', '/e']) {
+				expect(text).toContain(path);
+			}
+		});
+
+		test('marks cleared results so the engine knows to re-derive them', () => {
+			const { text } = transcriptOf(longRun);
+			expect(text).toContain('cleared');
+		});
+	});
+
+	describe('attachments', () => {
+		const withImage = user('1', 'look at this', {
+			content: [
+				{ type: 'text', text: 'look at this' },
+				{ type: 'image', mediaType: 'image/png', data: 'BASE64DATA' },
+			],
+		});
+
+		test('re-attaches images when the target supports them', () => {
+			const result = renderHandoff([withImage], ALL, 'codex')!;
+			const image = result.blocks.find(b => b.type === 'image');
+			expect(image).toBeDefined();
+			expect((image as { data: string }).data).toBe('BASE64DATA');
+			expect(result.stats.droppedAttachments).toBe(0);
+		});
+
+		test('degrades to a placeholder when the target cannot take them', () => {
+			const result = renderHandoff([withImage], TEXT_ONLY, 'codex')!;
+			expect(result.blocks.some(b => b.type === 'image')).toBe(false);
+			expect(result.stats.droppedAttachments).toBe(1);
+			expect((result.blocks[0] as { text: string }).text).toContain('not supported');
+		});
+	});
+});
+
+describe('withHandoff', () => {
+	test('prepends the blocks without mutating the original message', () => {
+		const prompt = user('1', 'the real question');
+		const merged = withHandoff(prompt, [{ type: 'text', text: 'CARRIED CONTEXT' }]);
+
+		// The original is what gets persisted and rendered — it must stay clean.
+		expect(prompt.content).toHaveLength(1);
+		expect(merged.content).toHaveLength(2);
+		expect((merged.content[0] as { text: string }).text).toBe('CARRIED CONTEXT');
+		expect((merged.content[1] as { text: string }).text).toBe('the real question');
+	});
+});

--- a/backend/chat/engine-handoff.ts
+++ b/backend/chat/engine-handoff.ts
@@ -1,0 +1,439 @@
+/**
+ * Cross-engine conversation handoff.
+ *
+ * Every engine keeps continuity in its own native session store — a Claude
+ * session id, a Codex rollout file, an OpenCode server session, Cline's
+ * in-memory transcript. Those ids are not portable, so a session that switches
+ * engine mid-conversation has nothing for the new engine to resume from. This
+ * module rebuilds the branch from Clopen's own DB and hands it to the new
+ * engine as prompt content, so the user can change engine without starting a
+ * new chat.
+ *
+ * ── The rule ──
+ * Replay the branch verbatim. When the replay exceeds the trigger threshold,
+ * tool results older than the last N tool uses are replaced with a placeholder
+ * — tool *inputs* are always kept.
+ *
+ * Both numbers are the shipped defaults of Anthropic's `clear_tool_uses_20250919`
+ * context-editing strategy (trigger 100k input tokens, keep 3 tool uses,
+ * `clear_tool_inputs: false`). We mirror them rather than inventing our own
+ * because they are measured: context editing alone reports +29% on agentic
+ * benchmarks, and an 84% token reduction on long tool-heavy runs while
+ * completing tasks that otherwise fail. See
+ * https://platform.claude.com/docs/en/build-with-claude/context-editing.
+ *
+ * Deliberately NOT keyed on `compact_boundary`: only the Claude adapter ever
+ * emits one (OpenCode drops compaction events, Pi disables compaction outright),
+ * so a boundary-based window would silently degenerate to "replay everything"
+ * on 7 of 8 engines.
+ *
+ * The handoff never touches the timeline: it is prepended to the *engine*
+ * prompt only, never to the `UserMessage` that gets persisted and rendered.
+ */
+
+import { messageQueries, sessionQueries } from '../database/queries';
+import { getModelsByEngine } from '$shared/constants/engines';
+import { debug } from '$shared/utils/logger';
+import type {
+	EngineType,
+	UnifiedMessage,
+	UserMessage,
+	AssistantMessage,
+	ReasoningMessage,
+	UserContentBlock,
+	ImageBlock,
+	DocumentBlock,
+} from '$shared/types/unified';
+
+// ============================================================================
+// Tunables — ported from clear_tool_uses_20250919 defaults
+// ============================================================================
+
+/** Replay stays fully verbatim below this estimated input-token count. */
+const TRIGGER_TOKENS = 100_000;
+
+/** Tool uses whose results survive clearing, counted from the end. */
+const KEEP_TOOL_USES = 3;
+
+/** Rough token estimate. Good enough to decide whether clearing is needed. */
+const CHARS_PER_TOKEN = 4;
+
+// ============================================================================
+// Intermediate representation
+// ============================================================================
+
+type Entry =
+	| { kind: 'user'; text: string; attachments: Array<ImageBlock | DocumentBlock> }
+	| { kind: 'assistant'; text: string }
+	| { kind: 'reasoning'; text: string }
+	| { kind: 'tool_use'; id: string; name: string; input: unknown }
+	| { kind: 'tool_result'; toolUseId: string; content: string; isError: boolean }
+	| { kind: 'compact' };
+
+export interface HandoffStats {
+	turns: number;
+	clearedToolResults: number;
+	droppedAttachments: number;
+	estimatedTokens: number;
+}
+
+export interface HandoffResult {
+	/** Blocks to prepend to the engine prompt. Never empty when non-null. */
+	blocks: UserContentBlock[];
+	stats: HandoffStats;
+}
+
+// ============================================================================
+// Branch inspection
+// ============================================================================
+
+function parse(data: string): UnifiedMessage | null {
+	try {
+		return JSON.parse(data) as UnifiedMessage;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * The engine that produced the trailing part of this branch, i.e. the engine
+ * whose native session a resume would target.
+ *
+ * Walks back to the most recent NON-user message and reads its `engine.type`.
+ * User messages carry the *sending* client's engine choice, which is exactly
+ * what we must not trust here. Falls back to `chat_sessions.engine` for legacy
+ * rows written before messages carried an engine block — that column is
+ * reliable because `chat:model-sync` persists it the moment anyone picks an
+ * engine, not only on send.
+ */
+export function resolveBranchEngine(chatSessionId: string): EngineType | null {
+	try {
+		const head = sessionQueries.getHead(chatSessionId);
+		if (head) {
+			const chain = messageQueries.getPathToRoot(head);
+			for (let i = chain.length - 1; i >= 0; i--) {
+				const msg = parse(chain[i].data);
+				if (!msg || msg.type === 'user') continue;
+				const type = msg.engine?.type;
+				if (type) return type as EngineType;
+			}
+		}
+	} catch (error) {
+		debug.error('chat', 'Failed to resolve branch engine:', error);
+	}
+
+	try {
+		const session = sessionQueries.getById(chatSessionId);
+		return (session?.engine as EngineType) || null;
+	} catch {
+		return null;
+	}
+}
+
+// ============================================================================
+// Attachment capability
+// ============================================================================
+
+/**
+ * Whether the target can actually carry an attachment kind.
+ *
+ * Two independent gates. The model catalog says what the MODEL accepts; this
+ * table says what the ADAPTER actually forwards. They genuinely differ —
+ * Codex, Cursor, Pi and Cline have no document path at all, so a PDF handed to
+ * them vanishes no matter what the catalog claims. Trusting the catalog alone
+ * would silently vaporise history.
+ */
+function attachmentSupport(engine: EngineType, modelId: string): { image: boolean; document: boolean } {
+	const ADAPTER_IMAGE: Record<EngineType, boolean> = {
+		'claude-code': true,
+		opencode: true,
+		codex: true,
+		cursor: true,
+		pi: true,
+		cline: true,
+		qwen: true,
+		copilot: true,
+	};
+	const ADAPTER_DOCUMENT: Record<EngineType, boolean> = {
+		'claude-code': true,
+		opencode: true,
+		qwen: true,
+		copilot: true,
+		codex: false,
+		cursor: false,
+		pi: false,
+		cline: false,
+	};
+
+	const model = getModelsByEngine(engine).find(m => m.engine.model.id === modelId);
+	// Unknown model (catalog not yet populated in this process): trust the
+	// adapter gate alone rather than stripping attachments that would work.
+	const modelImage = model ? model.modalities.input.image : true;
+	const modelDocument = model ? model.modalities.input.pdf : true;
+
+	return {
+		image: ADAPTER_IMAGE[engine] && modelImage,
+		document: ADAPTER_DOCUMENT[engine] && modelDocument,
+	};
+}
+
+// ============================================================================
+// Collection
+// ============================================================================
+
+function collect(messages: UnifiedMessage[]): Entry[] {
+	const entries: Entry[] = [];
+
+	for (const msg of messages) {
+		// Sub-agent traffic never reaches the root timeline and is already
+		// summarised by its parent tool result — replaying it would duplicate
+		// the same work in a far more verbose form.
+		if (msg.parent?.toolUseId) continue;
+
+		switch (msg.type) {
+			case 'user': {
+				const user = msg as UserMessage;
+				const texts: string[] = [];
+				const attachments: Array<ImageBlock | DocumentBlock> = [];
+				let emittedResult = false;
+
+				for (const block of user.content) {
+					if (block.type === 'text') {
+						if (block.text.trim()) texts.push(block.text);
+					} else if (block.type === 'image' || block.type === 'document') {
+						attachments.push(block);
+					} else if (block.type === 'tool_result') {
+						entries.push({
+							kind: 'tool_result',
+							toolUseId: block.toolUseId,
+							content: block.content,
+							isError: block.isError,
+						});
+						emittedResult = true;
+					}
+				}
+
+				// A tool-result carrier is not a conversational turn; the result
+				// entries above already represent it.
+				if (emittedResult) break;
+				// Synthetic post-compaction summaries ARE worth replaying: they are
+				// the engine's own compression of everything before them.
+				if (texts.length || attachments.length) {
+					entries.push({ kind: 'user', text: texts.join('\n'), attachments });
+				}
+				break;
+			}
+
+			case 'assistant': {
+				const assistant = msg as AssistantMessage;
+				for (const block of assistant.content) {
+					if (block.type === 'text') {
+						if (block.text.trim()) entries.push({ kind: 'assistant', text: block.text });
+					} else if (block.type === 'tool_use') {
+						entries.push({ kind: 'tool_use', id: block.id, name: block.name, input: block.input });
+					}
+				}
+				break;
+			}
+
+			case 'reasoning': {
+				const reasoning = msg as ReasoningMessage;
+				if (reasoning.text.trim()) entries.push({ kind: 'reasoning', text: reasoning.text });
+				break;
+			}
+
+			case 'compact_boundary':
+				entries.push({ kind: 'compact' });
+				break;
+		}
+	}
+
+	return entries;
+}
+
+// ============================================================================
+// Rendering
+// ============================================================================
+
+function stringifyInput(input: unknown): string {
+	try {
+		const json = JSON.stringify(input);
+		return json ?? String(input);
+	} catch {
+		return '[uninspectable input]';
+	}
+}
+
+function renderEntries(entries: Entry[], clearedToolUseIds: Set<string>, support: { image: boolean; document: boolean }): {
+	lines: string[];
+	attachments: Array<ImageBlock | DocumentBlock>;
+	droppedAttachments: number;
+} {
+	const lines: string[] = [];
+	const attachments: Array<ImageBlock | DocumentBlock> = [];
+	let droppedAttachments = 0;
+
+	for (const entry of entries) {
+		switch (entry.kind) {
+			case 'user': {
+				if (entry.text) lines.push(`[user]\n${entry.text}`);
+				for (const att of entry.attachments) {
+					const supported = att.type === 'image' ? support.image : support.document;
+					if (supported) {
+						attachments.push(att);
+						lines.push(`[user attachment: ${describeAttachment(att)}]`);
+					} else {
+						droppedAttachments++;
+						lines.push(`[user attachment: ${describeAttachment(att)} — not supported by this model, content omitted]`);
+					}
+				}
+				break;
+			}
+			case 'assistant':
+				lines.push(`[assistant]\n${entry.text}`);
+				break;
+			case 'reasoning':
+				lines.push(`[assistant thinking]\n${entry.text}`);
+				break;
+			case 'tool_use':
+				lines.push(`[tool call: ${entry.name}]\n${stringifyInput(entry.input)}`);
+				break;
+			case 'tool_result':
+				if (clearedToolUseIds.has(entry.toolUseId)) {
+					lines.push('[tool result cleared to save context — re-run the tool if you need it]');
+				} else {
+					lines.push(`[tool result${entry.isError ? ' (error)' : ''}]\n${entry.content}`);
+				}
+				break;
+			case 'compact':
+				// The boundary marker comes first, then the engine's own summary as
+				// a synthetic user message — that ordering is what message-grouper
+				// relies on, so the wording here must match it.
+				lines.push('[the previous engine compacted the conversation here; the summary that follows replaced everything above it]');
+				break;
+		}
+	}
+
+	return { lines, attachments, droppedAttachments };
+}
+
+function describeAttachment(att: ImageBlock | DocumentBlock): string {
+	if (att.type === 'document') return att.title ? `${att.title} (${att.mediaType})` : att.mediaType;
+	return att.mediaType;
+}
+
+function estimateTokens(lines: string[]): number {
+	let chars = 0;
+	for (const line of lines) chars += line.length + 1;
+	return Math.ceil(chars / CHARS_PER_TOKEN);
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Render a branch (already parsed, root → head order) into handoff blocks.
+ *
+ * Pure: no DB, no registry. `buildEngineHandoff` is the thin DB-reading wrapper
+ * around it, which is also what makes the interesting behaviour — clearing,
+ * attachment gating, sub-agent filtering — directly testable.
+ */
+export function renderHandoff(
+	messages: UnifiedMessage[],
+	support: { image: boolean; document: boolean },
+	previousEngine: EngineType | null
+): HandoffResult | null {
+	const entries = collect(messages);
+	if (!entries.length) return null;
+
+	// First pass: verbatim. Only if that exceeds the trigger do we clear, and
+	// then only the tool results outside the most recent KEEP_TOOL_USES.
+	const clearedToolUseIds = new Set<string>();
+	let render = renderEntries(entries, clearedToolUseIds, support);
+
+	if (estimateTokens(render.lines) > TRIGGER_TOKENS) {
+		const toolUseIds = entries.filter((e): e is Extract<Entry, { kind: 'tool_use' }> => e.kind === 'tool_use').map(e => e.id);
+		const kept = new Set(toolUseIds.slice(-KEEP_TOOL_USES));
+		for (const id of toolUseIds) {
+			if (!kept.has(id)) clearedToolUseIds.add(id);
+		}
+		render = renderEntries(entries, clearedToolUseIds, support);
+	}
+
+	const turns = entries.filter(e => e.kind === 'user' || e.kind === 'assistant').length;
+	const estimatedTokens = estimateTokens(render.lines);
+
+	const header = previousEngine
+		? `The conversation below happened in this same chat, driven by a different engine (${previousEngine}). You are taking over from it.`
+		: 'The conversation below happened earlier in this same chat. You are taking over from it.';
+
+	const transcript = [
+		header,
+		'Treat it as your own prior context: it is what you already said, did and learned. Do not greet the user as if this were a new conversation, and do not repeat work that is already done. Anything marked as cleared or omitted can be re-derived with your tools.',
+		'',
+		'<conversation-transcript>',
+		...render.lines,
+		'</conversation-transcript>',
+		'',
+		'The user\'s new message follows.',
+	].join('\n');
+
+	const blocks: UserContentBlock[] = [{ type: 'text', text: transcript }, ...render.attachments];
+
+	return {
+		blocks,
+		stats: {
+			turns,
+			clearedToolResults: clearedToolUseIds.size,
+			droppedAttachments: render.droppedAttachments,
+			estimatedTokens,
+		},
+	};
+}
+
+/**
+ * Build the handoff blocks for a branch, or null when there is nothing to hand
+ * over (empty session, unreadable chain).
+ *
+ * `targetEngine` / `targetModelId` describe the engine the user just switched
+ * TO — they decide which attachments can ride along.
+ *
+ * `excludeMessageId` is the turn's own user message. By the time this runs it
+ * has already been saved and IS the branch head, so without excluding it the
+ * transcript would end with a verbatim copy of the message the engine is about
+ * to be asked to answer.
+ */
+export function buildEngineHandoff(
+	chatSessionId: string,
+	targetEngine: EngineType,
+	targetModelId: string,
+	previousEngine: EngineType | null,
+	excludeMessageId?: string
+): HandoffResult | null {
+	let messages: UnifiedMessage[];
+	try {
+		const head = sessionQueries.getHead(chatSessionId);
+		if (!head) return null;
+		messages = messageQueries
+			.getPathToRoot(head)
+			.filter(row => row.id !== excludeMessageId)
+			.map(row => parse(row.data))
+			.filter((msg): msg is UnifiedMessage => msg !== null);
+	} catch (error) {
+		debug.error('chat', 'Engine handoff: failed to read branch:', error);
+		return null;
+	}
+	if (!messages.length) return null;
+
+	return renderHandoff(messages, attachmentSupport(targetEngine, targetModelId), previousEngine);
+}
+
+/**
+ * Prepend handoff blocks to a prompt, returning a new UserMessage. The original
+ * message is left untouched so the persisted/rendered timeline never sees the
+ * transcript.
+ */
+export function withHandoff(prompt: UserMessage, blocks: UserContentBlock[]): UserMessage {
+	return { ...prompt, content: [...blocks, ...prompt.content] };
+}

--- a/backend/chat/stream-manager.ts
+++ b/backend/chat/stream-manager.ts
@@ -40,6 +40,7 @@ import { projectContextService, refreshExpiringExternalOAuth } from '../mcp';
 import { resolveActiveProfileId } from '../profiles';
 import { browserMcpControl } from '../preview';
 import { extractMessageText } from '../snapshot/helpers';
+import { buildEngineHandoff, resolveBranchEngine, withHandoff } from './engine-handoff';
 import { debug } from '$shared/utils/logger';
 import { DEFAULT_MODEL_ID, DEFAULT_MODEL_NAME } from '$shared/constants/engines';
 
@@ -492,14 +493,26 @@ class StreamManager extends EventEmitter {
 			if (!projectPath) throw new Error('Project path is required. Please select a valid project directory.');
 			if (!projectPathExists) throw new Error(`Project path does not exist: ${projectPath}. Please select a valid project directory.`);
 
+			// Which engine produced the trailing part of this branch. When it differs
+			// from the engine the user just picked, the branch's SDK session id
+			// belongs to a foreign store and MUST NOT be used as a resume target —
+			// the conversation is carried over as prompt content instead (see
+			// buildEngineHandoff below). Null means a fresh branch: nothing to hand
+			// over, nothing to resume.
+			const branchEngine = chatSessionId ? resolveBranchEngine(chatSessionId) : null;
+			const engineSwitched = branchEngine !== null && branchEngine !== requestEngine.type;
+
 			// Get resume session ID (branch-aware).
 			// Primary: use parentSessionId carried by the UserMessage — set by the
 			// frontend from the last assistant/reasoning sessionId in the current branch.
 			// Fallback: walk the HEAD chain in the DB (handles messages sent from
 			// older clients or tool-result user messages that lack parentSessionId).
 			let resumeSessionId: string | undefined = undefined;
-			if (chatSessionId) {
-				// Primary source: parent.sessionId on the raw prompt
+			if (chatSessionId && !engineSwitched) {
+				// Primary source: parent.sessionId on the raw prompt.
+				// Note this is client-supplied and engine-blind, which is why the
+				// engineSwitched guard above is authoritative — an older client will
+				// happily send the previous engine's id.
 				const promptParentSessionId = rawPrompt?.parent?.sessionId;
 				if (promptParentSessionId && promptParentSessionId !== chatSessionId) {
 					resumeSessionId = promptParentSessionId;
@@ -586,9 +599,42 @@ class StreamManager extends EventEmitter {
 				return;
 			}
 
-			// Detect orphaned user messages and prepend context (claude-code only)
+			// ── Cross-engine handoff ──
+			// The user switched engine mid-conversation, so the new engine has no
+			// native session to resume. Replay the branch as prompt content. This
+			// is prepended to the ENGINE prompt only — `userMessage` (already saved
+			// above) stays clean, so the transcript never reaches the timeline.
 			let enginePrompt = userMessage;
-			if (requestEngine.type === 'claude-code' && chatSessionId) {
+			if (engineSwitched && chatSessionId) {
+				try {
+					const handoff = buildEngineHandoff(
+						chatSessionId,
+						requestEngine.type,
+						requestEngine.model.id || '',
+						branchEngine,
+						userMessageId
+					);
+					if (handoff) {
+						enginePrompt = withHandoff(userMessage, handoff.blocks);
+						const { turns, clearedToolResults, droppedAttachments, estimatedTokens } = handoff.stats;
+						debug.log(
+							'chat',
+							`Engine handoff ${branchEngine} → ${requestEngine.type}: ${turns} turn(s), ~${estimatedTokens} tokens` +
+							(clearedToolResults ? `, ${clearedToolResults} tool result(s) cleared` : '') +
+							(droppedAttachments ? `, ${droppedAttachments} attachment(s) omitted (unsupported by target)` : '')
+						);
+					}
+				} catch (error) {
+					// A failed handoff must not block the turn — the engine simply
+					// starts without carried context.
+					debug.error('chat', 'Engine handoff failed, continuing without carried context:', error);
+				}
+			}
+
+			// Detect orphaned user messages and prepend context (claude-code only).
+			// Same idea as the handoff above but for the in-engine case: messages the
+			// engine's own session never saw because an earlier turn was cancelled.
+			if (!engineSwitched && requestEngine.type === 'claude-code' && chatSessionId) {
 				try {
 					const head = sessionQueries.getHead(chatSessionId);
 					if (head) {

--- a/backend/engine/README.md
+++ b/backend/engine/README.md
@@ -70,7 +70,7 @@ map, then jump to the area you need.
 6. [Stack](./docs/stack.md) — registering a host tool or on-demand engine SDK in `install-recipes.ts` + the install runner.
 7. [Artifacts & Access](./docs/artifacts.md) — the extension layer (Skills, Commands, Subagents, Instructions, Permissions, Profiles, MCP), the capability matrix, and the `artifact-sync.ts` seam adapters call at stream start.
 8. [Adding a new engine](./docs/adding-an-engine.md) — the end-to-end, stage-by-stage checklist.
-9. [Lessons learned](./docs/lessons-learned.md) — §10 pitfalls (tool name/input canonicalisation, fork session, MCP reuse, auth-blob swap, sub-agent routing, OpenCode v1/v2, structured output, …).
+9. [Lessons learned](./docs/lessons-learned.md) — §10 pitfalls (tool name/input canonicalisation, fork session, MCP reuse, auth-blob swap, sub-agent routing, OpenCode v1/v2, structured output, cross-engine handoff, …).
 10. [Quick reference](./docs/quick-reference.md) — "I need X → look in file Y" table.
 
 ---
@@ -132,6 +132,9 @@ map, then jump to the area you need.
 │  backend/database/queries/        backend/chat/stream-manager.ts      │
 │    engine-queries.ts                routes EngineOutput → DB + WS     │
 │      engine_providers + engine_accounts                               │
+│                                   backend/chat/engine-handoff.ts      │
+│                                     replays the branch when the       │
+│                                     session changes engine            │
 └───────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -178,6 +181,18 @@ invariants.
 >      login/switch. Do **NOT** propose **per-account** home dirs
 >      (`CODEX_HOME=/foo/account-1/`); that splits session-state, breaks
 >      fork-by-copy, and loses token-refresh persistence. See §10.13.
+> 3. **A session may change engine mid-conversation.** Never assume one
+>    session ↔ one engine. `chat_sessions.engine` names the *currently
+>    selected* engine, so anything reasoning about "which engine produced
+>    this?" must read `engine.type` **per message** — resume-target
+>    derivation and checkpoint restore both do. An SDK session id is only
+>    meaningful to the engine that minted it; handing one to another engine
+>    fails differently on every adapter (silent fresh start on Codex,
+>    Copilot, Pi and Cline; an unknown-session error on OpenCode and Claude).
+>    Carrying the conversation across is already solved by
+>    `backend/chat/engine-handoff.ts` — do **NOT** propose a new adapter
+>    method, a portable session format, or per-engine history injection.
+>    See §10.23.
 
 ---
 

--- a/backend/engine/adapters/copilot/stream.ts
+++ b/backend/engine/adapters/copilot/stream.ts
@@ -37,6 +37,12 @@ import { fetchCopilotModels } from './models';
 // it from the SessionConfig field so we don't drift from the SDK.
 type UserInputResponse = Awaited<ReturnType<NonNullable<SessionConfig['onUserInputRequest']>>>;
 
+// `MessageOptions` is likewise not re-exported from the SDK root, so derive the
+// attachment element type from `session.send`'s options overload.
+type MessageAttachment = NonNullable<Parameters<CopilotSession['send']>[0] extends string
+	? never
+	: NonNullable<Extract<Parameters<CopilotSession['send']>[0], { prompt: string }>['attachments']>>[number];
+
 /**
  * Map a Copilot permission request to the token the permission policy matches on.
  * MCP / custom tools carry a `toolName`; everything else is matched by its
@@ -414,7 +420,11 @@ export class CopilotEngine implements AIEngine {
 			const promptText = artifactsContext
 				? `${artifactsContext}\n\n${extractPromptText(prompt)}`
 				: extractPromptText(prompt);
-			const sendPromise = session.send({ prompt: promptText }).catch(error => {
+			const promptAttachments = extractPromptAttachments(prompt);
+			const sendPromise = session.send({
+				prompt: promptText,
+				...(promptAttachments.length > 0 && { attachments: promptAttachments }),
+			}).catch(error => {
 				debug.error('engine', 'Copilot session.send error:', error);
 				pushEvent({
 					type: 'session.error',
@@ -705,4 +715,30 @@ function extractPromptText(prompt: EngineQueryOptions['prompt']): string {
 		}
 	}
 	return parts.join('\n').trim();
+}
+
+/**
+ * Image / document blocks → Copilot `blob` attachments.
+ *
+ * The SDK takes raw base64 in `data` plus a `mimeType` (see its README, "Image
+ * Support"), which lines up 1:1 with our unified blocks — no temp files needed,
+ * unlike the Codex path. Before this existed the adapter forwarded text only,
+ * so every attachment the user added was silently dropped even though
+ * `models.ts` advertises `image: !!supports?.vision`.
+ */
+function extractPromptAttachments(prompt: EngineQueryOptions['prompt']): MessageAttachment[] {
+	const attachments: MessageAttachment[] = [];
+	for (const block of prompt.content) {
+		if (block.type === 'image') {
+			attachments.push({ type: 'blob', data: block.data, mimeType: block.mediaType });
+		} else if (block.type === 'document') {
+			attachments.push({
+				type: 'blob',
+				data: block.data,
+				mimeType: block.mediaType,
+				...(block.title ? { displayName: block.title } : {}),
+			});
+		}
+	}
+	return attachments;
 }

--- a/backend/engine/docs/adding-an-engine.md
+++ b/backend/engine/docs/adding-an-engine.md
@@ -250,6 +250,14 @@ Other auto wiring:
       `shared/constants/tool-icons.ts`, which both `ENGINES` and the Stack
       cards reference. Add the SVG **there only** — never inline it a second
       time.
+- [ ] **Declare what the adapter really forwards** in
+      `backend/chat/engine-handoff.ts::attachmentSupport` (`ADAPTER_IMAGE` /
+      `ADAPTER_DOCUMENT`). These are `Record<EngineType, boolean>`, so a new
+      engine won't type-check until both are filled in — deliberately. Answer
+      from the adapter's own prompt-building code, **not** from
+      `models.ts`: the catalog says what the *model* accepts, this table says
+      what the *adapter* actually sends, and they routinely disagree. Getting
+      it wrong makes a cross-engine switch silently lose the user's images.
 - [ ] Verify: select engine → model list appears → send message → stream
       runs.
 
@@ -279,6 +287,13 @@ Then the minimum UI scenarios that must pass:
       message, and Artifacts → generate from a purpose. These are the two
       paths that break on a stale `providerSlug` and on JSON with trailing
       prose / raw newlines — Claude Code passing proves nothing (§10.16).
+- [ ] **Cross-engine handoff, both directions.** Run a few turns on another
+      engine (include a tool call and an image), switch to NewEngine, then ask
+      something that can only be answered from the earlier turns — it must
+      answer without asking the user to repeat themselves. Then switch back
+      and confirm the same. The `chat` debug log prints one
+      `Engine handoff <from> → <to>` line per switch with the turn count and
+      what was cleared or omitted (§10.23).
 - [ ] Restart Clopen → state survives (account, provider, last-used model
       in chat).
 

--- a/backend/engine/docs/frontend-and-chat.md
+++ b/backend/engine/docs/frontend-and-chat.md
@@ -198,6 +198,70 @@ level left over from a different model can never leak into the next request.
   `EngineNotReadyError`), the picker renders the same actionable notice as
   Settings, with an **Open Stack** button and a Configure-engine fallback.
   Both are admin-gated.
+- **No engine lock.** The engine is switchable at any point in a session; only
+  an in-flight stream disables the trigger. Mid-session switches are handled by
+  the cross-engine handoff (§6.2a). `ProfilePicker` is likewise unlocked — the
+  backend resolves the effective profile per stream.
+
+> **Local picks must mirror onto `sessionState.currentSession`.** The init
+> `$effect` restores engine/model/account/profile from the session object, and
+> it re-runs whenever that object is replaced — which any collaborator's
+> `chat:*-sync` broadcast does. The remote `chat:model-sync` listener already
+> mirrors ("so init $effect won't overwrite on re-render"); the local path must
+> too, because the sender ignores its own broadcast echo. Miss this and a
+> user's pick silently reverts a moment later. `selectEngine`, `selectModel`
+> and `ProfilePicker.select` all call through this mirror.
+
+### 6.2a Cross-engine handoff
+
+Switching engine mid-conversation is supported. The mechanism lives entirely in
+`backend/chat/engine-handoff.ts` — **no adapter, `AIEngine` or migration
+change**.
+
+Continuity is normally delegated to each engine's native session store, and
+those ids are not portable (a Claude session id, a Codex rollout file, an
+OpenCode server session, Cline's in-memory transcript). So when the branch's
+trailing engine differs from the requested one, `stream-manager`:
+
+1. **Suppresses `resume`.** `resolveBranchEngine(chatSessionId)` walks back to
+   the most recent **non-user** message and reads its `engine.type` (user
+   messages carry the *sender's* choice, which is exactly what must not be
+   trusted). Falls back to `chat_sessions.engine`, which is reliable because
+   `chat:model-sync` persists it at *selection* time, not on send.
+2. **Replays the branch as prompt content** via `buildEngineHandoff(...)`,
+   prepended to the **engine prompt only**. The persisted `UserMessage` is
+   untouched, so the transcript never reaches the DB or the timeline.
+
+**The rule — one rule, no fallback ladder.** Replay verbatim; when the replay
+exceeds the trigger, tool results older than the last N tool uses become a
+placeholder and tool *inputs* are always kept. Both numbers are the shipped
+defaults of Anthropic's [`clear_tool_uses_20250919`](https://platform.claude.com/docs/en/build-with-claude/context-editing)
+context-editing strategy (trigger 100k input tokens, keep 3 tool uses,
+`clear_tool_inputs: false`). Mirroring a measured default beats inventing a
+heuristic — context editing alone reports +29% on agentic benchmarks and an 84%
+token reduction on long tool-heavy runs.
+
+> ⚠️ **Do NOT key the replay window on `compact_boundary`.** It looks like the
+> natural boundary and it is not: only the **Claude** adapter ever emits one.
+> OpenCode drops compaction events (`message-converter.ts`, "Skip: … compaction")
+> and Pi disables compaction outright (`compaction: { enabled: false }`). A
+> boundary-based window silently degenerates to "replay everything from message
+> one" on 7 of 8 engines — precisely the unbounded case it was meant to prevent.
+
+Two further invariants the builder upholds:
+
+- **Exclude the turn's own user message.** It is already saved and *is* the
+  branch head by the time the handoff runs, so without `excludeMessageId` the
+  transcript ends with a copy of the message the engine is about to answer.
+- **Attachments pass two independent gates** — `modalities.input.image` / `.pdf`
+  (what the *model* accepts) **and** an adapter table (what the adapter actually
+  forwards). They genuinely differ: Codex, Cursor, Pi and Cline have no document
+  path at all, so a PDF handed to them vanishes whatever the catalog claims.
+  Unsupported attachments degrade to the same placeholder as cleared tool
+  results.
+
+After the handoff turn the new engine has minted its own session id, so every
+subsequent turn resumes natively — the cost is paid once per switch.
 
 ### 6.3 Send path → backend
 

--- a/backend/engine/docs/lessons-learned.md
+++ b/backend/engine/docs/lessons-learned.md
@@ -1272,3 +1272,74 @@ costs one effect and buys two things: the value sent with the turn always
 matches what actually ran (so `MessageEngine.reasoningEffort` in the Raw
 view is truthful), and a level valid for the previous model can never
 leak into a request for the next one.
+
+---
+
+### 10.23 Switching engine mid-session — replay the branch, and distrust "obvious" boundaries
+
+Continuity is delegated to each engine's native session store, and those
+ids are not portable: a Claude session id, a Codex rollout file, an
+OpenCode server session, Cline's in-memory transcript. So a chat that
+changes engine has nothing for the new engine to resume. Clopen's DB is
+the only engine-agnostic record of the conversation, which makes
+**replaying the branch as prompt content** the only mechanism that works
+for all eight adapters. It lives in `backend/chat/engine-handoff.ts` and
+needs no adapter, `AIEngine` or migration change.
+
+**Gate `resume` on the engine that produced the branch, not on the
+session.** `chat_sessions.engine` names the *currently selected* engine
+(`chat:model-sync` persists it the moment anyone picks one), which in a
+switched session is precisely the wrong answer. Walk back to the most
+recent **non-user** message and read its `engine.type`; user messages
+carry the sender's choice, not the producer's. Feeding a foreign id to an
+adapter degrades inconsistently — Codex, Copilot, Pi and Cline catch it
+and start fresh (silent amnesia), while OpenCode falls back to the raw id
+against a server that never had it, and Claude passes it straight to the
+SDK with no existence check.
+
+**Two boundary assumptions failed here; both looked obvious.**
+
+1. *"Replay from the last `compact_boundary` — that's what the engine
+   itself was holding."* Only the **Claude** adapter ever emits one.
+   OpenCode explicitly drops compaction events (`message-converter.ts`,
+   "Skip: … compaction") and Pi disables compaction outright
+   (`compaction: { enabled: false }`). On 7 of 8 engines the rule
+   silently becomes "replay everything from message one" — the unbounded
+   case it was supposed to prevent.
+2. *"No boundary means it all fit in the source engine's window."* Not
+   so. Context editing is explicitly designed around the client keeping
+   full history while the server edits it, so a client-side transcript
+   that is much larger than the engine's live context is the normal
+   case, not an exotic one.
+
+The window is therefore an **estimated token budget**, which every engine
+has, rather than a marker only one engine emits.
+
+**Copy a measured default instead of inventing a heuristic.** The rule is
+one sentence — replay verbatim; past the trigger, tool results older than
+the last N tool uses become a placeholder and tool *inputs* are always
+kept — and both numbers are the shipped defaults of Anthropic's
+[`clear_tool_uses_20250919`](https://platform.claude.com/docs/en/build-with-claude/context-editing)
+(trigger 100k input tokens, keep 3 tool uses, `clear_tool_inputs: false`).
+Tool results are the right thing to drop first because they are
+re-derivable — the new engine is in the same project directory and can
+read the file again — and because clearing them is *measured* to help:
++29% on agentic benchmarks, 84% token reduction on long tool-heavy runs.
+Resist adding a fallback ladder on top; a ladder is how a rule becomes
+unpredictable.
+
+**Two invariants that are easy to miss:**
+
+- The turn's own user message is already saved and *is* the branch head
+  when the handoff runs. Without `excludeMessageId` the transcript ends
+  with a verbatim copy of the message the engine is about to answer.
+- Attachments need **two** gates: `EngineModel.modalities.input` (what
+  the model accepts) and an adapter table (what the adapter forwards).
+  They disagree — Codex, Cursor, Pi and Cline have no document path at
+  all. Copilot forwarded text only until its `blob` attachment support
+  was wired up, silently dropping every image despite `models.ts`
+  advertising `image: !!supports?.vision`.
+
+Finally: the handoff is prepended to the **engine prompt only**. The
+persisted `UserMessage` stays clean, so the transcript never reaches the
+DB or the timeline, and the user sees nothing but a changed engine.

--- a/backend/engine/docs/quick-reference.md
+++ b/backend/engine/docs/quick-reference.md
@@ -39,6 +39,10 @@
 | Reasoning-effort levels a model offers      | `EngineModel.capabilities.reasoningControl` built in `<engine>/models.ts` via `toReasoningOptions` (`shared/constants/engines.ts`); §2.4a |
 | Apply the chosen reasoning level to the SDK | `claude/stream.ts` (`thinking` + `effort`), `codex/stream.ts` (`modelReasoningEffort`), `copilot/stream.ts` (`reasoningEffort`), `pi/stream.ts` (`thinkingLevel` + `clampThinkingLevel`), `cursor/stream.ts::buildCursorModelSelection` (`params[]`); §10.22 |
 | Per-session reasoning persistence + collab sync | `chat_sessions.reasoning_effort` (migration `065`), `sessionQueries.updateReasoning`, `chat:reasoning-sync` in `backend/ws/chat/stream.ts` |
+| Switch engine mid-session (carry the conversation) | `backend/chat/engine-handoff.ts::buildEngineHandoff` + `resolveBranchEngine`, wired in `backend/chat/stream-manager.ts` (suppress `resume`, prepend to the engine prompt only); frontend-and-chat §6.2a |
+| Is this SDK session id mine? (engine-aware resume) | `resolveBranchEngine` (backend, authoritative) + the `engine.type` guard in `frontend/services/chat/chat.service.ts`; also `backend/ws/snapshot/restore.ts` when restoring into another engine's region |
+| Which attachments actually survive to an engine | adapter table in `backend/chat/engine-handoff.ts::attachmentSupport` (what the adapter forwards) × `EngineModel.modalities.input` (what the model accepts) — the two disagree |
+| Collab sync of engine/model/account/profile   | `chat:model-sync` / `chat:account-sync` / `chat:profile-sync` in `backend/ws/chat/stream.ts`; local picks must ALSO mirror onto `sessionState.currentSession` (frontend-and-chat §6.2) |
 | Error normalisation                         | `claude/error-handler.ts`, `copilot/error-handler.ts`, `opencode/error-handler.ts`, `qwen/error-handler.ts`, `codex/error-handler.ts` |
 | DB provider/account access                  | `backend/database/queries/engine-queries.ts`              |
 | Host-tool + engine-SDK install recipes      | `backend/engine/install-recipes.ts`                       |

--- a/backend/engine/docs/websocket-routes.md
+++ b/backend/engine/docs/websocket-routes.md
@@ -276,5 +276,18 @@ Every one of these must be declared in **both** the `.on(...)` block and the
 `.emit(...)` schema block at the bottom of `backend/ws/chat/stream.ts` — an
 event that is only `.on`'d is received but never broadcast.
 
+Two consequences worth internalising:
+
+- **These persist at *selection* time, not on send.** `chat:model-sync` writes
+  `updateEngineModel` the moment anyone picks an engine, which is why
+  `chat_sessions.engine` is a trustworthy "currently selected engine" — and
+  equally why it is the *wrong* source for "which engine produced this
+  message" (read `engine.type` per message instead; see §10.23).
+- **The sender ignores its own echo**, so a local pick never comes back through
+  the listener. Whatever the remote listener does to
+  `sessionState.currentSession`, the local path must do too, or the init
+  `$effect` restores the pre-pick values the next time that object is replaced.
+  See frontend-and-chat §6.2.
+
 ---
 

--- a/backend/ws/snapshot/restore.ts
+++ b/backend/ws/snapshot/restore.ts
@@ -217,11 +217,41 @@ export const restoreHandler = createRouter()
 		// 5b. Update head_session_id so resume works correctly.
 		// Claude Code: skip cancelled fork session_ids (partial messages from cancelStream).
 		// OpenCode: simple walk — any session_id is valid (sessions created synchronously).
+		//
+		// Engine is read PER MESSAGE, not from `chat_sessions.engine`: a session can
+		// now switch engine mid-conversation, so the session column only names the
+		// currently selected engine. Restoring into a region driven by a different
+		// engine must apply that region's semantics, and must not adopt an SDK
+		// session id belonging to some other engine's store.
 		{
 			let foundSdkSessionId: string | null = null;
 			const msgLookup = new Map(allMessages.map(m => [m.id, m]));
-			const sessionRecord = sessionQueries.getById(sessionId);
-			const isClaudeCode = sessionRecord?.engine === 'claude-code';
+
+			const engineOf = (msg: UnifiedMessage): string | null => msg.engine?.type ?? null;
+
+			// The engine that owns the restored branch head — the only engine whose
+			// session ids are meaningful for a subsequent resume.
+			let branchEngine: string | null = null;
+			{
+				let probeId: string | null = sessionEnd.id;
+				while (probeId) {
+					const probeMsg = msgLookup.get(probeId);
+					if (!probeMsg) break;
+					try {
+						const msg = JSON.parse(probeMsg.data) as UnifiedMessage;
+						if (msg.type !== 'user') {
+							const type = engineOf(msg);
+							if (type) { branchEngine = type; break; }
+						}
+					} catch { /* skip */ }
+					probeId = probeMsg.parent_message_id || null;
+				}
+				if (!branchEngine) {
+					branchEngine = sessionQueries.getById(sessionId)?.engine ?? null;
+				}
+			}
+
+			const isClaudeCode = branchEngine === 'claude-code';
 
 			// Claude Code only: detect cancelled stream by stopReason on sessionEnd
 			let cancelledSessionId: string | null = null;
@@ -257,8 +287,12 @@ export const restoreHandler = createRouter()
 						continue;
 					}
 
-					// Any engine: message with sessionId
-					if (msg.sessionId) {
+					// Any engine: message with sessionId, but only from the branch's own
+					// engine. Crossing that line would store a foreign store's id.
+					// A message with no engine block is pre-migration: it cannot be
+					// proven foreign, so keep the old behaviour and accept it.
+					const msgEngine = engineOf(msg);
+					if (msg.sessionId && (!branchEngine || !msgEngine || msgEngine === branchEngine)) {
 						foundSdkSessionId = msg.sessionId;
 						break;
 					}

--- a/frontend/components/chat/input/components/EngineModelPicker.svelte
+++ b/frontend/components/chat/input/components/EngineModelPicker.svelte
@@ -361,12 +361,10 @@
 		sessionState.messages.some(m => m.type === 'user') || sessionState.hasMessageHistory
 	);
 
-	// Engine lock: once chat starts, the engine is locked for this session.
-	const lockedEngine = $derived<EngineType | null>(
-		hasStartedChat ? chatModelState.engine : null
-	);
-
-	const engineLocked = $derived(lockedEngine !== null);
+	// The engine is switchable at any point in a session. When it changes
+	// mid-conversation the backend replays the branch to the new engine as
+	// prompt content (backend/chat/engine-handoff.ts), so there is nothing to
+	// lock — the new engine picks up with the full conversation behind it.
 
 	// Read from local chat model state (isolated from Settings)
 	const currentEngine = $derived(ENGINES.find(e => e.type === chatModelState.engine));
@@ -698,9 +696,29 @@
 		return unsub;
 	});
 
-	async function selectEngine(engineType: EngineType) {
-		if (engineLocked) return;
+	/**
+	 * Mirror a local engine/model pick onto `sessionState.currentSession`.
+	 *
+	 * The remote `chat:model-sync` listener already does this (see its comment:
+	 * "so init $effect won't overwrite on re-render") but the LOCAL path never
+	 * did, because the sender ignores its own broadcast echo. That left
+	 * `currentSession.engine/model_id` stale after every local pick, so the next
+	 * time anything replaced the session object — a reasoning/account/profile
+	 * sync from a collaborator, a session list refresh — the init $effect read
+	 * the stale values back and silently reverted the user's choice.
+	 */
+	function mirrorSelectionToSession(engine: EngineType, provider: string, modelId: string, modelName: string) {
+		if (!sessionState.currentSession) return;
+		sessionState.currentSession = {
+			...sessionState.currentSession,
+			engine,
+			provider,
+			model_id: modelId,
+			model_name: modelName
+		};
+	}
 
+	async function selectEngine(engineType: EngineType) {
 		// Switch engine immediately so the active tab updates before model fetch
 		chatModelState.engine = engineType;
 		searchQuery = '';
@@ -724,6 +742,7 @@
 			chatModelState.modelName = target.engine.model.name;
 			chatModelState.engineModelMemory = { ...memory, [engineType]: { provider: target.engine.provider, id: target.engine.model.id, name: target.engine.model.name } };
 			chatModelState.reasoningEffort = settings.reasoningDefaults[target.engine.model.id] ?? null;
+			mirrorSelectionToSession(engineType, target.engine.provider, target.engine.model.id, target.engine.model.name);
 		}
 	}
 
@@ -737,6 +756,7 @@
 		};
 		// Restore the per-model reasoning default (null → engine/model default).
 		chatModelState.reasoningEffort = settings.reasoningDefaults[model.engine.model.id] ?? null;
+		mirrorSelectionToSession(chatModelState.engine, model.engine.provider, model.engine.model.id, model.engine.model.name);
 		closeDropdown();
 	}
 
@@ -1005,18 +1025,14 @@
 		<div class="flex border-b border-slate-200 dark:border-slate-700 flex-shrink-0 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
 			{#each ENGINES as engine (engine.type)}
 				{@const isActive = chatModelState.engine === engine.type}
-				{@const isDisabled = engineLocked && engine.type !== lockedEngine}
 				<button
 					type="button"
 					class="flex items-center justify-center gap-1.5 px-2 py-2 text-xs font-medium transition-all duration-150 whitespace-nowrap
 						{isActive ? 'flex-1' : 'flex-shrink-0'}
 						{isActive
 							? 'bg-violet-50 dark:bg-violet-900/20 text-violet-600 dark:text-violet-400 border-b-2 border-violet-600'
-							: isDisabled
-								? 'text-slate-300 dark:text-slate-600 cursor-not-allowed'
-								: 'text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-700/50'}"
-					onclick={() => !isDisabled && selectEngine(engine.type)}
-					disabled={isDisabled}
+							: 'text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-700/50'}"
+					onclick={() => selectEngine(engine.type)}
 					title={engine.name}
 				>
 					<div class="flex dark:hidden items-center justify-center w-3.5 h-3.5 flex-shrink-0 [&>svg]:w-full [&>svg]:h-full">{@html engine.icon.light}</div>
@@ -1024,22 +1040,9 @@
 					{#if isActive}
 						<span class="truncate max-w-28">{engine.name}</span>
 					{/if}
-					{#if isDisabled}
-						<Icon name="lucide:lock" class="w-3 h-3 flex-shrink-0" />
-					{/if}
 				</button>
 			{/each}
 		</div>
-
-		<!-- Engine locked notice -->
-		{#if engineLocked}
-			<div class="px-3 py-1.5 bg-amber-50 dark:bg-amber-900/10 border-b border-slate-200 dark:border-slate-700 flex-shrink-0">
-				<div class="flex items-center gap-1.5 text-3xs text-amber-600 dark:text-amber-400">
-					<Icon name="lucide:info" class="w-3 h-3 flex-shrink-0" />
-					<span>Engine is locked for this session. You can still switch models.</span>
-				</div>
-			</div>
-		{/if}
 
 		<!-- Search -->
 		<div class="px-2 py-2 border-b border-slate-200 dark:border-slate-700 flex-shrink-0">

--- a/frontend/components/chat/input/components/ProfilePicker.svelte
+++ b/frontend/components/chat/input/components/ProfilePicker.svelte
@@ -3,6 +3,7 @@
 	import { scale } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { appState } from '$frontend/stores/core/app.svelte';
 	import { projectState } from '$frontend/stores/core/projects.svelte';
 	import { sessionState } from '$frontend/stores/core/sessions.svelte';
 	import { userStore } from '$frontend/stores/features/user.svelte';
@@ -17,14 +18,11 @@
 	const isAdmin = $derived(authStore.isAdmin);
 	let projectDefaultId = $state<number | null>(null);
 
-	// Once the session has any activity, the active profile is locked for the rest
-	// of the session — mirrors the engine lock in EngineModelPicker. Switching
-	// profiles mid-session can route to a different server, so we pin it after the
-	// first message and keep it locked (not just while loading).
-	const hasStartedChat = $derived(
-		sessionState.messages.some(m => m.type === 'user') || sessionState.hasMessageHistory
-	);
-
+	// The profile is switchable at any point in a session. The backend resolves
+	// the effective profile per stream (`resolveActiveProfileId`, called at
+	// stream start), so a mid-session change simply scopes the next turn's
+	// artifacts and MCP servers — there is no engine state to invalidate and
+	// nothing to carry over. Only an in-flight stream blocks the picker.
 	let open = $state(false);
 	let searchQuery = $state('');
 	let triggerButton = $state<HTMLButtonElement | null>(null);
@@ -85,6 +83,13 @@
 
 	function select(profileId: number | null) {
 		chatModelState.profileId = profileId;
+		// Mirror onto the session object for the same reason the remote listener
+		// above does: the init $effect in EngineModelPicker restores profile_id
+		// from `currentSession`, so leaving it stale reverts this pick the next
+		// time anything replaces that object.
+		if (sessionState.currentSession) {
+			sessionState.currentSession = { ...sessionState.currentSession, profile_id: profileId };
+		}
 		const chatSessionId = sessionState.currentSession?.id;
 		if (chatSessionId) {
 			ws.emit('chat:profile-sync', {
@@ -116,12 +121,12 @@
 			text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-slate-700
 			disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-slate-100 dark:disabled:hover:bg-slate-800"
 		onclick={toggle}
-		disabled={hasStartedChat}
-		title={hasStartedChat ? 'Profile is locked for this session' : 'Active profile for this session'}
+		disabled={appState.isLoading}
+		title="Active profile for this session"
 	>
 		<Icon name="lucide:layers" class="w-3.5 h-3.5" />
 		<span class="font-medium max-w-32 truncate">{triggerLabel}</span>
-		<Icon name={hasStartedChat ? 'lucide:lock' : 'lucide:chevron-down'} class="w-3 h-3" />
+		<Icon name="lucide:chevron-down" class="w-3 h-3" />
 	</button>
 
 	{#if open}

--- a/frontend/services/chat/chat.service.ts
+++ b/frontend/services/chat/chat.service.ts
@@ -435,15 +435,28 @@ class ChatService {
       }
       const messageContent = contentBlocks.length > 0 ? contentBlocks : [{ type: 'text', text: userMessage }];
 
+      // Capture selected engine/model/account before sending
+      const selectedEngine = chatModelState.engine;
+      const selectedProvider = chatModelState.provider;
+      const selectedModelId = chatModelState.modelId;
+      const selectedModelName = chatModelState.modelName;
+
       // Determine the SDK session ID for the current branch HEAD.
       // After non-linear operations (edit/undo/restore), sessionState.messages
       // reflects the correct branch — find the last assistant/reasoning message
       // whose sessionId differs from the clopen session ID.
+      //
+      // Only messages produced by the SELECTED engine qualify: session ids are
+      // native to whichever engine minted them, so after an engine switch the
+      // previous engine's id would name a session the new engine's store has
+      // never heard of. The backend re-checks this (it must, for older clients),
+      // but sending a foreign id here would also make the request misleading.
       const currentSessionId = sessionState.currentSession.id;
       let parentSessionId: string | null = null;
       for (let i = sessionState.messages.length - 1; i >= 0; i--) {
         const m = sessionState.messages[i];
         if ((m.type === 'assistant' || m.type === 'reasoning') && 'sessionId' in m) {
+          if ((m as any).engine?.type && (m as any).engine.type !== selectedEngine) break;
           const sid = (m as any).sessionId as string;
           if (sid && sid !== currentSessionId) {
             parentSessionId = sid;
@@ -451,12 +464,6 @@ class ChatService {
           }
         }
       }
-
-      // Capture selected engine/model/account before sending
-      const selectedEngine = chatModelState.engine;
-      const selectedProvider = chatModelState.provider;
-      const selectedModelId = chatModelState.modelId;
-      const selectedModelName = chatModelState.modelName;
 
       // Create UserMessage format for prompt
       const userMsgId = crypto.randomUUID();


### PR DESCRIPTION
## Summary
A chat session can now change engine mid-conversation. The engine and profile
pickers are unlocked; when the engine changes, the backend replays the branch
to the new engine as prompt content so the conversation continues instead of
restarting.

## Why
Continuity was delegated entirely to each engine's native session store, and
those ids are not portable — so the only way to keep a conversation was to
never change engine. Clopen's DB is the one engine-agnostic record of the
conversation, which makes replaying it the only mechanism that works across
all eight adapters.

## Changes
- `backend/chat/engine-handoff.ts` — replay verbatim; past the trigger, tool
  results older than the last 3 tool uses become a placeholder while tool
  inputs are kept. Both numbers are the shipped defaults of Anthropic's
  `clear_tool_uses_20250919` context-editing strategy.
- `stream-manager` — derive the branch's owning engine per message and
  suppress `resume` across a switch. The transcript is prepended to the engine
  prompt only, never to the persisted message, so the timeline is untouched.
- `copilot/stream.ts` — forward images and documents as `blob` attachments;
  the adapter previously sent text only despite advertising vision support.
- `snapshot/restore.ts` — read engine per message rather than from
  `chat_sessions.engine`, and never adopt another engine's session id.
- Frontend — remove the engine/profile locks, stop sending a foreign
  `parent.sessionId`, and mirror local picks onto `sessionState.currentSession`
  so a collaborator's sync no longer reverts them.

## Notes
The replay window is deliberately NOT keyed on `compact_boundary`: only the
Claude adapter emits one, so that rule would silently degenerate to "replay
everything" on the other seven engines. Runtime QA across engine pairs is
still pending.