### PR TITLE
fix(workspace): stop watcher restart loop and load panels behind skeletons

### DIFF
--- a/backend/files/file-watcher.test.ts
+++ b/backend/files/file-watcher.test.ts
@@ -1,0 +1,160 @@
+/**
+ * File watcher tests.
+ *
+ * These exercise the real watcher against a real temp directory, because the
+ * bugs this code exists to prevent are all about what the OS actually reports:
+ * ignored directories still generating events, a rebuilt watcher announcing
+ * itself as a file change, and nested directories created after start-up going
+ * unwatched (which is only a risk on the platforms where recursion is emulated).
+ */
+
+import { describe, expect, mock, test, beforeAll, afterEach } from 'bun:test';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+interface Emitted {
+	projectId: string;
+	event: string;
+	payload: Record<string, unknown>;
+}
+
+const emitted: Emitted[] = [];
+
+mock.module('$backend/utils/ws', () => ({
+	ws: {
+		emit: {
+			project: (projectId: string, event: string, payload: Record<string, unknown>) => {
+				emitted.push({ projectId, event, payload });
+			},
+			user: () => {},
+			global: () => {}
+		}
+	}
+}));
+
+// Imported after the mock so the watcher binds to the stub.
+let fileWatcher: typeof import('./file-watcher').fileWatcher;
+
+beforeAll(async () => {
+	({ fileWatcher } = await import('./file-watcher'));
+});
+
+const tempRoots: string[] = [];
+
+async function makeProject(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), 'clopen-watch-'));
+	tempRoots.push(dir);
+	return dir;
+}
+
+/** Wait until `predicate` holds, or fail after `timeout` ms. */
+async function waitFor(predicate: () => boolean, timeout = 4000): Promise<void> {
+	const deadline = Date.now() + timeout;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await new Promise((r) => setTimeout(r, 25));
+	}
+	throw new Error('Timed out waiting for watcher event');
+}
+
+function changesFor(projectId: string): string[] {
+	return emitted
+		.filter((e) => e.projectId === projectId && e.event === 'files:changed')
+		.flatMap((e) => (e.payload.changes as { path: string }[]).map((c) => c.path));
+}
+
+afterEach(async () => {
+	for (const projectId of fileWatcher.getWatchedProjects()) {
+		fileWatcher.releaseProject(projectId);
+	}
+	emitted.length = 0;
+	await Promise.all(tempRoots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('FileWatcherManager', () => {
+	test('reports changes to files in the project root', async () => {
+		const root = await makeProject();
+		expect(await fileWatcher.startWatching('p1', root)).toBe(true);
+
+		await writeFile(join(root, 'index.ts'), 'export {}');
+
+		await waitFor(() => changesFor('p1').some((p) => p.endsWith('index.ts')));
+	});
+
+	test('reports changes in nested directories created after the watch started', async () => {
+		const root = await makeProject();
+		expect(await fileWatcher.startWatching('p2', root)).toBe(true);
+
+		// A directory that did not exist at start-up: on Linux this only works if
+		// the watcher attaches to newly created directories as it sees them.
+		const nested = join(root, 'src', 'deep');
+		await mkdir(nested, { recursive: true });
+		await waitFor(() => changesFor('p2').some((p) => p.endsWith('src')));
+
+		emitted.length = 0;
+		await writeFile(join(nested, 'mod.ts'), 'export {}');
+
+		await waitFor(() => changesFor('p2').some((p) => p.endsWith('mod.ts')));
+	});
+
+	test('never reports changes inside ignored directories', async () => {
+		const root = await makeProject();
+		await mkdir(join(root, 'node_modules', 'pkg'), { recursive: true });
+		await mkdir(join(root, '.git'), { recursive: true });
+		expect(await fileWatcher.startWatching('p3', root)).toBe(true);
+
+		await writeFile(join(root, 'node_modules', 'pkg', 'index.js'), '// noise');
+		await writeFile(join(root, '.git', 'COMMIT_EDITMSG'), 'wip');
+
+		// Space the writes out: the platform watchers coalesce bursts and can drop
+		// events that land in the same instant, which would make this pass for the
+		// wrong reason (or fail on the sentinel write below).
+		await new Promise((r) => setTimeout(r, 400));
+
+		// Write a watched file last; once it lands, the ignored writes have had at
+		// least as long to arrive, so their absence is meaningful rather than a race.
+		await writeFile(join(root, 'app.ts'), 'export {}');
+		await waitFor(() => changesFor('p3').some((p) => p.endsWith('app.ts')));
+
+		const paths = changesFor('p3');
+		expect(paths.some((p) => p.includes('node_modules'))).toBe(false);
+		expect(paths.some((p) => p.includes('.git'))).toBe(false);
+	});
+
+	test('does not emit an empty change list', async () => {
+		const root = await makeProject();
+		expect(await fileWatcher.startWatching('p4', root)).toBe(true);
+
+		await writeFile(join(root, 'a.ts'), 'export {}');
+		await waitFor(() => changesFor('p4').length > 0);
+
+		const empties = emitted.filter(
+			(e) => e.event === 'files:changed' && (e.payload.changes as unknown[]).length === 0
+		);
+		expect(empties).toHaveLength(0);
+	});
+
+	test('tracks dirty files for the snapshot system', async () => {
+		const root = await makeProject();
+		expect(await fileWatcher.startWatching('p5', root)).toBe(true);
+
+		await writeFile(join(root, 'tracked.ts'), 'export {}');
+		await waitFor(() => fileWatcher.getDirtyFiles('p5').has('tracked.ts'));
+
+		fileWatcher.clearDirtyFiles('p5');
+		expect(fileWatcher.getDirtyFiles('p5').size).toBe(0);
+	});
+
+	test('stops watching once the last viewer leaves', async () => {
+		const root = await makeProject();
+		expect(await fileWatcher.addViewer('conn-a', 'p6', root)).toBe(true);
+		expect(await fileWatcher.addViewer('conn-b', 'p6', root)).toBe(true);
+
+		fileWatcher.removeViewer('conn-a', 'p6');
+		expect(fileWatcher.isWatching('p6')).toBe(true);
+
+		fileWatcher.removeViewer('conn-b', 'p6');
+		expect(fileWatcher.isWatching('p6')).toBe(false);
+	});
+});

--- a/backend/files/file-watcher.ts
+++ b/backend/files/file-watcher.ts
@@ -7,10 +7,29 @@
  * - Debounced events to prevent spam
  * - Automatic cleanup on unwatch
  * - Cross-platform support (Windows/Unix)
+ *
+ * Watching strategy, per platform:
+ *
+ * macOS and Windows get a single `{ recursive: true }` watch on the project
+ * root. Both back it with one OS-level handle (FSEvents / ReadDirectoryChangesW)
+ * that covers the whole subtree, so recursion is essentially free and pruning
+ * would buy nothing.
+ *
+ * Linux cannot do that. There, recursion is emulated with inotify and costs one
+ * kernel watch per directory, with no way to exclude any of them. A project
+ * containing `node_modules` blows past `fs.inotify.max_user_watches`; the
+ * watcher faults with ENOSPC, gets rebuilt, and faults again — an endless
+ * restart loop that pegged the CPU and, because each restart announced itself as
+ * a file change, made clients reload every few seconds with nothing actually
+ * changing. So on Linux we walk the tree ourselves and never watch an ignored
+ * directory, which removes the overwhelming majority of the watch descriptors.
  */
 
+/** Whether the platform's recursive `fs.watch` is a single cheap OS handle. */
+const USE_NATIVE_RECURSIVE_WATCH = process.platform !== 'linux';
+
 import { watch, type FSWatcher, existsSync } from 'node:fs';
-import { stat } from 'node:fs/promises';
+import { stat, readdir } from 'node:fs/promises';
 import { join, relative, normalize, sep } from 'node:path';
 import { ws } from '$backend/utils/ws';
 import { debug } from '$shared/utils/logger';
@@ -20,6 +39,21 @@ import type { FileChange } from '$shared/types/filesystem';
  * Debounce configuration
  */
 const DEBOUNCE_MS = 300; // Debounce file change events
+
+/**
+ * Hard ceiling on directory watches per project (Linux manual recursion only).
+ * Even with ignored directories pruned, a pathological tree (generated code, a
+ * huge monorepo) could still exhaust `max_user_watches`. Stop adding watches
+ * past this point and tell the client its view may go stale, rather than
+ * faulting into the restart loop this whole design exists to prevent.
+ */
+const MAX_WATCHED_DIRS = 4000;
+
+/** Restart backoff after a watcher fault: 1s, 2s, 4s, 8s, then give up. */
+const RESTART_DELAYS_MS = [1000, 2000, 4000, 8000];
+
+/** How long a rebuilt watcher must survive before its fault count is forgiven. */
+const FAULT_FORGIVENESS_MS = 60_000;
 
 /**
  * Directories to ignore when watching
@@ -64,12 +98,18 @@ const GIT_DEBOUNCE_MS = 500;
  * Watcher instance for a project
  */
 interface ProjectWatcher {
-	watcher: FSWatcher;
 	projectPath: string;
 	projectId: string;
 	debounceTimer: ReturnType<typeof setTimeout> | null;
 	pendingChanges: Map<string, FileChange>;
-	subWatchers: Map<string, FSWatcher>;
+	/** Absolute directory path -> its (non-recursive) watcher. Includes the root. */
+	dirWatchers: Map<string, FSWatcher>;
+	/** Set once MAX_WATCHED_DIRS was hit, so the warning is emitted only once. */
+	truncated: boolean;
+	/** Consecutive watcher faults; reset after a clean restart. */
+	faults: number;
+	/** Flipped by stopWatching so in-flight async tree walks bail out. */
+	closed: boolean;
 	gitWatcher: FSWatcher | null;
 	gitRefsWatcher: FSWatcher | null;
 	gitDebounceTimer: ReturnType<typeof setTimeout> | null;
@@ -172,7 +212,7 @@ class FileWatcherManager {
 	 * near-simultaneous viewers (e.g. two devices) could each build a watcher and
 	 * leak one.
 	 */
-	async startWatching(projectId: string, projectPath: string): Promise<boolean> {
+	async startWatching(projectId: string, projectPath: string, faults = 0): Promise<boolean> {
 		// Already watching this project
 		if (this.watchers.has(projectId)) {
 			debug.log('file', `Already watching project: ${projectId}`);
@@ -182,7 +222,7 @@ class FileWatcherManager {
 		const inflight = this.starting.get(projectId);
 		if (inflight) return inflight;
 
-		const startPromise = this.doStartWatching(projectId, projectPath);
+		const startPromise = this.doStartWatching(projectId, projectPath, faults);
 		this.starting.set(projectId, startPromise);
 		try {
 			return await startPromise;
@@ -191,7 +231,11 @@ class FileWatcherManager {
 		}
 	}
 
-	private async doStartWatching(projectId: string, projectPath: string): Promise<boolean> {
+	private async doStartWatching(
+		projectId: string,
+		projectPath: string,
+		faults = 0
+	): Promise<boolean> {
 		try {
 			// Normalize path
 			const normalizedPath = normalize(projectPath);
@@ -203,47 +247,167 @@ class FileWatcherManager {
 				return false;
 			}
 
-			// Create main watcher for project root
-			const watcher = watch(normalizedPath, { recursive: true }, (eventType, filename) => {
-				if (filename) {
-					this.handleFileChange(projectId, normalizedPath, filename, eventType);
-				}
-			});
-
-			// Handle watcher errors. fs.watch can fault (and on some platforms go
-			// silently deaf) under heavy churn or after sleep/wake — recover by
-			// rebuilding the watcher instead of leaving the project stuck stale.
-			watcher.on('error', (error) => {
-				debug.error('file', `Watcher error for project ${projectId}:`, error);
-				ws.emit.project(projectId, 'files:watch-error', {
-					projectId,
-					error: error.message || 'File watcher error'
-				});
-				this.scheduleRestart(projectId);
-			});
-
-			// Store watcher instance
 			const projectWatcher: ProjectWatcher = {
-				watcher,
 				projectPath: normalizedPath,
 				projectId,
 				debounceTimer: null,
 				pendingChanges: new Map(),
-				subWatchers: new Map(),
+				dirWatchers: new Map(),
+				truncated: false,
+				faults,
+				closed: false,
 				gitWatcher: null,
 				gitRefsWatcher: null,
 				gitDebounceTimer: null
 			};
 			this.watchers.set(projectId, projectWatcher);
 
+			// Watch the root synchronously so events are never missed while the
+			// (async) subtree walk is still in progress.
+			if (!this.watchDir(projectWatcher, normalizedPath)) {
+				this.watchers.delete(projectId);
+				return false;
+			}
+
 			// Start git state watcher (for external git operations)
 			this.startGitWatcher(projectId, normalizedPath);
+
+			// On Linux the root watch only covers the root itself. Walk the tree in
+			// the background so every non-ignored directory gets its own watch;
+			// elsewhere the root's recursive handle already covers everything.
+			if (!USE_NATIVE_RECURSIVE_WATCH) {
+				void this.watchSubtree(projectWatcher, normalizedPath);
+			}
+
+			// Forgive earlier faults once a rebuild has held steady, so an isolated
+			// hiccup much later still gets the full retry budget instead of
+			// inheriting an exhausted one.
+			if (faults > 0) {
+				setTimeout(() => {
+					if (this.watchers.get(projectId) === projectWatcher) projectWatcher.faults = 0;
+				}, FAULT_FORGIVENESS_MS);
+			}
 
 			debug.log('file', `Started watching project: ${projectId} at ${normalizedPath}`);
 			return true;
 		} catch (error) {
 			debug.error('file', `Failed to start watching project ${projectId}:`, error);
 			return false;
+		}
+	}
+
+	/**
+	 * Attach a non-recursive watcher to a single directory.
+	 * Returns false when the directory could not be watched (gone, permission
+	 * denied, or the per-project ceiling was reached).
+	 */
+	private watchDir(pw: ProjectWatcher, dir: string): boolean {
+		if (pw.closed || pw.dirWatchers.has(dir)) return true;
+
+		if (pw.dirWatchers.size >= MAX_WATCHED_DIRS) {
+			if (!pw.truncated) {
+				pw.truncated = true;
+				debug.warn(
+					'file',
+					`Watch ceiling (${MAX_WATCHED_DIRS} dirs) reached for project ${pw.projectId}; deeper directories will not report changes`
+				);
+				ws.emit.project(pw.projectId, 'files:watch-error', {
+					projectId: pw.projectId,
+					error: `Project is too large to watch entirely (${MAX_WATCHED_DIRS}+ directories). Changes in deeply nested folders may not appear automatically.`
+				});
+			}
+			return false;
+		}
+
+		try {
+			// The root watch is recursive where that's a single OS handle; every
+			// other watch (and every Linux watch) covers exactly one directory.
+			// Either way `filename` arrives relative to `dir`, so the change handler
+			// resolves it the same way.
+			const recursive = USE_NATIVE_RECURSIVE_WATCH && dir === pw.projectPath;
+			const watcher = watch(dir, { recursive }, (eventType, filename) => {
+				if (filename) this.handleFileChange(pw.projectId, dir, filename, eventType);
+			});
+
+			// fs.watch can fault (and on some platforms go silently deaf) under heavy
+			// churn or after sleep/wake. A fault on a nested directory only costs us
+			// that subtree, so drop it quietly; a fault on the root means the project
+			// is unwatched and warrants a full rebuild.
+			watcher.on('error', (error) => {
+				if (dir === pw.projectPath) {
+					debug.error('file', `Watcher error for project ${pw.projectId}:`, error);
+					ws.emit.project(pw.projectId, 'files:watch-error', {
+						projectId: pw.projectId,
+						error: error.message || 'File watcher error'
+					});
+					this.scheduleRestart(pw.projectId);
+				} else {
+					debug.warn('file', `Dropping faulted watcher for ${dir}:`, error);
+					this.unwatchDir(pw, dir);
+				}
+			});
+
+			pw.dirWatchers.set(dir, watcher);
+			return true;
+		} catch (error) {
+			// ENOENT/EACCES on a nested directory is normal (it may have vanished
+			// between readdir and watch); only the root failing is fatal.
+			if (dir === pw.projectPath) {
+				debug.error('file', `Failed to watch project root ${dir}:`, error);
+				return false;
+			}
+			debug.log('file', `Skipped unwatchable directory ${dir}`);
+			return false;
+		}
+	}
+
+	/**
+	 * Close the watcher for `dir` and every directory beneath it.
+	 * Called when a directory is deleted or renamed away.
+	 */
+	private unwatchDir(pw: ProjectWatcher, dir: string): void {
+		const prefix = dir.endsWith(sep) ? dir : dir + sep;
+		for (const [watched, watcher] of pw.dirWatchers) {
+			if (watched !== dir && !watched.startsWith(prefix)) continue;
+			try {
+				watcher.close();
+			} catch {
+				// Already closed — nothing to do.
+			}
+			pw.dirWatchers.delete(watched);
+		}
+	}
+
+	/**
+	 * Recursively attach watchers to every non-ignored directory under `dir`.
+	 * Ignored directories (node_modules, .git, build output, …) are never
+	 * descended into — that pruning is what keeps the watch count survivable.
+	 */
+	private async watchSubtree(pw: ProjectWatcher, dir: string): Promise<void> {
+		if (pw.closed) return;
+
+		let entries;
+		try {
+			entries = await readdir(dir, { withFileTypes: true });
+		} catch {
+			return; // Directory vanished or is unreadable — nothing to watch.
+		}
+
+		for (const entry of entries) {
+			if (pw.closed) return;
+			if (!entry.isDirectory()) continue;
+
+			const childPath = join(dir, entry.name);
+			const relativePath = relative(pw.projectPath, childPath).replace(/\\/g, '/');
+			if (this.shouldIgnore(relativePath)) continue;
+
+			if (!this.watchDir(pw, childPath)) {
+				// Ceiling reached — stop descending entirely rather than watching an
+				// arbitrary subset that depends on directory ordering.
+				if (pw.truncated) return;
+				continue;
+			}
+			await this.watchSubtree(pw, childPath);
 		}
 	}
 
@@ -258,13 +422,18 @@ class FileWatcherManager {
 		}
 
 		try {
-			// Close main watcher
-			projectWatcher.watcher.close();
+			// Stop any in-flight subtree walk from re-adding watchers behind us.
+			projectWatcher.closed = true;
 
-			// Close all sub-watchers
-			for (const subWatcher of projectWatcher.subWatchers.values()) {
-				subWatcher.close();
+			// Close every directory watcher (the root included)
+			for (const dirWatcher of projectWatcher.dirWatchers.values()) {
+				try {
+					dirWatcher.close();
+				} catch {
+					// Already closed — nothing to do.
+				}
 			}
+			projectWatcher.dirWatchers.clear();
 
 			// Close git watchers
 			projectWatcher.gitWatcher?.close();
@@ -315,44 +484,60 @@ class FileWatcherManager {
 	}
 
 	/**
-	 * Handle file change event
+	 * Handle a change reported by the watcher on `dir`.
+	 * `filename` is relative to `dir`, not to the project root.
 	 */
 	private async handleFileChange(
 		projectId: string,
-		projectPath: string,
+		dir: string,
 		filename: string,
 		eventType: string
 	): Promise<void> {
 		const projectWatcher = this.watchers.get(projectId);
-		if (!projectWatcher) return;
+		if (!projectWatcher || projectWatcher.closed) return;
 
-		// Normalize filename to use forward slashes for consistency
-		const normalizedFilename = filename.replace(/\\/g, '/');
+		// Build full path, then derive the project-relative path — the ignore rules
+		// are defined against the project root, and `filename` is only relative to
+		// the directory that reported it.
+		const fullPath = join(dir, filename);
+		const relativePath = relative(projectWatcher.projectPath, fullPath).replace(/\\/g, '/');
 
-		// Check if should be ignored
-		if (this.shouldIgnore(normalizedFilename)) {
+		// Paths outside the project (possible on some platforms for rename events)
+		// and ignored paths never reach clients.
+		if (relativePath.startsWith('..') || this.shouldIgnore(relativePath)) {
 			return;
 		}
 
-		// Build full path
-		const fullPath = join(projectPath, filename);
-
 		// Determine change type
 		let changeType: 'created' | 'modified' | 'deleted';
+		let isDirectory = false;
 		if (eventType === 'change') {
 			changeType = 'modified';
 		} else {
 			// 'rename' event — check if file exists to distinguish create from delete
 			try {
-				await stat(fullPath);
+				const entryStat = await stat(fullPath);
+				isDirectory = entryStat.isDirectory();
 				changeType = 'created';
 			} catch {
 				changeType = 'deleted';
 			}
 		}
 
+		// Where recursion is emulated, keep the watch set in step with the tree: a
+		// new directory needs its own watcher, and a removed one must release its
+		// descendants' watchers so they can't leak.
+		if (!USE_NATIVE_RECURSIVE_WATCH) {
+			if (isDirectory && changeType === 'created') {
+				if (this.watchDir(projectWatcher, fullPath)) {
+					void this.watchSubtree(projectWatcher, fullPath);
+				}
+			} else if (changeType === 'deleted' && projectWatcher.dirWatchers.has(fullPath)) {
+				this.unwatchDir(projectWatcher, fullPath);
+			}
+		}
+
 		// Track dirty file for snapshot system
-		const relativePath = relative(projectPath, fullPath).replace(/\\/g, '/');
 		this.trackDirtyFile(projectId, relativePath);
 
 		// Create file change object
@@ -447,10 +632,14 @@ class FileWatcherManager {
 				// Silently ignore git watcher errors
 			});
 
-			// Watch .git/refs/ for branch/tag create/delete
+			// Watch .git/refs/ for branch/tag create/delete. Lock files are git's
+			// own write-in-progress scratch space: every ref update produces a
+			// `<ref>.lock` create AND delete, so forwarding them doubled the churn
+			// and fired a refresh before the ref itself had landed.
 			const refsDir = join(gitDir, 'refs');
 			if (existsSync(refsDir)) {
-				projectWatcher.gitRefsWatcher = watch(refsDir, { recursive: true }, (_eventType, _filename) => {
+				projectWatcher.gitRefsWatcher = watch(refsDir, { recursive: true }, (_eventType, filename) => {
+					if (filename && filename.replace(/\\/g, '/').endsWith('.lock')) return;
 					this.emitGitChanged(projectId);
 				});
 				projectWatcher.gitRefsWatcher.on('error', () => {
@@ -486,13 +675,37 @@ class FileWatcherManager {
 	}
 
 	/**
-	 * Schedule a debounced rebuild of a project's watcher after a fault.
-	 * Guarded so overlapping error events don't spawn multiple restarts.
+	 * Schedule a rebuild of a project's watcher after a fault, backing off on
+	 * each consecutive failure and giving up once the backoff is exhausted.
+	 *
+	 * The backoff matters: a fault whose cause is structural (the platform watch
+	 * limit, a permission change) reproduces immediately on restart. A fixed 1s
+	 * retry turned that into an endless rebuild loop that pegged the CPU and,
+	 * because each restart announced itself as a file change, made every client
+	 * reload its editor every second.
 	 */
 	private scheduleRestart(projectId: string): void {
 		if (this.restarting.has(projectId)) return;
 		// Only restart if someone is still viewing the project.
 		if (!this.viewers.get(projectId)?.size) return;
+
+		const current = this.watchers.get(projectId);
+		if (!current) return;
+
+		const attempt = current.faults;
+		const delay = RESTART_DELAYS_MS[attempt];
+		if (delay === undefined) {
+			debug.error(
+				'file',
+				`Watcher for project ${projectId} faulted ${attempt} times; giving up on automatic restart`
+			);
+			ws.emit.project(projectId, 'files:watch-error', {
+				projectId,
+				error: 'File watching stopped after repeated failures. Refresh to retry.'
+			});
+			return;
+		}
+
 		this.restarting.add(projectId);
 
 		setTimeout(async () => {
@@ -502,18 +715,23 @@ class FileWatcherManager {
 			const projectPath = this.watchers.get(projectId)?.projectPath;
 			if (!projectPath) return;
 
-			debug.warn('file', `Restarting faulted watcher for project ${projectId}`);
+			debug.warn(
+				'file',
+				`Restarting faulted watcher for project ${projectId} (attempt ${attempt + 1})`
+			);
 			this.stopWatching(projectId);
-			await this.startWatching(projectId, projectPath);
+			const ok = await this.startWatching(projectId, projectPath, attempt + 1);
+			if (!ok) return;
 
-			// A faulted watcher may have dropped events while down — nudge clients
-			// to reconcile so nothing stays stale.
-			ws.emit.project(projectId, 'files:changed', {
+			// A faulted watcher may have dropped events while down. Ask clients to
+			// reconcile — deliberately NOT via `files:changed`, which means "these
+			// specific paths changed" and made consumers tear down and rebuild live
+			// views (the open diff editor) on every restart.
+			ws.emit.project(projectId, 'files:resync', {
 				projectId,
-				changes: [],
 				timestamp: Date.now()
 			});
-		}, 1000);
+		}, delay);
 	}
 
 	/**

--- a/backend/git/git-executor.ts
+++ b/backend/git/git-executor.ts
@@ -35,6 +35,14 @@ export async function execGit(
 			...getCleanSpawnEnv(),
 			// Prevent git from prompting for credentials
 			GIT_TERMINAL_PROMPT: '0',
+			// Read-only commands must stay read-only. Without this, `git status`
+			// opportunistically rewrites `.git/index` to refresh cached stat data —
+			// which trips our own `.git` watcher, which emits `git:changed`, which
+			// makes the client re-run `git status`. That feedback loop refreshed the
+			// Git panel (and reloaded the open diff) every few seconds with nothing
+			// actually changing. Commands that genuinely need the index lock (commit,
+			// add, checkout) still take it; only the optional refresh is suppressed.
+			GIT_OPTIONAL_LOCKS: '0',
 			// Use English output for consistent parsing
 			LANG: 'en_US.UTF-8',
 			LC_ALL: 'en_US.UTF-8'

--- a/backend/ws/files/watch.ts
+++ b/backend/ws/files/watch.ts
@@ -146,6 +146,15 @@ export const watchHandler = createRouter()
 		timestamp: t.Number()
 	}))
 
+	// Emitted when the watcher was rebuilt after a fault and may have missed
+	// events. Consumers should re-fetch their own data, but must NOT treat this
+	// as "these files changed" — no path is known to have changed, so live views
+	// (an open diff, an editor tab) must be reconciled in place, not rebuilt.
+	.emit('files:resync', t.Object({
+		projectId: t.String(),
+		timestamp: t.Number()
+	}))
+
 	// Emitted on watcher errors
 	.emit('files:watch-error', t.Object({
 		projectId: t.String(),

--- a/frontend/components/preview/browser/BrowserPreview.svelte
+++ b/frontend/components/preview/browser/BrowserPreview.svelte
@@ -34,6 +34,7 @@
 	import ws from '$frontend/utils/ws';
 	import { projectState } from '$frontend/stores/core/projects.svelte';
 	import { appState } from '$frontend/stores/core/app.svelte';
+	import { isPanelLoading } from '$frontend/stores/ui/project-workspace.svelte';
 
 	let {
 		url = $bindable(''),
@@ -337,16 +338,17 @@
 
 	// Watch for project changes and reload sessions.
 	//
-	// Bail while a workspace switch is in flight: the singleton tabManager is
+	// Bail while the preview dock is still hydrating: the singleton tabManager is
 	// mid clear/restore/load during that window and adopting it now would race
 	// with the dock — observed as a spurious "New Tab" or duplicated/cross-
-	// project tabs once load() completes. Once the barrier drops, isSwitching
-	// flips and the effect re-runs against the authoritative state.
+	// project tabs once load() completes. Keying this on the dock's own loading
+	// state rather than the switch barrier matters: the barrier now drops as soon
+	// as the workspace is structurally correct, well before load() has finished.
 	let previousProjectId = '';
 	let initialRecoveryDone = false;
 	$effect(() => {
 		const currentProjectId = projectId;
-		if (appState.isSwitching) return;
+		if (appState.isSwitching || isPanelLoading('preview')) return;
 
 		// Initial recovery - trigger when projectId first becomes available after mount
 		if (!initialRecoveryDone && currentProjectId && previousProjectId === '') {

--- a/frontend/components/workspace/PanelContainer.svelte
+++ b/frontend/components/workspace/PanelContainer.svelte
@@ -11,6 +11,7 @@
 	import HistoryModal from '$frontend/components/history/HistoryModal.svelte';
 	import { workspaceState, type PanelId } from '$frontend/stores/ui/workspace.svelte';
 	import { appState } from '$frontend/stores/core/app.svelte';
+	import { isPanelLoading } from '$frontend/stores/ui/project-workspace.svelte';
 
 	interface Props {
 		panelId: PanelId;
@@ -93,10 +94,14 @@
 				<GitPanel bind:this={gitPanelRef} />
 			{/if}
 
-			<!-- During a project switch only the CONTENT is waiting on data. Blank it
-			     to a plain "Loading…" (the header stays live and updates instantly).
-			     No stale data from the previous project shows through. -->
-			{#if appState.isSwitching}
+			<!-- Two overlays, one look. `isSwitching` covers the structural swap, when
+			     every panel would otherwise show the previous project. `isPanelLoading`
+			     takes over per panel for the data that loads after the reveal — without
+			     it a panel renders its empty state ("No files in project", "Not a git
+			     repository") while its data is still in flight. They are visually
+			     identical and hand over without a gap, so the user sees one continuous
+			     loading state that clears panel by panel as data arrives. -->
+			{#if appState.isSwitching || isPanelLoading(panelId)}
 				<div
 					class="absolute inset-0 flex items-center justify-center gap-2 bg-white dark:bg-slate-900 text-sm text-slate-500 dark:text-slate-400"
 				>

--- a/frontend/components/workspace/panels/FilesPanel.svelte
+++ b/frontend/components/workspace/panels/FilesPanel.svelte
@@ -92,6 +92,7 @@
 		initIgnoredPaths,
 		refreshIgnoredPaths
 	} from '$frontend/stores/features/ignored-paths.svelte';
+	import { beginPanelLoad } from '$frontend/stores/ui/project-workspace.svelte';
 
 	// Props
 	interface Props {
@@ -392,10 +393,15 @@
 		const savedTreeScrollTop = treeScrollContainer
 			? treeScrollContainer.scrollTop
 			: pendingTreeScrollRestore ?? treeScrollTop;
+		const requestPath = projectPath;
 
-		if (!preserveState) {
-			isLoading = true;
-		}
+		// `preserveState` is about scroll/expansion, NOT about the loading flag —
+		// conflating the two is what made a project switch render the tree's empty
+		// state ("No files in project") while the tree was still being fetched, since
+		// a switch that restored panel state always passed preserveState=true. The
+		// flag is always set; the template only shows the spinner when there is
+		// nothing to show yet, so a background refresh still never blanks the tree.
+		isLoading = true;
 		error = '';
 
 		try {
@@ -407,6 +413,11 @@
 			}
 
 			const data = await ws.http('files:list-tree', requestData);
+
+			// The project may have changed while this was in flight — dropping the
+			// response is the only way to stop the previous project's tree from
+			// landing in the new project's panel.
+			if (requestPath !== projectPath) return;
 
 			const convertToFileNode = (apiFile: unknown): FileNode => {
 				if (typeof apiFile !== 'object' || apiFile === null) {
@@ -449,10 +460,11 @@
 				});
 			}
 		} catch (err) {
+			if (requestPath !== projectPath) return;
 			error = err instanceof Error ? err.message : 'Failed to load files';
 			projectFiles = [];
 		} finally {
-			isLoading = false;
+			if (requestPath === projectPath) isLoading = false;
 		}
 	}
 
@@ -1990,6 +2002,12 @@
 			activeTabPath = null;
 			expandedFolders = new Set();
 			viewMode = 'tree';
+			// Drop the outgoing project's tree. It used to survive here and stay on
+			// screen until the new tree arrived, which only looked right because the
+			// switch barrier hid it; now that panels reveal before their data lands,
+			// leaving it would show the wrong project's files.
+			projectFiles = [];
+			error = '';
 			// Drop the clipboard: it holds FileNode references from the previous
 			// project, which would be dangling/invalid pointers in the new one.
 			clipboard = null;
@@ -2007,40 +2025,50 @@
 	});
 
 	async function restoreAndLoad(targetProjectId: string, targetProjectPath: string) {
-		// Try in-memory snapshot first (instant for same-session mobile/desktop switch)
-		const inMem = projectFileStates.get(targetProjectPath);
-		let restored = false;
-
-		if (inMem) {
-			applyPersistedState(inMem, targetProjectPath);
-			restored = true;
-		}
-
-		// Always fetch DB state too — it may be newer (cross-device, refresh)
+		// Hold the Files panel's skeleton for the WHOLE restore, not just the tree
+		// fetch: the panel state round-trip happens first, and without this the
+		// panel would show an empty tree for its duration.
+		const releasePanel = beginPanelLoad('files');
 		try {
-			const result = await ws.http('files:get-panel-state', { projectId: targetProjectId });
-			if (projectId !== targetProjectId) return; // race: project changed mid-fetch
-			if (result?.state) {
-				try {
-					const parsed: PersistedPanelState = JSON.parse(result.state);
-					applyPersistedState(parsed, targetProjectPath);
-					restored = true;
-				} catch (err) {
-					debug.error('file', 'Failed to parse panel state JSON:', err);
-				}
+			// Try in-memory snapshot first (instant for same-session mobile/desktop switch)
+			const inMem = projectFileStates.get(targetProjectPath);
+			let restored = false;
+
+			if (inMem) {
+				applyPersistedState(inMem, targetProjectPath);
+				restored = true;
 			}
-		} catch (err) {
-			debug.error('file', 'Failed to fetch panel state:', err);
+
+			// Always fetch DB state too — it may be newer (cross-device, refresh)
+			try {
+				const result = await ws.http('files:get-panel-state', { projectId: targetProjectId });
+				if (projectId !== targetProjectId) return; // race: project changed mid-fetch
+				if (result?.state) {
+					try {
+						const parsed: PersistedPanelState = JSON.parse(result.state);
+						applyPersistedState(parsed, targetProjectPath);
+						restored = true;
+					} catch (err) {
+						debug.error('file', 'Failed to parse panel state JSON:', err);
+					}
+				}
+			} catch (err) {
+				debug.error('file', 'Failed to fetch panel state:', err);
+			}
+
+			if (projectId !== targetProjectId) return;
+
+			// Mark as loaded BEFORE loadProjectFiles so any post-load saves are kept
+			panelStateLoaded = true;
+
+			await loadProjectFiles(restored);
+
+			// After tree load, hydrate tab content for any restored tabs that
+			// don't yet have content (their loadTabContent was triggered in
+			// applyPersistedState but may still be in flight)
+		} finally {
+			releasePanel();
 		}
-
-		// Mark as loaded BEFORE loadProjectFiles so any post-load saves are kept
-		panelStateLoaded = true;
-
-		await loadProjectFiles(restored);
-
-		// After tree load, hydrate tab content for any restored tabs that
-		// don't yet have content (their loadTabContent was triggered in
-		// applyPersistedState but may still be in flight)
 	}
 
 	function applyPersistedState(state: PersistedPanelState, basePath: string) {
@@ -2114,6 +2142,7 @@
 
 		const unsubChanges = ws.on('files:changed', (payload) => {
 			if (payload.projectId !== projectId) return;
+			if (payload.changes.length === 0) return;
 
 			// Accumulate changes from all events before debounce fires
 			accumulatedChanges.push(...payload.changes);
@@ -2128,6 +2157,14 @@
 			}, 500);
 		});
 
+		// The watcher was rebuilt and may have missed events; no path is known to
+		// have changed, so re-read the tree in place (scroll and expansion kept)
+		// rather than reconciling a phantom change list.
+		const unsubResync = ws.on('files:resync', (payload) => {
+			if (payload.projectId !== projectId) return;
+			void loadProjectFiles(true);
+		});
+
 		const unsubWatching = ws.on('files:watching', (payload) => {
 			if (payload.projectId !== projectId) return;
 			isWatching = payload.watching;
@@ -2140,6 +2177,7 @@
 
 		return () => {
 			unsubChanges();
+			unsubResync();
 			unsubWatching();
 			unsubError();
 			if (watchDebounceTimer) clearTimeout(watchDebounceTimer);

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -29,6 +29,7 @@
 		type GitUiState,
 		type GitActiveDiff
 	} from '$frontend/stores/features/git-workspace.svelte';
+	import { beginPanelLoad } from '$frontend/stores/ui/project-workspace.svelte';
 	import { detectLanguageFromFilename } from '$frontend/components/common/editor/monaco-languages';
 	import type { IconName } from '$shared/types/ui/icons';
 	import type {
@@ -60,6 +61,11 @@
 
 	// Git state
 	let isRepo = $state(false);
+	// Whether `git:status` has answered for the CURRENT project. `isRepo` alone
+	// can't distinguish "not a repo" from "not asked yet", so the panel used to
+	// flash "Not a git repository" on every switch — and, coming from a repo,
+	// keep showing the previous project's repo UI until the answer arrived.
+	let statusLoaded = $state(false);
 	let isLoading = $state(false);
 	let gitStatus = $state<GitStatus>({ staged: [], unstaged: [], untracked: [], conflicted: [] });
 	let aiChangesSet = $state(new Set<string>());
@@ -1119,8 +1125,18 @@
 	// Data Loading
 	// ============================
 
-	async function loadAll() {
+	/**
+	 * Load everything the panel needs for the active project.
+	 *
+	 * `registerPanelLoad` is set for a project switch so the panel shows the
+	 * shared loading overlay for the whole fetch — the panel is revealed before
+	 * its data arrives, and without it the user would read the empty state
+	 * ("Not a git repository") as the answer. Background refreshes pass false:
+	 * they must never blank a panel that already has data on screen.
+	 */
+	async function loadAll(registerPanelLoad = false) {
 		if (!hasActiveProject || !projectId) return;
+		const releasePanel = registerPanelLoad ? beginPanelLoad('git') : null;
 		isLoading = true;
 		try {
 			// Stash + tags are loaded here too (not just lazily on their view) so the
@@ -1131,14 +1147,20 @@
 			debug.error('git', 'Failed to load git data:', err);
 		} finally {
 			isLoading = false;
+			releasePanel?.();
 		}
 	}
 
 	async function loadStatus() {
 		if (!projectId) return;
+		const requestProjectId = projectId;
 		try {
 			const data = await ws.http('git:status', { projectId });
+			// Drop a response that outlived its project — otherwise the previous
+			// project's changes render under the new project's header.
+			if (requestProjectId !== projectId) return;
 			isRepo = data.isRepo;
+			statusLoaded = true;
 			if (data.isRepo) {
 				gitStatus = {
 					staged: data.staged,
@@ -1146,9 +1168,14 @@
 					untracked: data.untracked,
 					conflicted: data.conflicted
 				};
+			} else {
+				gitStatus = { staged: [], unstaged: [], untracked: [], conflicted: [] };
 			}
 		} catch (err) {
 			debug.error('git', 'Failed to load status:', err);
+			// Still mark it answered: leaving it false would pin the panel on
+			// "Loading..." with no way out short of switching projects.
+			if (requestProjectId === projectId) statusLoaded = true;
 		}
 	}
 
@@ -1703,14 +1730,17 @@
 			return;
 		}
 
+		// Refresh in place: this runs on every file/git change event, so tearing the
+		// tab down would make the open diff flicker on unrelated edits.
+		const scrollTop = tab.scrollTop ?? 0;
 		if (stagedFile) {
-			await viewDiff(stagedFile, 'staged');
+			await viewDiff(stagedFile, 'staged', scrollTop, true);
 		} else if (unstagedFile) {
-			await viewDiff(unstagedFile, 'unstaged');
+			await viewDiff(unstagedFile, 'unstaged', scrollTop, true);
 		} else if (untrackedFile) {
-			await viewDiff(untrackedFile, 'unstaged');
+			await viewDiff(untrackedFile, 'unstaged', scrollTop, true);
 		} else if (conflictedFile) {
-			await viewDiff(conflictedFile, 'conflicted');
+			await viewDiff(conflictedFile, 'conflicted', scrollTop, true);
 		}
 	}
 
@@ -1754,26 +1784,46 @@
 		return isPreviewableFile(fileName) || isBinaryFile(fileName);
 	}
 
-	async function viewDiff(file: GitFileChange, section: string, restoreScrollTop = 0) {
+	/**
+	 * Open a file's diff in the Changes view.
+	 *
+	 * `silent` re-fetches the diff for the tab that is ALREADY open, leaving it on
+	 * screen while the new content is fetched and swapping it in only if it
+	 * actually differs. Background refreshes (a file-watch event, a git state
+	 * change) use it; without it every refresh tore the tab down and rebuilt it as
+	 * an empty spinner, so the editor visibly reloaded and lost its scroll
+	 * position — several times a minute on a busy working tree.
+	 */
+	async function viewDiff(
+		file: GitFileChange,
+		section: string,
+		restoreScrollTop = 0,
+		silent = false
+	) {
 		if (!projectId) return;
+		const requestProjectId = projectId;
 		const tabId = `${section}:${file.path}`;
 		const fileName = file.path.split(/[\\/]/).pop() || file.path;
 		const status = section === 'staged' ? file.indexStatus : file.workingStatus;
+		const existing = openTabs.find((t) => t.id === tabId);
+		const keepInPlace = silent && existing !== undefined && !existing.isLoading;
 
-		// Changes view: always replace with single tab
-		openTabs = [{
-			id: tabId,
-			filePath: file.path,
-			fileName,
-			section,
-			diff: null,
-			diffs: [],
-			isLoading: true,
-			status,
-			scrollTop: restoreScrollTop
-		}];
-		activeTabId = tabId;
-		if (!isTwoColumnMode) viewMode = 'diff';
+		if (!keepInPlace) {
+			// Changes view: always replace with single tab
+			openTabs = [{
+				id: tabId,
+				filePath: file.path,
+				fileName,
+				section,
+				diff: null,
+				diffs: [],
+				isLoading: true,
+				status,
+				scrollTop: restoreScrollTop
+			}];
+			activeTabId = tabId;
+			if (!isTwoColumnMode) viewMode = 'diff';
+		}
 
 		try {
 			let diffResult: GitFileDiff | null = null;
@@ -1906,17 +1956,35 @@
 				}
 			}
 
+			if (requestProjectId !== projectId) return;
+
+			// An unchanged diff must not be reassigned: DiffViewer re-renders (and
+			// resets its scroll) on identity change, so a silent refresh that found
+			// nothing new has to be a genuine no-op.
+			if (keepInPlace && sameDiff(existing?.diff ?? null, diffResult)) return;
+
 			openTabs = openTabs.map(t =>
-				t.id === tabId ? { ...t, diff: diffResult, isLoading: false } : t
+				t.id === tabId ? { ...t, diff: diffResult, status, isLoading: false } : t
 			);
 		} catch (err) {
 			debug.error('git', 'Failed to load diff:', err);
+			if (requestProjectId !== projectId) return;
+			// A failed background refresh keeps whatever is on screen rather than
+			// blanking a diff the user is reading.
+			if (keepInPlace) return;
 			openTabs = openTabs.map(t =>
 				t.id === tabId ? { ...t, diff: null, isLoading: false } : t
 			);
 		}
 		// Remember the open diff tab per-project (server-persisted).
 		markGitUiDirty();
+	}
+
+	/** Structural equality for two diffs, used to skip no-op editor updates. */
+	function sameDiff(a: GitFileDiff | null, b: GitFileDiff | null): boolean {
+		if (a === b) return true;
+		if (!a || !b) return false;
+		return JSON.stringify(a) === JSON.stringify(b);
 	}
 
 	async function viewCommitDiff(hash: string, repoPath?: string) {
@@ -3326,6 +3394,14 @@ ${bodies}`;
 
 					// Heavy data (open diffs, history) is always re-fetched lazily.
 					resetAllViewTabs();
+					// Drop the outgoing project's git state. `isRepo`/`gitStatus` used
+					// to persist across the switch, which the barrier hid; now that the
+					// panel is revealed before its data lands, stale changes from the
+					// previous project would be visible (and stageable).
+					statusLoaded = false;
+					isRepo = false;
+					gitStatus = { staged: [], unstaged: [], untracked: [], conflicted: [] };
+					branchInfo = null;
 					commits = [];
 					logStale = false;
 					logSkip = 0;
@@ -3370,7 +3446,7 @@ ${bodies}`;
 					// explicitly rather than leaning solely on the reactive view
 					// effects, which can miss the isRepo flip during a busy switch and
 					// leave History stuck on "No commits yet".
-					loadAll().then(() => {
+					loadAll(true).then(() => {
 						if (!isRepo) return;
 						reopenPendingChangesDiff();
 						if (activeView === 'log' && commits.length === 0) loadLog(true);
@@ -3472,19 +3548,44 @@ ${bodies}`;
 
 	// Debounce timer for file/git change events
 	let changeDebounce: ReturnType<typeof setTimeout> | null = null;
+	// Whether the pending refresh must also re-read the slow, rarely-changing
+	// data (stash/tags/contributors/log) — set by `git:changed` only.
+	let pendingFullRefresh = false;
 
-	// Shared refresh logic for both file changes and git state changes
-	function scheduleGitRefresh() {
+	/**
+	 * Shared, debounced refresh for both file changes and git state changes.
+	 *
+	 * Everything funnels through one timer on purpose: `git:changed` used to fire
+	 * six unbounded loads of its own on top of this one, so a burst of git
+	 * activity spawned dozens of overlapping git processes — which is exactly when
+	 * the panel felt slowest.
+	 */
+	function scheduleGitRefresh(full = false) {
+		pendingFullRefresh ||= full;
 		if (changeDebounce) clearTimeout(changeDebounce);
 		changeDebounce = setTimeout(async () => {
 			changeDebounce = null;
+			const isFull = pendingFullRefresh;
+			pendingFullRefresh = false;
+
 			// Refresh git status and branches (branch switch also modifies working tree)
 			const prevBranch = branchInfo?.current;
 			await Promise.all([loadStatus(), loadBranches()]);
 
-			// If branch changed, also refresh remotes
-			if (branchInfo?.current !== prevBranch) {
+			// A branch switch can change the remote set; so can an out-of-band git
+			// operation. Either way, re-read it at most once.
+			if (isFull || branchInfo?.current !== prevBranch) {
 				loadRemotes();
+			}
+
+			if (isFull) {
+				// Keep the Stash/Tags badge counts live when git changes out-of-band
+				// (e.g. `git stash` / `git tag` run from the terminal).
+				loadStash();
+				loadTags();
+				loadContributors();
+				// Refresh log if it was already loaded (History tab was visited)
+				if (commits.length > 0) refreshAllLogs();
 			}
 
 			// Refresh the active diff tab if currently viewing one. The file may
@@ -3502,11 +3603,22 @@ ${bodies}`;
 
 		const unsub = ws.on('files:changed', (payload: any) => {
 			if (payload.projectId !== projectId || !isRepo) return;
+			// An empty change list carries no information; refreshing on it just
+			// churns git and the open diff for nothing.
+			if (payload.changes.length === 0) return;
+			scheduleGitRefresh();
+		});
+
+		// The watcher was rebuilt and may have missed events. Reconcile status, but
+		// as a plain refresh — nothing is known to have changed.
+		const unsubResync = ws.on('files:resync', (payload: any) => {
+			if (payload.projectId !== projectId || !isRepo) return;
 			scheduleGitRefresh();
 		});
 
 		return () => {
 			unsub();
+			unsubResync();
 			if (changeDebounce) {
 				clearTimeout(changeDebounce);
 				changeDebounce = null;
@@ -3520,19 +3632,9 @@ ${bodies}`;
 
 		const unsub = ws.on('git:changed', (payload: any) => {
 			if (payload.projectId !== projectId || !isRepo) return;
-			scheduleGitRefresh();
-			// Refresh branches and remotes in case of branch switch/create/delete
-			loadBranches();
-			loadRemotes();
-			// Keep the Stash/Tags badge counts live when git changes out-of-band
-			// (e.g. `git stash` / `git tag` run from the terminal).
-			loadStash();
-			loadTags();
-			loadContributors();
-			// Refresh log if it was already loaded (History tab was visited)
-			if (commits.length > 0) {
-				refreshAllLogs();
-			}
+			// Full refresh: index/HEAD/refs moved, so branches, remotes, stash, tags,
+			// contributors and the log can all be stale.
+			scheduleGitRefresh(true);
 		});
 
 		return () => unsub();
@@ -5475,7 +5577,7 @@ ${bodies}`;
 			<Icon name="lucide:git-branch" class="w-10 h-10 opacity-30" />
 			<span>No project selected</span>
 		</div>
-	{:else if isLoading && !isRepo}
+	{:else if !statusLoaded}
 		<div class="flex-1 flex flex-col items-center justify-center gap-3 text-slate-600 dark:text-slate-500 text-sm">
 			<div class="w-6 h-6 border-2 border-slate-200 dark:border-slate-800 border-t-violet-600 rounded-full animate-spin"></div>
 			<span>Loading...</span>

--- a/frontend/stores/core/projects.svelte.ts
+++ b/frontend/stores/core/projects.svelte.ts
@@ -14,7 +14,10 @@ import { cleanupProjectState } from '$frontend/utils/project-state-cleanup';
 import {
 	activateProjectWorkspace,
 	raiseSwitchBarrier,
-	lowerSwitchBarrier
+	lowerSwitchBarrier,
+	beginProjectSwitch,
+	isCurrentSwitch,
+	beginPanelLoad
 } from '$frontend/stores/ui/project-workspace.svelte';
 
 // Subscribe to admin-driven project assignment changes for the current user.
@@ -71,68 +74,72 @@ export function currentProjectPath() {
 // PROJECT MANAGEMENT
 // ========================================
 
+/**
+ * Make `project` the active project.
+ *
+ * A switch is generation-guarded: every run takes a token and re-checks it after
+ * each `await` before writing shared state. Clicking through projects quickly
+ * used to leave several of these chains racing — a superseded one would finish
+ * last and publish ITS project as current, so the workspace ended up on a
+ * project the user had already moved past (or stuck behind a barrier whose
+ * raise/release no longer paired up).
+ *
+ * The structural swap (WS room, workspace layout, dock view-state) runs behind
+ * the switch barrier because showing anything mid-swap means showing the wrong
+ * project. Everything else — sessions, messages, edit mode, dock data — loads
+ * after reveal behind each panel's own skeleton, so switch latency is one round
+ * trip plus a blob fetch instead of the sum of every subsystem's load.
+ */
 export async function setCurrentProject(project: Project | null) {
-	// Only clear session if we're actually switching to a different project
-	const { sessionState, setCurrentSession } = await import('./sessions.svelte');
+	const { setCurrentSession } = await import('./sessions.svelte');
 	const { appState } = await import('./app.svelte');
 
-	// Sync project context with WebSocket (for room-based broadcasting)
-	// IMPORTANT: Must await to ensure server has context before other operations
-	await ws.setProject(project?.id ?? null);
-
-	// Check if we're switching to a different project
 	const currentProjectId = projectState.currentProject?.id;
 	const newProjectId = project?.id;
 	const isProjectSwitch = currentProjectId !== newProjectId;
 
-	// Raise the switch barrier as early as possible — BEFORE the terminal context
-	// swap below — so the uniform dock skeletons cover the entire transition,
-	// including the terminal's clear-then-restore. Balanced by lowerSwitchBarrier()
-	// in the session-transition block's finally (same isProjectSwitch condition).
-	if (isProjectSwitch) raiseSwitchBarrier();
-
-	// Handle project status tracking and terminal context switching
-	if (typeof window !== 'undefined') {
-		try {
-			// Import services dynamically to avoid circular dependency
-			const { projectStatusService } = await import('$frontend/services/project');
-
-			// Stop tracking previous project if switching
-			if (currentProjectId && currentProjectId !== newProjectId) {
-				await projectStatusService.stopTracking();
-
-				// Reset loading state when switching projects
-				appState.isLoading = false;
-			}
-
-			// Start tracking new project. The terminal context is now restored by the
-			// terminal dock inside activateProjectWorkspace() (below) — deterministically
-			// under the switch barrier — instead of out-of-band here, which used to race
-			// the WS room change and leave the new project's terminal blank until a
-			// second project-click.
-			if (project?.id) {
-				await projectStatusService.startTracking(project.id);
-			}
-		} catch (error) {
-			debug.error('project', 'Error updating project tracking:', error);
+	if (!isProjectSwitch) {
+		// Same project — no transition, just refresh the record.
+		await ws.setProject(newProjectId ?? null);
+		projectState.currentProject = project;
+		if (project) {
+			persistCurrentProjectId(project.id);
+			void refreshProjectRecord(project.id);
+		} else {
+			persistCurrentProjectId(null);
 		}
+		return;
 	}
 
-	// If switching to a different project, handle session transition.
-	// The switch barrier was already raised above (before the terminal swap); it
-	// is released in this block's finally so skeletons stay up for the whole
-	// transition — no stale data, no staggered fade-ins.
-	if (isProjectSwitch) {
-		try {
-		// Set restoring flag FIRST - prevents reactive effects from syncing stale state
-		// to the new project during transition
-		if (project) {
-			appState.isRestoring = true;
-		}
+	const token = beginProjectSwitch();
+
+	// Raise the barrier as early as possible so no frame of the outgoing project
+	// survives into the new one. Released as soon as the workspace is
+	// structurally correct — not once all data has arrived.
+	raiseSwitchBarrier();
+
+	// Held for the whole transition so panels keep their skeletons (and reactive
+	// effects keep their "don't persist stale state" guard) until the chat
+	// session has actually landed.
+	const releaseChat = project ? beginPanelLoad('chat', token) : null;
+	if (project) appState.isRestoring = true;
+
+	try {
+		// Sync project context with WebSocket (for room-based broadcasting).
+		// IMPORTANT: must complete before anything project-scoped is requested,
+		// so this one stays sequential.
+		await ws.setProject(newProjectId ?? null);
+		if (!isCurrentSwitch(token)) return;
+
+		// Presence tracking is independent of the workspace swap — startTracking()
+		// already leaves the previous project — so let it run alongside instead of
+		// adding two round trips in front of the visible transition.
+		const tracking = swapPresenceTracking(newProjectId);
+		if (currentProjectId) appState.isLoading = false;
 
 		// Swap the per-project workspace: clears all docks, restores this
-		// project's layout + dock view-state, and awaits dock data loads under
-		// the same barrier.
+		// project's layout + dock view-state, then starts each dock's data load
+		// behind its own panel skeleton.
 		//
 		// Publish the new current project via the coordinator's post-restore
 		// hook so it lands in the SAME synchronous flush as the layout swap.
@@ -140,105 +147,138 @@ export async function setCurrentProject(project: Project | null) {
 		// currentProject still points at the OLD project — they load the wrong
 		// project, then race a reload, and can end up blank until a full refresh.
 		// isRestoring is already true (set above), so effects that fire on this
-		// change still see the transition flag and won't persist stale state —
-		// matching the previous (late) assignment's intent.
-		await activateProjectWorkspace(project?.id ?? null, () => {
-			if (project) projectState.currentProject = project;
-		});
+		// change still see the transition flag and won't persist stale state.
+		await activateProjectWorkspace(
+			newProjectId ?? null,
+			() => {
+				if (project) projectState.currentProject = project;
+			},
+			token
+		);
+		if (!isCurrentSwitch(token)) return;
 
-		// Clear edit mode state from previous project (server retains per-project state)
 		const { onProjectLeave, onProjectEnter } = await import('$frontend/stores/ui/edit-mode.svelte');
 		onProjectLeave();
-
-		// Clear current session when switching projects
 		await setCurrentSession(null);
+		if (!isCurrentSwitch(token)) return;
 
-		// If we have a new project, try to restore or create a session for it
-		if (project) {
-			try {
-				// Import session management functions
-				const { createSession, getSessionsForProject, reloadSessionsForProject } = await import('./sessions.svelte');
-
-				// Reload all sessions for this project from server
-				// (local state may only have sessions from the previous project)
-				const savedSessionId = await reloadSessionsForProject();
-
-				// Check if there's an existing session for this project
-				const existingSessions = getSessionsForProject(project.id);
-				const activeSessions = existingSessions
-					.filter(s => !s.ended_at)
-					.sort((a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime());
-
-				// Try server-saved session first (preserves user's last selected session)
-				let activeSession = savedSessionId
-					? activeSessions.find(s => s.id === savedSessionId) || null
-					: null;
-				// Fall back to most recent active session
-				if (!activeSession) {
-					activeSession = activeSessions[0] || null;
-				}
-
-				if (activeSession) {
-					// Restore the most recent active session for this project
-					debug.log('project', 'Restoring existing session for project:', activeSession.id);
-					await setCurrentSession(activeSession);
-				} else {
-					// Create a new session for this project
-					debug.log('project', 'Creating new session for project:', project.id);
-					const newSession = await createSession(project.id, 'Chat Session', false);
-					if (newSession) {
-						await setCurrentSession(newSession);
-					}
-				}
-
-				// Restore edit mode from server for the new project
-				// (ws.setProject already completed, so server returns correct project's state)
-				await onProjectEnter();
-
-				// projectState.currentProject was already published above via the
-				// activateProjectWorkspace post-restore hook (batched with the layout
-				// swap). It is still set while isRestoring is true, so the original
-				// guarantee — reactive effects see the transition flag and don't
-				// persist stale state — is preserved.
-			} finally {
-				// Clear restoring flag after project state is fully set
-				appState.isRestoring = false;
-			}
-		}
-		} finally {
-			lowerSwitchBarrier();
-		}
-	} else {
-		projectState.currentProject = project;
+		await tracking;
+	} finally {
+		// Reveal: the workspace is now structurally the new project's.
+		lowerSwitchBarrier();
 	}
 
-	if (project) {
-		// Save current project ID to server
-		ws.http('user:save-state', { key: 'currentProjectId', value: project.id }).catch(err => {
-			debug.error('project', 'Error saving project state to server:', err);
-		});
+	if (!isCurrentSwitch(token)) {
+		releaseChat?.();
+		return;
+	}
 
-		try {
-			// Update last opened time via WebSocket
-			const updatedProject = await ws.http('projects:get', { id: project.id });
-
-			if (updatedProject) {
-				// Update in local state
-				const index = projectState.projects.findIndex(p => p.id === project.id);
-				if (index !== -1) {
-					projectState.projects[index] = updatedProject;
-				}
-				projectState.currentProject = updatedProject;
-			}
-		} catch (error) {
-			debug.error('project', 'Error updating project last opened:', error);
-		}
-	} else {
-		// Save null to server
-		ws.http('user:save-state', { key: 'currentProjectId', value: null }).catch(err => {
-			debug.error('project', 'Error clearing project state on server:', err);
-		});
+	if (!project) {
+		appState.isRestoring = false;
+		persistCurrentProjectId(null);
 		debug.log('project', 'Project cleared');
+		return;
+	}
+
+	persistCurrentProjectId(project.id);
+
+	// Everything below runs AFTER the reveal, behind the chat panel's skeleton.
+	try {
+		await restoreSessionForProject(project, token);
+	} finally {
+		if (isCurrentSwitch(token)) appState.isRestoring = false;
+		releaseChat?.();
+	}
+
+	if (isCurrentSwitch(token)) await refreshProjectRecord(project.id);
+}
+
+/** Move presence tracking to `projectId` (or drop it when null). */
+async function swapPresenceTracking(projectId: string | undefined): Promise<void> {
+	if (typeof window === 'undefined') return;
+	try {
+		const { projectStatusService } = await import('$frontend/services/project');
+		if (projectId) {
+			// startTracking() stops the previous project itself.
+			await projectStatusService.startTracking(projectId);
+		} else {
+			await projectStatusService.stopTracking();
+		}
+	} catch (error) {
+		debug.error('project', 'Error updating project tracking:', error);
+	}
+}
+
+/**
+ * Restore (or create) the chat session for a freshly-activated project and
+ * restore its edit mode. Runs after reveal; every write is guarded by `token`
+ * so a superseded switch can never install its session into the live project.
+ */
+async function restoreSessionForProject(project: Project, token: number): Promise<void> {
+	const { setCurrentSession, createSession, getSessionsForProject, reloadSessionsForProject } =
+		await import('./sessions.svelte');
+	const { onProjectEnter } = await import('$frontend/stores/ui/edit-mode.svelte');
+
+	try {
+		// Reload all sessions for this project from server
+		// (local state may only have sessions from the previous project)
+		const savedSessionId = await reloadSessionsForProject();
+		if (!isCurrentSwitch(token)) return;
+
+		const activeSessions = getSessionsForProject(project.id)
+			.filter((s) => !s.ended_at)
+			.sort((a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime());
+
+		// Try server-saved session first (preserves user's last selected session),
+		// then fall back to the most recent active one.
+		const activeSession =
+			(savedSessionId ? activeSessions.find((s) => s.id === savedSessionId) : null) ||
+			activeSessions[0] ||
+			null;
+
+		if (activeSession) {
+			debug.log('project', 'Restoring existing session for project:', activeSession.id);
+			await setCurrentSession(activeSession);
+		} else {
+			debug.log('project', 'Creating new session for project:', project.id);
+			const newSession = await createSession(project.id, 'Chat Session', false);
+			if (newSession && isCurrentSwitch(token)) {
+				await setCurrentSession(newSession);
+			}
+		}
+		if (!isCurrentSwitch(token)) return;
+
+		// Restore edit mode from server for the new project
+		// (ws.setProject already completed, so server returns correct project's state)
+		await onProjectEnter();
+	} catch (error) {
+		debug.error('project', 'Error restoring session for project:', error);
+	}
+}
+
+/** Persist the active project id server-side (fire and forget). */
+function persistCurrentProjectId(projectId: string | null): void {
+	ws.http('user:save-state', { key: 'currentProjectId', value: projectId }).catch((err) => {
+		debug.error('project', 'Error saving project state to server:', err);
+	});
+}
+
+/** Re-read a project so `last_opened_at` and any server-side edits are current. */
+async function refreshProjectRecord(projectId: string): Promise<void> {
+	try {
+		const updatedProject = await ws.http('projects:get', { id: projectId });
+		if (!updatedProject) return;
+
+		const index = projectState.projects.findIndex((p) => p.id === projectId);
+		if (index !== -1) {
+			projectState.projects[index] = updatedProject;
+		}
+		// Only adopt it as current if the user hasn't moved on in the meantime.
+		if (projectState.currentProject?.id === projectId) {
+			projectState.currentProject = updatedProject;
+		}
+	} catch (error) {
+		debug.error('project', 'Error updating project last opened:', error);
 	}
 }
 

--- a/frontend/stores/features/git-status.svelte.ts
+++ b/frontend/stores/features/git-status.svelte.ts
@@ -30,6 +30,7 @@ let inFlight = false;
 let pendingRefresh = false;
 let unsubscribeFiles: (() => void) | null = null;
 let unsubscribeGit: (() => void) | null = null;
+let unsubscribeResync: (() => void) | null = null;
 let lastProjectId = '';
 
 /**
@@ -147,11 +148,18 @@ export function initGitStatus(): void {
 	if (unsubscribeFiles || unsubscribeGit) return;
 	unsubscribeFiles = ws.on('files:changed', (payload) => {
 		if (payload.projectId !== projectState.currentProject?.id) return;
+		// An empty change list says nothing changed — refreshing on it would spawn
+		// a git process for no reason.
+		if (payload.changes.length === 0) return;
 		refreshGitStatus(500);
 	});
 	unsubscribeGit = ws.on('git:changed', (payload) => {
 		if (payload.projectId !== projectState.currentProject?.id) return;
 		refreshGitStatus(150);
+	});
+	unsubscribeResync = ws.on('files:resync', (payload) => {
+		if (payload.projectId !== projectState.currentProject?.id) return;
+		refreshGitStatus(500);
 	});
 }
 

--- a/frontend/stores/features/ignored-paths.svelte.ts
+++ b/frontend/stores/features/ignored-paths.svelte.ts
@@ -61,6 +61,8 @@ export function initIgnoredPaths(): void {
 	if (unsubscribeFiles || unsubscribeGit) return;
 	unsubscribeFiles = ws.on('files:changed', (payload) => {
 		if (payload.projectId !== projectState.currentProject?.id) return;
+		// Nothing actually changed — don't spend a round trip on it.
+		if (payload.changes.length === 0) return;
 		refreshIgnoredPaths(500);
 	});
 	unsubscribeGit = ws.on('git:changed', (payload) => {

--- a/frontend/stores/features/preview-tabs-workspace.svelte.ts
+++ b/frontend/stores/features/preview-tabs-workspace.svelte.ts
@@ -395,6 +395,7 @@ async function reconcileTabs(projectId: string): Promise<void> {
 
 registerDock({
 	id: 'preview-tabs',
+	panelId: 'preview',
 	clear() {
 		// Wipe the outgoing project's tabs so nothing flashes through the switch.
 		previewTabManager.clearAllTabs();
@@ -433,9 +434,10 @@ registerDock({
 		await reconcileTabs(projectId);
 
 		// Authoritative seeding: when neither snapshot nor backend produced any
-		// tabs, drop a single empty tab inside the switch barrier. This is the ONLY
-		// place the panel seeds itself on a project switch — the component never
-		// adds "New Tab" speculatively, so the count matches MCP/backend exactly.
+		// tabs, drop a single empty tab while the panel still shows its loading
+		// skeleton. This is the ONLY place the panel seeds itself on a project
+		// switch — the component never adds "New Tab" speculatively, so the count
+		// matches MCP/backend exactly.
 		if (previewTabManager.getAllTabs().length === 0) {
 			debug.log('preview', '📝 [dock load] Seeding empty tab for empty project');
 			previewTabManager.createTab('');

--- a/frontend/stores/features/terminal-workspace.svelte.ts
+++ b/frontend/stores/features/terminal-workspace.svelte.ts
@@ -59,6 +59,7 @@ export function markTerminalDirty(): void {
 
 registerDock({
 	id: 'terminal',
+	panelId: 'terminal',
 	snapshot() {
 		const projectId = getActiveWorkspaceProjectId();
 		if (!projectId) return undefined;

--- a/frontend/stores/ui/project-workspace.svelte.ts
+++ b/frontend/stores/ui/project-workspace.svelte.ts
@@ -11,8 +11,13 @@
  *                content can never flash through during a switch
  *   - snapshot() produce its serializable slice of the active project's blob
  *   - restore()  apply a restored slice before the new project is revealed
- *   - load()     kick async data loading; the switch barrier awaits this so all
- *                docks reveal together ("skeleton serempak")
+ *   - load()     kick async data loading; this runs AFTER the reveal, behind the
+ *                dock's panel skeleton, so one slow dock can't hold up the rest
+ *
+ * The transition is split in two on purpose. The switch barrier covers only the
+ * structural swap — the phase where any pixel on screen would belong to the
+ * previous project. Data loading happens after, per panel, so switch latency is
+ * bounded by one round trip rather than the sum of every subsystem's load.
  *
  * The coordinator is intentionally dependency-light: it never imports the dock
  * modules. Docks call `registerDock()` at module load and hand the coordinator
@@ -23,6 +28,9 @@ import ws from '$frontend/utils/ws';
 import { appState } from '$frontend/stores/core/app.svelte';
 import { registerProjectCleanup } from '$frontend/utils/project-state-cleanup';
 import { debug } from '$shared/utils/logger';
+// Type-only import: the layout dock lives in workspace.svelte and imports this
+// module at runtime, so anything but `import type` here would be a cycle.
+import type { PanelId } from '$frontend/stores/ui/workspace.svelte';
 
 const BLOB_VERSION = 1;
 
@@ -35,13 +43,18 @@ type WorkspaceBlob = {
 export interface DockController {
 	/** Stable id; also the key under which this dock's slice lives in the blob. */
 	id: string;
+	/**
+	 * Panel this dock's data belongs to. While `load()` runs, that panel shows a
+	 * skeleton (see `isPanelLoading`) instead of an empty state.
+	 */
+	panelId?: PanelId;
 	/** Reset in-memory view data so old-project content can't flash through. */
 	clear?: () => void;
 	/** Produce this dock's serializable slice for the active project. */
 	snapshot?: () => unknown;
 	/** Apply a restored slice (or undefined when the project has no saved blob). */
 	restore?: (slice: unknown) => void;
-	/** Kick async data load for the project; the switch barrier awaits this. */
+	/** Kick async data load for the project; runs after reveal, behind a skeleton. */
 	load?: (projectId: string) => Promise<void> | void;
 }
 
@@ -71,10 +84,40 @@ function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T
 let activeProjectId: string | null = null;
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 
+// True from the moment a switch starts until every dock has finished hydrating.
+// Spans past the barrier now that docks load after reveal, and suppresses saves
+// that would otherwise persist a half-loaded workspace.
+let settling = false;
+let settleTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Upper bound on any post-reveal loading state. Nothing that hides UI or blocks
+ * persistence may depend solely on a promise resolving: a socket that never
+ * answers would otherwise leave a panel on "Loading…" or stop workspace saves
+ * for the rest of the session, with no way back short of a refresh.
+ */
+const LOAD_SAFETY_TIMEOUT_MS = 15_000;
+
+function markSettling(): void {
+	settling = true;
+	if (settleTimer) clearTimeout(settleTimer);
+	settleTimer = setTimeout(() => {
+		settleTimer = null;
+		settling = false;
+	}, LOAD_SAFETY_TIMEOUT_MS);
+}
+
+function markSettled(): void {
+	if (settleTimer) clearTimeout(settleTimer);
+	settleTimer = null;
+	settling = false;
+}
+
 // The switch barrier is ref-counted so the project store can hold it up across
-// the *entire* switch (sessions, edit-mode, …) while the coordinator also
-// raises it for its own clear/restore/load phase. Skeletons stay visible until
-// every holder releases — so all docks reveal together exactly once.
+// the structural part of a switch while the coordinator also raises it for its
+// own clear/restore phase. It covers ONLY the phase during which showing
+// anything would mean showing the wrong project — data loading happens after
+// reveal, behind each panel's own skeleton (see `beginPanelLoad`).
 let barrierDepth = 0;
 
 export function raiseSwitchBarrier(): void {
@@ -85,6 +128,105 @@ export function raiseSwitchBarrier(): void {
 export function lowerSwitchBarrier(): void {
 	barrierDepth = Math.max(0, barrierDepth - 1);
 	if (barrierDepth === 0) appState.isSwitching = false;
+}
+
+// ============================================================
+// SWITCH GENERATION
+// ============================================================
+//
+// Every project switch takes a token. Any state write that happens after an
+// `await` must first check it still owns the current token, otherwise a switch
+// the user already abandoned (A→B→C in quick succession) finishes late and
+// overwrites the project they actually landed on. Without this, rapid switching
+// left panels showing a mix of two projects — or stuck on a skeleton, because a
+// superseded run's barrier release never matched its raise.
+
+let switchToken = 0;
+
+/** Start a new switch generation and return its token. */
+export function beginProjectSwitch(): number {
+	switchToken += 1;
+	// A new switch supersedes every panel load still attributed to the old one.
+	clearPanelLoads();
+	return switchToken;
+}
+
+/** Whether `token` is still the newest switch (i.e. its work is still wanted). */
+export function isCurrentSwitch(token: number): boolean {
+	return token === switchToken;
+}
+
+// ============================================================
+// PER-PANEL LOADING
+// ============================================================
+//
+// The switch barrier hides every panel at once, so it must be short. Everything
+// that loads after reveal registers here instead, and the panel renders a
+// skeleton for as long as it is registered. This is what stops a panel from
+// showing "No files in project" / "Not a git repository" while its data is
+// still in flight — an empty state now means genuinely empty, never "not
+// loaded yet".
+
+// The holder counts live in a PLAIN map, deliberately outside the reactive
+// graph. `beginPanelLoad` is called from inside component `$effect`s, and a
+// read-modify-write of reactive state there (`loads[id] = loads[id] + 1`) makes
+// the effect a reader of the very state it writes — it invalidates itself and
+// Svelte aborts with `effect_update_depth_exceeded`. Keeping the counter
+// non-reactive means registering a load only ever WRITES reactive state.
+const panelLoadCounts = new Map<PanelId, number>();
+
+// The reactive mirror consumers read. Keys are declared up front and only ever
+// reassigned, never added or deleted: on a `$state` object a new/removed key
+// invalidates every reader of the object, so one panel starting to load would
+// otherwise re-render all the others.
+const panelLoading = $state<Record<PanelId, boolean>>({
+	chat: false,
+	files: false,
+	git: false,
+	terminal: false,
+	preview: false
+});
+
+function setPanelLoadCount(panelId: PanelId, count: number): void {
+	if (count > 0) panelLoadCounts.set(panelId, count);
+	else panelLoadCounts.delete(panelId);
+	panelLoading[panelId] = count > 0;
+}
+
+/**
+ * Mark `panelId` as loading until the returned release function is called.
+ * Safe to nest; the panel stays in its loading state until the last holder
+ * releases. Releasing is idempotent, and a release belonging to a superseded
+ * switch is discarded rather than decrementing the new switch's count.
+ */
+export function beginPanelLoad(panelId: PanelId, token = switchToken): () => void {
+	if (token !== switchToken) return () => {};
+	setPanelLoadCount(panelId, (panelLoadCounts.get(panelId) ?? 0) + 1);
+
+	let released = false;
+	const release = () => {
+		if (released) return;
+		released = true;
+		clearTimeout(safety);
+		if (token !== switchToken) return;
+		setPanelLoadCount(panelId, (panelLoadCounts.get(panelId) ?? 1) - 1);
+	};
+
+	// A caller that never releases (a request that never answers, a component
+	// torn down mid-load) must not leave its panel showing "Loading…" forever.
+	const safety = setTimeout(release, LOAD_SAFETY_TIMEOUT_MS);
+	return release;
+}
+
+/** Whether `panelId` is waiting on data and should render a skeleton. */
+export function isPanelLoading(panelId: PanelId): boolean {
+	return panelLoading[panelId];
+}
+
+/** Drop every registered panel load (a new switch supersedes all of them). */
+function clearPanelLoads(): void {
+	for (const panelId of panelLoadCounts.keys()) panelLoading[panelId] = false;
+	panelLoadCounts.clear();
 }
 
 /** Register a dock controller. Idempotent per id (last registration wins). */
@@ -166,9 +308,11 @@ async function flushActiveBlob(): Promise<void> {
 export function requestWorkspaceSave(): void {
 	if (!activeProjectId) return;
 	// Ignore reactive saves triggered while a switch is in flight — the leaving
-	// project was already flushed and docks are mid clear/restore, so a save now
-	// would persist transient/cleared state. Real edits resume after the switch.
-	if (appState.isSwitching) return;
+	// project was already flushed and docks are mid clear/restore/hydrate, so a
+	// save now would persist transient/cleared state. `settling` extends this
+	// past the reveal, because docks keep hydrating after the barrier drops.
+	// Real edits resume once everything has landed.
+	if (appState.isSwitching || settling) return;
 	if (saveTimer) clearTimeout(saveTimer);
 	saveTimer = setTimeout(() => {
 		saveTimer = null;
@@ -194,12 +338,20 @@ async function flushPendingSave(): Promise<void> {
  *
  * Sequence:
  *   1. flush the outgoing project's blob so nothing is lost
- *   2. raise the switch barrier (docks show uniform skeletons)
+ *   2. raise the switch barrier (panels show a uniform "Loading…")
  *   3. clear() every dock so no stale data can flash through
  *   4. fetch the new project's blob and restore() every dock's slice
  *   4b. run `onAfterRestore` (see below)
- *   5. await every dock's load() so they're all ready before reveal
- *   6. drop the barrier — all docks reveal together
+ *   5. START every dock's load() WITHOUT awaiting it, each registered against
+ *      its panel so that panel renders a skeleton until its data lands
+ *   6. drop the barrier — the workspace is revealed as soon as it is structurally
+ *      correct, not once every byte has arrived
+ *
+ * Step 5 used to await all loads under the barrier. That made a switch cost the
+ * sum of every dock's slowest round-trip with the whole workspace blanked, which
+ * on a large project read as "switching projects is very slow". Loading behind
+ * per-panel skeletons costs the same wall-clock but the workspace is usable —
+ * and correct — almost immediately, and a slow dock only holds up its own panel.
  *
  * `onAfterRestore` runs synchronously between the dock restore loop (4) and the
  * load phase (5) — i.e. in the SAME synchronous block as `applyLayoutSlice`,
@@ -217,15 +369,21 @@ async function flushPendingSave(): Promise<void> {
  */
 export async function activateProjectWorkspace(
 	projectId: string | null,
-	onAfterRestore?: () => void
+	onAfterRestore?: () => void,
+	token = switchToken
 ): Promise<void> {
 	// Nothing to do if we're already on this project.
 	if (projectId === activeProjectId) return;
 
-	// 1. Persist the project we're leaving.
-	if (activeProjectId) {
+	// 1. Persist the project we're leaving — but only from a settled workspace.
+	// Mid-transition its docks are cleared or half-hydrated, and the switch that
+	// put them in that state already flushed it, so snapshotting now would
+	// overwrite a good blob with a transient one.
+	if (activeProjectId && !settling) {
 		await flushPendingSave();
 	}
+	if (!isCurrentSwitch(token)) return;
+	markSettling();
 
 	const previousId = activeProjectId;
 	activeProjectId = projectId;
@@ -243,6 +401,7 @@ export async function activateProjectWorkspace(
 	}
 
 	if (!projectId) {
+		markSettled();
 		lowerSwitchBarrier();
 		debug.log('workspace', `Workspace deactivated (was ${previousId ?? 'none'})`);
 		return;
@@ -251,6 +410,8 @@ export async function activateProjectWorkspace(
 	try {
 		// 4. Restore slices from the (cached or server) blob.
 		const blob = await fetchBlob(projectId);
+		if (!isCurrentSwitch(token)) return;
+
 		for (const dock of docks.values()) {
 			try {
 				dock.restore?.(blob.docks[dock.id]);
@@ -268,20 +429,28 @@ export async function activateProjectWorkspace(
 			debug.error('workspace', 'onAfterRestore failed:', err);
 		}
 
-		// 5. Await every dock's critical data load so they reveal together.
-		// Each load is bounded by a timeout: a single stalled dock (e.g. the
-		// terminal waiting on a slow WS round-trip) must never wedge the barrier
-		// up and leave the workspace stuck on "Loading…" forever. A timed-out dock
-		// simply finishes loading in the background after reveal.
-		await Promise.all(
-			[...docks.values()].map(async (dock) => {
-				try {
-					await withTimeout(Promise.resolve(dock.load?.(projectId)), 8000, undefined);
-				} catch (err) {
-					debug.error('workspace', `Dock ${dock.id} load failed:`, err);
-				}
-			})
-		);
+		// 5. Kick each dock's data load WITHOUT blocking the reveal. The load is
+		// registered against the dock's panel, so that panel shows a skeleton
+		// until its data lands while every other panel is already interactive.
+		// The timeout only bounds how long a stalled dock may hold its own
+		// skeleton up — it can no longer wedge the whole workspace.
+		const loads = [...docks.values()].map(async (dock) => {
+			if (!dock.load) return;
+			const release = dock.panelId ? beginPanelLoad(dock.panelId, token) : null;
+			try {
+				await withTimeout(Promise.resolve(dock.load(projectId)), 8000, undefined);
+			} catch (err) {
+				debug.error('workspace', `Dock ${dock.id} load failed:`, err);
+			} finally {
+				release?.();
+			}
+		});
+
+		// Resume workspace saves only once the loads settle: a save fired while a
+		// dock is still hydrating would snapshot its half-restored state.
+		void Promise.all(loads).then(() => {
+			if (isCurrentSwitch(token)) markSettled();
+		});
 	} finally {
 		// 6. Reveal (drops to hidden only once all barrier holders release).
 		lowerSwitchBarrier();
@@ -303,6 +472,7 @@ export function evictProjectWorkspace(projectId: string): void {
 export function clearAllWorkspaceCache(): void {
 	cache.clear();
 	activeProjectId = null;
+	markSettled();
 }
 
 // Drop a deleted project's cached blob automatically.


### PR DESCRIPTION
## Summary

Fixes three workspace-loading problems reported across platforms: a Git editor
that reloaded every few seconds on Linux, slow project switching, and panels
showing empty states while still loading.

## Why

**Editor reload loop (Linux).** `fs.watch` recursion is inotify-based on Linux
and costs one kernel watch per directory, with no way to exclude any. A project
containing `node_modules` exhausts `fs.inotify.max_user_watches`; the watcher
faults with ENOSPC, is rebuilt on a fixed 1s timer, and faults again — forever.
Each restart also emitted `files:changed` with an empty change list, which the
Git panel could not distinguish from a real edit, so it replaced the open diff
tab with a loading placeholder every cycle. Separately, `git status` rewrites
`.git/index`, which tripped our own `.git` watcher and fed the same refresh
path.

**Slow switching.** `setCurrentProject` was a fully sequential chain of ~10
round trips, and the "Loading…" barrier covered every panel for its entire
duration — so the wait was the *sum* of every subsystem's load, not the longest
one. Nothing was generation-guarded, so clicking through projects quickly left
several chains racing and a superseded one could finish last.

**Missing loaders.** Panels used `isLoading && list.length === 0`, which cannot
tell "not loaded yet" from "genuinely empty". FilesPanel made it unreachable:
a switch that restored panel state passed `preserveState=true`, which also
suppressed the loading flag, so the tree rendered its empty state — "No files in
project" — mid-fetch.

## Changes

- `backend/files/file-watcher.ts` — platform-split watching. Linux recurses
  manually and never watches an ignored directory; macOS/Windows keep the
  native recursive handle. Restarts use exponential backoff and give up; a
  rebuild emits the new `files:resync` instead of an empty `files:changed`.
  Directory watches are capped, with an honest warning to the client.
- `backend/git/git-executor.ts` — `GIT_OPTIONAL_LOCKS=0`, so read-only git
  commands stay read-only.
- `frontend/stores/ui/project-workspace.svelte.ts` — the barrier covers only
  the structural swap; dock `load()` runs after reveal against a per-panel
  loading registry. Switch generation tokens.
- `frontend/stores/core/projects.svelte.ts` — token-guarded switch, independent
  work parallelised.
- `GitPanel` — `viewDiff` refreshes in place instead of rebuilding the tab, and
  the six unbounded loads on `git:changed` are folded into one debounce.
- `FilesPanel`, `GitPanel`, `PanelContainer` — loading and empty states
  separated; per-panel skeleton overlay.

## Testing

`bun run check` and `bun run lint` are clean. Full suite: 410 pass / 12 fail —
the 12 failures are identical on a clean tree (pre-existing, unrelated to this
change).

Adds `backend/files/file-watcher.test.ts` (6 tests), run twice: once on the
native path and once with `USE_NATIVE_RECURSIVE_WATCH` forced to `false` so the
Linux manual-recursion branch is actually exercised, including watching
directories created after start-up.

## Notes

- While writing the tests, Bun's `fs.watch` was observed dropping events when
  several writes land in the same notification batch (reproduced on macOS).
  Not introduced here, but it means watching is best-effort under heavy churn —
  part of why `files:resync` exists.