### PR TITLE
fix(chat): contain tool renderer crashes behind error boundaries

### DIFF
--- a/frontend/App.svelte
+++ b/frontend/App.svelte
@@ -22,6 +22,7 @@
 	import ws from '$frontend/utils/ws';
 	import { showNotificationWithActions } from '$frontend/stores/ui/notification.svelte';
 	import { openTeamForUser } from '$frontend/stores/ui/settings-modal.svelte';
+	import { debug } from '$shared/utils/logger';
 
 	let servicesInitialized = false;
 
@@ -77,6 +78,13 @@
 	});
 </script>
 
+<!--
+	Last-resort boundary. Nested boundaries (e.g. per tool renderer) handle the
+	failures they can describe; this one only exists so that an unforeseen render
+	error degrades to a recoverable screen instead of an empty page the user
+	cannot navigate away from.
+-->
+<svelte:boundary onerror={(error) => debug.error('workspace', 'Unhandled render error:', error)}>
 {#if authStore.authState === 'loading'}
 	<LoadingScreen isVisible={true} progress={30} loadingText="Connecting..." />
 {:else if authStore.authState === 'setup'}
@@ -106,3 +114,22 @@
 	<RestartRequiredDialog />
 	<WhatsNewDialog />
 {/if}
+
+{#snippet failed(error)}
+	<div class="flex flex-col items-center justify-center gap-3 h-dvh w-screen p-6 text-center bg-slate-50 dark:bg-slate-900">
+		<h1 class="text-lg font-semibold text-slate-700 dark:text-slate-200">Something went wrong</h1>
+		<p class="max-w-md text-sm text-slate-500 dark:text-slate-400">
+			Clopen hit an unexpected error while rendering. Reloading usually recovers your session.
+		</p>
+		<p class="max-w-md font-mono text-xs break-words text-slate-400 dark:text-slate-500">
+			{error instanceof Error ? error.message : String(error)}
+		</p>
+		<button
+			class="px-4 py-1.5 text-sm font-medium rounded-md bg-blue-600 hover:bg-blue-700 text-white transition-colors"
+			onclick={() => location.reload()}
+		>
+			Reload
+		</button>
+	</div>
+{/snippet}
+</svelte:boundary>

--- a/frontend/components/chat/formatters/Tools.svelte
+++ b/frontend/components/chat/formatters/Tools.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import type { ToolUseBlock, KnownToolName } from '$shared/types/unified';
 	import { settings } from '$frontend/stores/features/settings.svelte';
+	import { debug } from '$shared/utils/logger';
 	import { CustomMcpTool, UnknownTool, CustomMcpToolCompact, UnknownToolCompact } from '../tools';
 	import { TOOL_COMPONENTS_CLASSIC, TOOL_COMPONENTS_COMPACT } from '../tools/registry';
+	import ToolRenderError from '../tools/ToolRenderError.svelte';
 
 	const { toolInput }: { toolInput: ToolUseBlock } = $props();
 
@@ -21,4 +23,15 @@
 	});
 </script>
 
