### PR TITLE
fix(settings): isolate test data dir and stop the wizard from resetting settings

### DIFF
--- a/backend/auth/auth-service.ts
+++ b/backend/auth/auth-service.ts
@@ -4,7 +4,8 @@
  * Core authentication logic: user creation, session management, invite handling.
  */
 
-import { authQueries, projectQueries, settingsQueries } from '$backend/database/queries';
+import { authQueries, projectQueries } from '$backend/database/queries';
+import { readSystemSettings, writeSystemSettings } from '$backend/settings/system-settings';
 import type { Project } from '$shared/types/database/schema';
 import { generateSessionToken, generatePAT, generateInviteToken, generateDeviceCode, hashToken, getTokenType } from './tokens';
 import { generateColorFromString, getInitials } from '$backend/utils/user-helpers';
@@ -85,38 +86,57 @@ export function needsSetup(): boolean {
 }
 
 /**
- * Get parsed system settings from DB (cached per call).
+ * Onboarding (setup wizard) state.
+ *
+ * `pending` is only ever reported when we positively know the wizard is
+ * unfinished — a fresh install, or a run that recorded the marker and has not
+ * completed yet. Everything else resolves to `complete`, because sending a
+ * working instance back through the wizard is destructive: it re-asks for the
+ * auth mode and lets the user overwrite live settings.
+ *
+ * `getOnboardingState()` deliberately does NOT catch read failures. A database
+ * error must surface to the caller instead of being reported as "never
+ * onboarded" — that silent downgrade is what used to drop users into the wizard
+ * at random.
  */
