### PR TITLE
fix(git): support undoing the root commit and guard empty repos

### DIFF
--- a/backend/git/git-service.test.ts
+++ b/backend/git/git-service.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execGit } from './git-executor';
+import { gitService } from './git-service';
+
+/**
+ * These cover the two states where HEAD-relative revisions don't resolve:
+ * an unborn HEAD (fresh `git init`) and a lone root commit (no `HEAD~1`).
+ * Both used to surface git's raw `fatal: ambiguous argument` in the UI.
+ */
+
+let repo: string;
+
+async function git(...args: string[]) {
+	const result = await execGit(args, repo);
+	if (result.exitCode !== 0) throw new Error(`git ${args.join(' ')}: ${result.stderr}`);
+	return result.stdout;
+}
+
+async function commitAll(message: string) {
+	await git('add', '-A');
+	await git('commit', '-m', message);
+}
+
+beforeEach(async () => {
+	repo = await mkdtemp(path.join(tmpdir(), 'clopen-git-'));
+	await git('init', '-b', 'main', '.');
+	await git('config', 'user.email', 'test@example.com');
+	await git('config', 'user.name', 'Test');
+	await git('config', 'commit.gpgsign', 'false');
+});
+
+afterEach(async () => {
+	await rm(repo, { recursive: true, force: true });
+});
+
+describe('undoLastCommit — no commits yet', () => {
+	test('reports an actionable message instead of git\'s fatal', async () => {
+		await expect(gitService.undoLastCommit(repo, 'soft')).rejects.toThrow(/no commits yet/i);
+	});
+});
+
+describe('undoLastCommit — root commit', () => {
+	beforeEach(async () => {
+		await writeFile(path.join(repo, 'a.txt'), 'hello\n');
+		await mkdir(path.join(repo, 'src'), { recursive: true });
+		await writeFile(path.join(repo, 'src', 'b.txt'), 'world\n');
+		await commitAll('init');
+		// An unrelated untracked file must survive every mode, including --hard.
+		await writeFile(path.join(repo, 'keep.txt'), 'untracked\n');
+	});
+
+	test('soft removes the commit and keeps its files staged', async () => {
+		await gitService.undoLastCommit(repo, 'soft');
+
+		const status = await gitService.getStatus(repo);
+		expect(status.staged.map(f => f.path).sort()).toEqual(['a.txt', 'src/b.txt']);
+		expect((await execGit(['rev-parse', '--verify', '--quiet', 'HEAD'], repo)).exitCode).not.toBe(0);
+		expect(existsSync(path.join(repo, 'keep.txt'))).toBe(true);
+	});
+
+	test('mixed removes the commit and leaves its files untracked', async () => {
+		await gitService.undoLastCommit(repo, 'mixed');
+
+		const status = await gitService.getStatus(repo);
+		expect(status.staged).toHaveLength(0);
+		expect(status.untracked.map(f => f.path).sort()).toEqual(['a.txt', 'keep.txt', 'src/b.txt']);
+	});
+
+	test('hard removes the commit and deletes only its files', async () => {
+		await gitService.undoLastCommit(repo, 'hard');
+
+		expect(existsSync(path.join(repo, 'a.txt'))).toBe(false);
+		expect(existsSync(path.join(repo, 'src', 'b.txt'))).toBe(false);
+		expect(existsSync(path.join(repo, 'keep.txt'))).toBe(true);
+		expect((await execGit(['rev-parse', '--verify', '--quiet', 'HEAD'], repo)).exitCode).not.toBe(0);
+	});
+
+	test('hard on an empty root commit leaves the repo unborn without erroring', async () => {
+		await rm(path.join(repo, 'keep.txt'));
+		await git('update-ref', '-d', 'HEAD');
+		await git('reset');
+		await git('commit', '--allow-empty', '-m', 'empty');
+
+		await gitService.undoLastCommit(repo, 'hard');
+
+		expect((await execGit(['rev-parse', '--verify', '--quiet', 'HEAD'], repo)).exitCode).not.toBe(0);
+	});
+});
+
+describe('undoLastCommit — with a parent commit', () => {
+	test('soft moves HEAD back one commit and restages the change', async () => {
+		await writeFile(path.join(repo, 'a.txt'), 'one\n');
+		await commitAll('first');
+		await writeFile(path.join(repo, 'a.txt'), 'two\n');
+		await commitAll('second');
+
+		await gitService.undoLastCommit(repo, 'soft');
+
+		const log = await gitService.getLog(repo);
+		expect(log.commits.map(c => c.message)).toEqual(['first']);
+		const status = await gitService.getStatus(repo);
+		expect(status.staged.map(f => f.path)).toEqual(['a.txt']);
+	});
+});
+
+describe('other actions on a repo with no commits', () => {
+	test('getLog reports an empty history rather than throwing', async () => {
+		expect(await gitService.getLog(repo)).toEqual({ commits: [], total: 0, hasMore: false });
+	});
+
+	test('revertCommit explains there is nothing to revert', async () => {
+		const result = await gitService.revertCommit(repo);
+		expect(result.success).toBe(false);
+		expect(result.message).toMatch(/no commits yet/i);
+	});
+
+	test('amendCommit points at creating the first commit', async () => {
+		await expect(gitService.amendCommit(repo)).rejects.toThrow(/no commit to amend/i);
+	});
+
+	test('stashSave explains a commit is required', async () => {
+		await writeFile(path.join(repo, 'a.txt'), 'hello\n');
+		await expect(gitService.stashSave(repo)).rejects.toThrow(/at least one commit/i);
+	});
+
+	test('push explains there is nothing to push', async () => {
+		await git('remote', 'add', 'origin', path.join(repo, 'nonexistent.git'));
+		const result = await gitService.push(repo, 'origin', 'main');
+		expect(result.success).toBe(false);
+		expect(result.message).toMatch(/nothing to push/i);
+	});
+});