-<Component {toolInput} />
+<!--
+	Every tool renderer is isolated. Tool inputs originate from the engine and are
+	not guaranteed to match their declared schema, so a single bad block must not
+	be able to tear down the surrounding chat — or the app.
+-->
+<svelte:boundary onerror={(error) => debug.error('chat', `Tool renderer failed for ${toolInput.name}:`, error)}>
+	<Component {toolInput} />
+
+	{#snippet failed(error, reset)}
+		<ToolRenderError {toolInput} {error} {reset} />
+	{/snippet}
+</svelte:boundary>

--- a/frontend/components/chat/tools/ToolRenderError.svelte
+++ b/frontend/components/chat/tools/ToolRenderError.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	/**
+	 * Fallback rendered when a tool component throws.
+	 *
+	 * Tool inputs come from the engine and can violate their declared schema —
+	 * a call rejected by the harness is still emitted and still persisted, so a
+	 * renderer that trusts its input crashes on every load once such a block is
+	 * in the history. Because the active session is restored automatically, that
+	 * used to take the whole app down permanently. Containing the failure here
+	 * keeps the damage to a single bubble and surfaces the underlying error
+	 * instead of hiding it.
+	 */
+	import type { ToolUseBlock } from '$shared/types/unified';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+
+	const { toolInput, error, reset }: {
+		toolInput: ToolUseBlock;
+		error: unknown;
+		reset: () => void;
+	} = $props();
+
+	const reason = $derived(error instanceof Error ? error.message : String(error));
+
+	const rawInput = $derived.by(() => {
+		try {
+			return JSON.stringify(toolInput.input, null, 2);
+		} catch {
+			return String(toolInput.input);
+		}
+	});
+</script>
+
+<div class="bg-white dark:bg-slate-800 rounded-lg border border-red-200/60 dark:border-red-800/40 p-3 space-y-2">
+	<div class="flex items-center gap-2">
+		<Icon name="lucide:triangle-alert" class="text-red-500 w-4 h-4 shrink-0" />
+		<span class="text-sm font-medium text-slate-700 dark:text-slate-200">
+			Couldn't display this {toolInput.name} call
+		</span>
+		<button
+			class="ml-auto text-xs px-2 py-0.5 rounded border border-slate-200 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
+			onclick={reset}
+		>
+			Retry
+		</button>
+	</div>
+
+	{#if toolInput.result?.content}
+		<p class="text-xs text-red-500 dark:text-red-400 whitespace-pre-wrap break-words">
+			{toolInput.result.content}
+		</p>
+	{/if}
+
+	<details class="text-xs text-slate-500 dark:text-slate-400">
+		<summary class="cursor-pointer select-none">Details</summary>
+		<p class="mt-1 font-mono break-words">{reason}</p>
+		<pre class="mt-1 p-2 rounded bg-slate-50 dark:bg-slate-900 overflow-x-auto">{rawInput}</pre>
+	</details>
+</div>

--- a/frontend/components/chat/tools/variants/classic/AskUserQuestionTool.svelte
+++ b/frontend/components/chat/tools/variants/classic/AskUserQuestionTool.svelte
@@ -10,6 +10,11 @@
 	const input = $derived(toolInput.input as AskUserQuestionInput);
 	const result = $derived(toolInput.result);
 
+	// `questions` is required by the type but not by reality: a call the harness
+	// rejects for a missing/malformed `questions` is still emitted and persisted.
+	// Every read goes through this normalized list so no code path can assume it.
+	const questions = $derived(Array.isArray(input?.questions) ? input.questions : []);
+
 	function parseResultAnswers(content: string, questions: { question: string }[]): Record<string, string> {
 		const answers: Record<string, string> = {};
 		try {
@@ -44,7 +49,7 @@
 	const hasResult = $derived(!!result?.content);
 	let parsedAnswers = $derived.by(() => {
 		if (!result?.content) return {};
-		return parseResultAnswers(result.content, input.questions);
+		return parseResultAnswers(result.content, questions);
 	});
 	const isError = $derived(hasResult && Object.keys(parsedAnswers).length === 0);
 	const isAnswered = $derived(hasResult && !isError);
@@ -57,11 +62,10 @@
 	const isInterrupted = $derived(toolInput.interrupted);
 
 	$effect(() => {
-		if (!input.questions) return;
 		const initial: Record<number, Set<string>> = {};
 		const initialCustom: Record<number, string> = {};
 		const initialOther: Record<number, boolean> = {};
-		for (let i = 0; i < input.questions.length; i++) {
+		for (let i = 0; i < questions.length; i++) {
 			initial[i] = new Set();
 			initialCustom[i] = '';
 			initialOther[i] = false;
@@ -102,7 +106,6 @@
 		isSubmitting = true;
 		try {
 			const answers: Record<string, string> = {};
-			const questions = input.questions;
 			for (let i = 0; i < questions.length; i++) {
 				const q = questions[i];
 				const selected = selections[i] || new Set();
@@ -140,9 +143,21 @@
 	}
 </script>
 
-{#if isError || isInterrupted}
+{#if questions.length === 0}
+	<!-- The call carried no usable questions — show why instead of an empty form. -->
+	<div class="bg-white dark:bg-slate-800 rounded-lg border border-red-200/60 dark:border-red-800/40 p-4 space-y-2">
+		<div class="flex items-center gap-2">
+			<Icon name="lucide:circle-x" class="text-red-500 w-4 h-4 shrink-0" />
+			<span class="text-sm font-medium text-slate-700 dark:text-slate-200">Question could not be displayed</span>
+		</div>
+		<p class="text-xs text-red-500 dark:text-red-400 whitespace-pre-wrap break-words">
+			{result?.content || 'The engine sent this question without any content.'}
+		</p>
+	</div>
+
+{:else if isError || isInterrupted}
 	<div class="space-y-3">
-		{#each input.questions as question}
+		{#each questions as question}
 			<div class="bg-white dark:bg-slate-800 rounded-lg border border-red-200/60 dark:border-red-800/40 p-4 space-y-2.5">
 				<div class="flex items-center gap-2">
 					<Icon name="lucide:circle-x" class="text-red-500 w-4 h-4 shrink-0" />
@@ -164,7 +179,7 @@
 
 {:else if isAnswered}
 	<div class="space-y-3">
-		{#each input.questions as question}
+		{#each questions as question}
 			<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200/60 dark:border-slate-700/60 p-4 space-y-2.5">
 				<div class="flex items-center gap-2">
 					<Icon name="lucide:circle-check" class="text-green-500 w-4 h-4 shrink-0" />
@@ -184,7 +199,7 @@
 
 {:else if hasSubmitted}
 	<div class="space-y-3">
-		{#each input.questions as question, idx}
+		{#each questions as question, idx}
 			{@const selected = selections[idx] || new Set()}
 			{@const customText = customInputs[idx]?.trim()}
 			{@const isOther = otherActive[idx]}
@@ -211,7 +226,7 @@
 
 {:else}
 	<div class="space-y-3">
-		{#each input.questions as question, idx}
+		{#each questions as question, idx}
 			<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200/60 dark:border-slate-700/60 p-4 space-y-3">
 				<div class="flex items-center gap-2">
 					<Icon name="lucide:message-circle-question-mark" class="text-blue-500 dark:text-blue-400 w-4 h-4 shrink-0" />
@@ -225,7 +240,7 @@
 				<p class="text-sm font-medium text-slate-700 dark:text-slate-200">{question.question}</p>
 
 				<div class="space-y-1.5">
-					{#each question.options as option}
+					{#each question.options ?? [] as option}
 						<button
 							class="w-full text-left flex items-start gap-3 p-2.5 rounded-md border transition-colors
 								{isSelected(idx, option.label)

--- a/frontend/components/chat/tools/variants/compact/AskUserQuestionTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/AskUserQuestionTool.svelte
@@ -9,6 +9,11 @@
 	const input = $derived(toolInput.input as AskUserQuestionInput);
 	const result = $derived(toolInput.result);
 
+	// `questions` is required by the type but not by reality: a call the harness
+	// rejects for a missing/malformed `questions` is still emitted and persisted.
+	// Every read goes through this normalized list so no code path can assume it.
+	const questions = $derived(Array.isArray(input?.questions) ? input.questions : []);
+
 	function parseResultAnswers(content: string, questions: { question: string }[]): Record<string, string> {
 		const answers: Record<string, string> = {};
 		try {
@@ -34,7 +39,7 @@
 	const hasResult = $derived(!!result?.content);
 	const parsedAnswers = $derived.by(() => {
 		if (!result?.content) return {};
-		return parseResultAnswers(result.content, input.questions);
+		return parseResultAnswers(result.content, questions);
 	});
 	const isError = $derived(hasResult && Object.keys(parsedAnswers).length === 0);
 	const isAnswered = $derived(hasResult && !isError);
@@ -47,11 +52,10 @@
 	const isInterrupted = $derived(toolInput.interrupted);
 
 	$effect(() => {
-		if (!input.questions) return;
 		const init: Record<number, Set<string>> = {};
 		const initCustom: Record<number, string> = {};
 		const initOther: Record<number, boolean> = {};
-		for (let i = 0; i < input.questions.length; i++) {
+		for (let i = 0; i < questions.length; i++) {
 			init[i] = new Set();
 			initCustom[i] = '';
 			initOther[i] = false;
@@ -91,8 +95,8 @@
 		isSubmitting = true;
 		try {
 			const answers: Record<string, string> = {};
-			for (let i = 0; i < input.questions.length; i++) {
-				const q = input.questions[i];
+			for (let i = 0; i < questions.length; i++) {
+				const q = questions[i];
 				const selected = selections[i] || new Set();
 				const customText = customInputs[i]?.trim();
 				const isOther = otherActive[i];
@@ -119,9 +123,18 @@
 
 <!-- Opaque background so the timeline rail doesn't clash with the question borders -->
 <div class="bg-slate-50 dark:bg-slate-900">
-{#if isError || isInterrupted}
+{#if questions.length === 0}
+	<!-- The call carried no usable questions — show why instead of an empty form. -->
+	<div class="border-l-2 border-red-300 dark:border-red-800 pl-2 space-y-0.5">
+		<div class="text-sm font-medium text-slate-600 dark:text-slate-400">Question could not be displayed</div>
+		<p class="text-sm text-red-500 dark:text-red-400 whitespace-pre-wrap break-words">
+			{result?.content || 'The engine sent this question without any content.'}
+		</p>
+	</div>
+
+{:else if isError || isInterrupted}
 	<div class="space-y-1.5">
-		{#each input.questions as question}
+		{#each questions as question}
 			<div class="border-l-2 border-slate-300 dark:border-slate-600 pl-2 space-y-0.5">
 				{#if question.header}
 					<div class="text-sm font-medium text-slate-600 dark:text-slate-400">{question.header}</div>
@@ -136,7 +149,7 @@
 
 {:else if isAnswered || hasSubmitted}
 	<div class="space-y-2">
-		{#each input.questions as question, idx}
+		{#each questions as question, idx}
 			{@const answer = isAnswered
 				? parsedAnswers[question.question]
 				: (() => {
@@ -159,14 +172,14 @@
 
 {:else}
 	<div class="space-y-2">
-		{#each input.questions as question, idx}
+		{#each questions as question, idx}
 			<div class="border-l-2 border-slate-300 dark:border-slate-600 pl-2.5 space-y-1.5">
 				{#if question.header}
 					<div class="text-sm font-semibold text-slate-700 dark:text-slate-300">{question.header}</div>
 				{/if}
 				<p class="text-sm text-slate-600 dark:text-slate-400">{question.question}</p>
 				<div class="space-y-1">
-					{#each question.options as option}
+					{#each question.options ?? [] as option}
 						<button
 							class="w-full text-left flex items-start gap-2 px-2 py-1 rounded text-sm transition-colors
 								{isSelected(idx, option.label)


### PR DESCRIPTION
A tool call rejected by the harness is still emitted and persisted with a partial input. AskUserQuestionTool read `input.questions` unguarded, so such a block threw on render. With no boundary anywhere in the app the throw reached mount() and killed the whole tree, and because the active session is restored on load the crash replayed on every reload — leaving Clopen stuck on a blank page with no way out.

Wrap every tool renderer in a boundary at the dispatch point so one bad block degrades to a single error card, add a last-resort boundary at the app root, and normalize `questions`/`options` in both AskUserQuestion variants so the rejected call renders its validation error instead of crashing.