-function getSystemSettingsParsed(): Record<string, unknown> {
-	try {
-		const setting = settingsQueries.get('system:settings');
-		if (setting?.value) {
-			return typeof setting.value === 'string' ? JSON.parse(setting.value) : setting.value;
-		}
-	} catch {
-		// Settings may not exist yet
+export type OnboardingState = 'pending' | 'complete';
+
+export function getOnboardingState(): OnboardingState {
+	const stored = readSystemSettings();
+
+	// `onboarding` is the current marker; `onboardingComplete` is the legacy
+	// boolean, still read (and written) so a downgrade keeps working.
+	if (stored.onboarding === 'complete' || stored.onboardingComplete === true) return 'complete';
+	if (stored.onboarding === 'pending') return 'pending';
+
+	// No marker at all. An install that already has users has, by definition,
+	// been through setup — the wizard is what created them. Record that so a
+	// single missing key can never flap the whole instance back to setup.
+	if (!needsSetup()) {
+		markOnboardingComplete();
+		debug.log('auth', 'Onboarding marker missing but users exist — recorded as complete');
+		return 'complete';
 	}
-	return {};
+
+	return 'pending';
 }
 
-/**
- * Get the current auth mode from system settings.
- * Returns 'required' by default (before setup is complete).
- */
-export function getAuthMode(): 'none' | 'required' {
-	const parsed = getSystemSettingsParsed();
-	if (parsed.authMode === 'none' || parsed.authMode === 'required') {
-		return parsed.authMode as 'none' | 'required';
-	}
-	return 'required';
-}
-
-/**
- * Check if the initial onboarding wizard has been completed.
- */
+/** True when the setup wizard has been completed. */
 export function isOnboardingComplete(): boolean {
-	const parsed = getSystemSettingsParsed();
-	return parsed.onboardingComplete === true;
+	return getOnboardingState() === 'complete';
+}
+
+/**
+ * Record that a fresh install has entered the wizard, so a refresh mid-setup
+ * resumes it instead of being mistaken for a completed install.
+ */
+export function markOnboardingPending(): void {
+	writeSystemSettings({ onboarding: 'pending', onboardingComplete: false });
+}
+
+/** Record that the wizard finished. Writes both the current and legacy markers. */
+export function markOnboardingComplete(): void {
+	writeSystemSettings({ onboarding: 'complete', onboardingComplete: true });
 }
 
 /**

--- a/backend/auth/onboarding.test.ts
+++ b/backend/auth/onboarding.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression tests for the setup-wizard gate.
+ *
+ * These lock in the two properties that stopped a working install from being
+ * sent back through onboarding (and having its settings reset by the wizard):
+ * the data directory is isolated while testing, and a missing onboarding marker
+ * on an install that already has users resolves to "complete" instead of
+ * "never onboarded".
+ */
+
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+
+import { getOnboardingState, markOnboardingComplete } from './auth-service';
+import { readSystemSettings, writeSystemSettings, SYSTEM_SETTINGS_KEY } from '../settings/system-settings';
+import { getClopenDir } from '../utils/paths';
+import { authQueries, settingsQueries } from '../database/queries';
+import { initializeDatabase, closeDatabase } from '../database';
+
+let testUserId: string;
+let originalSettings: string | null = null;
+
+beforeAll(async () => {
+	await initializeDatabase();
+	originalSettings = settingsQueries.get(SYSTEM_SETTINGS_KEY)?.value ?? null;
+
+	// The self-heal path is only correct for an install that has users, so make
+	// sure one exists regardless of what else ran before this file.
+	testUserId = `user-${randomUUID()}`;
+	authQueries.createUser({
+		id: testUserId,
+		name: 'Onboarding Test User',
+		color: '#000000',
+		avatar: 'OT',
+		role: 'admin',
+		personal_access_token_hash: `hash-${randomUUID()}`,
+		created_at: new Date().toISOString()
+	});
+});
+
+afterAll(() => {
+	authQueries.deleteUser(testUserId);
+	if (originalSettings === null) {
+		settingsQueries.delete(SYSTEM_SETTINGS_KEY);
+	} else {
+		settingsQueries.set(SYSTEM_SETTINGS_KEY, originalSettings);
+	}
+	closeDatabase();
+});
+
+describe('data directory isolation', () => {
+	test('tests never resolve to the production data directory', () => {
+		// The whole class of bug this file guards against started here: the test
+		// runner sets NODE_ENV=test, which used to fall through to ~/.clopen and
+		// let the suite rewrite live rows in the developer's own install.
+		const dir = getClopenDir();
+		expect(dir).toContain('.clopen-test');
+		expect(dir.endsWith('/.clopen')).toBe(false);
+	});
+});
+
+describe('system settings writes', () => {
+	test('merge into the stored blob instead of replacing it', () => {
+		writeSystemSettings({ onboarding: 'complete', maxFileSizeMB: 123 });
+		writeSystemSettings({ authMode: 'required' });
+
+		const stored = readSystemSettings();
+		expect(stored.authMode).toBe('required');
+		expect(stored.maxFileSizeMB).toBe(123);
+		// The sibling that used to disappear.
+		expect(stored.onboarding).toBe('complete');
+	});
+});
+
+describe('onboarding state', () => {
+	test('is complete once the marker is recorded', () => {
+		markOnboardingComplete();
+		expect(getOnboardingState()).toBe('complete');
+	});
+
+	test('respects an explicitly pending wizard so a refresh resumes setup', () => {
+		writeSystemSettings({ onboarding: 'pending', onboardingComplete: false });
+		expect(getOnboardingState()).toBe('pending');
+	});
+
+	test('still honours the legacy onboardingComplete boolean', () => {
+		settingsQueries.set(SYSTEM_SETTINGS_KEY, JSON.stringify({ onboardingComplete: true }));
+		expect(getOnboardingState()).toBe('complete');
+	});
+
+	test('self-heals when the marker is missing but users exist', () => {
+		// Exactly the state a stray full-blob write leaves behind.
+		settingsQueries.set(SYSTEM_SETTINGS_KEY, JSON.stringify({ authMode: 'required' }));
+
+		expect(getOnboardingState()).toBe('complete');
+		// And it is persisted, so the next read cannot flap back to the wizard.
+		expect(readSystemSettings().onboarding).toBe('complete');
+	});
+
+	test('self-heals when the whole settings row is gone', () => {
+		settingsQueries.delete(SYSTEM_SETTINGS_KEY);
+
+		expect(getOnboardingState()).toBe('complete');
+		expect(readSystemSettings().onboarding).toBe('complete');
+	});
+});

--- a/backend/auth/permissions.ts
+++ b/backend/auth/permissions.ts
@@ -5,7 +5,7 @@
  * Used by the auth gate in WSRouter.handleMessage().
  */
 
-import { getAuthMode } from './auth-service';
+import { getAuthMode } from '$backend/settings/system-settings';
 
 /** Routes that can be accessed WITHOUT authentication */
 export const PUBLIC_ROUTES = new Set([

--- a/backend/database/utils/connection.ts
+++ b/backend/database/utils/connection.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import { mkdirSync } from 'fs';
 import { Database } from 'bun:sqlite';
 import type { DatabaseConnection } from '$shared/types/database/connection';
 
@@ -29,37 +30,12 @@ export class DatabaseManager {
 		debug.log('database', '🔗 Connecting to database...');
 
 		try {
-			// Create clopen directory if it doesn't exist
-			const clopenDir = getClopenDir();
-			const dirFile = Bun.file(clopenDir);
-
-			// Check if directory exists, if not create it
-			try {
-				await dirFile.stat();
-			} catch {
-				// Directory doesn't exist, create using Bun.write workaround
-				const tempFile = join(clopenDir, '.init');
-				await Bun.write(tempFile, '');
-				// Remove the temp file
-				try {
-					const tempFileHandle = Bun.file(tempFile);
-					if (await tempFileHandle.exists()) {
-						if (process.platform === 'win32') {
-							await Bun.spawn(['cmd', '/c', 'del', '/f', '/q', tempFile.replace(/\//g, '\\')], {
-								stdout: 'ignore',
-								stderr: 'ignore'
-							}).exited;
-						} else {
-							await Bun.spawn(['rm', '-f', tempFile], {
-								stdout: 'ignore',
-								stderr: 'ignore'
-							}).exited;
-						}
-					}
-				} catch {
-					// Ignore cleanup errors
-				}
-			}
+			// Ensure the data directory exists before SQLite touches the path.
+			// This has to be reliable: on a first run the directory is missing, and
+			// opening a database inside a missing directory fails in ways that
+			// surface much later as "no such table". `mkdirSync` is atomic, creates
+			// parents, and no-ops when the directory is already there.
+			mkdirSync(getClopenDir(), { recursive: true });
 
 			// Use Bun's native SQLite exclusively
 			this.db = new Database(this.dbPath);

--- a/backend/files/file-size-limit.ts
+++ b/backend/files/file-size-limit.ts
@@ -7,7 +7,7 @@
  * defaults to 500MB when the setting is missing or invalid.
  */
 
-import { settingsQueries } from '../database/queries';
+import { readSystemSetting } from '../settings/system-settings';
 
 /** Default maximum file size in megabytes when no admin setting is present. */
 export const DEFAULT_MAX_FILE_SIZE_MB = 500;
@@ -19,19 +19,10 @@ export const DEFAULT_MAX_FILE_SIZE_MB = 500;
  * (e.g. on first boot before the admin writes any system setting).
  */
 export function getMaxFileSize(): number {
-	let limitMB = DEFAULT_MAX_FILE_SIZE_MB;
-	try {
-		const row = settingsQueries.get('system:settings');
-		if (row?.value) {
-			const parsed = typeof row.value === 'string' ? JSON.parse(row.value) : row.value;
-			const candidate = Number(parsed?.maxFileSizeMB);
-			if (Number.isFinite(candidate) && candidate > 0) {
-				limitMB = candidate;
-			}
-		}
-	} catch {
-		// Fall back to default on any read/parse failure.
-	}
+	const limitMB = readSystemSetting((settings) => {
+		const candidate = Number(settings.maxFileSizeMB);
+		return Number.isFinite(candidate) && candidate > 0 ? candidate : undefined;
+	}, DEFAULT_MAX_FILE_SIZE_MB);
 	return Math.floor(limitMB * 1024 * 1024);
 }
 

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -50,7 +50,7 @@ import { handleMcpRequest, handleExternalMcpRequest, closeMcpServer, completeAut
 
 // Auth middleware
 import { checkRouteAccess, PUBLIC_ROUTES } from './auth/permissions';
-import { getAuthMode } from './auth/auth-service';
+import { getAuthMode } from './settings/system-settings';
 import { authQueries } from './database/queries';
 import { authRateLimiter } from './auth';
 import { sessionCleanupScheduler } from './auth/session-cleanup';
@@ -232,10 +232,15 @@ async function startServer() {
 		debug.warn('path', '⚠️ Initial PATH enrichment failed:', error);
 	}
 
-	// Initialize database first before accepting connections
+	// Initialize database first before accepting connections.
+	//
+	// A failure here is fatal on purpose. Serving requests without a database
+	// means every settings read fails, and callers that fall back to defaults
+	// report a configured instance as unconfigured — an empty project list, an
+	// unfinished setup wizard. Refusing to start is both louder and safer.
 	try {
 		await initializeDatabase();
-		debug.log('database', '✅ Database initialized successfully');
+		debug.log('database', `✅ Database initialized successfully (data dir: ${SERVER_ENV.DATA_DIR})`);
 		// Re-establish code-defined built-ins that live outside migrations/seeders
 		// (internal MCP servers like Browser Automation + the default engine).
 		// Shared with the clear-data handler so a DB wipe on the live process
@@ -245,7 +250,9 @@ async function startServer() {
 		sessionCleanupScheduler.start();
 		uploadTempCleanup.start();
 	} catch (error) {
-		debug.warn('database', '⚠️ Database initialization failed:', error);
+		console.error('❌ Database initialization failed — refusing to start:', error);
+		console.error(`   Data directory: ${SERVER_ENV.DATA_DIR}`);
+		process.exit(1);
 	}
 
 	// Start listening after database is ready

--- a/backend/mcp/internal/remote-server.test.ts
+++ b/backend/mcp/internal/remote-server.test.ts
@@ -13,7 +13,8 @@ import { randomUUID } from 'node:crypto';
 
 import { handleMcpRequest } from './remote-server';
 import { getMcpServiceToken } from './service-token';
-import { authQueries, settingsQueries } from '../../database/queries';
+import { authQueries } from '../../database/queries';
+import { writeSystemSettings } from '../../settings/system-settings';
 import { generatePAT, generateSessionToken, hashToken } from '../../auth/tokens';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database';
 
@@ -22,7 +23,11 @@ let sessionToken: string;
 let patToken: string;
 
 function setAuthMode(mode: 'none' | 'required'): void {
-	settingsQueries.set('system:settings', JSON.stringify({ authMode: mode }));
+	// Merge rather than replace: the system settings blob holds unrelated state
+	// (the onboarding marker, admin limits) and a test must never be able to drop
+	// it — the data directory is isolated under NODE_ENV=test, but the habit is
+	// what keeps it isolated if that ever changes.
+	writeSystemSettings({ authMode: mode });
 }
 
 function sessionCount(userId: string): number {
@@ -80,7 +85,7 @@ beforeAll(async () => {
 afterAll(() => {
 	authQueries.deleteSessionsByUserId(testUserId);
 	authQueries.deleteUser(testUserId);
-	settingsQueries.set('system:settings', JSON.stringify({ authMode: 'required' }));
+	setAuthMode('required');
 	closeDatabase();
 });
 

--- a/backend/mcp/internal/remote-server.ts
+++ b/backend/mcp/internal/remote-server.ts
@@ -23,7 +23,7 @@ import { createExternalProxyServer } from '../external/proxy';
 import { debug } from '$shared/utils/logger';
 import { authQueries } from '$backend/database/queries';
 import { hashToken } from '$backend/auth/tokens';
-import { getAuthMode } from '$backend/auth/auth-service';
+import { getAuthMode } from '$backend/settings/system-settings';
 import { isMcpServiceToken } from './service-token';
 import type { EngineType } from '$shared/types/unified';
 

--- a/backend/settings/system-settings.ts
+++ b/backend/settings/system-settings.ts
@@ -1,0 +1,97 @@
+/**
+ * System Settings — single source of truth for the `system:settings` row.
+ *
+ * Every reader and writer of that blob goes through here. Two rules keep the
+ * "wizard came back / settings reset themselves" class of bug from returning:
+ *
+ * 1. A failed read is never flattened into "the setting is unset".
+ *    `readSystemSettings()` throws when the database is unavailable or the blob
+ *    is unparseable, so each caller has to pick its fallback deliberately. The
+ *    old copy-pasted readers swallowed every error and returned `{}`, which told
+ *    a perfectly healthy install that it had never been onboarded.
+ * 2. Writes always merge into the stored blob, never replace it, so a caller
+ *    holding a stale copy of the settings cannot drop sibling fields.
+ */
+
+import { settingsQueries } from '$backend/database/queries';
+import type { AuthMode, SystemSettings } from '$shared/types/stores/settings';
+import { debug } from '$shared/utils/logger';
+
+/** The settings-table key the whole system-settings blob lives under. */
+export const SYSTEM_SETTINGS_KEY = 'system:settings';
+
+/**
+ * Stored shape: the typed fields, plus anything a newer or older build wrote.
+ * Unknown keys are preserved by every write so a downgrade never loses data.
+ */
+export type StoredSystemSettings = Partial<SystemSettings> & Record<string, unknown>;
+
+/**
+ * Read and parse the system settings blob.
+ *
+ * Returns `{}` only when the row genuinely does not exist yet (fresh install).
+ * THROWS when the database is unreachable or the stored value is not valid
+ * JSON — those are failures, not "no settings", and callers must not treat them
+ * the same way.
+ */
+export function readSystemSettings(): StoredSystemSettings {
+	const row = settingsQueries.get(SYSTEM_SETTINGS_KEY);
+	if (!row?.value) return {};
+
+	const parsed = typeof row.value === 'string' ? JSON.parse(row.value) : row.value;
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		throw new Error(`${SYSTEM_SETTINGS_KEY} holds a non-object value`);
+	}
+	return parsed as StoredSystemSettings;
+}
+
+/**
+ * Read a single field with an explicit fallback, tolerating an unreadable blob.
+ *
+ * Use this for settings where continuing with the default is genuinely correct
+ * (a size limit, a public URL). Do NOT use it for state that decides whether the
+ * user has already completed something — see `auth-service`'s onboarding state.
+ */
+export function readSystemSetting<T>(pick: (settings: StoredSystemSettings) => T | undefined, fallback: T): T {
+	try {
+		const value = pick(readSystemSettings());
+		return value === undefined ? fallback : value;
+	} catch (error) {
+		debug.warn('settings', 'System settings unreadable, using default for one field:', error);
+		return fallback;
+	}
+}
+
+/**
+ * Merge a patch into the stored blob — the only writer of this row.
+ *
+ * Returns the merged result so callers can confirm what was persisted.
+ */
+export function writeSystemSettings(patch: StoredSystemSettings): StoredSystemSettings {
+	let current: StoredSystemSettings = {};
+	try {
+		current = readSystemSettings();
+	} catch (error) {
+		// The blob is unreadable, so rebuilding from the patch is the only way
+		// forward — but it is also the moment sibling settings are lost, so it is
+		// logged as an error rather than quietly absorbed.
+		debug.error('settings', 'System settings unreadable, rebuilding from patch:', error);
+	}
+
+	const merged = { ...current, ...patch };
+	settingsQueries.set(SYSTEM_SETTINGS_KEY, JSON.stringify(merged));
+	return merged;
+}
+
+/**
+ * Current auth mode.
+ *
+ * Fail-secure: an unreadable blob resolves to 'required' (login enforced), and
+ * this runs inside the WebSocket auth gate, so it must never throw.
+ */
+export function getAuthMode(): AuthMode {
+	return readSystemSetting(
+		(s) => (s.authMode === 'none' || s.authMode === 'required' ? s.authMode : undefined),
+		'required'
+	);
+}

--- a/backend/tunnel/public-origin.ts
+++ b/backend/tunnel/public-origin.ts
@@ -16,7 +16,7 @@
 
 import { tunnelKit, portFromService } from './tunnel-config';
 import { SERVER_ENV } from '../utils/env';
-import { settingsQueries } from '$backend/database/queries';
+import { readSystemSetting } from '$backend/settings/system-settings';
 import { debug } from '$shared/utils/logger';
 
 export type PublicOriginSource = 'configured' | 'domain' | 'tunnel';
@@ -50,18 +50,10 @@ function normalizeOrigin(url: string): string {
 
 /** Read the admin-configured public base URL from system settings, if any. */
 function getConfiguredPublicBaseUrl(): string | null {
-	try {
-		const setting = settingsQueries.get('system:settings');
-		if (!setting?.value) return null;
-		const parsed = typeof setting.value === 'string' ? JSON.parse(setting.value) : setting.value;
-		const url = parsed?.publicBaseUrl;
-		if (typeof url === 'string' && url.trim()) {
-			return normalizeOrigin(url.trim());
-		}
-	} catch {
-		// Settings may not exist yet.
-	}
-	return null;
+	return readSystemSetting((settings) => {
+		const url = settings.publicBaseUrl;
+		return typeof url === 'string' && url.trim() ? normalizeOrigin(url.trim()) : undefined;
+	}, null);
 }
 
 /** Find an already-running quick tunnel pointing at the given local port. */

--- a/backend/utils/env.ts
+++ b/backend/utils/env.ts
@@ -16,12 +16,41 @@
 
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { homedir } from 'os';
 
 // ── Server configuration (read once at import time) ─────────────────
 const isDev = process.env.NODE_ENV !== 'production';
 
+/**
+ * Resolve the Clopen data directory — the single decision point for where ALL
+ * persisted state lives (app.db, engine homes, stack, snapshots, tunnel…).
+ *
+ * Resolved once, at import time, for two reasons:
+ *
+ * 1. `NODE_ENV` is not stable at runtime. Any dependency that assigns to
+ *    `process.env.NODE_ENV` mid-process would otherwise silently move the data
+ *    directory out from under a running server.
+ * 2. The test runner sets `NODE_ENV=test`, which used to fall through to the
+ *    production directory — so `bun test` opened the developer's real
+ *    `~/.clopen/app.db` and rewrote live rows (that is what kept resetting the
+ *    onboarding flag and system settings). Tests get their own directory here,
+ *    once, so no individual test has to remember to isolate itself.
+ *
+ * `CLOPEN_DATA_DIR` overrides everything, for deployments that keep state
+ * outside the home directory.
+ */
+function resolveDataDir(): string {
+	const override = process.env.CLOPEN_DATA_DIR?.trim();
+	if (override) return override;
+	if (process.env.NODE_ENV === 'test') return join(homedir(), '.clopen-test');
+	if (process.env.NODE_ENV === 'development') return join(homedir(), '.clopen-dev');
+	return join(homedir(), '.clopen');
+}
+
 export const SERVER_ENV = {
 	NODE_ENV: (process.env.NODE_ENV || 'development') as string,
+	/** Absolute path to the Clopen data directory — see `resolveDataDir()`. */
+	DATA_DIR: resolveDataDir(),
 	/** Backend port — dev: CLOPEN_PORT_BACKEND (default 9161), prod: CLOPEN_PORT (default 9141) */
 	PORT: isDev
 		? (process.env.CLOPEN_PORT_BACKEND ? parseInt(process.env.CLOPEN_PORT_BACKEND) : 9161)

--- a/backend/utils/paths.ts
+++ b/backend/utils/paths.ts
@@ -1,13 +1,19 @@
 import { join, resolve } from 'path';
-import { homedir } from 'os';
+import { SERVER_ENV } from './env';
 
 /**
  * Returns the Clopen data directory.
  * - development: ~/.clopen-dev
- * - everything else (production, undefined): ~/.clopen
+ * - test:        ~/.clopen-test  (never the real one — see resolveDataDir)
+ * - production:  ~/.clopen
+ * - `CLOPEN_DATA_DIR` overrides all of the above.
+ *
+ * The value is resolved once at import time in `SERVER_ENV.DATA_DIR`; this is
+ * only a named accessor for it, so every caller sees the same directory for the
+ * lifetime of the process.
  */
 export function getClopenDir(): string {
-	return join(homedir(), process.env.NODE_ENV === 'development' ? '.clopen-dev' : '.clopen');
+	return SERVER_ENV.DATA_DIR;
 }
 
 /**

--- a/backend/ws/auth/login.test.ts
+++ b/backend/ws/auth/login.test.ts
@@ -53,6 +53,8 @@ const mockCreateUserFromInvite = mock((inviteToken: string, name: string) => ({
 
 const mockNeedsSetup = mock(() => true);
 const mockGetAuthMode = mock(() => 'none');
+const mockMarkOnboardingPending = mock(() => {});
+const mockWriteSystemSettings = mock((patch: Record<string, unknown>) => patch);
 
 // Mock settings
 let mockSettings: any = { value: JSON.stringify({ authMode: 'required' }) };
@@ -83,12 +85,17 @@ mock.module('$backend/database/queries', () => ({
 	}
 }));
 
+mock.module('$backend/settings/system-settings', () => ({
+	getAuthMode: mockGetAuthMode,
+	writeSystemSettings: mockWriteSystemSettings
+}));
+
 mock.module('$backend/auth/auth-service', () => ({
 	createAdmin: mockCreateAdmin,
 	createOrGetNoAuthAdmin: mockCreateOrGetNoAuthAdmin,
 	createUserFromInvite: mockCreateUserFromInvite,
 	needsSetup: mockNeedsSetup,
-	getAuthMode: mockGetAuthMode,
+	markOnboardingPending: mockMarkOnboardingPending,
 	loginWithToken: mock(() => ({})),
 	logout: mock(() => {}),
 	logoutAllSessions: mock(() => 0),

--- a/backend/ws/auth/login.ts
+++ b/backend/ws/auth/login.ts
@@ -2,7 +2,6 @@ import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import {
 	createAdmin,
-	getAuthMode,
 	loginWithToken,
 	createUserFromInvite,
 	logout,
@@ -11,9 +10,11 @@ import {
 	regeneratePAT,
 	updateUserName,
 	createOrGetNoAuthAdmin,
-	needsSetup
+	needsSetup,
+	markOnboardingPending
 } from '$backend/auth/auth-service';
-import { settingsQueries, auditLogQueries } from '$backend/database/queries';
+import { getAuthMode, writeSystemSettings } from '$backend/settings/system-settings';
+import { auditLogQueries } from '$backend/database/queries';
 import { getTokenType } from '$backend/auth/tokens';
 import { authRateLimiter } from '$backend/auth/rate-limiter';
 import { ws } from '$backend/utils/ws';
@@ -42,15 +43,22 @@ export const loginHandler = createRouter()
 			expiresAt: t.String()
 		})
 	}, async ({ data, conn }) => {
+		// Refuse before touching any state. This route is public, so without the
+		// guard a stray call against a live instance would flip the onboarding
+		// marker below and send every user back through the wizard.
+		if (!needsSetup()) {
+			throw new Error('Setup already completed. Admin account exists.');
+		}
+
+		// Mark the wizard as in-progress BEFORE the first user exists, so a refresh
+		// between here and "Finish" resumes setup instead of looking like a
+		// completed install (which is how onboarding state is inferred).
+		markOnboardingPending();
+
 		const result = createAdmin(data.name, { userAgent: data.userAgent, ipAddress: clientIpFromConnection(conn) });
 
 		// Save authMode to system settings
-		const currentSettings = settingsQueries.get('system:settings');
-		const parsed = currentSettings?.value
-			? (typeof currentSettings.value === 'string' ? JSON.parse(currentSettings.value) : currentSettings.value)
-			: {};
-		parsed.authMode = 'required';
-		settingsQueries.set('system:settings', JSON.stringify(parsed));
+		writeSystemSettings({ authMode: 'required' });
 
 		auditLogQueries.logEvent({
 			userId: result.user.id,
@@ -80,13 +88,12 @@ export const loginHandler = createRouter()
 			throw new Error('Setup already completed.');
 		}
 
+		// Same ordering as auth:setup — record the in-progress wizard before the
+		// first user exists.
+		markOnboardingPending();
+
 		// Save authMode to system settings
-		const currentSettings = settingsQueries.get('system:settings');
-		const parsed = currentSettings?.value
-			? (typeof currentSettings.value === 'string' ? JSON.parse(currentSettings.value) : currentSettings.value)
-			: {};
-		parsed.authMode = 'none';
-		settingsQueries.set('system:settings', JSON.stringify(parsed));
+		writeSystemSettings({ authMode: 'none' });
 
 		// Create or get default admin
 		const result = createOrGetNoAuthAdmin();

--- a/backend/ws/auth/status.ts
+++ b/backend/ws/auth/status.ts
@@ -1,6 +1,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
-import { needsSetup, getUserById, getAuthMode, isOnboardingComplete } from '$backend/auth/auth-service';
+import { needsSetup, getUserById, isOnboardingComplete, markOnboardingComplete } from '$backend/auth/auth-service';
+import { getAuthMode } from '$backend/settings/system-settings';
 import { ws } from '$backend/utils/ws';
 
 export const statusHandler = createRouter()
@@ -22,6 +23,10 @@ export const statusHandler = createRouter()
 		})
 	}, async ({ conn }) => {
 		const setup = needsSetup();
+		// Deliberately NOT wrapped in a try/catch: if onboarding state cannot be
+		// read, this request must fail so the client keeps its current screen.
+		// Reporting "not onboarded" on a read error is what used to drop working
+		// installs into the setup wizard.
 		const onboardingDone = isOnboardingComplete();
 		const authMode = getAuthMode();
 		const authenticated = ws.isAuthenticated(conn);
@@ -38,4 +43,22 @@ export const statusHandler = createRouter()
 		}
 
 		return { needsSetup: setup, onboardingComplete: onboardingDone, authenticated, authMode, user };
+	})
+
+	// Mark the setup wizard as finished.
+	//
+	// The server owns this marker rather than letting the client write the raw
+	// settings key: the wizard may only be dismissed once persistence is
+	// confirmed, otherwise a failed write drops the user straight back into it on
+	// the next refresh — silently, because the old client-side write was
+	// fire-and-forget. The response echoes the stored state so the client can
+	// verify instead of assume.
+	.http('auth:complete-onboarding', {
+		data: t.Object({}),
+		response: t.Object({
+			onboardingComplete: t.Boolean()
+		})
+	}, async () => {
+		markOnboardingComplete();
+		return { onboardingComplete: isOnboardingComplete() };
 	});

--- a/backend/ws/settings/crud.ts
+++ b/backend/ws/settings/crud.ts
@@ -10,6 +10,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { settingsQueries, engineQueries } from '../../database/queries';
+import { SYSTEM_SETTINGS_KEY, writeSystemSettings } from '../../settings/system-settings';
 import { initializeEngine } from '../../engine';
 import { checkEngineSetup } from '../../engine/engine-setup';
 import { registerModels } from '$shared/constants/engines';
@@ -49,6 +50,13 @@ export const crudHandler = createRouter()
 			throw new Error('Key and value are required');
 		}
 
+		if (key === SYSTEM_SETTINGS_KEY) {
+			// The system blob is never replaced wholesale — a caller sending a
+			// partial copy would silently drop every field it does not know about
+			// (that is how the onboarding marker used to disappear). Merge instead.
+			throw new Error(`Use settings:update-system to change ${SYSTEM_SETTINGS_KEY}`);
+		}
+
 		settingsQueries.set(key, value);
 		const setting = settingsQueries.get(key);
 
@@ -56,34 +64,18 @@ export const crudHandler = createRouter()
 	})
 
 	// Merge-update system settings (admin only).
-	// Reads the current `system:settings` blob, merges the provided patch, and
-	// writes it back atomically. Sending only the changed keys prevents a partial
-	// update from clobbering sibling fields (e.g. onboardingComplete) when a
-	// client's in-memory copy of the settings is stale.
+	// Sending only the changed keys prevents a partial update from clobbering
+	// sibling fields (e.g. the onboarding marker) when a client's in-memory copy
+	// of the settings is stale. The merge itself lives in the system-settings
+	// module, which is the only writer of that row.
 	.http('settings:update-system', {
 		data: t.Object({
 			patch: t.Record(t.String(), t.Any())
 		}),
 		response: t.Any()
 	}, async ({ data }) => {
-		const KEY = 'system:settings';
-		const existing = settingsQueries.get(KEY);
-
-		let current: Record<string, unknown> = {};
-		if (existing?.value) {
-			try {
-				current = typeof existing.value === 'string'
-					? JSON.parse(existing.value)
-					: (existing.value as Record<string, unknown>);
-			} catch {
-				current = {};
-			}
-		}
-
-		const merged = { ...current, ...data.patch };
-		settingsQueries.set(KEY, JSON.stringify(merged));
-
-		return settingsQueries.get(KEY);
+		writeSystemSettings(data.patch);
+		return settingsQueries.get(SYSTEM_SETTINGS_KEY);
 	})
 
 	// Batch update multiple settings

--- a/frontend/components/auth/SetupPage.svelte
+++ b/frontend/components/auth/SetupPage.svelte
@@ -81,16 +81,29 @@
 		}
 	}
 
+	let finishError = $state('');
+	let finishLoading = $state(false);
+
 	async function finishWizard() {
+		finishError = '';
+		finishLoading = true;
 		try {
-			const status = await ws.http('engine:opencode-status', {}).catch(() => null);
-			if (status?.installed) {
-				await opencodeProvidersStore.restartServer(true);
+			try {
+				const status = await ws.http('engine:opencode-status', {}).catch(() => null);
+				if (status?.installed) {
+					await opencodeProvidersStore.restartServer(true);
+				}
+			} catch {
+				// Ignore — best effort restart
 			}
-		} catch {
-			// Ignore — best effort restart
+			// Only leaves the wizard once the server confirms setup is recorded;
+			// otherwise the next refresh would land right back here.
+			await authStore.completeSetup();
+		} catch (err) {
+			finishError = err instanceof Error ? err.message : 'Setup could not be saved';
+		} finally {
+			finishLoading = false;
 		}
-		authStore.completeSetup();
 	}
 
 	// ─── Step Labels ───
@@ -711,6 +724,10 @@
 						</div>
 					</div>
 
+					{#if finishError}
+						<p class="text-sm text-red-500 text-left">{finishError}</p>
+					{/if}
+
 					<div class="flex gap-2 sticky bottom-0 z-10 pt-3 pb-3 bg-white dark:bg-slate-950 border-t border-slate-200/70 dark:border-slate-800/70">
 						<button
 							onclick={goToPrevStep}
@@ -720,9 +737,10 @@
 						</button>
 						<button
 							onclick={finishWizard}
-							class="flex-1 py-2.5 px-4 rounded-lg bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium transition-colors"
+							disabled={finishLoading}
+							class="flex-1 py-2.5 px-4 rounded-lg bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
 						>
-							Finish Setup
+							{finishLoading ? 'Saving...' : 'Finish Setup'}
 						</button>
 					</div>
 				</div>

--- a/frontend/components/workspace/WorkspaceLayout.svelte
+++ b/frontend/components/workspace/WorkspaceLayout.svelte
@@ -28,6 +28,7 @@
 	import { initializeSessions } from '$frontend/stores/core/sessions.svelte';
 	import { initializeNotifications, notificationStore } from '$frontend/stores/ui/notification.svelte';
 	import { applyServerSettings, loadSystemSettings } from '$frontend/stores/features/settings.svelte';
+	import { loadUserState } from '$frontend/stores/core/user-state.svelte';
 	import { applyTodoPanelState } from '$frontend/stores/ui/todo-panel.svelte';
 	import { applyCommandUsage } from '$frontend/stores/ui/command-usage.svelte';
 	import { presenceState, initPresence } from '$frontend/stores/core/presence.svelte';
@@ -78,27 +79,19 @@
 			setProgress(20, 'Connecting...');
 			await ws.waitUntilConnected(10000);
 
-			// Step 3: Restore user state from server
+			// Step 3: Restore user state from server.
+			// Shared loader — auth already fetched this for the current session, so
+			// this is normally a cache hit and never a second round trip.
 			setProgress(30, 'Restoring state...');
-			let serverState: {
-				currentProjectId: string | null;
-				lastView: string | null;
-				settings: any;
-				unreadSessions: any;
-				todoPanelState: any;
-				projectOrder: string[] | null;
-				commandUsage: any;
-			} | null = null;
-			try {
-				serverState = await ws.http('user:restore-state', {});
-				debug.log('workspace', 'Server state restored:', serverState);
-			} catch (err) {
-				debug.warn('workspace', 'Failed to restore server state, using defaults:', err);
-			}
+			const serverState = await loadUserState();
+			debug.log('workspace', 'Server state restored:', serverState);
 
 			// Step 4: Apply restored state + load system settings + setup presence
 			setProgress(40);
-			if (serverState?.settings) {
+			// Only mark settings hydrated when the restore actually succeeded —
+			// applying defaults over a failed load is what used to overwrite the
+			// user's saved settings on the next change.
+			if (serverState) {
 				applyServerSettings(serverState.settings);
 			}
 			applyTodoPanelState(serverState?.todoPanelState);

--- a/frontend/stores/core/user-state.svelte.ts
+++ b/frontend/stores/core/user-state.svelte.ts
@@ -1,0 +1,76 @@
+/**
+ * User Server State — single loader for `user:restore-state`.
+ *
+ * Every per-user value the app persists (settings, last view, project order,
+ * unread sessions, todo panel, command usage) arrives in one round trip. This
+ * module owns that call so there is exactly one place that decides whether the
+ * client actually holds the user's saved state.
+ *
+ * That distinction matters: stores here persist by sending their whole object
+ * back to the server, so acting on defaults that were never replaced by the
+ * server's copy silently overwrites the real one. Callers must therefore treat
+ * `null` as "not loaded" and refuse to save — see `settings.svelte.ts`.
+ *
+ * The load is single-flight and cached on success; a failure is not cached, so
+ * the next caller retries.
+ */
+
+import ws from '$frontend/utils/ws';
+import { debug } from '$shared/utils/logger';
+
+/** Mirrors the `user:restore-state` response — free-form values stay untyped. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RestoredValue = any;
+
+export interface UserServerState {
+	currentProjectId: string | null;
+	lastView: string | null;
+	settings: RestoredValue;
+	unreadSessions: RestoredValue;
+	todoPanelState: RestoredValue;
+	projectOrder: string[] | null;
+	commandUsage: RestoredValue;
+}
+
+let loaded: UserServerState | null = null;
+let inFlight: Promise<UserServerState | null> | null = null;
+
+/**
+ * Fetch the current user's server-side state, reusing an in-flight or completed
+ * load. Returns `null` when the state could not be retrieved — never throws, so
+ * a failed restore cannot take down the caller's initialization path.
+ */
+export async function loadUserState(): Promise<UserServerState | null> {
+	if (loaded) return loaded;
+	if (inFlight) return inFlight;
+
+	inFlight = ws.http('user:restore-state', {})
+		.then((state) => {
+			loaded = state as UserServerState;
+			debug.log('user', 'User state loaded');
+			return loaded;
+		})
+		.catch((err) => {
+			debug.error('user', 'Failed to load user state:', err);
+			return null;
+		})
+		.finally(() => {
+			inFlight = null;
+		});
+
+	return inFlight;
+}
+
+/** The loaded state, or `null` if it has not been successfully loaded yet. */
+export function getLoadedUserState(): UserServerState | null {
+	return loaded;
+}
+
+/**
+ * Drop the cached state. Called on sign-out so the next session never inherits
+ * (or persists over) the previous user's saved state.
+ */
+export function resetUserState(): void {
+	loaded = null;
+	inFlight = null;
+}

--- a/frontend/stores/features/auth.svelte.ts
+++ b/frontend/stores/features/auth.svelte.ts
@@ -8,6 +8,11 @@
  */
 
 import ws from '$frontend/utils/ws';
+import {
+	hydrateSettings,
+	resetSettingsHydration,
+	updateSystemSettings
+} from '$frontend/stores/features/settings.svelte';
 import { debug } from '$shared/utils/logger';
 import type { AuthMode } from '$shared/types/stores/settings';
 
@@ -31,14 +36,36 @@ let sessionToken = $state<string | null>(null);
 let personalAccessToken = $state<string | null>(null);
 let authMode = $state<AuthMode>('required');
 
-// Listen for server-side force-logout (auth mode switched to required)
-ws.on('auth:force-logout', (payload) => {
-	debug.log('auth', `Force logout received: ${payload.reason}`);
+/**
+ * Load this session's per-user state before showing any screen that can write
+ * it back. The setup wizard edits settings too, so hydration cannot wait for the
+ * workspace to mount — an un-hydrated store persists defaults over the user's
+ * real settings. Never throws: a failed load simply leaves saving disabled.
+ */
+async function hydrateSession(): Promise<void> {
+	try {
+		if (!(await hydrateSettings())) {
+			debug.warn('auth', 'User settings could not be loaded — they will not be saved until a successful reload');
+		}
+	} catch (err) {
+		debug.error('auth', 'User settings hydration failed:', err);
+	}
+}
+
+/** Clear session-scoped client state shared by every sign-out path. */
+function clearSessionState(): void {
 	currentUser = null;
 	sessionToken = null;
 	personalAccessToken = null;
 	localStorage.removeItem(SESSION_TOKEN_KEY);
 	ws.setSessionToken(null);
+	resetSettingsHydration();
+}
+
+// Listen for server-side force-logout (auth mode switched to required)
+ws.on('auth:force-logout', (payload) => {
+	debug.log('auth', `Force logout received: ${payload.reason}`);
+	clearSessionState();
 	authMode = 'required';
 	authState = 'login';
 });
@@ -46,11 +73,7 @@ ws.on('auth:force-logout', (payload) => {
 // Listen for targeted force-logout (e.g., project access revoked)
 ws.on('auth:force-logout-user', (payload) => {
 	debug.log('auth', `User force-logout received: ${payload.reason}`);
-	currentUser = null;
-	sessionToken = null;
-	personalAccessToken = null;
-	localStorage.removeItem(SESSION_TOKEN_KEY);
-	ws.setSessionToken(null);
+	clearSessionState();
 	authState = 'login';
 });
 
@@ -95,6 +118,10 @@ export const authStore = {
 					// Fetch auth mode and onboarding status from server
 					const status = await ws.http('auth:status', {});
 					authMode = status.authMode;
+
+					// Load saved settings before any screen renders — the wizard can
+					// write them too, so this must not wait for the workspace.
+					await hydrateSession();
 
 					// If onboarding not yet completed, show wizard instead of going to ready
 					if (!status.onboardingComplete) {
@@ -171,6 +198,7 @@ export const authStore = {
 		sessionToken = result.sessionToken;
 		localStorage.setItem(SESSION_TOKEN_KEY, result.sessionToken);
 		ws.setSessionToken(result.sessionToken);
+		await hydrateSession();
 		authState = 'ready';
 		debug.log('auth', `No-auth auto-login: ${result.user.name}`);
 	},
@@ -186,6 +214,7 @@ export const authStore = {
 		localStorage.setItem(SESSION_TOKEN_KEY, result.sessionToken);
 		ws.setSessionToken(result.sessionToken);
 		authMode = 'required';
+		await hydrateSession();
 		// Don't set authState to 'ready' yet — setup page shows PAT first
 		debug.log('auth', `Admin setup complete: ${result.user.name}`);
 	},
@@ -200,6 +229,7 @@ export const authStore = {
 		localStorage.setItem(SESSION_TOKEN_KEY, result.sessionToken);
 		ws.setSessionToken(result.sessionToken);
 		authMode = 'none';
+		await hydrateSession();
 		// Don't set authState to 'ready' yet — wizard continues to next step
 		debug.log('auth', `No-auth setup complete: ${result.user.name}`);
 	},
@@ -209,8 +239,9 @@ export const authStore = {
 	 * Regenerates PAT for the existing no-auth admin and updates authMode setting.
 	 */
 	async switchToWithAuth() {
-		const { updateSystemSettings } = await import('$frontend/stores/features/settings.svelte');
-		await updateSystemSettings({ authMode: 'required' });
+		if (!(await updateSystemSettings({ authMode: 'required' }))) {
+			throw new Error('Could not switch to login mode. Please try again.');
+		}
 
 		const result = await ws.http('auth:regenerate-pat', {});
 		personalAccessToken = result.personalAccessToken;
@@ -223,30 +254,31 @@ export const authStore = {
 	 * Only updates the authMode setting; existing user remains unchanged.
 	 */
 	async switchToNoAuth() {
-		const { updateSystemSettings } = await import('$frontend/stores/features/settings.svelte');
-		await updateSystemSettings({ authMode: 'none' });
+		if (!(await updateSystemSettings({ authMode: 'none' }))) {
+			throw new Error('Could not switch to no-login mode. Please try again.');
+		}
 
 		authMode = 'none';
 		debug.log('auth', 'Switched to no-auth mode');
 	},
 
 	/**
-	 * Complete setup — transition to ready state after wizard is done.
-	 * Saves onboardingComplete flag so wizard won't show again.
+	 * Complete setup — transition to ready state after the wizard is done.
+	 *
+	 * The wizard is only dismissed once the server confirms it recorded the
+	 * completion. Persisting this best-effort is what let a failed write send the
+	 * user silently back through setup on the next refresh; now the failure is
+	 * raised so the wizard can show it and let them retry.
 	 */
 	async completeSetup() {
-		personalAccessToken = null;
-
-		// Save onboardingComplete to system settings
-		try {
-			const { updateSystemSettings } = await import('$frontend/stores/features/settings.svelte');
-			await updateSystemSettings({ onboardingComplete: true });
-		} catch {
-			// Best-effort — if this fails, wizard may show again
-			debug.warn('auth', 'Failed to save onboardingComplete flag');
+		const result = await ws.http('auth:complete-onboarding', {});
+		if (!result?.onboardingComplete) {
+			throw new Error('Setup could not be saved. Please try again.');
 		}
 
+		personalAccessToken = null;
 		authState = 'ready';
+		debug.log('auth', 'Onboarding recorded as complete');
 	},
 
 	/**
@@ -262,6 +294,7 @@ export const authStore = {
 		// Check if onboarding is pending
 		const status = await ws.http('auth:status', {});
 		authMode = status.authMode;
+		await hydrateSession();
 		if (!status.onboardingComplete) {
 			authState = 'setup';
 			debug.log('auth', `Logged in, onboarding pending: ${result.user.name}`);
@@ -284,6 +317,7 @@ export const authStore = {
 		ws.setSessionToken(result.sessionToken);
 		// Clear invite hash from URL
 		window.location.hash = '';
+		await hydrateSession();
 		debug.log('auth', `Invite accepted: ${result.user.name}`);
 	},
 
@@ -311,6 +345,7 @@ export const authStore = {
 		// Respect a pending onboarding wizard, mirroring login().
 		const status = await ws.http('auth:status', {});
 		authMode = status.authMode;
+		await hydrateSession();
 		if (!status.onboardingComplete) {
 			authState = 'setup';
 			debug.log('auth', `Device signed in, onboarding pending: ${result.user.name}`);
@@ -330,11 +365,7 @@ export const authStore = {
 		} catch {
 			// Ignore errors during logout
 		}
-		currentUser = null;
-		sessionToken = null;
-		personalAccessToken = null;
-		localStorage.removeItem(SESSION_TOKEN_KEY);
-		ws.setSessionToken(null);
+		clearSessionState();
 		authState = 'login';
 		debug.log('auth', 'Logged out');
 	},
@@ -348,11 +379,7 @@ export const authStore = {
 		} catch {
 			// Ignore errors
 		}
-		currentUser = null;
-		sessionToken = null;
-		personalAccessToken = null;
-		localStorage.removeItem(SESSION_TOKEN_KEY);
-		ws.setSessionToken(null);
+		clearSessionState();
 		authState = 'login';
 		debug.log('auth', 'All sessions logged out');
 	},

--- a/frontend/stores/features/settings.svelte.ts
+++ b/frontend/stores/features/settings.svelte.ts
@@ -10,6 +10,7 @@ import { DEFAULT_MODEL_ID, DEFAULT_MODEL_NAME, DEFAULT_ENGINE } from '$shared/co
 import { DEFAULT_BRANCH_SEPARATOR } from '$shared/constants/git';
 import type { AppSettings, SystemSettings } from '$shared/types/stores/settings';
 import { builtInPresets } from '$frontend/stores/ui/workspace.svelte';
+import { loadUserState, resetUserState } from '$frontend/stores/core/user-state.svelte';
 import ws from '$frontend/utils/ws';
 
 import { debug } from '$shared/utils/logger';
@@ -80,8 +81,24 @@ export function applyFontSize(size: number): void {
 }
 
 /**
+ * Whether `settings` reflects the server's copy of this user's settings.
+ *
+ * Until this is true the store holds nothing but defaults, and saving it would
+ * replace the user's real settings with those defaults — every save writes the
+ * whole object. So saving is blocked until hydration happens. This is what used
+ * to wipe engine/model memory, font size, chat appearance and the commit
+ * generator config whenever the app rendered without a successful restore
+ * (most visibly during the setup wizard, which mounts outside the workspace).
+ */
+let hydrated = false;
+
+/**
  * Apply server-provided per-user settings during initialization.
- * Called from WorkspaceLayout with state from user:restore-state.
+ *
+ * Call with `null` when the server has no saved settings for this user: that is
+ * still a successful hydration (a brand-new user legitimately starts on
+ * defaults) and unblocks saving. Only call this after `user:restore-state`
+ * actually succeeded.
  */
 export function applyServerSettings(serverSettings: Partial<AppSettings> | null): void {
 	if (serverSettings && typeof serverSettings === 'object') {
@@ -95,6 +112,30 @@ export function applyServerSettings(serverSettings: Partial<AppSettings> | null)
 		applyFontSize(settings.fontSize);
 		debug.log('settings', 'Applied server settings');
 	}
+	hydrated = true;
+}
+
+/**
+ * Load this user's settings from the server and apply them.
+ * Safe to call from several entry points — the underlying request is shared.
+ * Returns false when the state could not be loaded, in which case the store
+ * stays un-hydrated and refuses to persist anything.
+ */
+export async function hydrateSettings(): Promise<boolean> {
+	const state = await loadUserState();
+	if (!state) return false;
+	applyServerSettings((state.settings as Partial<AppSettings> | null) ?? null);
+	return true;
+}
+
+/**
+ * Forget the hydrated state on sign-out, so the next user's session cannot be
+ * saved over with the previous user's settings.
+ */
+export function resetSettingsHydration(): void {
+	hydrated = false;
+	Object.assign(settings, defaultSettings);
+	resetUserState();
 }
 
 /**
@@ -117,23 +158,39 @@ export async function loadSystemSettings(): Promise<void> {
 
 /**
  * Save system settings (admin only).
+ * Returns whether the change was persisted; on failure the local copy is rolled
+ * back so the UI never shows a setting the server did not accept.
  */
-export async function updateSystemSettings(newSettings: Partial<SystemSettings>): Promise<void> {
+export async function updateSystemSettings(newSettings: Partial<SystemSettings>): Promise<boolean> {
+	const previous = Object.fromEntries(
+		Object.keys(newSettings).map((key) => [key, systemSettings[key as keyof SystemSettings]])
+	) as Partial<SystemSettings>;
+
 	// Optimistically update the local reactive copy.
 	Object.assign(systemSettings, newSettings);
 	try {
 		// Send ONLY the changed keys — the backend merges them into the stored
-		// blob, so a partial write never clobbers sibling fields (e.g.
-		// onboardingComplete) even if our in-memory copy was stale.
+		// blob, so a partial write never clobbers sibling fields even if our
+		// in-memory copy was stale.
 		await ws.http('settings:update-system', { patch: { ...newSettings } });
 		debug.log('settings', 'System settings saved');
+		return true;
 	} catch (err) {
+		Object.assign(systemSettings, previous);
 		debug.error('settings', 'Failed to save system settings:', err);
+		return false;
 	}
 }
 
-// Save per-user settings to server (fire-and-forget)
+// Save per-user settings to server (fire-and-forget).
+// Blocked until hydration: saving a store that still holds defaults would
+// replace the user's real settings with them, because every save sends the
+// whole object.
 function saveSettings(): void {
+	if (!hydrated) {
+		debug.warn('settings', 'Not saving settings — server copy not loaded yet (would overwrite it with defaults)');
+		return;
+	}
 	ws.http('user:save-state', { key: 'settings', value: { ...settings } }).catch(err => {
 		debug.error('settings', 'Failed to save settings to server:', err);
 	});

--- a/shared/types/stores/settings.ts
+++ b/shared/types/stores/settings.ts
@@ -92,7 +92,17 @@ export type AuthMode = 'none' | 'required';
 export interface SystemSettings {
 	/** Authentication mode: 'none' = single user no login, 'required' = multi-user with login. Default: 'required'. */
 	authMode: AuthMode;
-	/** Whether the initial setup wizard has been completed. Default: false. */
+	/**
+	 * Setup wizard state — the authoritative marker.
+	 * 'pending' is only written by a fresh install that entered the wizard; an
+	 * install with users and no marker at all is treated (and recorded) as
+	 * complete. Read server-side via `auth:status`, never decided by the client.
+	 */
+	onboarding?: 'pending' | 'complete';
+	/**
+	 * Legacy boolean mirror of `onboarding`, still written so an older build
+	 * downgraded onto the same database keeps recognising a completed setup.
+	 */
 	onboardingComplete: boolean;
 	/** Restrict folder browser to only these base paths. Empty = no restriction. */
 	allowedBasePaths: string[];


### PR DESCRIPTION
## Summary
Fixes the recurring "suddenly back in the setup wizard, with some settings reset to defaults" bug.

## Why
`bun test` runs with `NODE_ENV=test`. The data-directory rule only special-cased `development`, so `test` fell through to production and the suite opened the real `~/.clopen/app.db`. `remote-server.test.ts` then wrote `system:settings` as a full replace, deleting `onboardingComplete` and every other system setting. The next page refresh showed the wizard, and clicking through it persisted default per-user settings over the real ones, because the settings store is only hydrated when the workspace mounts — which never happens while the wizard is up.

## Changes
- **Data dir**: resolved once in `SERVER_ENV.DATA_DIR` (`CLOPEN_DATA_DIR` > test > development > production); `getClopenDir()` is now just an accessor.
- **System settings**: new `backend/settings/system-settings.ts` is the only reader/writer — reads throw on failure instead of returning `{}`, writes always merge. Four duplicated parsers now delegate to it; `settings:update` rejects the system key.
- **Onboarding**: state is `pending` only when positively known; a missing marker on an install with users resolves to complete and is written back. `auth:setup` refuses once users exist. New `auth:complete-onboarding` route; the wizard only closes on confirmed persistence and shows failures.
- **Per-user settings**: saving is blocked until hydration; `user:restore-state` moved behind one single-flight loader shared by auth and the workspace.
- **Startup**: exit when the database fails to initialize; create the data directory with `mkdirSync`.
- **Tests**: `backend/auth/onboarding.test.ts` locks in the isolation, the merge semantics, and the self-heal.

## Verification
`bun run check` (0 errors), `bun run lint` (clean), `bun run test` (447 pass / 0 fail). Confirmed the production database is byte-identical before and after a full test run, and that the suite now writes to `~/.clopen-test`.