### PR TITLE
docs(contributing): resync the guide with how the repo actually works

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,13 @@ This document provides guidelines for Claude Code when working on the Clopen pro
 
 ### After Coding
 
-- Run `bun run check` and `bun run lint` to ensure code functions properly
+- Run `bun run check` and `bun run lint`; add `bun run test` when the change touches tested logic
 - Do not create any .md files unless explicitly instructed
-- Suggest a branch name and commit message following CONTRIBUTING.md conventions:
+- Hand back the three artifacts from CONTRIBUTING.md → Delivering a Change:
   - Branch: `<type>/<description>` — lowercase, kebab-case, concise
-  - Commit: `<type>(<scope>): <subject>` — imperative mood, lowercase, no period, max 72 chars
-  - Do NOT create the branch or commit automatically — only suggest the names for review
+  - One commit: `<type>(<scope>): <subject>` (imperative, lowercase, no period) **plus a body** — what broke, why it happened, what the change does about it, wrapped at 72 columns
+  - PR description from the template, ready to paste — or a PR comment if the work extends an open PR
+  - Do NOT create the branch, commit, or PR automatically — draft all three for review
 
 ---
 
@@ -64,7 +65,7 @@ This document provides guidelines for Claude Code when working on the Clopen pro
 
 ### Testing
 