--- a/backend/git/git-service.ts
+++ b/backend/git/git-service.ts
@@ -3,7 +3,7 @@
  * High-level git operations built on top of executor and parser
  */
 
-import { execGit, isGitRepo, getGitRoot } from './git-executor';
+import { execGit, isGitRepo, getGitRoot, type GitExecResult } from './git-executor';
 import { resolveBinary } from '../utils/cli';
 import { getCleanSpawnEnv } from '../utils/env';
 import {
@@ -67,6 +67,32 @@ export class GitService {
 		if (result.exitCode !== 0) {
 			throw new Error(`git init failed: ${result.stderr}`);
 		}
+	}
+
+	// ============================================
+	// Revision probes
+	// ============================================
+
+	/**
+	 * True when the repo has at least one commit.
+	 *
+	 * A freshly `git init`ed repo has an unborn HEAD: every HEAD-relative revision
+	 * (`HEAD`, `HEAD~1`, `HEAD^`) fails to resolve, and git reports it as a raw
+	 * `fatal: ambiguous argument` / `bad revision`. Callers probe this so they can
+	 * answer with an actionable message — or skip the operation entirely — instead
+	 * of leaking that fatal into a toast.
+	 */
+	private async hasCommits(cwd: string): Promise<boolean> {
+		return (await execGit(['rev-parse', '--verify', '--quiet', 'HEAD'], cwd)).exitCode === 0;
+	}
+
+	/**
+	 * True when `ref` has a parent commit — false for a root (parentless) commit,
+	 * where `<ref>^` / `<ref>~1` cannot resolve even though `<ref>` itself does.
+	 */
+	private async hasParent(cwd: string, ref = 'HEAD'): Promise<boolean> {
+		assertSafeGitRevish(ref, 'parent probe ref');
+		return (await execGit(['rev-parse', '--verify', '--quiet', `${ref}^`], cwd)).exitCode === 0;
 	}
 
 	// ============================================
@@ -175,6 +201,11 @@ export class GitService {
 		}
 		const result = await execGit(args, cwd);
 		if (result.exitCode !== 0) {
+			// Unborn HEAD — git says "You have nothing to amend", which reads like a
+			// failure rather than "commit normally instead".
+			if (!(await this.hasCommits(cwd))) {
+				throw new Error('There is no commit to amend yet — create the first commit instead.');
+			}
 			throw new Error(`git commit --amend failed: ${result.stderr}`);
 		}
 		const hashResult = await execGit(['rev-parse', 'HEAD'], cwd);
@@ -212,8 +243,7 @@ export class GitService {
 		// changed". Detect the parentless case and diff against the empty tree via
 		// `diff-tree --root` so the initial commit's files show up as additions.
 		// Commits with a parent (including merges) keep the original behaviour.
-		const hasParent =
-			(await execGit(['rev-parse', '--verify', '--quiet', `${commitHash}^`], cwd)).exitCode === 0;
+		const hasParent = await this.hasParent(cwd, commitHash);
 		// Fetch the full commit message alongside the diff so the detail view can
 		// render the body. `%s\0%b` splits cleanly on NUL since a subject never
 		// contains one; the body is kept verbatim (it may span many lines).
@@ -460,6 +490,11 @@ export class GitService {
 
 		const result = await execGit(args, cwd);
 		if (result.exitCode !== 0) {
+			// A repo with no commits yet isn't an error — `git log` just has nothing
+			// to walk. Report it as an empty history so the UI shows its empty state.
+			if (!(await this.hasCommits(cwd))) {
+				return { commits: [], total: 0, hasMore: false };
+			}
 			throw new Error(`git log failed: ${result.stderr}`);
 		}
 
@@ -510,6 +545,24 @@ export class GitService {
 		};
 	}
 
+	/**
+	 * Shape a `git push` outcome. On an unborn HEAD git only reports
+	 * `src refspec <branch> does not match any`, which reads like a broken remote
+	 * rather than "there is nothing here to push yet".
+	 */
+	private async describePushResult(
+		cwd: string,
+		result: GitExecResult
+	): Promise<{ success: boolean; message: string }> {
+		if (result.exitCode === 0) {
+			return { success: true, message: result.stderr || result.stdout };
+		}
+		if (!(await this.hasCommits(cwd))) {
+			return { success: false, message: 'This branch has no commits yet, so there is nothing to push.' };
+		}
+		return { success: false, message: result.stderr };
+	}
+
 	async push(cwd: string, remote = 'origin', branch?: string, force = false): Promise<{ success: boolean; message: string }> {
 		assertSafeGitRemoteName(remote);
 		const args = ['push', remote];
@@ -520,11 +573,7 @@ export class GitService {
 		if (force) args.push('--force-with-lease');
 		// Set upstream if needed
 		args.push('-u');
-		const result = await execGit(args, cwd, 60000);
-		return {
-			success: result.exitCode === 0,
-			message: result.exitCode === 0 ? (result.stderr || result.stdout) : result.stderr
-		};
+		return this.describePushResult(cwd, await execGit(args, cwd, 60000));
 	}
 
 	/**
@@ -554,11 +603,7 @@ export class GitService {
 			else if (mode === 'force') args.push('--force');
 			args.push('-u');
 		}
-		const result = await execGit(args, cwd, 60000);
-		return {
-			success: result.exitCode === 0,
-			message: result.exitCode === 0 ? (result.stderr || result.stdout) : result.stderr
-		};
+		return this.describePushResult(cwd, await execGit(args, cwd, 60000));
 	}
 
 	/** Fetch every configured remote and prune deleted remote-tracking refs. */
@@ -636,6 +681,10 @@ export class GitService {
 				throw new Error(
 					'Stashing staged changes only requires Git 2.35 or newer. Please update Git to use this option.'
 				);
+			}
+			// Stashing needs a commit to record the base state against.
+			if (!(await this.hasCommits(cwd))) {
+				throw new Error('Stashing requires at least one commit — create the first commit first.');
 			}
 			throw new Error(`git stash failed: ${result.stderr}`);
 		}
@@ -868,12 +917,55 @@ export class GitService {
 	 *  - `soft`  keeps the changes staged
 	 *  - `mixed` keeps the changes in the working tree (unstaged)
 	 *  - `hard`  discards the changes entirely (destructive)
+	 *
+	 * The root commit has no `HEAD~1` to reset onto, so undoing it means deleting
+	 * the branch ref itself: `update-ref -d HEAD` returns the repo to the unborn
+	 * state while leaving the index intact — which is exactly `--soft`. `--mixed`
+	 * and `--hard` then unwind the index (and working tree) from there.
 	 */
 	async undoLastCommit(cwd: string, mode: 'soft' | 'mixed' | 'hard'): Promise<void> {
-		const flag = mode === 'soft' ? '--soft' : mode === 'hard' ? '--hard' : '--mixed';
-		const result = await execGit(['reset', flag, 'HEAD~1'], cwd);
-		if (result.exitCode !== 0) {
-			throw new Error(`git reset ${flag} failed: ${result.stderr}`);
+		if (!(await this.hasCommits(cwd))) {
+			throw new Error('This repository has no commits yet, so there is nothing to undo.');
+		}
+
+		if (await this.hasParent(cwd)) {
+			const flag = mode === 'soft' ? '--soft' : mode === 'hard' ? '--hard' : '--mixed';
+			const result = await execGit(['reset', flag, 'HEAD~1'], cwd);
+			if (result.exitCode !== 0) {
+				throw new Error(`git reset ${flag} failed: ${result.stderr}`);
+			}
+			return;
+		}
+
+		// Root commit. `--hard` must discard the working tree while HEAD still
+		// resolves — once the ref is gone there is no commit left to reset onto.
+		if (mode === 'hard') {
+			const discard = await execGit(['reset', '--hard', 'HEAD'], cwd);
+			if (discard.exitCode !== 0) {
+				throw new Error(`git reset --hard failed: ${discard.stderr}`);
+			}
+		}
+
+		const removeRef = await execGit(['update-ref', '-d', 'HEAD'], cwd);
+		if (removeRef.exitCode !== 0) {
+			throw new Error(`git update-ref -d HEAD failed: ${removeRef.stderr}`);
+		}
+
+		if (mode === 'mixed') {
+			// Drop the index so the commit's files come back as untracked changes.
+			const unstage = await execGit(['reset'], cwd);
+			if (unstage.exitCode !== 0) {
+				throw new Error(`git reset failed: ${unstage.stderr}`);
+			}
+		} else if (mode === 'hard') {
+			// Delete exactly what the commit tracked — unrelated untracked files
+			// survive, matching `reset --hard HEAD~1` on a non-root commit. The
+			// `:/` pathspec covers the whole work tree even when cwd is a subdir,
+			// and `--ignore-unmatch` keeps an empty root commit from erroring.
+			const clearIndex = await execGit(['rm', '-rf', '--quiet', '--ignore-unmatch', '--', ':/'], cwd);
+			if (clearIndex.exitCode !== 0) {
+				throw new Error(`git rm failed: ${clearIndex.stderr}`);
+			}
 		}
 	}
 
@@ -881,6 +973,10 @@ export class GitService {
 	async revertCommit(cwd: string, ref = 'HEAD'): Promise<{ success: boolean; message: string }> {
 		assertSafeGitRevish(ref, 'revert ref');
 		const result = await execGit(['revert', '--no-edit', ref], cwd);
+		if (result.exitCode !== 0 && !(await this.hasCommits(cwd))) {
+			// Unborn HEAD — git only reports `bad revision 'HEAD'`.
+			return { success: false, message: 'This repository has no commits yet, so there is nothing to revert.' };
+		}
 		return {
 			success: result.exitCode === 0,
 			message: result.exitCode === 0 ? (result.stdout || result.stderr) : result.stderr


### PR DESCRIPTION
## Summary
"Undo last commit" failed outright on a repository's first commit. It now works there too, and the neighbouring git actions stop leaking git's internal fatals when a repository has no commits yet.

## Why
Undo ran a bare `git reset <flag> HEAD~1`. On a repository whose only commit is the root commit, `HEAD` resolves but `HEAD~1` does not, so the action died and the panel showed git's plumbing error verbatim:

```
git reset --soft failed: fatal: ambiguous argument 'HEAD~1': unknown revision
or path not in the working tree. Use '--' to separate paths from revisions,
like this: 'git <command> [<revision>...] -- [<file>...]'
```

There is nothing exotic about that state — it is every repository between `git init` and its second commit, which is exactly when a user is most likely to want the first commit back.

Probing for it turned up a second, related state: an unborn HEAD, where `HEAD` itself does not resolve. Five more actions leaked a raw fatal there, each one a normal situation rather than a failure:

| Action | What the user saw on a repo with no commits |
|--------|---------------------------------------------|
| Undo last commit | `fatal: ambiguous argument 'HEAD~1'` |
| Revert last commit | `fatal: bad revision 'HEAD'` |
| Amend | `fatal: You have nothing to amend.` |
| Stash | `You do not have the initial commit yet` |
| Push | `error: src refspec main does not match any` |
| History tab | threw — an error toast where an empty state belongs |

The defensive shape already existed in this file (`getDiffCommit` checks for a parentless commit, `unstageFile` / `unstageAll` fall back to `rm --cached` on the initial commit); it had just never been applied consistently. This PR makes it a shared probe instead of a per-call-site habit.

## Changes
`backend/git/git-service.ts`

- Two probes as the single source of truth: `hasCommits()` (unborn HEAD) and `hasParent()` (root commit). `getDiffCommit` drops its inline `rev-parse …^` check and uses `hasParent()`, so the rule lives in one place.
- `undoLastCommit()` branches three ways. No commits → an actionable message. Root commit → `git update-ref -d HEAD`, which returns the repo to the unborn state with the index intact — precisely `--soft`; `mixed` then runs `git reset`, and `hard` discards the work tree with `reset --hard HEAD` *before* the ref is deleted, then clears the index with `git rm -rf --ignore-unmatch -- :/`. Anything else keeps the original `HEAD~1` path.
- Unborn-HEAD guards on `amendCommit()`, `revertCommit()`, and `stashSave()`; `getLog()` returns an empty history instead of throwing, so a fresh repo shows the History tab's empty state.
- `push()` and `pushAdvanced()` built their result object with the same duplicated expression; that is now `describePushResult()`, which also translates the `src refspec` error into "this branch has no commits yet".

Every guard sits on the failure path, so the happy path pays no extra `rev-parse`. `undoLastCommit` is the exception — its behaviour branches, so it has to probe up front.

Two deliberate details in the `hard` path: the `:/` pathspec (not `.`) keeps it correct when the working directory is a subdirectory of the repository, and `--ignore-unmatch` keeps an empty root commit (`--allow-empty`) from raising a spurious error.

`backend/git/git-service.test.ts` (new) — 13 tests driving real git repositories in a temp directory: all three undo modes on a root commit, the empty root commit, the ordinary `HEAD~1` path, and each unborn-HEAD guard.

No frontend change was needed. `undoCommit`, `handleUndoHeadCommit`, and `revertLast` in `GitPanel.svelte` already surface `err.message` / `result.message` in a toast, and both undo entry points go through the same `git:undo-commit` handler.

## Test plan
- [x] `bun run check` — 0 errors
- [x] `bun run lint` — clean
- [x] `bun test backend/` — 424 pass, 0 fail (13 new)
- [x] `--hard` on a root commit deletes only the files that commit tracked; an unrelated untracked file survives, matching `reset --hard HEAD~1` on a non-root commit. Asserted in the tests, not just observed.

## Notes
`bun run build` was not run locally; the change is confined to backend service code with no build-surface impact.

Undoing a root commit deletes the branch ref, so the commit leaves the branch's reflog. It stays recoverable as a dangling object (`git fsck --lost-found`) until it is garbage-collected, but it is less recoverable than an ordinary undo — the `--hard` variant is already behind a confirmation dialog.