-- Run `bun run check` for type checking and `bun run lint` for linting
+- Run `bun run check` for type checking, `bun run lint` for linting, `bun run test` for the suite (`--isolate`, data in `~/.clopen-test`)
 - Ensure all checks pass before committing
 
 ### Communication

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,10 @@ Thanks for considering a contribution. This guide covers the development environ
   - [Formatting](#formatting)
   - [Tests](#tests)
 - [Submitting Changes](#submitting-changes)
+  - [Delivering a Change](#delivering-a-change)
   - [Branch Naming](#branch-naming)
   - [Commit Messages](#commit-messages)
-  - [Pre-commit Checklist](#pre-commit-checklist)
+  - [Before You Push](#before-you-push)
   - [Pull Request Format](#pull-request-format)
   - [Comments on Existing PRs](#comments-on-existing-prs)
 - [After You Submit](#after-you-submit)
@@ -46,6 +47,9 @@ Thanks for considering a contribution. This guide covers the development environ
   - [Codex](https://github.com/openai/codex) by OpenAI
   - [GitHub Copilot CLI](https://github.com/github/copilot-cli) by GitHub
   - [Qwen Code](https://github.com/QwenLM/qwen-code) by Alibaba Qwen
+  - [Pi](https://github.com/earendil-works/pi) by Earendil Works
+  - [Cline](https://github.com/cline/cline) by Cline Bot Inc.
+  - [Cursor](https://cursor.com) by Anysphere
 
 Engines install on demand via **Settings → Stack** after first launch (into a clopen-managed directory, not your global setup).
 
@@ -78,7 +82,15 @@ git push origin main   # optional: also sync your fork's main on GitHub
 
 ### Development Data Directory
 
-When running `bun run dev`, Clopen stores data in `~/.clopen-dev` instead of `~/.clopen`. This keeps development data separate from any production instance — especially important since Clopen can be used to develop itself.
+Clopen resolves its data directory once at startup, from `NODE_ENV`:
+
+| Context | Directory |
+|---------|-----------|
+| `bun run dev` | `~/.clopen-dev` |
+| `bun run test` | `~/.clopen-test` |
+| Installed release | `~/.clopen` |
+
+`CLOPEN_DATA_DIR` overrides all three. The separation matters because Clopen is often used to develop itself — neither the dev server nor the test suite can reach the database of a running production instance. Don't reintroduce a code path that reads `NODE_ENV` to pick a directory; use `SERVER_ENV.DATA_DIR` (`backend/utils/env.ts`), which is resolved a single time so a dependency mutating `process.env` mid-run can't move state out from under the server.
 
 ---
 
@@ -94,14 +106,14 @@ git checkout main && git pull upstream main
 git checkout -b feature/your-feature
 
 # 3. Develop & verify locally
-bun run check && bun run lint && bun run build
+bun run check && bun run lint && bun run test && bun run build
 
-# 4. Commit
-git commit -m "feat(scope): description"
+# 4. Commit — one commit, subject and body (see Delivering a Change)
+git commit
 
 # 5. Sync with upstream main again (resolve conflicts locally, not in the GitHub UI)
 git fetch upstream && git merge upstream/main
-bun run check && bun run lint && bun run build   # re-verify after merge
+bun run check && bun run lint && bun run test && bun run build   # re-verify after merge
 
 # 6. Push & open PR
 git push origin feature/your-feature
@@ -160,17 +172,29 @@ Skip tests for changes that are inherently observable (UI tweaks, log strings, d
 For security fixes, tests are expected — at minimum a case that fails before the patch and passes after. Cover the boundary explicitly (the exact value that should be rejected) and at least one happy path.
 
 ```bash
-bun test path/to/file.test.ts   # single file
-bun test                        # full suite
+bun test path/to/file.test.ts   # single file, while iterating
+bun run test                    # full suite — what CI runs
 ```
 
-Tests must pass before opening the PR.
+Use `bun run test` for the full suite, not bare `bun test`. The script adds `--isolate`, which is what keeps one test's global state out of the next one's.
+
+CI runs the full suite on every PR, so it must pass whether or not your change touched a test file.
 
 ---
 
 ## Submitting Changes
 
 All written content on the repository — branch names, commit messages, PR titles, PR descriptions, and PR comments — must be in **English**, regardless of the language you and the maintainers use elsewhere. This keeps the contribution trail readable across the project's audience.
+
+### Delivering a Change
+
+Once the work is done and verified, it is delivered as **one commit on one branch**. Decide all three pieces before you push:
+
+1. **Branch name** — `<type>/<description>`, per [Branch Naming](#branch-naming).
+2. **One commit** — subject *and* body, per [Commit Messages](#commit-messages). Squash your local work-in-progress into it rather than pushing a trail of "wip" and "fix typo" commits.
+3. **PR description** — filled in from the template in [Pull Request Format](#pull-request-format), ready to paste when you open the PR. If the work extends a PR that's already open, post it as a comment following [Comments on Existing PRs](#comments-on-existing-prs) instead.
+
+One commit is the delivery shape, not a rule against history. After the branch is pushed, address review feedback in **new commits on top** — don't amend or force-push a branch a maintainer is reading, since that detaches their review threads. The squash-merge collapses the follow-ups when the PR lands.
 
 ### Branch Naming
 
@@ -196,47 +220,85 @@ Examples: `feature/database-management`, `fix/websocket-connection`, `docs/maint
 
 ### Commit Messages
 
-Format: `<type>(<scope>): <subject>` — imperative mood, lowercase, no period, max 72 characters.
+Format: `<type>(<scope>): <subject>` — imperative mood, lowercase, no period.
 
 | Type | Use |
 |------|-----|
 | `feat` | New feature |
 | `fix` | Bug fix |
 | `docs` | Documentation |
-| `chore` | Refactor, build, perf, dependencies |
-| `release` | Version release |
+| `refactor` | Restructuring with no behavior change |
+| `perf` | Performance work |
+| `chore` | Build, dependencies, tooling, miscellaneous |
 
-Examples:
+The scope is the area the change lands in — `chat`, `terminal`, `engine`, `preview`, `settings`. Omit it when the change is genuinely repo-wide; don't invent one to fill the slot.
 
 ```
 feat(chat): add message export
 fix(terminal): resolve memory leak
+refactor(engine): install engine SDKs on demand into a managed Stack dir
 docs(maintainers): document pr reshape workflow
 chore: update dependencies
 ```
 
-Keep the subject focused on **why** the change exists, not what files moved. If the change needs a longer explanation, put it in the PR description, not the commit body — repo convention is subject-only.
+Version-bump commits are the one exception: maintainers commit those as a bare version number (`0.4.28`), no type or scope. Contributors never write one.
 
-### Pre-commit Checklist
+**Length.** Aim for 72 characters and treat ~80 as the hard ceiling. Squash-merge appends ` (#NNN)` to the PR title, so a subject at the ceiling lands near 88 on `main` — that's the trade the repo already makes for subjects that stay specific. Trim by cutting words, not by going vague: `fix(settings): isolate test data dir` beats `fix(settings): fix settings bug` at any length.
 
-Before pushing each commit:
+Keep the subject focused on **why** the change exists, not what files moved.
 
-- [ ] `bun run check` passes
-- [ ] `bun run lint` passes
-- [ ] `bun run build` works
-- [ ] `bun test` passes if any test file was added or modified
+#### Commit Body
+
+Every non-trivial commit carries a body. Leave it off only when the subject is the whole story — a dependency bump, a version release, a one-line typo fix.
+
+Separate it from the subject with a blank line and wrap at 72 columns. Write prose paragraphs, not bullets, covering three things in order:
+
+1. **What was broken or missing** — the symptom as a user or reviewer would hit it.
+2. **Why it happened** — the root cause, named precisely enough that someone could find it again.
+3. **What the change does about it** — the mechanism, not a file list.
+
+Describe the code, not your work on it: *"Undo used a bare `HEAD~1`, which cannot resolve on a root commit"*, not *"I rewrote the undo function"*. Skip anything the diff already says plainly. When a change spans several areas, give each its own paragraph behind a short label (`Watcher:`, `Switching:`, `Loaders:`).
+
+```
+fix(git): support undoing the root commit and guard empty repos
+
+Undo used a bare `HEAD~1`, which cannot resolve on a root commit or an
+unborn HEAD, so the Git panel surfaced git's raw "fatal: ambiguous
+argument" instead of doing the undo. Undoing the root commit now deletes
+the branch ref; the same probes translate the unborn-HEAD failures in
+revert, amend, stash, push, and log.
+```
+
+The body and the PR description overlap by design. The body is the durable record on `main` — it's what someone reads years later while bisecting. The PR description adds the review-time layer on top: test plan, screenshots, follow-ups, anything that stops mattering once the PR is merged.
+
+Recent commits on `main` are the reference. Run `git log` and read the last few before writing yours.
+
+### Before You Push
+
+CI (`.github/workflows/ci.yml`) runs these four on every PR, in this order. Run them locally first — a red PR costs a round trip:
+
+```bash
+bun run check   # type check
+bun run lint    # eslint
+bun run test    # full suite, --isolate
+bun run build   # must produce dist/
+```
+
+Then check what CI can't:
+
 - [ ] New non-trivial logic has a `*.test.ts` (see [Tests](#tests))
-- [ ] Commit message follows the format above
+- [ ] Commit message follows the format above, with a body unless the subject is the whole story
 - [ ] No `console.*` (use the `debug` module)
-- [ ] No sensitive data (tokens, credentials, internal URLs)
+- [ ] No sensitive data (tokens, credentials, internal URLs) — including in test fixtures, where a real local path is a leak
+- [ ] Nothing outside the change's scope crept into the diff
 
-If a pre-commit hook fails, fix the underlying issue rather than skipping with `--no-verify`. Hooks exist for the same reasons CI does.
+The repo ships no git hooks, so nothing stops you from pushing a failing commit; CI is the only gate and it runs after you've already asked for review. If you do have local hooks and one fails, fix the underlying issue rather than skipping with `--no-verify`.
 
 ### Pull Request Format
 
 #### Title
 
-Same format as commit messages: `<type>(<scope>): <subject>` (lowercase, imperative, no period, ≤72 chars). GitHub uses this as the squash-commit subject on `main`.
+Same format and length as the commit subject: `<type>(<scope>): <subject>`, lowercase, imperative, no period. Make it identical to your commit subject — GitHub uses the PR title, not the commit, as the squash subject on `main`, and appends ` (#NNN)` to it.
 
 #### Description Template
 
@@ -334,11 +396,13 @@ If you disagree with feedback, push back with a concrete scenario, file/line ref
 ### Commands
 
 ```bash
-bun run dev          # Dev server
+bun run dev          # Dev server (data in ~/.clopen-dev)
 bun run check        # Type check
 bun run lint         # Lint
 bun run lint:fix     # Auto-fix lint
-bun run build        # Build
+bun run test         # Full test suite (data in ~/.clopen-test)
+bun run build        # Build to dist/
+bun run start        # Serve a built dist/
 ```
 
 ### Troubleshooting
@@ -350,8 +414,10 @@ rm -rf node_modules && bun install
 # Lint errors
 bun run lint:fix
 
-# Git conflicts
-git fetch upstream && git rebase upstream/main
+# Conflicts with upstream — merge, don't rebase: rebasing rewrites the
+# commit hashes a reviewer is already reading, and landing it needs a
+# force-push, which detaches their review threads.
+git fetch upstream && git merge upstream/main
 ```
 
 ### Resources

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -117,7 +117,8 @@ When the PR is ready:
 
 - **Strategy:** Always squash-merge via the GitHub UI.
 - **Subject:** Use GitHub's default (`<PR title> (#NNN)`). The PR title must already follow the conventional commit format from [CONTRIBUTING.md → Commit Messages](./CONTRIBUTING.md#commit-messages).
-- **Extended description:** Leave empty. Repo convention is subject-only — check recently-merged PRs on `main` if unsure of the current style. Detail belongs in the PR description, not duplicated into the commit body. **Exception:** `Co-authored-by:` trailer when the PR is a reshape of a contributor's earlier work — see [`Co-authored-by` Trailer Format](#co-authored-by-trailer-format).
+- **Extended description:** Carry the commit body — what was broken, why, and what the change does about it, per [CONTRIBUTING.md → Commit Body](./CONTRIBUTING.md#commit-body). GitHub pre-fills this box with every commit message from the branch; replace that with a single clean body rather than shipping the concatenation. Leave it empty only when the subject is the whole story (dependency bump, release, typo). Review-time detail — test plan, screenshots, follow-ups — stays in the PR description and does not belong here. Check recently-merged commits on `main` if unsure of the current style.
+- **`Co-authored-by:` trailer:** Required when the PR is a reshape of a contributor's earlier work — see [`Co-authored-by` Trailer Format](#co-authored-by-trailer-format).
 - **Branch deletion:** Delete the source branch via the GitHub button immediately after merge.
 
 #### Local cleanup
@@ -141,7 +142,7 @@ Worked examples are illustrative templates, not literal copy-paste. The recurrin
 Use when the audit is clean — no adjacent gaps, established patterns followed, scope appropriate, and tests are present where [CONTRIBUTING.md → Tests](./CONTRIBUTING.md#tests) requires them. Post a short approval comment, then proceed to [Merge](#4-merge).
 
 ```markdown
-Thanks @contributor — nice catch on this one, and the `<specific thing they did well>` made the audit straightforward. Checked adjacent call sites in `path/to/dir` and they all follow the same shape, no gaps. `bun run check` / `bun run lint` / `bun test` green locally. Merging.
+Thanks @contributor — nice catch on this one, and the `<specific thing they did well>` made the audit straightforward. Checked adjacent call sites in `path/to/dir` and they all follow the same shape, no gaps. `bun run check` / `bun run lint` / `bun run test` green locally. Merging.
 ```
 
 The opener has to name something specific — the regression test that pinned the boundary, the choice to follow an existing pattern, the threat model in the description. "Thanks for the PR!" alone is filler.
@@ -406,7 +407,7 @@ Builds on #NNN by @contributor, reshaped after review to <one-sentence reason>.
 
 This creates two-way cross-links: the closed PR shows "Referenced in PR #MMM", and the new PR shows the original as context.
 
-At squash-merge time, add a `Co-authored-by:` trailer to the squash commit body. This is the **only acceptable exception** to the "leave extended description empty" rule. See [`Co-authored-by` Trailer Format](#co-authored-by-trailer-format) for the strict format.
+At squash-merge time, add a `Co-authored-by:` trailer to the squash commit body — below the body prose, separated by one blank line. See [`Co-authored-by` Trailer Format](#co-authored-by-trailer-format) for the strict format.
 
 ### Path F — Close as Not Actionable
 
@@ -563,7 +564,7 @@ This is the canonical exception to "section headers belong in PR descriptions" �
 
 When you're contributing review work to a PR you are **not** personally merging — AI assistants, sub-reviewers doing first-pass triage, anyone whose output the merging maintainer will adopt — the audit response always ships with exactly two artifacts:
 
-1. **A suggested commit message** following [CONTRIBUTING.md → Commit Messages](./CONTRIBUTING.md#commit-messages). If a branch name needs to be proposed, follow [CONTRIBUTING.md → Branch Naming](./CONTRIBUTING.md#branch-naming) exactly. Comment-only paths ([Path D — *Comment and Wait*](#path-d--comment-and-wait) and [Path F — *Close as Not Actionable*](#path-f--close-as-not-actionable)) have no maintainer commit, so omit this artifact. For Path D, note that the existing PR title will serve as the squash subject if the contributor's revisions land. For Path F, there is no squash subject because the PR is being closed.
+1. **A suggested commit message** — subject and body — following [CONTRIBUTING.md → Commit Messages](./CONTRIBUTING.md#commit-messages). If a branch name needs to be proposed, follow [CONTRIBUTING.md → Branch Naming](./CONTRIBUTING.md#branch-naming) exactly. Comment-only paths ([Path D — *Comment and Wait*](#path-d--comment-and-wait) and [Path F — *Close as Not Actionable*](#path-f--close-as-not-actionable)) have no maintainer commit, so omit this artifact. For Path D, note that the existing PR title will serve as the squash subject if the contributor's revisions land. For Path F, there is no squash subject because the PR is being closed.
 2. **A suggested PR comment** matching the chosen review path — start from the worked example in the relevant subsection of [Review Paths](#review-paths) and adapt to the actual diff.
 
 **Draft these inline with the audit; never ask permission to draft.** "Should I draft a comment?" is the wrong question — the artifacts are part of the deliverable, not a follow-up offer. Confirmation gates exist only for *acting* on the suggestion (Stage 1: editing the working tree; Stage 2: committing, pushing, posting). A draft that lives only in chat hasn't touched the repo and doesn't need a gate.


### PR DESCRIPTION
## Summary
Audit `CONTRIBUTING.md` against the repo and correct every rule that no longer
matches it, then add the two conventions that were missing: what a commit body
must contain, and what a finished change ships with.

## Why
Nine rules in the guide are contradicted by the repo they document. Each was
checked against its source, not against another doc:

| Guide said | Repo says | Source |
|---|---|---|
| "repo convention is subject-only" | last 5 substantive merges carry bodies | `git log` |
| `release` is a commit type | 0 uses in 400 commits; releases are bare `0.4.28` | `git log` |
| `refactor`/`perf` belong under `chore` | 10 and 1 real uses of their own | `git log` |
| subject max 72 chars | merged subjects reach 81, then ` (#NNN)` is appended | `git log` |
| five supported engines | eight | `README.md` |
| run `bun test` | the script CI runs is `bun run test` (`--isolate`) | `package.json`, `ci.yml` |
| tests only if a test file changed | CI runs the full suite on every PR | `ci.yml` |
| "if a pre-commit hook fails…" | the repo ships no hooks at all | `.git/hooks` |
| troubleshoot conflicts with `rebase` | three other sections say `merge` | internal |

The hook one is the most costly: it implies something guards your push. Nothing
does, so a contributor learns their commit was broken only after asking for
review. Dropping `--isolate` matters for the same reason it did in #477 — that
flag is what keeps one test's global state out of the next one's.

## Changes
- **Commit Messages** — real type table (`refactor`, `perf` in; `release` out,
  with a note that version bumps are bare and maintainer-only), scope guidance,
  and a length rule that accounts for the ` (#NNN)` suffix.
- **Commit Body** (new) — symptom, root cause, mechanism; prose wrapped at 72;
  labeled paragraphs for multi-area changes; worked example from `fb93041`.
- **Delivering a Change** (new) — branch name, one commit with body, PR
  description. Scoped so it doesn't contradict the ban on force-pushing a
  branch under review.
- **Pre-commit Checklist → Before You Push** — mirrors the four commands in
  `ci.yml`, in order; states that no hook guards the push.
- **Development Data Directory** — `~/.clopen-dev` / `~/.clopen-test` /
  `~/.clopen` plus `CLOPEN_DATA_DIR`, and a pointer to `SERVER_ENV.DATA_DIR` as
  the single resolution point.
- **Prerequisites / Tests / Commands / Troubleshooting** — engine list, the
  `bun run test` correction, missing scripts, `merge` instead of `rebase`.
- `MAINTAINERS.md` — squash description carries the body; `Co-authored-by:`
  becomes its own rule instead of an exception to a deleted one.
- `CLAUDE.md` — names the three delivery artifacts and stops duplicating the
  subject-length number.

## Notes
Docs only — no code paths touched. `bun run check` reports 0 errors (2
pre-existing Svelte warnings in untouched files); `bun run lint` passes; all
internal anchors resolve.

The guide now cites `ci.yml`, `package.json`, `README.md`, and
`backend/utils/env.ts` by name at each point it depends on them, so the next
drift is visible at the source rather than only in the doc.