### PR TITLE
perf(memory): persist the graph layout, bound the canvas, and let the shape follow the data

### DIFF
--- a/backend/database/migrations/067_add_memory_graph_layout.ts
+++ b/backend/database/migrations/067_add_memory_graph_layout.ts
@@ -1,0 +1,91 @@
+import type { DatabaseConnection } from '$shared/types/database/connection';
+import { debug } from '$shared/utils/logger';
+
+export const description =
+	'Persist memory-graph communities and layout positions, and index the graph view ordering';
+
+/**
+ * Make the Memory view stop paying for the whole graph on every look.
+ *
+ * Two things used to be recomputed from scratch on every single fetch, and both
+ * of them grow with the store rather than with what is being displayed:
+ *
+ *   - COMMUNITY DETECTION. Louvain ran inside `buildGraphView`, so opening the
+ *     modal, changing a filter, or any conversation writing a memory made every
+ *     connected client re-cluster the graph server-side. The result is stable
+ *     per dataset, so it belonged in a table all along.
+ *
+ *   - LAYOUT. ForceAtlas2 ran in the browser on every open, from a deterministic
+ *     seed — several hundred iterations to arrive at the same arrangement it
+ *     arrived at last time, discarded the moment the modal closed. That is what
+ *     made opening the modal janky once the graph got big: the animation and a
+ *     few hundred milliseconds of layout were competing for one thread.
+ *
+ * `graph_layout` holds both, keyed by node. It is deliberately a SEPARATE table
+ * rather than columns on `graph_nodes`: a position is a property of an
+ * arrangement, not of a memory, so a re-layout must never look like an edit to
+ * the memory itself — `updated_at` on `graph_nodes` drives recall ranking, and
+ * bumping it every time a node drifted two pixels would have quietly reordered
+ * what agents get told.
+ *
+ * The row is derived data. Losing it costs a background pass, never a memory,
+ * which is why it cascades away with its node and is safe to delete wholesale.
+ */
+export const up = (db: DatabaseConnection): void => {
+	debug.log('migration', 'Creating the memory graph layout table...');
+
+	// `placed` separates the two halves of what a pass produces, and they do NOT
+	// have the same reach. Community detection runs over every live node — it is
+	// linear in the edges and it is what the overview groups by, so leaving nodes
+	// out of it would leave them out of the picture entirely. The force simulation
+	// is superlinear and therefore capped, so the lowest-ranked nodes get their
+	// community's neighbourhood as a position rather than a computed one.
+	//
+	// Without the flag those two are indistinguishable, and a guessed position
+	// would be handed to the client as though it were a real one — every member of
+	// a large lobe stacked on a single point, with nothing to say they should be
+	// spread out.
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS graph_layout (
+			node_id     TEXT     PRIMARY KEY REFERENCES graph_nodes(id) ON DELETE CASCADE,
+			community   INTEGER  NOT NULL DEFAULT 0,
+			x           REAL     NOT NULL DEFAULT 0,
+			y           REAL     NOT NULL DEFAULT 0,
+			placed      INTEGER  NOT NULL DEFAULT 1,
+			updated_at  TEXT     NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)
+	`);
+
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_graph_layout_community ON graph_layout (community)`);
+
+	// Zooming into part of the map asks for the nodes inside a rectangle, which
+	// without this is a scan of the whole arrangement for a handful of rows.
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_graph_layout_position ON graph_layout (x, y)`);
+
+	/**
+	 * The graph view's own ordering, which had no index at all.
+	 *
+	 * `graphQueries.list` selects `ORDER BY pinned DESC, weight DESC, updated_at
+	 * DESC LIMIT n`, and with nothing to read that order from SQLite had to scan
+	 * every live row and sort ALL of them before taking the first few thousand.
+	 * That is the one part of a fetch that grew without bound: the cap limited
+	 * what was returned, never what was examined.
+	 *
+	 * Partial on the same predicate the view always applies, so it stays the size
+	 * of the live graph however much history accumulates behind it.
+	 */
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_graph_nodes_view
+		ON graph_nodes (pinned DESC, weight DESC, updated_at DESC)
+		WHERE archived_at IS NULL AND superseded_by IS NULL
+	`);
+
+	debug.log('migration', 'Memory graph layout table ready');
+};
+
+export const down = (db: DatabaseConnection): void => {
+	db.exec(`DROP INDEX IF EXISTS idx_graph_nodes_view`);
+	db.exec(`DROP INDEX IF EXISTS idx_graph_layout_position`);
+	db.exec(`DROP INDEX IF EXISTS idx_graph_layout_community`);
+	db.exec(`DROP TABLE IF EXISTS graph_layout`);
+};

--- a/backend/database/migrations/index.ts
+++ b/backend/database/migrations/index.ts
@@ -65,6 +65,7 @@ import * as migration063 from './063_add_invite_project_ids';
 import * as migration064 from './064_create_messages_fts';
 import * as migration065 from './065_add_session_reasoning_effort';
 import * as migration066 from './066_create_memory_graph';
+import * as migration067 from './067_add_memory_graph_layout';
 
 // Export all migrations in order
 export const migrations = [
@@ -463,6 +464,12 @@ export const migrations = [
 		description: migration066.description,
 		up: migration066.up,
 		down: migration066.down
+	},
+	{
+		id: '067',
+		description: migration067.description,
+		up: migration067.up,
+		down: migration067.down
 	}
 ];
 

--- a/backend/database/queries/graph-queries.ts
+++ b/backend/database/queries/graph-queries.ts
@@ -269,57 +269,89 @@ export interface GraphListFilter {
  * Kept in one place because the three drifting apart is how a node ends up
  * counted but not shown, or shown in the graph after being forgotten.
  */
-function appendProjectFilter(filter: GraphListFilter, where: string[], params: unknown[]): void {
+/**
+ * An id set as ONE bound parameter instead of one placeholder per id.
+ *
+ * The graph view hands these queries up to three thousand ids at a time, and
+ * `IN (?, ?, … ×3000)` builds a different SQL string for every distinct length —
+ * so the statement cache never hits and SQLite recompiles the query on each
+ * call. `edgesWithin` was the worst of them, repeating the set twice for six
+ * thousand bound parameters. `json_each` takes the whole set as a single JSON
+ * argument, which makes the SQL text constant and the statement cacheable.
+ */
+const ID_SET = '(SELECT value FROM json_each(?))';
+
+const idSet = (ids: string[]): string => JSON.stringify(ids);
+
+function appendProjectFilter(
+	filter: GraphListFilter,
+	where: string[],
+	params: unknown[],
+	as: string = ''
+): void {
 	if (filter.projectIds !== undefined) {
 		// Nothing selected is "global only", not "everything": the user has narrowed
 		// away every repository, and what remains is what was never a repository's.
-		if (filter.projectIds.length === 0) where.push(`project_id IS NULL`);
+		if (filter.projectIds.length === 0) where.push(`${as}project_id IS NULL`);
 		else {
-			where.push(`(project_id IN (${filter.projectIds.map(() => '?').join(',')}) OR project_id IS NULL)`);
+			where.push(
+				`(${as}project_id IN (${filter.projectIds.map(() => '?').join(',')}) OR ${as}project_id IS NULL)`
+			);
 			params.push(...filter.projectIds);
 		}
 		return;
 	}
 	if (filter.projectId === undefined) return;
 	if (filter.projectId === null) {
-		where.push(`project_id IS NULL`);
+		where.push(`${as}project_id IS NULL`);
 		return;
 	}
 	// A project view also shows the global memories that apply to it —
 	// conventions and preferences are part of that project's context.
-	where.push(`(project_id = ? OR project_id IS NULL)`);
+	where.push(`(${as}project_id = ? OR ${as}project_id IS NULL)`);
 	params.push(filter.projectId);
 }
 
-function buildNodeFilter(filter: GraphListFilter): { where: string[]; params: unknown[] } {
+/**
+ * The graph view's WHERE clause, optionally qualified by a table alias.
+ *
+ * The alias exists for the queries that join `graph_nodes` to itself through an
+ * edge — the cluster-adjacency rollup has to apply the SAME narrowing to both
+ * ends of every edge, and unqualified column names are ambiguous there. Callers
+ * pass `'n.'`; everything else keeps the bare form it always had.
+ */
+function buildNodeFilter(
+	filter: GraphListFilter,
+	as: string = ''
+): { where: string[]; params: unknown[] } {
 	const where: string[] = [];
 	const params: unknown[] = [];
 
-	appendProjectFilter(filter, where, params);
+	appendProjectFilter(filter, where, params, as);
 	if (filter.kinds?.length) {
-		where.push(`kind IN (${filter.kinds.map(() => '?').join(',')})`);
+		where.push(`${as}kind IN (${filter.kinds.map(() => '?').join(',')})`);
 		params.push(...filter.kinds);
 	}
 	if (filter.subkinds?.length) {
-		where.push(`subkind IN (${filter.subkinds.map(() => '?').join(',')})`);
+		where.push(`${as}subkind IN (${filter.subkinds.map(() => '?').join(',')})`);
 		params.push(...filter.subkinds);
 	}
 	if (filter.scopes?.length) {
-		where.push(`scope IN (${filter.scopes.map(() => '?').join(',')})`);
+		where.push(`${as}scope IN (${filter.scopes.map(() => '?').join(',')})`);
 		params.push(...filter.scopes);
 	}
 	if (filter.sources?.length) {
-		where.push(`source IN (${filter.sources.map(() => '?').join(',')})`);
+		where.push(`${as}source IN (${filter.sources.map(() => '?').join(',')})`);
 		params.push(...filter.sources);
 	}
 
-	if (filter.archivedOnly) where.push(`archived_at IS NOT NULL`);
-	else if (!filter.includeArchived) where.push(`archived_at IS NULL`);
+	if (filter.archivedOnly) where.push(`${as}archived_at IS NOT NULL`);
+	else if (!filter.includeArchived) where.push(`${as}archived_at IS NULL`);
 
 	// The graph view shows current beliefs. Superseded ones stay reachable by
 	// walking a `supersedes` edge from the node that replaced them, which is where
 	// that history belongs.
-	if (!filter.includeSuperseded) where.push(`superseded_by IS NULL`);
+	if (!filter.includeSuperseded) where.push(`${as}superseded_by IS NULL`);
 
 	return { where, params };
 }
@@ -437,10 +469,9 @@ export const graphQueries = {
 
 	getByIds(ids: string[]): GraphNode[] {
 		if (ids.length === 0) return [];
-		const placeholders = ids.map(() => '?').join(',');
 		const rows = getDatabase()
-			.prepare(`SELECT * FROM graph_nodes WHERE id IN (${placeholders})`)
-			.all(...ids) as GraphNodeRow[];
+			.prepare(`SELECT * FROM graph_nodes WHERE id IN ${ID_SET}`)
+			.all(idSet(ids)) as GraphNodeRow[];
 		return rows.map(toNode);
 	},
 
@@ -767,11 +798,13 @@ export const graphQueries = {
 		if (nodeIds.length === 0) return byNode;
 		const rows = getDatabase()
 			.prepare(
-				`SELECT node_id, name FROM graph_node_entities WHERE node_id IN (${nodeIds.map(() => '?').join(',')})`
+				`SELECT node_id, name FROM graph_node_entities WHERE node_id IN ${ID_SET}`
 			)
-			.all(...nodeIds) as { node_id: string; name: string }[];
+			.all(idSet(nodeIds)) as { node_id: string; name: string }[];
 		for (const row of rows) {
-			byNode.set(row.node_id, [...(byNode.get(row.node_id) ?? []), row.name]);
+			const names = byNode.get(row.node_id);
+			if (names) names.push(row.name);
+			else byNode.set(row.node_id, [row.name]);
 		}
 		return byNode;
 	},
@@ -813,7 +846,7 @@ export const graphQueries = {
 		/** Links each memory draws per group, toward the heaviest members. */
 		const LINKS_PER_MEMBER = 4;
 
-		const placeholders = nodeIds.map(() => '?').join(',');
+		const set = idSet(nodeIds);
 		const edges: { srcId: string; dstId: string; weight: number; via: 'subject' | 'project' }[] = [];
 		const seen = new Set<string>();
 
@@ -837,12 +870,21 @@ export const graphQueries = {
 				`SELECT e.entity_key AS groupKey, e.node_id AS nodeId
 				 FROM graph_node_entities e
 				 INNER JOIN graph_nodes n ON n.id = e.node_id
-				 WHERE e.node_id IN (${placeholders})
+				 WHERE e.node_id IN ${ID_SET}
 				 ORDER BY e.entity_key, n.weight DESC, n.updated_at DESC`
 			)
-			.all(...nodeIds) as { groupKey: string; nodeId: string }[];
+			.all(set) as { groupKey: string; nodeId: string }[];
+		// Appended, not rebuilt. Spreading the existing array on every row made this
+		// quadratic in the size of a group — invisible for the subject groups, which
+		// are capped at two dozen, and the dominant cost of the whole call for the
+		// project groups, which routinely run to hundreds before the size check
+		// below discards them.
 		const bySubject = new Map<string, string[]>();
-		for (const row of rows) bySubject.set(row.groupKey, [...(bySubject.get(row.groupKey) ?? []), row.nodeId]);
+		for (const row of rows) {
+			const members = bySubject.get(row.groupKey);
+			if (members) members.push(row.nodeId);
+			else bySubject.set(row.groupKey, [row.nodeId]);
+		}
 		// `members` is heaviest-first, so linking forward attaches the tail of a
 		// subject to its most reinforced memories rather than to whichever happened
 		// to be written first.
@@ -861,12 +903,16 @@ export const graphQueries = {
 		const projectRows = getDatabase()
 			.prepare(
 				`SELECT project_id AS groupKey, id AS nodeId FROM graph_nodes
-				 WHERE id IN (${placeholders}) AND project_id IS NOT NULL AND kind = 'episodic'
+				 WHERE id IN ${ID_SET} AND project_id IS NOT NULL AND kind = 'episodic'
 				 ORDER BY project_id, weight DESC, updated_at DESC`
 			)
-			.all(...nodeIds) as { groupKey: string; nodeId: string }[];
+			.all(set) as { groupKey: string; nodeId: string }[];
 		const byProject = new Map<string, string[]>();
-		for (const row of projectRows) byProject.set(row.groupKey, [...(byProject.get(row.groupKey) ?? []), row.nodeId]);
+		for (const row of projectRows) {
+			const members = byProject.get(row.groupKey);
+			if (members) members.push(row.nodeId);
+			else byProject.set(row.groupKey, [row.nodeId]);
+		}
 		for (const members of byProject.values()) connect(members, 0.4, 'project');
 
 		return edges;
@@ -1250,14 +1296,30 @@ export const graphQueries = {
 	/** Every edge with both ends inside the given set — the induced subgraph. */
 	edgesWithin(nodeIds: string[]): GraphEdge[] {
 		if (nodeIds.length === 0) return [];
-		const placeholders = nodeIds.map(() => '?').join(',');
+
+		/**
+		 * Driven from the index, with the second end checked in JS.
+		 *
+		 * `WHERE src_id IN (…) AND dst_id IN (…)` reads naturally and is 200× slower,
+		 * measured: SQLite scans `graph_edges` and tests each row against a set of up
+		 * to three thousand values twice over, using neither of the indexes on the
+		 * columns being tested. 220 ms for 1,789 edges. Joining the id set to
+		 * `idx_graph_edges_src` turns it into one seek per id — 1 ms for the same
+		 * data — and the surviving rows are few enough that filtering the far end
+		 * against a `Set` here costs nothing.
+		 *
+		 * The placeholder form this replaced was no better; the cost was never the
+		 * binding, it was the plan.
+		 */
+		const wanted = new Set(nodeIds);
 		const rows = getDatabase()
 			.prepare(
-				`SELECT * FROM graph_edges
-				 WHERE src_id IN (${placeholders}) AND dst_id IN (${placeholders})`
+				`SELECT e.* FROM json_each(?) ids
+				 INNER JOIN graph_edges e ON e.src_id = ids.value`
 			)
-			.all(...nodeIds, ...nodeIds) as GraphEdgeRow[];
-		return rows.map(toEdge);
+			.all(idSet(nodeIds)) as GraphEdgeRow[];
+
+		return rows.filter(row => wanted.has(row.dst_id)).map(toEdge);
 	},
 
 	/**
@@ -1348,6 +1410,36 @@ export const graphQueries = {
 		const rows = getDatabase()
 			.prepare(
 				`SELECT * FROM graph_nodes ${clause}
+				 ORDER BY pinned DESC, weight DESC, updated_at DESC
+				 LIMIT ?`
+			)
+			.all(...params) as GraphNodeRow[];
+		return rows.map(toNode);
+	},
+
+	/**
+	 * The same listing, narrowed to a rectangle of the persisted layout.
+	 *
+	 * This is what opening a bin reads, and it is why the view can be complete
+	 * without being unbounded: zooming into part of the map costs that part. The
+	 * bounds come from the layout's own coordinate space, which the client already
+	 * holds — every mark it drew carries the cell it stands for.
+	 */
+	listInRegion(
+		filter: GraphListFilter & { limit?: number },
+		region: { minX: number; maxX: number; minY: number; maxY: number }
+	): GraphNode[] {
+		const { where, params } = buildNodeFilter(filter);
+		where.push(
+			`id IN (SELECT node_id FROM graph_layout
+			        WHERE x >= ? AND x <= ? AND y >= ? AND y <= ?)`
+		);
+		params.push(region.minX, region.maxX, region.minY, region.maxY);
+		params.push(filter.limit ?? 2000);
+
+		const rows = getDatabase()
+			.prepare(
+				`SELECT * FROM graph_nodes WHERE ${where.join(' AND ')}
 				 ORDER BY pinned DESC, weight DESC, updated_at DESC
 				 LIMIT ?`
 			)
@@ -1760,5 +1852,298 @@ export const graphQueries = {
 			changes?: number;
 		};
 		return Number(result.changes ?? 0);
+	}
+};
+
+/** One node's place in the persisted arrangement. */
+export interface GraphLayoutRow {
+	nodeId: string;
+	community: number;
+	x: number;
+	y: number;
+	/**
+	 * 1 when the force simulation computed this position, 0 when it is a guess
+	 * from the community's neighbourhood. See migration 067 for why the two must
+	 * stay distinguishable.
+	 */
+	placed: number;
+}
+
+/** How many nodes match a filter, and the rectangle their layout occupies. */
+export interface GraphLayoutExtent {
+	total: number;
+	/** Matching nodes with no position yet — counted, but outside the bounds. */
+	unplaced: number;
+	minX: number;
+	maxX: number;
+	minY: number;
+	maxY: number;
+}
+
+/** The grid a binned view is rolled up to, in layout coordinates. */
+export interface GraphBinGrid {
+	originX: number;
+	originY: number;
+	cellWidth: number;
+	cellHeight: number;
+}
+
+/** One occupied cell: how many it holds, where they average, and which speaks for it. */
+export interface GraphBinRow {
+	cellX: number;
+	cellY: number;
+	members: number;
+	x: number;
+	y: number;
+	/** The most reinforced member — the mark itself when `members` is 1. */
+	id: string;
+	label: string;
+	community: number;
+}
+
+export interface GraphBinEdgeRow {
+	srcX: number;
+	srcY: number;
+	dstX: number;
+	dstY: number;
+	weight: number;
+}
+
+/**
+ * Reading and writing the persisted arrangement (see migration 067).
+ *
+ * Kept apart from `graphQueries` because it answers a different question:
+ * `graphQueries` is about what is remembered, this is about how it is drawn.
+ * Every row here is derived and disposable — deleting the table costs one
+ * background pass and no memory.
+ */
+export const graphLayoutQueries = {
+	/** Positions and communities for a set of nodes. */
+	read(nodeIds: string[]): Map<string, GraphLayoutRow> {
+		const result = new Map<string, GraphLayoutRow>();
+		if (nodeIds.length === 0) return result;
+		const rows = getDatabase()
+			.prepare(
+				`SELECT node_id AS nodeId, community, x, y, placed FROM graph_layout
+				 WHERE node_id IN ${ID_SET}`
+			)
+			.all(idSet(nodeIds)) as GraphLayoutRow[];
+		for (const row of rows) result.set(row.nodeId, row);
+		return result;
+	},
+
+	/** Replace the arrangement for the nodes given, in one transaction. */
+	writeMany(rows: GraphLayoutRow[]): number {
+		if (rows.length === 0) return 0;
+		return graphQueries.transaction(() => {
+			const statement = getDatabase().prepare(
+				`INSERT INTO graph_layout (node_id, community, x, y, placed, updated_at)
+				 VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+				 ON CONFLICT(node_id) DO UPDATE SET
+				   community = excluded.community, x = excluded.x, y = excluded.y,
+				   placed = excluded.placed, updated_at = CURRENT_TIMESTAMP`
+			);
+			for (const row of rows) {
+				statement.run(row.nodeId, row.community, row.x, row.y, row.placed);
+			}
+			return rows.length;
+		});
+	},
+
+	/**
+	 * Live nodes in the order the view itself ranks them, for the layout pass.
+	 *
+	 * Capped, because a force layout over an unbounded set is unbounded work. What
+	 * survives the cap is what the view would have shown anyway — pinned, then
+	 * most reinforced, then most recent — so anything left unplaced is also the
+	 * least likely to be looked at.
+	 */
+	liveNodeIds(limit: number): string[] {
+		const rows = getDatabase()
+			.prepare(
+				// `id` is the tiebreak, and it is load-bearing rather than tidy. Most
+				// live nodes share a weight and a timestamp, so without it SQLite is
+				// free to return ties in any order — and this order decides the order
+				// the layout graph is built in, which ForceAtlas2 is sensitive to. The
+				// same store laid out to a different map on every pass.
+				`SELECT id FROM graph_nodes
+				 WHERE archived_at IS NULL AND superseded_by IS NULL
+				 ORDER BY pinned DESC, weight DESC, updated_at DESC, id ASC
+				 LIMIT ?`
+			)
+			.all(limit) as { id: string }[];
+		return rows.map(row => row.id);
+	},
+
+	/** Whether any live node is still waiting to be placed. */
+	hasUnplaced(): boolean {
+		const row = getDatabase()
+			.prepare(
+				`SELECT 1 AS present FROM graph_nodes n
+				 LEFT JOIN graph_layout l ON l.node_id = n.id
+				 WHERE n.archived_at IS NULL AND n.superseded_by IS NULL AND l.node_id IS NULL
+				 LIMIT 1`
+			)
+			.get() as { present: number } | null;
+		return row !== null && row !== undefined;
+	},
+
+	/** Rows whose node no longer exists. Foreign keys are not always enforced. */
+	pruneOrphans(): number {
+		const result = getDatabase()
+			.prepare(`DELETE FROM graph_layout WHERE node_id NOT IN (SELECT id FROM graph_nodes)`)
+			.run() as { changes?: number };
+		return Number(result.changes ?? 0);
+	},
+
+	/** Drop the whole arrangement — used when the graph is purged. */
+	clear(): void {
+		getDatabase().prepare(`DELETE FROM graph_layout`).run();
+	},
+
+	/**
+	 * How many nodes match, and the rectangle their arrangement occupies.
+	 *
+	 * One pass answering both, because the two are always wanted together: the
+	 * count decides whether the view has to bin at all, and the extent is what the
+	 * grid is laid over. `MIN`/`MAX` skip NULLs, so a node still waiting to be
+	 * placed is counted without dragging the bounds toward the origin.
+	 */
+	extent(filter: GraphListFilter): GraphLayoutExtent {
+		const { where, params } = buildNodeFilter(filter, 'n.');
+		const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+		const row = getDatabase()
+			.prepare(
+				`SELECT COUNT(*) AS total,
+				        SUM(CASE WHEN l.node_id IS NULL THEN 1 ELSE 0 END) AS unplaced,
+				        MIN(l.x) AS minX, MAX(l.x) AS maxX,
+				        MIN(l.y) AS minY, MAX(l.y) AS maxY
+				 FROM graph_nodes n
+				 LEFT JOIN graph_layout l ON l.node_id = n.id
+				 ${clause}`
+			)
+			.get(...params) as {
+			total: number;
+			unplaced: number | null;
+			minX: number | null;
+			maxX: number | null;
+			minY: number | null;
+			maxY: number | null;
+		};
+
+		return {
+			total: row.total ?? 0,
+			unplaced: row.unplaced ?? 0,
+			minX: row.minX ?? 0,
+			maxX: row.maxX ?? 0,
+			minY: row.minY ?? 0,
+			maxY: row.maxY ?? 0
+		};
+	},
+
+	/**
+	 * One row per occupied cell of the grid: its size, its centroid, and its most
+	 * reinforced member.
+	 *
+	 * The count of rows is bounded by the grid, not by the store — that is the
+	 * whole point. A cell holding one memory comes back with `members = 1` and
+	 * that memory's id, so the caller can return the memory ITSELF rather than a
+	 * bin standing for it; below the render budget that is every cell, and the
+	 * view is bit-for-bit the flat one.
+	 *
+	 * `CAST(... AS INTEGER)` truncates toward zero, which would fold the cells on
+	 * either side of the origin into one — the grid is therefore anchored at the
+	 * arrangement's minimum, so every offset it sees is positive.
+	 */
+	binnedNodes(filter: GraphListFilter, grid: GraphBinGrid): GraphBinRow[] {
+		const { where, params } = buildNodeFilter(filter, 'n.');
+		const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+		return getDatabase()
+			.prepare(
+				`SELECT cellX, cellY, members, cx AS x, cy AS y, id, label, community
+				 FROM (
+				   SELECT cellX, cellY, id, label, community,
+				          COUNT(*) OVER (PARTITION BY cellX, cellY) AS members,
+				          AVG(x) OVER (PARTITION BY cellX, cellY) AS cx,
+				          AVG(y) OVER (PARTITION BY cellX, cellY) AS cy,
+				          ROW_NUMBER() OVER (
+				            PARTITION BY cellX, cellY
+				            ORDER BY pinned DESC, weight DESC, updated_at DESC
+				          ) AS rn
+				   FROM (
+				     SELECT CAST((l.x - ?) / ? AS INTEGER) AS cellX,
+				            CAST((l.y - ?) / ? AS INTEGER) AS cellY,
+				            l.x AS x, l.y AS y, l.community AS community,
+				            n.id AS id, n.label AS label,
+				            n.pinned AS pinned, n.weight AS weight, n.updated_at AS updated_at
+				     FROM graph_nodes n
+				     INNER JOIN graph_layout l ON l.node_id = n.id
+				     ${clause}
+				   )
+				 )
+				 WHERE rn = 1`
+			)
+			.all(
+				grid.originX,
+				grid.cellWidth,
+				grid.originY,
+				grid.cellHeight,
+				...params
+			) as GraphBinRow[];
+	},
+
+	/**
+	 * Edges rolled up to the same grid, so the binned picture keeps its structure.
+	 *
+	 * Stored edges only. The derived ones (see `derivedEdges`) exist to hold a
+	 * subject's memories together, and the layout pass already consumed them —
+	 * their effect is in the POSITIONS, which is where it belongs at this
+	 * resolution. Recomputing them here would mean handing this query the id of
+	 * every matching node, which is the unbounded thing the grid exists to avoid.
+	 *
+	 * Edges inside a single cell are dropped: both ends are the same mark.
+	 */
+	binnedEdges(filter: GraphListFilter, grid: GraphBinGrid, limit: number): GraphBinEdgeRow[] {
+		const src = buildNodeFilter(filter, 'na.');
+		const dst = buildNodeFilter(filter, 'nb.');
+		const conditions = [...src.where, ...dst.where];
+		const clause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+		return getDatabase()
+			.prepare(
+				`SELECT srcX, srcY, dstX, dstY, SUM(weight) AS weight
+				 FROM (
+				   SELECT CAST((la.x - ?) / ? AS INTEGER) AS srcX,
+				          CAST((la.y - ?) / ? AS INTEGER) AS srcY,
+				          CAST((lb.x - ?) / ? AS INTEGER) AS dstX,
+				          CAST((lb.y - ?) / ? AS INTEGER) AS dstY,
+				          e.weight AS weight
+				   FROM graph_edges e
+				   INNER JOIN graph_layout la ON la.node_id = e.src_id
+				   INNER JOIN graph_layout lb ON lb.node_id = e.dst_id
+				   INNER JOIN graph_nodes na ON na.id = e.src_id
+				   INNER JOIN graph_nodes nb ON nb.id = e.dst_id
+				   ${clause}
+				 )
+				 WHERE NOT (srcX = dstX AND srcY = dstY)
+				 GROUP BY 1, 2, 3, 4
+				 ORDER BY weight DESC
+				 LIMIT ?`
+			)
+			.all(
+				grid.originX,
+				grid.cellWidth,
+				grid.originY,
+				grid.cellHeight,
+				grid.originX,
+				grid.cellWidth,
+				grid.originY,
+				grid.cellHeight,
+				...src.params,
+				...dst.params,
+				limit
+			) as GraphBinEdgeRow[];
 	}
 };

--- a/backend/memory/bootstrap.ts
+++ b/backend/memory/bootstrap.ts
@@ -20,6 +20,7 @@ import { notifyMemoryReadiness } from './notify';
 import { resetGraphEmptiness } from './context';
 import { reconcileVectorIndex } from './indexer';
 import { startMemoryMaintenance } from './maintenance';
+import { resetGraphLayoutState, scheduleGraphLayout } from './layout';
 import { ensureMemoryModel } from './model';
 import { startExtractionRunner } from './extract';
 
@@ -41,6 +42,14 @@ export function bootstrapMemoryGraph(): void {
 	// cache is still holding describes rows that no longer exist.
 	vectorCache.reset();
 	resetGraphEmptiness();
+
+	// Same reason as the caches above: "Clear All Data" wipes the database under a
+	// live process, so what the last pass laid out describes rows that no longer
+	// exist. Scheduling one here is also what places an EXISTING graph the first
+	// time the upgrade runs — until it lands the view falls back to the flat
+	// listing it always used, so nothing is missing meanwhile.
+	resetGraphLayoutState();
+	scheduleGraphLayout();
 
 	// Duplicate collapse and retention are pure SQL and are worth running whether
 	// or not the artifact ever lands, so maintenance starts independently of the

--- a/backend/memory/layout.ts
+++ b/backend/memory/layout.ts
@@ -1,0 +1,985 @@
+/**
+ * The persisted arrangement of the Memory graph.
+ *
+ * Community detection and force layout both used to run on the read path — one
+ * on the server inside `buildGraphView`, the other in the browser on every open —
+ * and both produce the SAME answer for the same dataset. They were being
+ * recomputed, not computed: opening the modal twice paid for the identical
+ * arrangement twice, and every conversation that recorded a memory made every
+ * connected client pay for it again.
+ *
+ * That is what made the modal's opening animation stutter once the graph got
+ * large. The animation is two hundred milliseconds of one thread, and a few
+ * hundred milliseconds of layout was landing inside it.
+ *
+ * So it happens HERE instead: once, in the background, written to `graph_layout`,
+ * and read back as two numbers per node. Reading a laid-out graph is then a
+ * table lookup whatever the graph costs to lay out, and the browser never runs a
+ * force simulation for the whole store again.
+ *
+ * ── Warm, not cold ────────────────────────────────────────────────────────────
+ * A pass starts from where the last one finished. That is not only cheaper, it is
+ * the thing that makes the view stable to look at: a memory arriving must not
+ * rearrange the map somebody has learned. New nodes are seeded at the centroid of
+ * whatever they connect to and a short pass settles them into the gaps, exactly
+ * as the client's incremental path used to do for a single session.
+ *
+ * ── Bounded on purpose ────────────────────────────────────────────────────────
+ * `MAX_LAYOUT_NODES` caps the simulation. A force layout is superlinear and the
+ * store grows without limit, so an uncapped pass would eventually take longer
+ * than the interval between the writes that trigger it. What survives the cap is
+ * what the view ranks highest anyway; anything below it is reachable by search
+ * and by expanding a lobe, neither of which needs a position.
+ */
+
+import Graph from 'graphology';
+import louvain from 'graphology-communities-louvain';
+import forceAtlas2 from 'graphology-layout-forceatlas2';
+import { graphQueries, graphLayoutQueries, type GraphLayoutRow } from '$backend/database/queries/graph-queries';
+import { broadcastGraphChanged } from './notify';
+import { debug } from '$shared/utils/logger';
+
+/**
+ * Two caps, because the two halves of a pass scale differently.
+ *
+ * COMMUNITY DETECTION is roughly linear in the edges, and it is what the overview
+ * groups by — a node left out of it has no lobe to belong to and would vanish
+ * from the picture entirely, which is exactly the failure a cap is supposed to
+ * prevent. So it runs over everything live, up to a ceiling far beyond any real
+ * store.
+ *
+ * THE FORCE SIMULATION is superlinear and measurably so — around 15 ms per
+ * iteration at 1,200 nodes and 90 ms at 5,000 — so it runs only over the
+ * highest-ranked nodes. The rest keep their real community and get a position
+ * near it, marked `placed = 0` so nothing downstream mistakes the guess for a
+ * computed arrangement.
+ */
+const MAX_COMMUNITY_NODES = 50_000;
+const MAX_LAYOUT_NODES = 6_000;
+
+/**
+ * How long to wait after a write before laying out again.
+ *
+ * `notifyGraphChanged` already folds a turn's ingestion burst into one event at
+ * 600 ms; this sits on top because a layout pass is far more expensive than a
+ * broadcast and a user watching the graph does not need the new node to have
+ * found its final place within the second — it appears immediately either way,
+ * seeded next to what it connects to.
+ */
+const DEBOUNCE_MS = 4_000;
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+let running = false;
+/** A change arrived mid-pass, so the result is already out of date. */
+let rerunRequested = false;
+
+/**
+ * What the last pass laid out.
+ *
+ * Reinforcement bumps `weight` and `updated_at` on every recall, so the change
+ * notification fires constantly without the SET of nodes moving at all. Laying
+ * out an unchanged set produces an unchanged answer, so this skips it.
+ */
+let lastMembership = '';
+
+/** Cheap order-sensitive fingerprint of an id list. */
+function membershipOf(ids: string[]): string {
+	let hash = 2166136261;
+	for (const id of ids) {
+		for (let i = 0; i < id.length; i++) {
+			hash ^= id.charCodeAt(i);
+			hash = Math.imul(hash, 16777619);
+		}
+	}
+	return `${ids.length}:${(hash >>> 0).toString(36)}`;
+}
+
+/**
+ * Note that the graph changed and a new arrangement will be needed.
+ *
+ * Cheap and idempotent — call it after any write rather than working out whether
+ * this particular write moved anything.
+ */
+export function scheduleGraphLayout(): void {
+	if (timer) return;
+	timer = setTimeout(() => {
+		timer = null;
+		void runGraphLayout();
+	}, DEBOUNCE_MS);
+	// Housekeeping — never a reason to hold the process open at shutdown.
+	timer.unref?.();
+}
+
+/** Forget what was laid out, so the next pass rebuilds from nothing. */
+export function resetGraphLayoutState(): void {
+	lastMembership = '';
+}
+
+/**
+ * Recompute communities and positions for the live graph.
+ *
+ * Never throws: a missing arrangement costs the client a seeded layout of its
+ * own, which is what it used to do for everything, so a failure here degrades to
+ * the previous behaviour instead of breaking the view.
+ */
+export async function runGraphLayout(): Promise<void> {
+	if (running) {
+		rerunRequested = true;
+		return;
+	}
+	running = true;
+
+	try {
+		// Rank-ordered, so "the first N" is also "the N the view would have shown".
+		const ids = graphLayoutQueries.liveNodeIds(MAX_COMMUNITY_NODES);
+		if (ids.length === 0) {
+			graphLayoutQueries.clear();
+			lastMembership = membershipOf(ids);
+			return;
+		}
+
+		const membership = membershipOf(ids);
+		// Same nodes as last time and nothing waiting to be placed: the answer is
+		// the one already in the table.
+		if (membership === lastMembership && !graphLayoutQueries.hasUnplaced()) return;
+
+		const started = Date.now();
+		const existing = graphLayoutQueries.read(ids);
+		const graph = buildLayoutGraph(ids);
+
+		// Louvain needs at least one edge; an edgeless graph leaves every node in
+		// its own community, which is also the honest answer.
+		let communities: Record<string, number> = {};
+		if (graph.size > 0) {
+			try {
+				// `rng` is NOT optional here, whatever the signature suggests.
+				// graphology-communities-louvain defaults to `Math.random` and walks the
+				// graph in random order, so the same store produced different lobes on
+				// every pass — and since everything downstream is seeded from the
+				// community structure, that alone made the whole map move. A fixed seed
+				// keeps the randomised traversal (which is what the algorithm wants)
+				// while making the answer reproducible.
+				communities = louvain(graph, { getEdgeWeight: 'weight', rng: seededRandom() });
+			} catch (error) {
+				debug.warn('memory', 'Community detection failed; laying out without lobes', error);
+			}
+		}
+
+		const simulatedIds = ids.slice(0, MAX_LAYOUT_NODES);
+		const simulated = simulatedIds.length === ids.length ? graph : restrictTo(graph, simulatedIds);
+
+		const cold = existing.size === 0;
+		const rows = await arrange(simulated, communities, existing, cold);
+
+		// Everything below the simulation cap. It keeps its real community — so the
+		// view counts it and groups it correctly — and sits near the members of that
+		// community that WERE placed, spread by its own id so a lobe of ten thousand
+		// does not become one dot. `placed: 0` tells the view this is a
+		// neighbourhood rather than an arrangement.
+		if (simulatedIds.length < ids.length) {
+			const centroids = new Map<number, { x: number; y: number; count: number }>();
+			for (const row of rows) {
+				const centroid = centroids.get(row.community) ?? { x: 0, y: 0, count: 0 };
+				centroid.x += row.x;
+				centroid.y += row.y;
+				centroid.count++;
+				centroids.set(row.community, centroid);
+			}
+
+			for (let i = simulatedIds.length; i < ids.length; i++) {
+				const id = ids[i];
+				const community = communities[id] ?? 0;
+				const centroid = centroids.get(community);
+				const anchor = centroid
+					? { x: centroid.x / centroid.count, y: centroid.y / centroid.count }
+					: { x: 0, y: 0 };
+				const radius = centroid ? 40 + 8 * Math.sqrt(centroid.count) : 200;
+				const jitter = jitterOf(id);
+
+				rows.push({
+					nodeId: id,
+					community,
+					x: anchor.x + jitter.x * radius,
+					y: anchor.y + jitter.y * radius,
+					placed: 0
+				});
+			}
+		}
+
+		graphLayoutQueries.writeMany(rows);
+		graphLayoutQueries.pruneOrphans();
+		lastMembership = membership;
+
+		// Tell open views, or they never learn. The arrangement changes several
+		// seconds AFTER the write that triggered it — long after the doorbell for
+		// that write has been answered — so without this a modal that was open the
+		// whole time keeps drawing positions it computed for itself, and only a
+		// close-and-reopen picks up the real ones.
+		broadcastGraphChanged('layout');
+		debug.log(
+			'memory',
+			`Laid out ${simulated.order} of ${rows.length} memory node(s) in ${Date.now() - started}ms`
+		);
+	} catch (error) {
+		debug.warn('memory', 'Memory graph layout failed (non-fatal)', error);
+	} finally {
+		running = false;
+		if (rerunRequested) {
+			rerunRequested = false;
+			scheduleGraphLayout();
+		}
+	}
+}
+
+/**
+ * The graph the simulation runs on: stored edges plus the derived ones.
+ *
+ * Both are included because the derived edges are most of the structure the
+ * episodic half has (see `graphQueries.derivedEdges`) — laying out without them
+ * scatters memories that plainly belong together.
+ */
+function buildLayoutGraph(ids: string[]): Graph {
+	const graph = new Graph({ type: 'undirected', multi: false });
+	for (const id of ids) graph.addNode(id, { x: 0, y: 0, size: 1 });
+
+	const link = (source: string, target: string, weight: number): void => {
+		if (source === target) return;
+		if (!graph.hasNode(source) || !graph.hasNode(target)) return;
+		if (graph.hasEdge(source, target)) return;
+		graph.addUndirectedEdge(source, target, { weight });
+	};
+
+	for (const edge of graphQueries.edgesWithin(ids)) link(edge.srcId, edge.dstId, edge.weight);
+	for (const edge of graphQueries.derivedEdges(ids)) link(edge.srcId, edge.dstId, edge.weight);
+
+	// ForceAtlas2 reads mass from `size`; a hub that weighs more holds its
+	// neighbours' fan open instead of being dragged into the middle of it.
+	graph.forEachNode(id => {
+		graph.setNodeAttribute(id, 'size', 1 + Math.sqrt(graph.degree(id)));
+	});
+	return graph;
+}
+
+/** The induced subgraph over `ids` — the part the simulation will actually move. */
+function restrictTo(graph: Graph, ids: string[]): Graph {
+	const keep = new Set(ids);
+	const subgraph = new Graph({ type: 'undirected', multi: false });
+	for (const id of ids) {
+		if (graph.hasNode(id)) subgraph.addNode(id, { ...graph.getNodeAttributes(id) });
+	}
+	graph.forEachUndirectedEdge((_edge, attributes, source, target) => {
+		if (!keep.has(source) || !keep.has(target)) return;
+		if (subgraph.hasEdge(source, target)) return;
+		subgraph.addUndirectedEdge(source, target, { ...attributes });
+	});
+	return subgraph;
+}
+
+/**
+ * Arrange the graph — the step that decides its SHAPE.
+ *
+ * ── Why the old view was always a circle ─────────────────────────────────────
+ * Two causes, and the second is by far the larger.
+ *
+ * The seed was a golden-angle spiral of community regions, which is a disc by
+ * construction. That much was known and only half-fixed: an earlier pass sized
+ * the regions by membership and left them on the spiral, so the silhouette stayed
+ * round however lopsided the data was.
+ *
+ * But the real cause is that a memory graph is not connected. Measured on a real
+ * store: 1,801 live nodes in 146 components — one giant of 961, a handful in the
+ * hundreds, and 108 lone nodes with no relationship to anything. ForceAtlas2
+ * exerts NO force between components, so the only thing arranging them was
+ * gravity, and gravity is an isotropic pull toward one point. Repulsion pushes
+ * out, gravity pulls in, and every unrelated component settles at roughly the
+ * same radius. That is the ring of small stars around the edge, and it is why the
+ * outline was a circle regardless of what the graph contained.
+ *
+ * ── What replaces it ─────────────────────────────────────────────────────────
+ * Each component is laid out in ITS OWN local space, where gravity is a local
+ * force that keeps it cohesive instead of a global one that rounds everything
+ * off. The components are then packed, and the packing is what the outline comes
+ * from: sizes and counts, which differ per dataset, rather than a formula that
+ * does not. Lone nodes go into the gaps between the packed components, which is
+ * what dissolves the ring — they were a third of the marks and all of them were
+ * on it.
+ *
+ * Deterministic throughout. Every scatter is derived from a node id or a
+ * community index, both stable for a given dataset, so reopening the modal
+ * settles into the same map. Different data gives a different shape; the same
+ * data does not.
+ *
+ * ── And it is cheaper ────────────────────────────────────────────────────────
+ * Repulsion is O(n²), so laying out components separately costs Σn²ᵢ instead of
+ * (Σnᵢ)². On the store measured above that is 1.0M against 3.2M — the shape is
+ * better AND the pass is a third of the work.
+ */
+async function arrange(
+	simulated: Graph,
+	communities: Record<string, number>,
+	existing: Map<string, GraphLayoutRow>,
+	cold: boolean
+): Promise<GraphLayoutRow[]> {
+	const components = componentsOf(simulated);
+	const singletons: string[] = [];
+	const placed: PlacedComponent[] = [];
+
+	for (const member of components) {
+		if (member.length === 1) {
+			singletons.push(member[0]);
+			continue;
+		}
+
+		const part = restrictTo(simulated, member);
+		// A component that was already on the map keeps its place. Only its interior
+		// is re-settled, so a memory arriving in one lobe cannot rearrange the
+		// others — the map somebody has learned survives the pass.
+		const anchor = existingCentroid(member, existing);
+		seedComponent(part, communities, existing, anchor);
+		await settle(part, cold || !anchor ? iterationsFor(part.order) : warmIterationsFor(part.order));
+
+		placed.push(measure(part, anchor));
+	}
+
+	packComponents(placed);
+	const rows: GraphLayoutRow[] = [];
+
+	for (const component of placed) {
+		for (let i = 0; i < component.ids.length; i++) {
+			rows.push({
+				nodeId: component.ids[i],
+				community: communities[component.ids[i]] ?? 0,
+				x: component.xs[i] + component.offsetX,
+				y: component.ys[i] + component.offsetY,
+				placed: 1
+			});
+		}
+	}
+
+	for (const row of scatterSingletons(singletons, placed, communities, existing)) rows.push(row);
+	return rows;
+}
+
+/** One component, laid out in local space and waiting to be given a place. */
+interface PlacedComponent {
+	ids: string[];
+	xs: Float64Array;
+	ys: Float64Array;
+	/** Enclosing radius in local space, for the packing to keep clear. */
+	radius: number;
+	offsetX: number;
+	offsetY: number;
+	/** Where it already sat, when it was on the map before this pass. */
+	anchored: boolean;
+}
+
+/**
+ * Connected components, largest first.
+ *
+ * Ordered by size and then by the lowest id it contains, so the ordering — and
+ * therefore everything the packing derives from it — is stable for a given
+ * dataset rather than dependent on insertion order.
+ */
+function componentsOf(graph: Graph): string[][] {
+	const seen = new Set<string>();
+	const components: string[][] = [];
+
+	for (const start of graph.nodes()) {
+		if (seen.has(start)) continue;
+
+		const member: string[] = [start];
+		seen.add(start);
+		const stack = [start];
+		while (stack.length > 0) {
+			const current = stack.pop() as string;
+			graph.forEachNeighbor(current, neighbour => {
+				if (seen.has(neighbour)) return;
+				seen.add(neighbour);
+				member.push(neighbour);
+				stack.push(neighbour);
+			});
+		}
+		member.sort();
+		components.push(member);
+	}
+
+	components.sort((a, b) => b.length - a.length || (a[0] < b[0] ? -1 : 1));
+	return components;
+}
+
+/** The centroid this component occupied before the pass, if it was on the map. */
+function existingCentroid(
+	member: string[],
+	existing: Map<string, GraphLayoutRow>
+): { x: number; y: number } | null {
+	let sumX = 0;
+	let sumY = 0;
+	let count = 0;
+	for (const id of member) {
+		const previous = existing.get(id);
+		if (!previous || previous.placed !== 1) continue;
+		sumX += previous.x;
+		sumY += previous.y;
+		count++;
+	}
+	return count > 0 ? { x: sumX / count, y: sumY / count } : null;
+}
+
+/**
+ * Where a component's nodes start, in LOCAL space.
+ *
+ * Local is what makes gravity harmless: a component sitting far from the origin
+ * would otherwise be dragged toward it a little on every pass, and after enough
+ * passes every component would have crept into one pile — the disc again, arrived
+ * at slowly instead of immediately.
+ *
+ * Nodes that already had a position keep it, translated into local space, which
+ * is what makes successive passes refinements of one arrangement rather than a
+ * new arrangement each time.
+ */
+function seedComponent(
+	part: Graph,
+	communities: Record<string, number>,
+	existing: Map<string, GraphLayoutRow>,
+	anchor: { x: number; y: number } | null
+): void {
+	const meta = communityMetaSeed(part, communities);
+	const placedIds = new Set<string>();
+
+	part.forEachNode(id => {
+		const previous = existing.get(id);
+		if (!previous || previous.placed !== 1 || !anchor) return;
+		part.setNodeAttribute(id, 'x', previous.x - anchor.x);
+		part.setNodeAttribute(id, 'y', previous.y - anchor.y);
+		placedIds.add(id);
+	});
+
+	part.forEachNode(id => {
+		if (placedIds.has(id)) return;
+
+		// Near whatever it connects to that is already placed — an arriving memory
+		// belongs next to its subject, not wherever its community happens to sit.
+		let sumX = 0;
+		let sumY = 0;
+		let count = 0;
+		part.forEachNeighbor(id, neighbour => {
+			if (!placedIds.has(neighbour)) return;
+			sumX += part.getNodeAttribute(neighbour, 'x') as number;
+			sumY += part.getNodeAttribute(neighbour, 'y') as number;
+			count++;
+		});
+
+		const jitter = jitterOf(id);
+		if (count > 0) {
+			part.setNodeAttribute(id, 'x', sumX / count + jitter.x * 12);
+			part.setNodeAttribute(id, 'y', sumY / count + jitter.y * 12);
+			return;
+		}
+
+		const region = meta.get(communities[id] ?? 0);
+		part.setNodeAttribute(id, 'x', (region?.x ?? 0) + jitter.x * (region?.radius ?? 120));
+		part.setNodeAttribute(id, 'y', (region?.y ?? 0) + jitter.y * (region?.radius ?? 120));
+	});
+}
+
+/**
+ * Where each community inside a component starts, from the communities' own graph.
+ *
+ * This is what replaced the spiral, and the difference is not only that it is
+ * irregular. A spiral orders lobes by size and says nothing about them; laying
+ * out a META-GRAPH — one node per community, edges weighted by how many real
+ * edges cross between them — puts lobes near the lobes they are actually
+ * connected to. The macro arrangement starts meaning something, and the forces
+ * that follow refine a structure instead of fighting a formula.
+ *
+ * Tens of nodes at most, so it costs nothing next to the component it seeds.
+ */
+function communityMetaSeed(
+	part: Graph,
+	communities: Record<string, number>
+): Map<number, { x: number; y: number; radius: number }> {
+	const sizes = new Map<number, number>();
+	part.forEachNode(id => {
+		const community = communities[id] ?? 0;
+		sizes.set(community, (sizes.get(community) ?? 0) + 1);
+	});
+
+	const regions = new Map<number, { x: number; y: number; radius: number }>();
+	if (sizes.size === 0) return regions;
+
+	/** Local radius per √member — area proportional to membership. */
+	const SCALE = 26;
+
+	if (sizes.size === 1) {
+		const [[community, size]] = [...sizes.entries()];
+		regions.set(community, { x: 0, y: 0, radius: Math.max(40, SCALE * Math.sqrt(size)) });
+		return regions;
+	}
+
+	const meta = new Graph({ type: 'undirected', multi: false });
+	for (const [community, size] of sizes) {
+		const jitter = jitterOf(`community-${community}`);
+		const radius = Math.max(40, SCALE * Math.sqrt(size));
+		// Deterministic scatter rather than a ring: a ring is the shape the forces
+		// would then have to escape, and they do not escape it.
+		meta.addNode(String(community), {
+			x: jitter.x * 400,
+			y: jitter.y * 400,
+			size: 1 + Math.sqrt(size),
+			radius
+		});
+	}
+
+	part.forEachUndirectedEdge((_edge, _attributes, source, target) => {
+		const a = String(communities[source] ?? 0);
+		const b = String(communities[target] ?? 0);
+		if (a === b || !meta.hasNode(a) || !meta.hasNode(b)) return;
+		if (meta.hasEdge(a, b)) {
+			meta.updateEdgeAttribute(a, b, 'weight', (weight: unknown) => (weight as number) + 1);
+			return;
+		}
+		meta.addUndirectedEdge(a, b, { weight: 1 });
+	});
+
+	if (meta.size > 0) {
+		forceAtlas2.assign(meta, {
+			iterations: 300,
+			settings: {
+				...forceAtlas2.inferSettings(meta),
+				outboundAttractionDistribution: true,
+				gravity: 0.05,
+				scalingRatio: 200,
+				adjustSizes: false,
+				edgeWeightInfluence: 1,
+				barnesHutOptimize: false
+			}
+		});
+	}
+
+	meta.forEachNode((key, attributes) => {
+		regions.set(Number(key), {
+			x: attributes.x as number,
+			y: attributes.y as number,
+			radius: attributes.radius as number
+		});
+	});
+	return regions;
+}
+
+/** Centre a settled component on its own centroid and measure what it needs. */
+function measure(part: Graph, anchor: { x: number; y: number } | null): PlacedComponent {
+	const ids = part.nodes();
+	const xs = new Float64Array(ids.length);
+	const ys = new Float64Array(ids.length);
+
+	let sumX = 0;
+	let sumY = 0;
+	for (let i = 0; i < ids.length; i++) {
+		xs[i] = part.getNodeAttribute(ids[i], 'x') as number;
+		ys[i] = part.getNodeAttribute(ids[i], 'y') as number;
+		sumX += xs[i];
+		sumY += ys[i];
+	}
+	const centreX = sumX / ids.length;
+	const centreY = sumY / ids.length;
+
+	let radius = 0;
+	for (let i = 0; i < ids.length; i++) {
+		xs[i] -= centreX;
+		ys[i] -= centreY;
+		radius = Math.max(radius, Math.sqrt(xs[i] * xs[i] + ys[i] * ys[i]));
+	}
+
+	return {
+		ids,
+		xs,
+		ys,
+		radius: Math.max(radius, 20),
+		// An anchored component keeps its old centroid; the drift the settle
+		// introduced is absorbed by re-centring rather than accumulating.
+		offsetX: anchor ? anchor.x + centreX : 0,
+		offsetY: anchor ? anchor.y + centreY : 0,
+		anchored: anchor !== null
+	};
+}
+
+/**
+ * Give every unanchored component a place, and separate any that overlap.
+ *
+ * The outline this produces is the point. Components are scattered into a box
+ * whose AREA follows the total they need and whose aspect is deliberately not
+ * square, then pushed apart until they no longer collide — so the silhouette is
+ * decided by how many components there are and how big each one is, both of which
+ * are properties of the data. Every spiral, ring or fill-outward-from-a-point
+ * strategy converges on a disc no matter how its regions are sized; that lesson
+ * cost two attempts.
+ *
+ * Anchored components do not move: they are where the user last saw them.
+ */
+function packComponents(placed: PlacedComponent[]): void {
+	if (placed.length === 0) return;
+
+	const total = placed.reduce((sum, component) => sum + Math.PI * component.radius ** 2, 0);
+	/** Air, as a multiple of the area the components themselves occupy. */
+	const BREATHING = 2.6;
+	/** Wider than tall, so the default outline is not a square either. */
+	const ASPECT = 1.45;
+	const width = Math.sqrt(total * BREATHING * ASPECT);
+	const height = width / ASPECT;
+
+	for (const component of placed) {
+		if (component.anchored) continue;
+		const jitter = jitterOf(component.ids[0]);
+		component.offsetX = (jitter.x * width) / 2;
+		component.offsetY = (jitter.y * height) / 2;
+	}
+
+	/** Clear space between two components, as a fraction of the smaller radius. */
+	const GAP = 0.15;
+	const PASSES = 220;
+
+	for (let pass = 0; pass < PASSES; pass++) {
+		// Over-relaxed early and settling toward an exact correction: separating one
+		// pair nudges both into their other neighbours, so overshooting clears a
+		// crowd far faster, and easing off stops it oscillating near the answer.
+		const relax = 1.4 - 0.4 * (pass / PASSES);
+		let collided = false;
+
+		for (let i = 0; i < placed.length; i++) {
+			for (let j = i + 1; j < placed.length; j++) {
+				const a = placed[i];
+				const b = placed[j];
+				if (a.anchored && b.anchored) continue;
+
+				const minimum = a.radius + b.radius + GAP * Math.min(a.radius, b.radius);
+				let dx = b.offsetX - a.offsetX;
+				let dy = b.offsetY - a.offsetY;
+				const squared = dx * dx + dy * dy;
+				if (squared >= minimum * minimum) continue;
+
+				let distance = Math.sqrt(squared);
+				if (distance < 1e-9) {
+					const angle = jitterOf(a.ids[0] + b.ids[0]).angle;
+					dx = Math.cos(angle);
+					dy = Math.sin(angle);
+					distance = 1;
+				}
+
+				const push = (relax * (minimum - distance)) / distance;
+				// An anchored neighbour absorbs none of the correction — the mover
+				// takes all of it, which is what keeps a known map still.
+				const shareA = a.anchored ? 0 : b.anchored ? 1 : 0.5;
+				const shareB = b.anchored ? 0 : a.anchored ? 1 : 0.5;
+				a.offsetX -= dx * push * shareA;
+				a.offsetY -= dy * push * shareA;
+				b.offsetX += dx * push * shareB;
+				b.offsetY += dy * push * shareB;
+				collided = true;
+			}
+		}
+
+		if (!collided) break;
+	}
+}
+
+/**
+ * Place the nodes that connect to nothing, in the gaps between what does.
+ *
+ * These were the ring. A third of the marks on the measured store are lone
+ * nodes, and with no edges there is no force to arrange them — so under the old
+ * global gravity they all settled at one radius and drew a circle around
+ * everything else. Filling the gaps instead removes the ring and puts them where
+ * there is room, which is also where the eye is not already busy.
+ *
+ * The grid is coarse on purpose: it only has to answer "is anything here", and a
+ * fine one would cost more than the question is worth.
+ */
+function scatterSingletons(
+	singletons: string[],
+	placed: PlacedComponent[],
+	communities: Record<string, number>,
+	existing: Map<string, GraphLayoutRow>
+): GraphLayoutRow[] {
+	if (singletons.length === 0) return [];
+
+	const rows: GraphLayoutRow[] = [];
+
+	/**
+	 * One that was already on the map stays exactly where it was.
+	 *
+	 * Anchoring these matters more than anchoring components, and measurement is
+	 * what showed it: the free-cell grid is derived from where the components
+	 * ended up, so a single memory arriving anywhere changed one component's
+	 * radius, which changed the grid, which reassigned EVERY lone node. A warm
+	 * pass moved a hundred of them clear across the map — the one thing a
+	 * background pass must never do to a view somebody is reading.
+	 */
+	const ordered: string[] = [];
+	for (const id of [...singletons].sort()) {
+		const previous = existing.get(id);
+		if (previous && previous.placed === 1) {
+			rows.push({
+				nodeId: id,
+				community: communities[id] ?? 0,
+				x: previous.x,
+				y: previous.y,
+				placed: 1
+			});
+			continue;
+		}
+		ordered.push(id);
+	}
+	if (ordered.length === 0) return rows;
+
+	// Nothing else on the map — spread them over a box of their own rather than
+	// piling them on the origin.
+	if (placed.length === 0) {
+		const span = 120 * Math.sqrt(ordered.length);
+		for (const id of ordered) {
+			const jitter = jitterOf(id);
+			rows.push({
+				nodeId: id,
+				community: communities[id] ?? 0,
+				x: jitter.x * span,
+				y: (jitter.y * span) / 1.45,
+				placed: 1
+			});
+		}
+		return rows;
+	}
+
+	let minX = Infinity;
+	let maxX = -Infinity;
+	let minY = Infinity;
+	let maxY = -Infinity;
+	for (const component of placed) {
+		minX = Math.min(minX, component.offsetX - component.radius);
+		maxX = Math.max(maxX, component.offsetX + component.radius);
+		minY = Math.min(minY, component.offsetY - component.radius);
+		maxY = Math.max(maxY, component.offsetY + component.radius);
+	}
+
+	// A thin margin, not a ring. At 12% this added a whole outer band of candidate
+	// cells, and combined with spreading across every free cell it put the lone
+	// nodes OUTSIDE the components — measured, they reached 9,790 wide where the
+	// components reached 7,996, which is the ring reappearing one layer out. Just
+	// enough air that a tightly packed store still has somewhere to put them.
+	const margin = 0.04 * Math.max(maxX - minX, maxY - minY);
+	minX -= margin;
+	maxX += margin;
+	minY -= margin;
+	maxY += margin;
+
+	// Roughly four candidate cells per node, which leaves enough free ones to
+	// spread across after the occupied ones are struck out.
+	const columns = Math.max(4, Math.round(Math.sqrt(ordered.length * 4 * 1.45)));
+	const rowsCount = Math.max(4, Math.round(columns / 1.45));
+	const cellWidth = (maxX - minX) / columns;
+	const cellHeight = (maxY - minY) / rowsCount;
+
+	const free: { x: number; y: number; distance: number }[] = [];
+	for (let column = 0; column < columns; column++) {
+		for (let row = 0; row < rowsCount; row++) {
+			const x = minX + (column + 0.5) * cellWidth;
+			const y = minY + (row + 0.5) * cellHeight;
+
+			let occupied = false;
+			for (const component of placed) {
+				const dx = x - component.offsetX;
+				const dy = y - component.offsetY;
+				if (dx * dx + dy * dy < component.radius * component.radius) {
+					occupied = true;
+					break;
+				}
+			}
+			// And the lone nodes already anchored here, so an arrival does not land
+			// on top of one that has been sitting there since a previous pass.
+			if (!occupied) {
+				const reach = Math.min(cellWidth, cellHeight) * 0.5;
+				for (const row of rows) {
+					if (Math.abs(row.x - x) < reach && Math.abs(row.y - y) < reach) {
+						occupied = true;
+						break;
+					}
+				}
+			}
+			if (occupied) continue;
+			free.push({ x, y, distance: Math.hypot(x, y) });
+		}
+	}
+
+	// Nearest the middle first, so the gaps between the big components fill before
+	// the empty edges do — which is what stops them re-forming a ring.
+	free.sort((a, b) => a.distance - b.distance || a.x - b.x || a.y - b.y);
+
+	for (let i = 0; i < ordered.length; i++) {
+		const id = ordered[i];
+		const jitter = jitterOf(id);
+
+		if (free.length === 0) {
+			rows.push({
+				nodeId: id,
+				community: communities[id] ?? 0,
+				x: jitter.x * (maxX - minX) * 0.5,
+				y: jitter.y * (maxY - minY) * 0.5,
+				placed: 1
+			});
+			continue;
+		}
+
+		// NEAREST free cells first while there are enough of them, so the lone nodes
+		// fill the gaps between the components rather than reaching for the edge.
+		// Spreading across the whole list unconditionally was what sent them to the
+		// outermost cells even when the interior had room to spare.
+		const cell =
+			ordered.length <= free.length
+				? free[i]
+				: free[Math.floor((i * free.length) / ordered.length)];
+		rows.push({
+			nodeId: id,
+			community: communities[id] ?? 0,
+			x: cell.x + jitter.x * cellWidth * 0.4,
+			y: cell.y + jitter.y * cellHeight * 0.4,
+			placed: 1
+		});
+	}
+
+	return rows;
+}
+
+/**
+ * A deterministic offset in [-1, 1]², plus an angle, derived from a string.
+ *
+ * Every scatter in this file comes through here, which is what makes the whole
+ * arrangement reproducible: node ids and community indices are both stable for a
+ * given dataset, so the same store settles into the same map however many times
+ * it is laid out. Nothing here reads a clock or a random number.
+ */
+function jitterOf(key: string): { x: number; y: number; angle: number } {
+	const hash = hashOf(key);
+	return {
+		x: (hash % 65536) / 65536 * 2 - 1,
+		y: ((hash >>> 16) % 65536) / 65536 * 2 - 1,
+		angle: ((hash % 3600) / 3600) * Math.PI * 2
+	};
+}
+
+
+/** FNV-1a — cheap, well-distributed, and deterministic across restarts. */
+function hashOf(id: string): number {
+	let hash = 2166136261;
+	for (let i = 0; i < id.length; i++) {
+		hash ^= id.charCodeAt(i);
+		hash = Math.imul(hash, 16777619);
+	}
+	return hash >>> 0;
+}
+
+/**
+ * A cold pass has to discover the shape; smaller graphs can afford to converge.
+ *
+ * Lower than the numbers the browser used to run, and deliberately: the seed is
+ * already grouped by community, so these iterations refine an arrangement rather
+ * than construct one. Measured, an iteration costs ~15 ms at 1,200 nodes and
+ * ~90 ms at 5,000, so the counts have to come down as the graph goes up or a
+ * cold pass turns into minutes.
+ */
+function iterationsFor(order: number): number {
+	if (order > 3_000) return 120;
+	if (order > 1_500) return 200;
+	if (order > 400) return 300;
+	return 600;
+}
+
+/** A warm pass only has to absorb what arrived since the last one. */
+function warmIterationsFor(order: number): number {
+	if (order > 3_000) return 40;
+	if (order > 1_500) return 60;
+	return 90;
+}
+
+/**
+ * Run the simulation, yielding between chunks.
+ *
+ * The yield is the whole point of doing this on a timer rather than inline: Bun
+ * serves the WebSocket from the same loop, so a pass that ran to completion
+ * without returning to the event loop would stall every open session for as long
+ * as it took. Chunked, the cost is spread across frames nobody is waiting on.
+ */
+async function settle(graph: Graph, iterations: number): Promise<void> {
+	const settings = {
+		...forceAtlas2.inferSettings(graph),
+		// Divides attraction by mass, so a hub does not drag its neighbours onto
+		// itself — which is what turns a hub and its forty leaves into a fan rather
+		// than a dot, and fans are most of what makes a large graph readable.
+		outboundAttractionDistribution: true,
+		/**
+		 * Very low, and now it can be: this runs per COMPONENT, in that component's
+		 * own local space, so gravity is only holding one connected thing together
+		 * rather than gathering unrelated things into a disc. Attraction along the
+		 * edges does most of that work anyway; this just stops a long chain from
+		 * stretching without limit.
+		 *
+		 * Run globally, at any strength, it is what made every graph round — an
+		 * isotropic pull toward one point is a circle, and 146 components with no
+		 * forces between them had nothing else deciding where they went.
+		 */
+		gravity: 0.05,
+		scalingRatio: 50,
+		// A local correction that enforces minimum spacing from node sizes, which
+		// flattens exactly the density differences the layout exists to show.
+		adjustSizes: false,
+		edgeWeightInfluence: 1,
+		/**
+		 * OFF, which is not what the browser did and not what the setting's name
+		 * suggests. Measured against this workload, graphology's Barnes-Hut costs
+		 * more than the naive repulsion it replaces at every size that reaches this
+		 * code: at 5,000 nodes it took 142 ms per iteration against 93 ms without.
+		 * It rebuilds its quadtree every iteration, and below the tens of thousands
+		 * that tree costs more than the pairs it saves.
+		 */
+		barnesHutOptimize: false
+	};
+
+	/**
+	 * Iterations per `assign` call, derived from the graph's SIZE and nothing else.
+	 *
+	 * This used to adapt to measured time, which was faster and quietly
+	 * non-reproducible. FA2 keeps a per-node convergence factor — its adaptive
+	 * local speed — and `graphToByteArrays` re-initialises it to 1 on every
+	 * `assign` call, so where the iterations are split changes the trajectory. With
+	 * the split decided by a clock, the same store settled into a different map
+	 * every pass.
+	 *
+	 * Size is the right basis instead: it bounds how long one call blocks the event
+	 * loop (an iteration costs roughly linearly in the node count here) and it is a
+	 * property of the data, so two passes over the same graph split identically.
+	 */
+	const chunk = Math.max(1, Math.min(50, Math.round(6_000 / Math.max(1, graph.order))));
+
+	let done = 0;
+	while (done < iterations) {
+		const batch = Math.min(chunk, iterations - done);
+		forceAtlas2.assign(graph, { iterations: batch, settings });
+		done += batch;
+		await new Promise<void>(resolve => setTimeout(resolve, 0));
+	}
+}
+
+/**
+ * A seeded PRNG — mulberry32.
+ *
+ * Fixed seed, no clock, no entropy: the arrangement has to be the same map every
+ * time it is computed, and anything that reaches for `Math.random` breaks that
+ * however good its distribution is.
+ */
+function seededRandom(): () => number {
+	let state = 0x9e3779b9;
+	return () => {
+		state = (state + 0x6d2b79f5) | 0;
+		let t = state;
+		t = Math.imul(t ^ (t >>> 15), t | 1);
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}

--- a/backend/memory/notify.ts
+++ b/backend/memory/notify.ts
@@ -20,6 +20,7 @@
  */
 
 import { ws } from '$backend/utils/ws';
+import { scheduleGraphLayout } from './layout';
 import { debug } from '$shared/utils/logger';
 
 /**
@@ -44,20 +45,45 @@ let statusTimer: ReturnType<typeof setTimeout> | null = null;
 export function notifyGraphChanged(reason: string, projectId: string | null = null): void {
 	pendingReason = reason;
 	pendingProjectId = projectId;
+
+	// The arrangement is derived from the graph, so anything that changes one
+	// changes the other. Hanging it off this call rather than off each write path
+	// keeps a single answer to "the graph moved" — and the pass debounces far
+	// longer than the broadcast does, because a position that settles four
+	// seconds late costs nothing while a view that updates four seconds late is
+	// the bug this notification exists to fix.
+	scheduleGraphLayout();
+
 	if (timer) return;
 
 	timer = setTimeout(() => {
 		timer = null;
-		try {
-			ws.emit.global('memory:changed', { reason: pendingReason, projectId: pendingProjectId });
-		} catch (error) {
-			// A view that misses a refresh is a stale view, not a broken one, and this
-			// is called from write paths that must never fail for a UI concern.
-			debug.warn('memory', 'Failed to broadcast memory change', error);
-		}
+		broadcastGraphChanged(pendingReason, pendingProjectId);
 	}, COALESCE_MS);
 	// Housekeeping — never a reason to hold the process open at shutdown.
 	timer.unref?.();
+}
+
+/**
+ * Ring the doorbell without asking for a new arrangement.
+ *
+ * The layout pass calls this when it has written new positions. It must NOT go
+ * through `notifyGraphChanged`, which schedules a layout — a pass announcing its
+ * own result would ask for another one, and while that next pass would find
+ * nothing to do and return early, a job that re-queues itself every time it
+ * succeeds is a shape worth not having.
+ *
+ * Uncoalesced, because a pass is already debounced by seconds and produces at
+ * most one of these.
+ */
+export function broadcastGraphChanged(reason: string, projectId: string | null = null): void {
+	try {
+		ws.emit.global('memory:changed', { reason, projectId });
+	} catch (error) {
+		// A view that misses a refresh is a stale view, not a broken one, and this
+		// is called from write paths that must never fail for a UI concern.
+		debug.warn('memory', 'Failed to broadcast memory change', error);
+	}
 }
 
 /**

--- a/backend/memory/view.ts
+++ b/backend/memory/view.ts
@@ -1,39 +1,68 @@
 /**
  * Graph view assembly for the visualization.
  *
- * Community detection runs HERE, not in the browser. Louvain is O(n log n)-ish
- * but iterative, and running it on the client would compete with the force
- * simulation for the same main thread on exactly the low-powered devices this
- * has to stay usable on. It is also stable per dataset, so computing it server
- * side lets the result be sent once instead of recomputed on every mount.
+ * ── What this file is NOT allowed to do any more ─────────────────────────────
+ * It used to run Louvain on every call. Community detection is stable per
+ * dataset, so opening the modal, changing a filter, or any conversation
+ * recording a memory made every connected client pay for the same clustering
+ * again — and the cost grew with the store rather than with what was on screen.
+ * It now lives in `graph_layout`, written by the background pass in `layout.ts`,
+ * and this file only reads it.
  *
- * Communities are what make the view legible: each becomes a coloured "lobe", so
- * the clustering the user sees comes out of their own memory's structure rather
- * than being imposed by a layout algorithm.
+ * ── Showing everything, at bounded cost ──────────────────────────────────────
+ * The old view answered scale with a cap: return the three thousand most
+ * reinforced memories and set `truncated`. That is not a scale strategy, it is a
+ * silent ceiling — past it the rest of the store simply was not in the picture,
+ * with no way to reach it but narrowing a filter.
+ *
+ * The answer here is to aggregate by POSITION rather than to trim by rank, and
+ * the difference is what the user sees. Grouping by community — the obvious
+ * alternative, and the first thing tried — replaces the picture: you get lobes
+ * instead of memories, and reaching any memory means opening one first. Grouping
+ * by position keeps the picture. The layout plane is divided into a grid fine
+ * enough that the number of OCCUPIED cells is bounded, and each occupied cell
+ * becomes one mark. Marks merge only where their dots would have overlapped
+ * anyway, so the silhouette, the lobes and the colours are the ones the full
+ * graph would have drawn, and nothing is missing from it.
+ *
+ * Below `RENDER_BUDGET` no cell holds more than one memory, so every mark IS a
+ * memory and the view is exactly the flat one it always was. Above it, a cell
+ * holding one memory still returns that memory — fidelity is lost only where
+ * the display had none to give.
+ *
+ * Zooming into a mark asks for its cell as a rectangle, which costs that
+ * rectangle rather than the store.
  */
 
-import Graph from 'graphology';
-import louvain from 'graphology-communities-louvain';
-import { graphQueries } from '$backend/database/queries/graph-queries';
-import { debug } from '$shared/utils/logger';
+import { graphQueries, graphLayoutQueries, type GraphBinGrid } from '$backend/database/queries/graph-queries';
 import type {
+	GraphNode,
 	GraphNodeKind,
+	GraphRegion,
 	GraphScope,
 	GraphSource,
 	GraphView,
+	GraphViewBin,
+	GraphViewBinEdge,
 	GraphViewEdge,
 	GraphViewNode
 } from '$shared/types/memory';
 
 /**
- * Nodes sent to the client at once.
+ * Marks the client is asked to draw at once.
  *
- * Beyond a few thousand, a force layout stops communicating structure — it
- * becomes a hairball — and the payload starts costing more than it explains. The
- * cap is reported through `truncated` so the UI can say so rather than implying
- * the graph is smaller than it is.
+ * A ceiling on the WORK, not on the content: past it marks merge rather than
+ * disappear. Set where a WebGL scene stays comfortable on a low-powered machine
+ * — the graph build, sigma's indexation and the per-frame reducers are all
+ * linear in this number, and it is the only number they are linear in.
  */
-const MAX_VIEW_NODES = 3_000;
+const RENDER_BUDGET = 3_000;
+
+/** Bin edges drawn at once, heaviest first. Lines are cheaper than marks, not free. */
+const MAX_BIN_EDGES = 6_000;
+
+/** Longest caption a mark carries; the full text belongs to the inspector. */
+const BIN_LABEL_MAX = 60;
 
 export interface GraphViewFilter {
 	/** `undefined` = every project (cross-project view); `null` = global only. */
@@ -49,28 +78,75 @@ export interface GraphViewFilter {
 	includeArchived?: boolean;
 	/** Show memories that have been replaced by a newer belief. Off by default. */
 	includeSuperseded?: boolean;
+	/**
+	 * A rectangle of the layout to restrict to — how a mark is opened.
+	 *
+	 * Navigation, not filtering: it narrows what is DRAWN without changing what
+	 * the graph is, which is why the totals it reports are the region's.
+	 */
+	region?: GraphRegion;
 	limit?: number;
 }
 
 export function buildGraphView(filter: GraphViewFilter): GraphView {
-	const limit = Math.min(filter.limit ?? MAX_VIEW_NODES, MAX_VIEW_NODES);
+	const limit = Math.min(filter.limit ?? RENDER_BUDGET, RENDER_BUDGET);
+	const region = filter.region ?? null;
 
-	// `list` orders by pinned, then weight, then recency — so when the cap bites,
-	// what survives is what the user reinforced and touched most recently.
-	const nodes = graphQueries.list({ ...filter, limit });
-	const totalNodes = graphQueries.count(filter);
-
-	if (nodes.length === 0) {
-		return { nodes: [], edges: [], totalNodes, truncated: false };
+	// Zoomed in: the rectangle is already a bounded slice of the arrangement, so
+	// it is drawn at full fidelity and counted within itself.
+	if (region) {
+		const nodes = graphQueries.listInRegion({ ...filter, limit }, region);
+		return flat(nodes, region, nodes.length, false);
 	}
 
-	const ids = nodes.map(n => n.id);
+	const extent = graphLayoutQueries.extent(filter);
+
+	// Either it fits, or nothing has been laid out yet — a fresh install, or the
+	// first fetch after the upgrade added the table. Both draw the flat view: the
+	// second because binning needs positions, and falling back to what the feature
+	// always did means the graph is never empty while the background pass catches
+	// up.
+	const laidOut = extent.total - extent.unplaced;
+	if (extent.total <= RENDER_BUDGET || laidOut === 0) {
+		const nodes = graphQueries.list({ ...filter, limit });
+		return flat(nodes, null, extent.total, extent.total > nodes.length);
+	}
+
+	return binned(filter, extent, limit);
+}
+
+/**
+ * Every matching memory, drawn individually.
+ *
+ * The ordinary case and the one the view is tuned for — below the render budget
+ * this is the whole story, and it is unchanged from before any of this existed.
+ */
+function flat(
+	nodes: GraphNode[],
+	region: GraphRegion | null,
+	totalNodes: number,
+	truncated: boolean
+): GraphView {
+	if (nodes.length === 0) {
+		return {
+			level: 'flat',
+			nodes: [],
+			edges: [],
+			bins: [],
+			binEdges: [],
+			region,
+			totalNodes,
+			truncated: false
+		};
+	}
+
+	const ids = nodes.map(node => node.id);
 	const stored = graphQueries.edgesWithin(ids);
 
 	// Two memories about the same subject ARE connected, and that connection is
 	// stated by extraction rather than inferred from how they are worded. It is
 	// derived here rather than stored, so it can never outlive the claim it came
-	// from — see `derivedEntityEdges`.
+	// from — see `derivedEdges`.
 	//
 	// Without it the episodic half has almost no structure at all. Similarity
 	// linking used to supply it, badly: on a real graph 144 of 371 edges were
@@ -88,68 +164,298 @@ export function buildGraphView(filter: GraphViewFilter): GraphView {
 		weight: edge.weight
 	}));
 
-	// Undirected for community detection: `about` and `imports` point one way, but
-	// whether two nodes belong to the same cluster does not depend on direction,
-	// and treating them as directed splits obvious groups in half.
-	const graph = new Graph({ type: 'undirected', multi: false });
-	for (const node of nodes) graph.addNode(node.id);
-
+	// Degree is counted over what is being DRAWN, so a node's size answers "how
+	// connected is this within what I am looking at" — which is the question the
+	// eye is actually asking.
 	const degree = new Map<string, number>();
-	const link = (srcId: string, dstId: string, weight: number): void => {
+	const bump = (srcId: string, dstId: string): void => {
 		degree.set(srcId, (degree.get(srcId) ?? 0) + 1);
 		degree.set(dstId, (degree.get(dstId) ?? 0) + 1);
-		if (srcId === dstId) return;
-		if (!graph.hasNode(srcId) || !graph.hasNode(dstId)) return;
-		if (!graph.hasEdge(srcId, dstId)) graph.addUndirectedEdge(srcId, dstId, { weight });
 	};
-	for (const edge of stored) link(edge.srcId, edge.dstId, edge.weight);
-	for (const edge of derived) link(edge.source, edge.target, edge.weight);
+	for (const edge of stored) bump(edge.srcId, edge.dstId);
+	for (const edge of derived) bump(edge.source, edge.target);
 
-	let communities: Record<string, number> = {};
-	try {
-		// Louvain needs at least one edge; an edgeless graph leaves every node in
-		// its own community, which is also the honest answer.
-		if (graph.size > 0) {
-			communities = louvain(graph, { getEdgeWeight: 'weight' });
-		}
-	} catch (error) {
-		// A failed clustering must not cost the user their graph — the view just
-		// renders in one colour.
-		debug.warn('memory', 'Community detection failed; rendering without lobes', error);
-		communities = {};
+	const layout = graphLayoutQueries.read(ids);
+	const viewNodes = nodes.map(node => toViewNode(node, degree.get(node.id) ?? 0, layout.get(node.id)));
+	placeArrivals(viewNodes, [...stored.map(edge => ({ source: edge.srcId, target: edge.dstId })), ...derived]);
+
+	return {
+		level: 'flat',
+		nodes: viewNodes,
+		edges: [
+			...stored.map(edge => ({
+				id: edge.id,
+				source: edge.srcId,
+				target: edge.dstId,
+				rel: edge.rel,
+				weight: edge.weight
+			})),
+			...derived
+		],
+		bins: [],
+		binEdges: [],
+		region,
+		totalNodes,
+		truncated
+	};
+}
+
+/**
+ * The whole graph, with crowded neighbourhoods folded into single marks.
+ *
+ * Cells holding exactly one memory come back as that memory, so this is a flat
+ * view everywhere the display could have drawn one — which, in a force layout,
+ * is most of the periphery. Only the dense middle merges, and only as far as it
+ * was going to overlap.
+ */
+function binned(
+	filter: GraphViewFilter,
+	extent: { total: number; minX: number; maxX: number; minY: number; maxY: number },
+	limit: number
+): GraphView {
+	const grid = gridFor(extent);
+	const cells = graphLayoutQueries.binnedNodes(filter, grid);
+
+	// A cell of one is not a bin, it is a memory. Splitting them here is what
+	// keeps the picture inspectable: everything the grid did not have to merge
+	// stays clickable, hoverable and highlightable exactly as before.
+	const singles = cells.filter(cell => cell.members === 1);
+	const groups = cells.filter(cell => cell.members > 1);
+
+	const nodes = graphQueries.getByIds(singles.map(cell => cell.id));
+	const byId = new Map(nodes.map(node => [node.id, node]));
+	const layout = graphLayoutQueries.read(nodes.map(node => node.id));
+
+	// Which mark each cell is, so the rolled-up edges can name their ends. A
+	// single's mark is the memory's own id; a group's is the cell.
+	const markOf = new Map<string, string>();
+	for (const cell of cells) {
+		markOf.set(cellKey(cell.cellX, cell.cellY), cell.members === 1 ? cell.id : binId(cell.cellX, cell.cellY));
 	}
 
-	const viewNodes: GraphViewNode[] = nodes.map(node => ({
+	const binEdges: GraphViewBinEdge[] = [];
+	const nodeEdges: GraphViewEdge[] = [];
+	let syntheticId = -1;
+
+	for (const edge of graphLayoutQueries.binnedEdges(filter, grid, MAX_BIN_EDGES)) {
+		const source = markOf.get(cellKey(edge.srcX, edge.srcY));
+		const target = markOf.get(cellKey(edge.dstX, edge.dstY));
+		if (!source || !target || source === target) continue;
+
+		// An edge between two singles is a real edge between two real memories, and
+		// the canvas dims and highlights those against the node it is anchored on.
+		// Demoting it to a bin edge would break hover on exactly the marks that did
+		// not need binning in the first place.
+		if (byId.has(source) && byId.has(target)) {
+			nodeEdges.push({
+				id: syntheticId--,
+				source,
+				target,
+				rel: 'relates_to',
+				weight: edge.weight
+			});
+		} else {
+			binEdges.push({ source, target, weight: edge.weight });
+		}
+	}
+
+	// Degree over what is drawn, same as the flat path — counting both kinds of
+	// edge, because a memory next to a dense clump is well connected whether or
+	// not the thing it connects to had to be merged.
+	const degree = new Map<string, number>();
+	const bump = (id: string): void => {
+		degree.set(id, (degree.get(id) ?? 0) + 1);
+	};
+	for (const edge of nodeEdges) {
+		bump(edge.source);
+		bump(edge.target);
+	}
+	for (const edge of binEdges) {
+		bump(edge.source);
+		bump(edge.target);
+	}
+
+	const bins: GraphViewBin[] = groups.map(cell => ({
+		id: binId(cell.cellX, cell.cellY),
+		members: cell.members,
+		label: truncate(cell.label ?? ''),
+		community: cell.community,
+		x: cell.x,
+		y: cell.y,
+		region: {
+			minX: grid.originX + cell.cellX * grid.cellWidth,
+			maxX: grid.originX + (cell.cellX + 1) * grid.cellWidth,
+			minY: grid.originY + cell.cellY * grid.cellHeight,
+			maxY: grid.originY + (cell.cellY + 1) * grid.cellHeight
+		}
+	}));
+
+	return {
+		level: 'binned',
+		nodes: singles
+			.map(cell => byId.get(cell.id))
+			.filter((node): node is GraphNode => node !== undefined)
+			.map(node => toViewNode(node, degree.get(node.id) ?? 0, layout.get(node.id))),
+		edges: nodeEdges,
+		bins,
+		binEdges,
+		region: null,
+		totalNodes: extent.total,
+		// Nothing was left out — every memory is inside one of these marks. The
+		// only thing a binned view withholds is which memory is which inside a
+		// crowd, and opening the mark answers that.
+		truncated: nodes.length + bins.length > limit
+	};
+}
+
+/**
+ * The grid, sized so the number of cells cannot exceed the render budget.
+ *
+ * Cells are square in layout space rather than fitted to the extent's aspect
+ * ratio: a non-square cell merges more readily along one axis than the other,
+ * which shows up as marks that smear horizontally or vertically — the eye reads
+ * that as structure, and there is none.
+ */
+function gridFor(extent: { minX: number; maxX: number; minY: number; maxY: number }): GraphBinGrid {
+	const width = Math.max(1e-6, extent.maxX - extent.minX);
+	const height = Math.max(1e-6, extent.maxY - extent.minY);
+
+	// One axis of the grid. Squared, this is the cell count, so it is the budget's
+	// square root — and the longer side sets the cell size for both.
+	const perAxis = Math.max(1, Math.floor(Math.sqrt(RENDER_BUDGET)));
+	const cell = Math.max(width, height) / perAxis;
+
+	return {
+		originX: extent.minX,
+		originY: extent.minY,
+		cellWidth: cell,
+		cellHeight: cell
+	};
+}
+
+function toViewNode(
+	node: GraphNode,
+	degree: number,
+	placed?: { community: number; x: number; y: number; placed: number }
+): GraphViewNode {
+	return {
 		id: node.id,
 		kind: node.kind,
 		subkind: node.subkind,
 		scope: node.scope,
 		label: node.label,
 		projectId: node.projectId,
-		degree: degree.get(node.id) ?? 0,
+		degree,
 		weight: node.weight,
 		pinned: node.pinned,
-		community: communities[node.id] ?? 0,
-		createdAt: node.createdAt
-	}));
-
-	const viewEdges: GraphViewEdge[] = [
-		...stored.map(edge => ({
-			id: edge.id,
-			source: edge.srcId,
-			target: edge.dstId,
-			rel: edge.rel,
-			weight: edge.weight
-		})),
-		...derived
-	];
-
-	return {
-		nodes: viewNodes,
-		edges: viewEdges,
-		totalNodes,
-		truncated: totalNodes > nodes.length
+		community: placed?.community ?? 0,
+		createdAt: node.createdAt,
+		// Sent ONLY when the simulation computed it. A memory written since the
+		// last pass has no row at all, and one below the simulation cap has a row
+		// holding a guess — in both cases the client seeds it from its neighbours,
+		// which is a far better answer than drawing a whole lobe on one point.
+		...(placed?.placed === 1 && { x: placed.x, y: placed.y })
 	};
+}
+
+/**
+ * Give a position to anything the arrangement has not reached yet.
+ *
+ * A memory recorded while the modal is open has no layout row: the background
+ * pass is debounced behind the notification that announces the memory, so the
+ * first fetch after it lands is always a few seconds early. Sending it without
+ * coordinates left the client to invent some, and what it invented was the
+ * middle of the map — a new memory appearing nowhere near the subject it is
+ * about.
+ *
+ * Derived HERE instead, from the same rule the layout pass itself uses: the
+ * centroid of whatever it connects to. The answer is therefore the one the pass
+ * will confirm a few seconds later rather than one it will have to correct, and
+ * the client stops having an opinion about placement at all.
+ *
+ * Read-time only — nothing is written. A position that has not been through the
+ * simulation is a guess, and guesses do not belong in the table the simulation
+ * owns.
+ *
+ * A node with no placed neighbour is deliberately LEFT without a position. That
+ * is the honest signal for "the arrangement does not cover this yet", and it is
+ * what the client's cold fallback keys on — inventing a centroid for a store that
+ * has never been laid out would replace a considered scatter with a meaningless
+ * one.
+ */
+function placeArrivals(nodes: GraphViewNode[], edges: { source: string; target: string }[]): void {
+	const arrivals = nodes.filter(node => node.x === undefined);
+	if (arrivals.length === 0) return;
+
+	const byId = new Map(nodes.map(node => [node.id, node]));
+	const adjacency = new Map<string, string[]>();
+	const link = (from: string, to: string): void => {
+		const neighbours = adjacency.get(from);
+		if (neighbours) neighbours.push(to);
+		else adjacency.set(from, [to]);
+	};
+	for (const edge of edges) {
+		link(edge.source, edge.target);
+		link(edge.target, edge.source);
+	}
+
+	// Three passes, so a small cluster of arrivals resolves outward from whichever
+	// end touches the existing map rather than all of them giving up at once.
+	for (let pass = 0; pass < 3; pass++) {
+		let settled = 0;
+
+		for (const node of arrivals) {
+			if (node.x !== undefined) continue;
+
+			let sumX = 0;
+			let sumY = 0;
+			let count = 0;
+			for (const neighbour of adjacency.get(node.id) ?? []) {
+				const other = byId.get(neighbour);
+				if (!other || other.x === undefined || other.y === undefined) continue;
+				sumX += other.x;
+				sumY += other.y;
+				count++;
+			}
+			if (count === 0) continue;
+
+			// Nudged off the exact centroid, or several arrivals about one subject
+			// land on the same point and read as a single node.
+			const jitter = jitterOf(node.id);
+			node.x = sumX / count + jitter.x * 24;
+			node.y = sumY / count + jitter.y * 24;
+			settled++;
+		}
+
+		if (settled === 0) break;
+	}
+}
+
+/** A deterministic offset in [-1, 1]², derived from an id. FNV-1a. */
+function jitterOf(id: string): { x: number; y: number } {
+	let hash = 2166136261;
+	for (let i = 0; i < id.length; i++) {
+		hash ^= id.charCodeAt(i);
+		hash = Math.imul(hash, 16777619);
+	}
+	hash = hash >>> 0;
+	return {
+		x: ((hash % 65536) / 65536) * 2 - 1,
+		y: (((hash >>> 16) % 65536) / 65536) * 2 - 1
+	};
+}
+
+/** Namespaced so a bin's id can never collide with a node's. */
+function binId(cellX: number, cellY: number): string {
+	return `bin:${cellX}:${cellY}`;
+}
+
+function cellKey(cellX: number, cellY: number): string {
+	return `${cellX}:${cellY}`;
+}
+
+function truncate(label: string): string {
+	return label.length > BIN_LABEL_MAX ? `${label.slice(0, BIN_LABEL_MAX - 1)}…` : label;
 }
 
 /** A node plus the nodes it reaches — what the inspector renders. */

--- a/backend/ws/memory/crud.ts
+++ b/backend/ws/memory/crud.ts
@@ -24,8 +24,9 @@ import { createRouter, type WSConnection } from '$shared/utils/ws-server';
 import { ws } from '$backend/utils/ws';
 import { projectContextService } from '$backend/mcp/internal/project-context';
 import { debug } from '$shared/utils/logger';
-import { graphQueries } from '$backend/database/queries/graph-queries';
+import { graphQueries, graphLayoutQueries } from '$backend/database/queries/graph-queries';
 import { buildGraphView, buildNodeDetail } from '$backend/memory/view';
+import { resetGraphLayoutState } from '$backend/memory/layout';
 import { markConsulted, retrieve } from '$backend/memory/retrieval';
 import { scheduleVectorIndexing } from '$backend/memory/indexer';
 import { getMemoryConfig, setMemoryConfig } from '$backend/memory/config';
@@ -176,9 +177,20 @@ export const memoryCrudHandler = createRouter()
 			sources: t.Optional(t.Array(SOURCE)),
 			includeArchived: t.Optional(t.Boolean()),
 			includeSuperseded: t.Optional(t.Boolean()),
+			// The rectangle of the layout to zoom into, when a mark was opened.
+			// Absent asks for the whole graph at whatever resolution fits.
+			region: t.Optional(
+				t.Object({
+					minX: t.Number(),
+					maxX: t.Number(),
+					minY: t.Number(),
+					maxY: t.Number()
+				})
+			),
 			limit: t.Optional(t.Number())
 		}),
 		response: t.Object({
+			level: t.String(),
 			nodes: t.Array(t.Object({
 				id: t.String(),
 				kind: t.String(),
@@ -190,7 +202,9 @@ export const memoryCrudHandler = createRouter()
 				weight: t.Number(),
 				pinned: t.Boolean(),
 				community: t.Number(),
-				createdAt: t.String()
+				createdAt: t.String(),
+				x: t.Optional(t.Number()),
+				y: t.Optional(t.Number())
 			})),
 			edges: t.Array(t.Object({
 				id: t.Number(),
@@ -199,6 +213,34 @@ export const memoryCrudHandler = createRouter()
 				rel: t.String(),
 				weight: t.Number()
 			})),
+			bins: t.Array(t.Object({
+				id: t.String(),
+				members: t.Number(),
+				label: t.String(),
+				community: t.Number(),
+				x: t.Number(),
+				y: t.Number(),
+				region: t.Object({
+					minX: t.Number(),
+					maxX: t.Number(),
+					minY: t.Number(),
+					maxY: t.Number()
+				})
+			})),
+			binEdges: t.Array(t.Object({
+				source: t.String(),
+				target: t.String(),
+				weight: t.Number()
+			})),
+			region: t.Union([
+				t.Object({
+					minX: t.Number(),
+					maxX: t.Number(),
+					minY: t.Number(),
+					maxY: t.Number()
+				}),
+				t.Null()
+			]),
 			totalNodes: t.Number(),
 			truncated: t.Boolean()
 		})
@@ -212,6 +254,7 @@ export const memoryCrudHandler = createRouter()
 			sources: data.sources as GraphSource[] | undefined,
 			includeArchived: data.includeArchived,
 			includeSuperseded: data.includeSuperseded,
+			region: data.region,
 			limit: data.limit
 		});
 	})
@@ -597,6 +640,11 @@ export const memoryCrudHandler = createRouter()
 		// may now be looking at an empty graph.
 		vectorCache.reset();
 		resetGraphEmptiness();
+		// The arrangement describes nodes that are gone. Dropping the orphans now
+		// rather than waiting for the next pass is what stops the overview counting
+		// lobes whose members no longer exist.
+		graphLayoutQueries.pruneOrphans();
+		resetGraphLayoutState();
 		notifyGraphChanged('purged', data.projectIds?.[0] ?? null);
 		debug.log('memory', `Purged ${result.nodes} node(s) and ${result.edges} edge(s)`);
 		return result;

--- a/frontend/components/common/overlay/Modal.svelte
+++ b/frontend/components/common/overlay/Modal.svelte
@@ -7,6 +7,17 @@
 	interface Props {
 		isOpen: boolean;
 		onClose: () => void;
+		/**
+		 * Called once the opening transition has finished.
+		 *
+		 * For a modal whose contents are expensive to build — a graph, a database
+		 * client — this is the difference between an animation and a freeze. The
+		 * open is two hundred milliseconds of the main thread; anything heavy that
+		 * mounts in the same flush competes with it directly, and the user sees the
+		 * modal jump into place rather than scale into it. Defer the expensive part
+		 * to this and the two stop fighting.
+		 */
+		onOpened?: () => void;
 		title?: string;
 		size?: 'sm' | 'md' | 'lg' | 'xl' | 'full';
 		closable?: boolean;
@@ -23,6 +34,7 @@
 	let {
 		isOpen = $bindable(),
 		onClose,
+		onOpened,
 		title,
 		size = 'md',
 		closable = true,
@@ -123,6 +135,7 @@
 			tabindex="-1"
 			in:scale={{ duration: 200, easing: cubicOut, start: 0.95 }}
 			out:scale={{ duration: 150, easing: cubicOut, start: 0.95 }}
+			onintroend={() => onOpened?.()}
 		>
 			{#if bare}
 				{#if children}

--- a/frontend/components/memory/MemoryGraphCanvas.svelte
+++ b/frontend/components/memory/MemoryGraphCanvas.svelte
@@ -10,19 +10,34 @@
 	 * and resetting the camera. Everything a reducer touches therefore lives in a
 	 * plain variable. The rule to keep: a reducer must never read a rune.
 	 *
+	 * ── Why it no longer computes a layout ────────────────────────────────────
+	 * It used to run ForceAtlas2 on every open — several hundred iterations to
+	 * arrive at the same arrangement it arrived at last time, thrown away when the
+	 * modal closed. That was the bulk of what made opening the modal stutter: the
+	 * open animation is two hundred milliseconds of this thread, and the build plus
+	 * the first layout batches landed inside it.
+	 *
+	 * Positions now arrive with the data, computed once in the background (see
+	 * `backend/memory/layout.ts`). The simulation still exists here, but only for
+	 * nodes that have no position yet — memories written since the last pass — and
+	 * it is a short settle of a handful of arrivals rather than a solve of
+	 * everything.
+	 *
+	 * ── Two resolutions ───────────────────────────────────────────────────────
+	 * Past a render budget the server merges memories that share a cell of the
+	 * layout grid into one mark, so what is drawn stays bounded however much
+	 * memory accumulates — but only where the dots would have overlapped anyway,
+	 * and a cell holding one memory still arrives as that memory. Both shapes are
+	 * normalised into `DrawNode` here, because everything below this — sizing,
+	 * colouring, emphasis, hover — is the same work either way.
+	 *
 	 * ── Why it looks the way it does ──────────────────────────────────────────
 	 * Quiet at rest, informative on contact. Small nodes and hairline edges, so the
 	 * structure is carried by the arrangement rather than by the ink; unfocused
 	 * nodes dim but stay visible rather than vanishing; and NOTHING is labelled
-	 * until it is pointed at.
-	 *
-	 * That last one used to be a matter of degree — labels were thinned by size and
-	 * by a grid, which still left full sentences drawn over each other wherever the
-	 * graph was busy, and reading them as a layer of noise on top of the shape. They
-	 * are now off entirely (`renderLabels: false`) and only the hover pill remains.
-	 * Sigma draws that from `renderHighlightedNodes`, which is independent of the
-	 * label layer, so turning labels off costs nothing on contact. Nodes still carry
-	 * a `label` attribute because the hover renderer reads it.
+	 * until it is pointed at, at either resolution. Captions were tried for the
+	 * merged marks on the theory that a crowd needs naming, and they reproduced the
+	 * same overlapping text layer over a picture whose entire value is its shape.
 	 */
 	import { onDestroy, onMount } from 'svelte';
 	import Sigma from 'sigma';
@@ -30,8 +45,9 @@
 	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import { memoryGraphStore } from '$frontend/stores/features/memory-graph.svelte';
 	import { themeStore } from '$frontend/stores/ui/theme.svelte';
+	import { debug } from '$shared/utils/logger';
 	import type { IconName } from '$shared/types/ui/icons';
-	import type { GraphView, GraphViewNode } from '$shared/types/memory';
+	import type { GraphView } from '$shared/types/memory';
 
 	interface Props {
 		/** Currently inspected node — highlighted and always labelled. */
@@ -54,6 +70,37 @@
 
 	const { selectedId, highlightIds = [], bottomInset = 0, onSelect }: Props = $props();
 
+	/**
+	 * One shape for both resolutions.
+	 *
+	 * A bin and a memory differ in what they MEAN, which is why the wire format
+	 * keeps them apart, but they are drawn by the same code — so they are unified
+	 * once, here, instead of every sizing and colouring function branching.
+	 */
+	interface DrawNode {
+		id: string;
+		label: string;
+		community: number;
+		/** Connections for a memory, members for a bin; both drive size. */
+		magnitude: number;
+		kind: 'episodic' | 'structural' | 'bin';
+		/** From the persisted arrangement. Absent means "not placed yet". */
+		x?: number;
+		y?: number;
+	}
+
+	interface DrawEdge {
+		source: string;
+		target: string;
+		weight: number;
+	}
+
+	interface Scene {
+		level: 'flat' | 'binned';
+		nodes: DrawNode[];
+		edges: DrawEdge[];
+	}
+
 	let container: HTMLDivElement | null = null;
 	let sigma: Sigma | null = null;
 	let graph: Graph | null = null;
@@ -66,7 +113,20 @@
 	let isDark = false;
 	let workerNodeIds: string[] = [];
 	let renderedSignature = '';
+	/** The arrangement currently drawn, tracked apart from the structure. */
+	let renderedLayout = '';
 	let framed = false;
+
+	/**
+	 * The drawn id lists, cached rather than re-derived per frame.
+	 *
+	 * The emphasis animation repaints on every frame and has to tell sigma WHICH
+	 * elements to reprocess — see `repaintDrawn`. Asking graphology for them each
+	 * time allocated two arrays of up to three thousand strings per frame for a
+	 * list that only changes when the graph does.
+	 */
+	let drawnNodeIds: string[] = [];
+	let drawnEdgeIds: string[] = [];
 
 	/** Where the layout wants each node, as opposed to where it is drawn now. */
 	const targets = new Map<string, { x: number; y: number }>();
@@ -100,6 +160,44 @@
 	const nodeEmphasis = new Map<string, number>();
 
 	/**
+	 * The entrance, 0 to 1 — nodes growing in, then the edges drawing between them.
+	 *
+	 * ── Why it animates SIZE and not position ────────────────────────────────
+	 * The obvious entrance is the one this view used to have by accident: nodes
+	 * drifting from a seed to where they belong. Two things rule it out now.
+	 *
+	 * Sigma renders with `autoRescale`, which normalises positions to their
+	 * bounding box before drawing — so a uniform move toward the final layout is
+	 * partly cancelled by the rescale, and a non-uniform one makes the whole graph
+	 * breathe as its extent changes underneath the animation. And `x`/`y` are the
+	 * attributes sigma treats as layout-impacting, so every frame of a positional
+	 * animation forces it to reprocess the scene: rebuild the extent, the
+	 * normalization and the program indexation for every element. That is the
+	 * expensive shape this whole change exists to stop paying.
+	 *
+	 * `size` is neither. It is not in sigma's layout-impacting set, so the frames
+	 * go through the same partial repaint that hovering already uses — the cost is
+	 * one reducer pass over what is drawn, which is bounded by the render budget
+	 * by construction. And a graph assembling itself out of nothing reads as the
+	 * data arriving, which is what is actually happening.
+	 */
+	let reveal = 1;
+	let revealFrames = 0;
+
+	/**
+	 * Frames the entrance runs for — roughly 600 ms, and deliberately counted in
+	 * FRAMES rather than milliseconds. A machine that cannot keep 60 fps here is
+	 * exactly the one where a wall-clock animation would skip most of itself and
+	 * arrive as a flash; counting frames lets it play out slightly slower instead
+	 * of not playing at all.
+	 */
+	const REVEAL_FRAMES = 36;
+	/** Of the whole entrance, how much is spent staggering rather than growing. */
+	const REVEAL_STAGGER = 0.55;
+	/** Where in the entrance the edges start drawing in behind the nodes. */
+	const EDGE_REVEAL_START = 0.35;
+
+	/**
 	 * Longest label the hover pill will show; the full text lives in the inspector.
 	 *
 	 * Roomier than it was, because this is no longer drawn on the canvas at rest —
@@ -108,11 +206,9 @@
 	 */
 	const LABEL_MAX = 60;
 
-	/**
-	 * Lobe palettes, per theme. A single palette for both was the earlier mistake:
-	 * hues that read on dark slate turn muddy on white, and the greys used for
-	 * structural nodes disappeared entirely.
-	 */
+	/** Clear air between two marks, so they read as separate rather than tangent. */
+	const MARK_GAP = 3;
+
 	/**
 	 * A community's colour, generated rather than picked from a list.
 	 *
@@ -167,13 +263,14 @@
 	 * lighter body reads as vivid without going neon.
 	 */
 	function communityColor(community: number, dark: boolean): string {
-		const hue = Math.round((community * GOLDEN_ANGLE) % 360);
+		// A community index is never negative in practice, but a modulo of one would
+		// be — and a negative hue silently parses to black.
+		const index = Math.abs(community);
+		const hue = Math.round((index * GOLDEN_ANGLE) % 360);
 		// Two alternating lightness bands, so that even if two hues ever landed
 		// close together they would still separate by brightness.
-		const band = community % 2;
-		return dark
-			? hslToHex(hue, 72, band ? 58 : 66)
-			: hslToHex(hue, 78, band ? 44 : 52);
+		const band = index % 2;
+		return dark ? hslToHex(hue, 72, band ? 58 : 66) : hslToHex(hue, 78, band ? 44 : 52);
 	}
 
 	/**
@@ -212,11 +309,58 @@
 
 	const view = $derived(memoryGraphStore.view);
 
+	/**
+	 * Flatten whichever resolution arrived into one drawable set.
+	 *
+	 * Kept a plain function rather than a `$derived` because the build effect is
+	 * the only caller and it is keyed on the store's signature — deriving it would
+	 * add a second reactive path to the same data with no second reader.
+	 */
+	function sceneOf(current: GraphView): Scene {
+		// Both arrays, always, and in that order. A binned view is not an
+		// alternative to a flat one — it IS the flat one everywhere the grid did not
+		// have to merge, so the memories and the crowded marks are drawn together as
+		// one picture rather than the client choosing between two.
+		const nodes: DrawNode[] = current.nodes.map(node => ({
+			id: node.id,
+			label: node.label,
+			community: node.community,
+			magnitude: node.degree,
+			kind: node.kind,
+			...(node.x !== undefined && { x: node.x }),
+			...(node.y !== undefined && { y: node.y })
+		}));
+
+		for (const bin of current.bins) {
+			nodes.push({
+				id: bin.id,
+				label: bin.label,
+				community: bin.community,
+				magnitude: bin.members,
+				kind: 'bin',
+				x: bin.x,
+				y: bin.y
+			});
+		}
+
+		const edges: DrawEdge[] = current.edges.map(edge => ({
+			source: edge.source,
+			target: edge.target,
+			weight: edge.weight
+		}));
+
+		for (const edge of current.binEdges) {
+			edges.push({ source: edge.source, target: edge.target, weight: edge.weight });
+		}
+
+		return { level: current.level, nodes, edges };
+	}
+
 	function truncate(label: string): string {
 		return label.length > LABEL_MAX ? `${label.slice(0, LABEL_MAX - 1)}…` : label;
 	}
 
-	function nodeColor(node: GraphViewNode): string {
+	function nodeColor(node: DrawNode): string {
 		// Structural nodes stay neutral on purpose. They are scaffolding — the files
 		// and symbols memories hang off — and giving them community hues too would
 		// make the coloured lobes read as one undifferentiated field.
@@ -224,18 +368,55 @@
 		return communityColor(node.community, isDark);
 	}
 
-	/** Lookup and scale for node/edge styling, rebuilt whenever the view is. */
-	let nodeById = new Map<string, GraphViewNode>();
-	let degreeScale = 1;
+	/** Lookup and scales for node/edge styling, rebuilt whenever the scene is. */
+	let nodeById = new Map<string, DrawNode>();
+	let magnitudeScale = 1;
+	/** Whether anything in the current scene stands for more than one memory. */
+	let hasBins = false;
+
+	/**
+	 * How much a merged mark is shrunk so the map's ink fits its canvas.
+	 *
+	 * Relaxation can only separate marks that CAN be separated. Measured on a
+	 * crowded map, pushing apart 241 large marks in a 600×400 canvas
+	 * never converges — not because the solver is weak but because the circles do
+	 * not fit, and a solver asked to fit them just oscillates. One scale factor
+	 * over every mark keeps the RATIOS, which is what carries meaning here, and
+	 * gives the relaxation a problem with an answer.
+	 */
+	let binScale = 1;
+
+	/** Fraction of the canvas the marks may cover before they are scaled down. */
+	const MAX_INK_COVERAGE = 0.2;
 
 	/** Refresh what the styling functions read. Call before building a graph. */
-	function indexView(current: GraphView): void {
-		nodeById = new Map(current.nodes.map(node => [node.id, node]));
-		degreeScale = scaleDegree(current.nodes);
+	function indexScene(scene: Scene): void {
+		nodeById = new Map(scene.nodes.map(node => [node.id, node]));
+		magnitudeScale = scaleMagnitude(scene.nodes);
+		hasBins = scene.nodes.some(node => node.kind === 'bin');
+		binScale = hasBins ? inkScaleFor(scene) : 1;
+	}
+
+	/** One factor for every mark, from the room they would otherwise need. */
+	function inkScaleFor(scene: Scene): number {
+		if (!sigma) return 1;
+		const { width, height } = sigma.getDimensions();
+		const room = width * height * MAX_INK_COVERAGE;
+		if (!Number.isFinite(room) || room <= 0) return 1;
+
+		// Computed against the UNSCALED sizes, so the factor is derived from the
+		// scene rather than from the last factor applied to it.
+		const ink = scene.nodes.reduce((total, node) => {
+			if (node.kind !== 'bin') return total;
+			const radius = baseBinSize(node) + MARK_GAP;
+			return total + Math.PI * radius * radius;
+		}, 0);
+
+		return ink > room ? Math.sqrt(room / ink) : 1;
 	}
 
 	/**
-	 * The degree that counts as "fully connected" for sizing purposes.
+	 * The magnitude that counts as "fully connected" for sizing purposes.
 	 *
 	 * Normalising against the true maximum let one outlier flatten the whole view:
 	 * a single hub with a hundred edges pushes every ordinary node's share below
@@ -245,9 +426,9 @@
 	 * range, which is the correct reading — past a point, more connected is more
 	 * connected and the exact count stops mattering.
 	 */
-	function scaleDegree(nodes: GraphViewNode[]): number {
+	function scaleMagnitude(nodes: DrawNode[]): number {
 		if (nodes.length === 0) return 1;
-		const sorted = nodes.map(node => node.degree).sort((a, b) => a - b);
+		const sorted = nodes.map(node => node.magnitude).sort((a, b) => a - b);
 		const index = Math.min(sorted.length - 1, Math.floor(sorted.length * 0.95));
 		return Math.max(1, sorted[index]);
 	}
@@ -267,12 +448,29 @@
 	 * leaf already sat near 6px and a degree-5 node near 9px — most of the graph was
 	 * large, and "large" therefore meant nothing. At 0.85 the floor stays populated
 	 * and only genuine hubs climb, which is what makes the skeleton visible.
+	 *
+	 * A merged mark is sized on a different scale entirely, because it stands in
+	 * for a crowd rather than for one memory, and how big that crowd is is the one
+	 * fact a
+	 * merged mark exists to convey.
 	 */
-	function nodeSize(node: GraphViewNode): number {
+	function nodeSize(node: DrawNode): number {
+		// Scaled HERE rather than after the fact, so a repaint — a theme flip, a
+		// live update — recomputes the same size the layout was spread for. Applied
+		// as a post-multiplier it would have been silently undone by the first
+		// repaint, and the marks would drift back into each other.
+		if (node.kind === 'bin') return Math.max(3, baseBinSize(node) * binScale);
+
+		const share = magnitudeScale <= 1 ? 0 : Math.min(1, node.magnitude / magnitudeScale);
 		const min = node.kind === 'structural' ? 1.5 : 2;
 		const max = node.kind === 'structural' ? 6 : 9;
-		const share = degreeScale <= 1 ? 0 : Math.min(1, node.degree / degreeScale);
 		return min + (max - min) * Math.pow(share, 0.85);
+	}
+
+	/** A mark's size before the ink scale — the size its membership asks for. */
+	function baseBinSize(node: DrawNode): number {
+		const share = magnitudeScale <= 1 ? 0 : Math.min(1, node.magnitude / magnitudeScale);
+		return 8 + 22 * Math.pow(share, 0.6);
 	}
 
 	/**
@@ -314,9 +512,15 @@
 	 * information at all despite being computed.
 	 */
 	function edgeSize(sourceId: string, targetId: string): number {
-		const degree = Math.max(nodeById.get(sourceId)?.degree ?? 1, nodeById.get(targetId)?.degree ?? 1);
-		const share = degreeScale <= 1 ? 0 : Math.min(1, degree / degreeScale);
-		return 0.25 + 0.95 * Math.pow(share, 0.7);
+		const magnitude = Math.max(
+			nodeById.get(sourceId)?.magnitude ?? 1,
+			nodeById.get(targetId)?.magnitude ?? 1
+		);
+		const share = magnitudeScale <= 1 ? 0 : Math.min(1, magnitude / magnitudeScale);
+		const width = 0.25 + 0.95 * Math.pow(share, 0.7);
+		// A line into a crowded mark stands for many, so it can afford to be seen.
+		const merged = nodeById.get(sourceId)?.kind === 'bin' || nodeById.get(targetId)?.kind === 'bin';
+		return merged ? width * 2.2 : width;
 	}
 
 	/** Hex with an alpha channel — the only transparent form sigma's parser reads. */
@@ -325,53 +529,6 @@
 			.toString(16)
 			.padStart(2, '0');
 		return `${hex}${value}`;
-	}
-
-	/**
-	 * A fingerprint of everything the canvas actually DRAWS.
-	 *
-	 * It used to be the node count, the edge count and the list of ids — which
-	 * silently declared a view unchanged whenever the same nodes came back wearing
-	 * different attributes. Renaming a memory, reinforcing one into a different
-	 * community, or trading one edge for another all left the counts and the ids
-	 * intact, so the guard below returned early and nothing was repainted at all.
-	 * The graph was correct in the store and stale on screen until the browser was
-	 * reloaded.
-	 *
-	 * Every field that feeds a colour, a size or a caption is folded in, and
-	 * nothing else: `weight` and `rel` are absent because no drawn property is
-	 * derived from them, and including them would buy repaints that change no
-	 * pixels.
-	 *
-	 * Hashed rather than concatenated. The ids alone were already a string joined
-	 * from up to three thousand entries; adding labels to that would build a few
-	 * hundred kilobytes on every refetch to then throw it away.
-	 */
-	function signatureOf(current: GraphView): string {
-		let hash = 2166136261;
-		const feed = (value: string | number): void => {
-			const text = typeof value === 'number' ? value.toString(36) : value;
-			for (let i = 0; i < text.length; i++) {
-				hash ^= text.charCodeAt(i);
-				hash = Math.imul(hash, 16777619);
-			}
-			// A field separator, so ("ab","c") and ("a","bc") cannot collide.
-			hash ^= 0x1f;
-			hash = Math.imul(hash, 16777619);
-		};
-
-		for (const node of current.nodes) {
-			feed(node.id);
-			feed(node.label);
-			feed(node.kind);
-			feed(node.community);
-			feed(node.degree);
-		}
-		for (const edge of current.edges) {
-			feed(edge.source);
-			feed(edge.target);
-		}
-		return `${current.nodes.length}:${current.edges.length}:${(hash >>> 0).toString(36)}`;
 	}
 
 	/** FNV-1a — cheap, well-distributed, and short enough to read. */
@@ -385,144 +542,89 @@
 	}
 
 	/**
-	 * Where a node starts before the layout has an opinion.
+	 * Where a node starts when the server has no position for it.
 	 *
-	 * This has now been wrong twice, in opposite directions, and the reason is
-	 * worth stating because it explains what the seed is actually for.
+	 * This used to mirror the backend's community-region seeding — the same spiral,
+	 * the same sizing, reimplemented here. Two copies of an arrangement is one too
+	 * many: they drifted apart, and the shape a node was given here was one the
+	 * background pass would immediately overrule anyway.
 	 *
-	 * FIRST it was a ring: every node placed on a circle by index. Deterministic,
-	 * which was the real requirement — reloading a graph should settle into a
-	 * familiar shape — but a ring is a very strong prior, and ForceAtlas2 never
-	 * escapes it. Every node starts equidistant from the centre and gravity pulls
-	 * inward uniformly, so every graph converged on the same disc regardless of its
-	 * edges. The view was circular because it had been told to be.
-	 *
-	 * THEN it was a hash scatter: deterministic and shapeless, which fixed the
-	 * circle. But shapeless is not neutral either. Starting from noise, a force
-	 * layout has to discover the community structure from scratch, and in a few
-	 * hundred iterations over a graph this sparse it does not finish — it stops
-	 * somewhere partway, which is the hairball. The giveaway was that toggling a
-	 * filter repeatedly gradually improved the layout: each toggle re-heated from
-	 * where it left off, so the iterations accumulated and the structure slowly
-	 * emerged. The layout was never wrong, only unfinished.
-	 *
-	 * NOW the seed carries the answer the layout was searching for. Louvain
-	 * communities are already computed server-side for the colouring, so each
-	 * community is given its own region and nodes start scattered within it. The
-	 * forces then refine a layout that is already structured instead of
-	 * constructing one from noise, so the first frame the user sees is grouped.
-	 *
-	 * And the regions are SIZED BY MEMBERSHIP, not laid out uniformly, which is the
-	 * third correction. A spiral of equal regions is still a disc, and it gave a
-	 * forty-node community exactly as much room as a three-node one — both of which
-	 * survived into the finished render as "always round" and "the big lobes are
-	 * always the crowded ones". See `seedRing`.
-	 *
-	 * It stays fully deterministic: community index, community size and node id all
-	 * are.
+	 * So the client no longer has an opinion about the macro arrangement. A node
+	 * with no position gets dropped near the middle of whatever IS drawn, and
+	 * either the short local settle or the next background pass puts it where it
+	 * belongs — and in practice it almost never runs, because the server derives a
+	 * position for an arrival from whatever it connects to before sending it (see
+	 * `placeArrivals`).
 	 */
-	function seedPosition(
-		node: { id: string; community: number },
-		communitySizes: Map<number, number>
-	): { x: number; y: number } {
+	function seedPosition(node: DrawNode, centre: { x: number; y: number; spread: number }): { x: number; y: number } {
 		const hash = hashOf(node.id);
 		const jitterX = ((hash % 65536) / 65536 - 0.5) * 2;
 		const jitterY = (((hash >>> 16) % 65536) / 65536 - 0.5) * 2;
 
-		// A single community carries no positional information, so fall back to a
-		// plain scatter rather than piling everything on one point.
-		if (communitySizes.size <= 1) {
-			return { x: jitterX * 300, y: jitterY * 300 };
-		}
-
-		const order = seedRing(communitySizes);
-		const region = order.get(node.community);
-		if (!region) return { x: jitterX * 300, y: jitterY * 300 };
-
 		return {
-			x: region.x + jitterX * region.radius,
-			y: region.y + jitterY * region.radius
+			x: centre.x + jitterX * centre.spread,
+			y: centre.y + jitterY * centre.spread
 		};
 	}
 
 	/**
-	 * Where each community's region sits, and how big it is.
+	 * The middle of what is already placed, and how far it reaches.
 	 *
-	 * The earlier version put every community on one golden-angle spiral at
-	 * `120·√(index+1)`, which is a disc by construction and gave a forty-node
-	 * community exactly as much room as a three-node one. Both of those show up in
-	 * the finished render: the silhouette was always round, and the large lobes were
-	 * always the crowded ones.
-	 *
-	 * Now the radius of a region scales with √(members) — area proportional to
-	 * size — and the regions are laid out largest-first on a spiral whose step
-	 * accounts for the radii already placed. The result is a seed whose SHAPE
-	 * follows the data, which matters because the forces refine the seed rather
-	 * than replacing it: a graph with one dominant group and three small ones now
-	 * starts, and therefore ends, looking like that.
-	 *
-	 * Fully deterministic — the ordering is by size then community index, both of
-	 * which are stable for a given dataset, so reloading settles into the same pose.
+	 * Derived from the nodes the server DID place, so an arrival lands inside the
+	 * picture rather than at an origin the arrangement may be nowhere near — the
+	 * layout is no longer centred on (0, 0) now that components are packed.
 	 */
-	function seedRing(communitySizes: Map<number, number>): Map<number, { x: number; y: number; radius: number }> {
-		const ordered = [...communitySizes.entries()].sort((a, b) => b[1] - a[1] || a[0] - b[0]);
-
-		/** Pixels of region radius per √member. Tuned against real graphs. */
-		const SCALE = 26;
-		/** Empty space between regions, as a fraction of the radius. */
-		const GAP = 0.5;
-
-		const regions = new Map<number, { x: number; y: number; radius: number }>();
-		let placedRadius = 0;
-
-		ordered.forEach(([community, size], index) => {
-			const radius = Math.max(40, SCALE * Math.sqrt(size));
-			// The largest community takes the centre; the rest spiral outward at the
-			// golden angle, which spaces them evenly without ever putting two adjacent.
-			const angle = index * GOLDEN_ANGLE * (Math.PI / 180);
-			const distance = index === 0 ? 0 : placedRadius + radius * (1 + GAP);
-			regions.set(community, {
-				x: Math.cos(angle) * distance,
-				y: Math.sin(angle) * distance,
-				radius
-			});
-			// Grow the ring by a fraction of what was just placed, so successive
-			// regions climb outward instead of stacking on one circle.
-			placedRadius += radius * 0.55;
-		});
-
-		return regions;
-	}
-
-	/** How many nodes each community holds, in the current view. */
-	function communitySizesOf(current: GraphView): Map<number, number> {
-		const sizes = new Map<number, number>();
-		for (const node of current.nodes) {
-			sizes.set(node.community, (sizes.get(node.community) ?? 0) + 1);
+	function drawnCentre(scene: Scene): { x: number; y: number; spread: number } {
+		let sumX = 0;
+		let sumY = 0;
+		let count = 0;
+		for (const node of scene.nodes) {
+			if (node.x === undefined || node.y === undefined) continue;
+			sumX += node.x;
+			sumY += node.y;
+			count++;
 		}
-		return sizes;
+		if (count === 0) return { x: 0, y: 0, spread: 300 };
+
+		const x = sumX / count;
+		const y = sumY / count;
+
+		let furthest = 0;
+		for (const node of scene.nodes) {
+			if (node.x === undefined || node.y === undefined) continue;
+			furthest = Math.max(furthest, Math.hypot(node.x - x, node.y - y));
+		}
+		// A fraction of the reach, so an unplaced node lands in the picture rather
+		// than out on its rim where it would read as a component of its own.
+		return { x, y, spread: Math.max(40, furthest * 0.25) };
 	}
 
-	function buildGraph(current: GraphView): void {
+	function buildGraph(scene: Scene): void {
 		if (!sigma) return;
 
 		graph = new Graph({ type: 'undirected', multi: false });
 
-		indexView(current);
-		const communitySizes = communitySizesOf(current);
-		current.nodes.forEach(node => {
-			const seed = seedPosition(node, communitySizes);
-			graph!.addNode(node.id, {
+		indexScene(scene);
+		const centre = drawnCentre(scene);
+		let unplaced = 0;
+
+		for (const node of scene.nodes) {
+			const placed = node.x !== undefined && node.y !== undefined;
+			if (!placed) unplaced++;
+			const seed = placed ? { x: node.x as number, y: node.y as number } : seedPosition(node, centre);
+			graph.addNode(node.id, {
 				x: seed.x,
 				y: seed.y,
 				size: nodeSize(node),
 				label: truncate(node.label),
 				color: nodeColor(node),
-				kind: node.kind
+				kind: node.kind,
+				// Overwritten by `assignRevealDelays` once every position is known.
+				delay: 0
 			});
-		});
+		}
 
-		for (const edge of current.edges) {
+		for (const edge of scene.edges) {
 			if (!graph.hasNode(edge.source) || !graph.hasNode(edge.target)) continue;
 			if (edge.source === edge.target) continue;
 			if (graph.hasEdge(edge.source, edge.target)) continue;
@@ -532,14 +634,229 @@
 			});
 		}
 
+		// A merged mark is drawn far larger than the dots it replaced, so it spills
+		// over its neighbours — the centroid says where its memories are, not how
+		// much room the mark standing for them needs.
+		if (hasBins) spreadMarks(graph);
+
+		assignRevealDelays(graph);
+
+		// BEFORE `setGraph`, which renders synchronously. Armed afterwards, that
+		// render would draw the finished graph for one frame and the entrance would
+		// begin by shrinking it away again.
+		//
+		// A fresh picture gets an entrance; incremental updates deliberately do not.
+		// Replaying it every time a conversation records a memory would make the
+		// graph flinch at somebody who is reading it.
+		startReveal();
+
 		sigma.setGraph(graph);
+		cacheDrawnIds();
 		framed = false;
-		startLayout(current);
+
+		// The simulation here is a COLD FALLBACK and nothing more: it runs only when
+		// the server has placed nothing at all — a fresh install, or the first fetch
+		// after the arrangement was dropped.
+		//
+		// It must never run otherwise, and that is not an optimisation. This worker
+		// lays out the WHOLE scene with a single global gravity, which is exactly
+		// the isotropic pull that puts every disconnected component at one radius —
+		// the circle the backend arrangement exists to avoid. Running it because a
+		// handful of newly recorded memories had no position yet threw away the
+		// packed arrangement for all of them and drew a disc again.
+		if (unplaced < scene.nodes.length) {
+			stopLayout();
+			framed = true;
+			sigma.getCamera().animatedReset({ duration: 300 });
+			return;
+		}
+
+		startLayout(scene);
 	}
 
-	function startLayout(current: GraphView, options?: { iterations?: number }): void {
+	/**
+	 * Push overlapping marks apart, without losing where they came from.
+	 *
+	 * A merged mark is placed at the centroid of the memories it stands for, which
+	 * answers "where are they" and says nothing about how much room the mark needs
+	 * — and it is drawn far larger than the dots it replaced, because the size of
+	 * the crowd is the point. In a dense middle those marks spill over each other
+	 * and over the individual memories around them.
+	 *
+	 * Relaxation rather than a fresh layout: the centroids carry real information
+	 * about which lobes sit near which, and re-solving would throw that away to
+	 * fix a spacing problem. This only separates what collides and leaves
+	 * everything else where the arrangement put it.
+	 *
+	 * ── Units, which are the whole difficulty ────────────────────────────────
+	 * Sizes are SCREEN pixels and positions are graph space, and sigma rescales
+	 * one into the other at render time — so "these two circles overlap" cannot be
+	 * tested without knowing the mapping. It is recovered here from the extent of
+	 * the marks against the container: the graph is fitted to the viewport, so one
+	 * pixel is `span / viewport` in graph units.
+	 */
+	function spreadMarks(target: Graph): void {
+		const order = target.order;
+		if (!sigma || order < 2) return;
+
+		const { width, height } = sigma.getDimensions();
+		const viewport = Math.min(width, height);
+		if (!Number.isFinite(viewport) || viewport <= 0) return;
+
+		const ids = target.nodes();
+		const xs = new Float64Array(order);
+		const ys = new Float64Array(order);
+		const radii = new Float64Array(order);
+
+		let minX = Infinity;
+		let maxX = -Infinity;
+		let minY = Infinity;
+		let maxY = -Infinity;
+		for (let i = 0; i < order; i++) {
+			const attributes = target.getNodeAttributes(ids[i]) as { x: number; y: number; size: number };
+			xs[i] = attributes.x;
+			ys[i] = attributes.y;
+			minX = Math.min(minX, xs[i]);
+			maxX = Math.max(maxX, xs[i]);
+			minY = Math.min(minY, ys[i]);
+			maxY = Math.max(maxY, ys[i]);
+		}
+
+		const span = Math.max(maxX - minX, maxY - minY);
+		if (!Number.isFinite(span) || span <= 0) return;
+		const perPixel = span / viewport;
+
+		for (let i = 0; i < order; i++) {
+			const size = target.getNodeAttribute(ids[i], 'size') as number;
+			radii[i] = (size + MARK_GAP) * perPixel;
+		}
+
+		// Enough to resolve a crowded ring, few enough to stay imperceptible. The
+		// pass is O(n²) and `n` is the community count, which the server caps —
+		// measured at 28 ms for 241 marks, and it exits early the moment nothing
+		// collides (8 passes for the ~100-lobe case this was reported on).
+		const PASSES = 240;
+		for (let pass = 0; pass < PASSES; pass++) {
+			// Over-relaxed at first and settling toward an exact correction. Pushing
+			// by exactly half the overlap converges very slowly in a crowd, because
+			// every separation nudges both marks into their other neighbours;
+			// overshooting early clears the crowd faster, and easing off stops it
+			// oscillating once the arrangement is nearly right. Measured, the fixed
+			// exact push left more overlaps after 900 passes than this does after 240.
+			const relax = 1.4 - 0.4 * (pass / PASSES);
+			let collided = false;
+
+			for (let i = 0; i < order; i++) {
+				for (let j = i + 1; j < order; j++) {
+					const minimum = radii[i] + radii[j];
+					let dx = xs[j] - xs[i];
+					let dy = ys[j] - ys[i];
+
+					// Compared squared first: the square root is the expensive part and
+					// most pairs in a spread-out map are nowhere near touching.
+					const squared = dx * dx + dy * dy;
+					if (squared >= minimum * minimum) continue;
+					let distance = Math.sqrt(squared);
+
+					// Exactly coincident — two lobes whose members averaged to the same
+					// point. Deterministic from the ids, so a reload separates them the
+					// same way rather than picking a new direction each time.
+					if (distance < 1e-9) {
+						const angle = (hashOf(ids[i] + ids[j]) % 3600) / 3600 * Math.PI * 2;
+						dx = Math.cos(angle);
+						dy = Math.sin(angle);
+						distance = 1;
+					}
+
+					const push = (relax * (minimum - distance)) / 2 / distance;
+					xs[i] -= dx * push;
+					ys[i] -= dy * push;
+					xs[j] += dx * push;
+					ys[j] += dy * push;
+					collided = true;
+				}
+			}
+
+			if (!collided) break;
+		}
+
+		for (let i = 0; i < order; i++) {
+			target.setNodeAttribute(ids[i], 'x', xs[i]);
+			target.setNodeAttribute(ids[i], 'y', ys[i]);
+		}
+	}
+
+	/**
+	 * Give every node the moment it should appear, as a node attribute.
+	 *
+	 * Radial from the centre of the arrangement, so the graph opens outward rather
+	 * than all at once — which is both nicer to watch and more informative, since
+	 * what emerges first is the dense middle the layout put there.
+	 *
+	 * Stored on the node instead of recomputed per frame because it never changes:
+	 * the reducer runs for every element on every frame of the entrance, and a
+	 * square root in there is a square root sixty times a second times the render
+	 * budget. `repaint` never touches it — its update hints name only the three
+	 * attributes it does write — so it survives a theme flip and a live update.
+	 */
+	function assignRevealDelays(target: Graph): void {
+		const order = target.order;
+		if (order === 0) return;
+
+		let sumX = 0;
+		let sumY = 0;
+		target.forEachNode((_id, attributes) => {
+			sumX += attributes.x as number;
+			sumY += attributes.y as number;
+		});
+		const centreX = sumX / order;
+		const centreY = sumY / order;
+
+		let furthest = 0;
+		const distances = new Map<string, number>();
+		target.forEachNode((id, attributes) => {
+			const dx = (attributes.x as number) - centreX;
+			const dy = (attributes.y as number) - centreY;
+			const distance = Math.sqrt(dx * dx + dy * dy);
+			distances.set(id, distance);
+			if (distance > furthest) furthest = distance;
+		});
+
+		target.updateEachNodeAttributes(
+			(id, attributes) => ({
+				...attributes,
+				delay: furthest > 0 ? ((distances.get(id) ?? 0) / furthest) * REVEAL_STAGGER : 0
+			}),
+			{ attributes: ['delay'] }
+		);
+	}
+
+	/** How far into its own growth a node is, given the entrance's progress. */
+	function revealOf(delay: number): number {
+		if (reveal >= 1) return 1;
+		const span = Math.max(0.001, 1 - REVEAL_STAGGER);
+		const progress = Math.min(1, Math.max(0, (reveal - delay) / span));
+		// Ease-out cubic: quick to appear, gentle to settle. A linear grow reads as
+		// mechanical at this duration.
+		return 1 - Math.pow(1 - progress, 3);
+	}
+
+	/** Play the entrance from the beginning. */
+	function startReveal(): void {
+		reveal = 0;
+		revealFrames = 0;
+		startAnimation();
+	}
+
+	/** Remember what is drawn, so per-frame repaints do not re-derive it. */
+	function cacheDrawnIds(): void {
+		drawnNodeIds = graph ? graph.nodes() : [];
+		drawnEdgeIds = graph ? graph.edges() : [];
+	}
+
+	function startLayout(scene: Scene, options?: { iterations?: number }): void {
 		stopLayout();
-		if (current.nodes.length === 0) return;
+		if (scene.nodes.length === 0) return;
 
 		worker = new Worker(new URL('$frontend/services/memory/graph-layout.worker.ts', import.meta.url), {
 			type: 'module'
@@ -559,23 +876,7 @@
 				return;
 			}
 			if (message.type === 'positions') {
-				if (!graph) return;
-
-				const tween = graph.order <= MAX_TWEENED_NODES;
-				for (let i = 0; i < workerNodeIds.length; i++) {
-					const id = workerNodeIds[i];
-					if (!graph.hasNode(id)) continue;
-					const x = message.coords[i * 2];
-					const y = message.coords[i * 2 + 1];
-
-					if (tween) {
-						targets.set(id, { x, y });
-					} else {
-						graph.setNodeAttribute(id, 'x', x);
-						graph.setNodeAttribute(id, 'y', y);
-					}
-				}
-				if (tween) startTween();
+				applyPositions(message.coords);
 				return;
 			}
 			if (message.type === 'done') {
@@ -587,33 +888,77 @@
 					framed = true;
 					sigma?.getCamera().animatedReset({ duration: 300 });
 				}
+				// Positions have stopped moving, so rebuild the indices the tween was
+				// allowed to skip — hit detection reads them.
+				sigma?.refresh();
 			}
 		};
 
-		indexView(current);
-		const communitySizes = communitySizesOf(current);
+		indexScene(scene);
+		const centre = drawnCentre(scene);
 
-		// Seeded from the community structure, the layout is refining rather than
-		// discovering, so these buy convergence instead of merely progress.
+		// Refining what the server already arranged rather than discovering it, so
+		// these buy convergence instead of merely progress.
 		const iterations =
 			options?.iterations ??
-			(current.nodes.length > 1200 ? 260 : current.nodes.length > 400 ? 500 : 900);
+			(scene.nodes.length > 1200 ? 260 : scene.nodes.length > 400 ? 500 : 900);
 
 		worker.postMessage({
 			type: 'start',
-			nodes: current.nodes.map(node => {
+			nodes: scene.nodes.map(node => {
 				// Positions already on screen are kept, so a graph that gains a few
 				// nodes re-heats from where it is instead of being thrown back to its
 				// seed and re-settling into a different pose.
 				const existing = graph?.hasNode(node.id)
 					? (graph.getNodeAttributes(node.id) as { x: number; y: number })
 					: null;
-				const seed = existing ?? seedPosition(node, communitySizes);
-				return { id: node.id, x: seed.x, y: seed.y, degree: node.degree };
+				const seed = existing ?? seedPosition(node, centre);
+				return { id: node.id, x: seed.x, y: seed.y, degree: node.magnitude };
 			}),
-			edges: current.edges.map(edge => ({ source: edge.source, target: edge.target, weight: edge.weight })),
+			edges: scene.edges.map(edge => ({
+				source: edge.source,
+				target: edge.target,
+				weight: edge.weight
+			})),
 			iterations
 		});
+	}
+
+	/**
+	 * Fold a batch of worker positions into the drawn graph.
+	 *
+	 * Written as ONE `updateEachNodeAttributes` rather than two
+	 * `setNodeAttribute` calls per node, and the difference is not stylistic: sigma
+	 * subscribes to graphology's per-attribute events, so the old form fired two
+	 * events per node per batch and sigma answered each one by re-running its node
+	 * reducer and marking the whole scene for reprocessing. At a thousand nodes
+	 * that is two thousand reducer invocations to move a thousand dots. The bulk
+	 * form emits a single event carrying which attributes changed.
+	 */
+	function applyPositions(coords: Float32Array): void {
+		if (!graph) return;
+
+		const tween = graph.order <= MAX_TWEENED_NODES;
+		const incoming = new Map<string, { x: number; y: number }>();
+		for (let i = 0; i < workerNodeIds.length; i++) {
+			const id = workerNodeIds[i];
+			if (!graph.hasNode(id)) continue;
+			incoming.set(id, { x: coords[i * 2], y: coords[i * 2 + 1] });
+		}
+
+		if (tween) {
+			for (const [id, position] of incoming) targets.set(id, position);
+			startTween();
+			return;
+		}
+
+		graph.updateEachNodeAttributes(
+			(id, attributes) => {
+				const position = incoming.get(id);
+				return position ? { ...attributes, x: position.x, y: position.y } : attributes;
+			},
+			{ attributes: ['x', 'y'] }
+		);
 	}
 
 	/**
@@ -632,28 +977,33 @@
 			if (!graph || !sigma) return;
 
 			let moving = false;
-			for (const [id, target] of targets) {
-				if (!graph.hasNode(id)) continue;
-				const x = graph.getNodeAttribute(id, 'x') as number;
-				const y = graph.getNodeAttribute(id, 'y') as number;
-				const dx = target.x - x;
-				const dy = target.y - y;
+			graph.updateEachNodeAttributes(
+				(id, attributes) => {
+					const target = targets.get(id);
+					if (!target) return attributes;
 
-				// Snap once the remaining distance stops being visible, so the loop
-				// terminates instead of chasing an asymptote forever.
-				if (Math.abs(dx) < 0.05 && Math.abs(dy) < 0.05) {
-					graph.setNodeAttribute(id, 'x', target.x);
-					graph.setNodeAttribute(id, 'y', target.y);
-					continue;
-				}
+					const x = attributes.x as number;
+					const y = attributes.y as number;
+					const dx = target.x - x;
+					const dy = target.y - y;
 
-				graph.setNodeAttribute(id, 'x', x + dx * TWEEN_EASE);
-				graph.setNodeAttribute(id, 'y', y + dy * TWEEN_EASE);
-				moving = true;
-			}
+					// Snap once the remaining distance stops being visible, so the loop
+					// terminates instead of chasing an asymptote forever.
+					if (Math.abs(dx) < 0.05 && Math.abs(dy) < 0.05) {
+						return { ...attributes, x: target.x, y: target.y };
+					}
 
-			sigma.refresh({ skipIndexation: true });
+					moving = true;
+					return { ...attributes, x: x + dx * TWEEN_EASE, y: y + dy * TWEEN_EASE };
+				},
+				{ attributes: ['x', 'y'] }
+			);
+
 			if (moving) tweenFrame = requestAnimationFrame(step);
+			// The final frame leaves the indices stale — positions moved with
+			// indexation skipped — so hit detection is restored once, at the end,
+			// rather than rebuilt on every frame of the animation.
+			else sigma.refresh();
 		};
 
 		tweenFrame = requestAnimationFrame(step);
@@ -666,10 +1016,37 @@
 	}
 
 	/**
-	 * Ease `emphasis` and every node's own emphasis toward their targets, so
-	 * focusing and unfocusing are transitions rather than switches.
+	 * Redraw what is already on screen, without touching the graph.
+	 *
+	 * This is what the emphasis animation runs on every frame, and it is where the
+	 * single most expensive mistake in this component lived: it used to call
+	 * `sigma.refresh({ skipIndexation: true })`. That flag only applies to a
+	 * PARTIAL refresh — with no `partialGraph`, sigma takes the full path, which
+	 * clears every node and edge index and rebuilds them from scratch. Hovering a
+	 * node therefore re-indexed the entire graph sixty times a second, and the flag
+	 * that was supposed to prevent exactly that was being ignored because the call
+	 * never named what it wanted refreshed.
 	 */
-	function startEmphasisTween(): void {
+	function repaintDrawn(): void {
+		if (!sigma) return;
+		guardRepaint(() =>
+			sigma!.refresh({
+				partialGraph: { nodes: drawnNodeIds, edges: drawnEdgeIds },
+				skipIndexation: true
+			})
+		);
+	}
+
+	/**
+	 * The one animation loop: the entrance, and the emphasis that follows focus.
+	 *
+	 * Deliberately ONE. Both animate numbers the reducers read and both finish by
+	 * repainting everything drawn, so as two `requestAnimationFrame` loops they
+	 * would each repaint the same scene in the same frame — twice the cost for one
+	 * picture, and worst of all exactly while the graph is opening, which is when
+	 * both are most likely to be running.
+	 */
+	function startAnimation(): void {
 		if (emphasisFrame !== null) return;
 
 		const step = (): void => {
@@ -677,6 +1054,12 @@
 			if (!sigma) return;
 
 			let moving = false;
+
+			if (reveal < 1) {
+				revealFrames++;
+				reveal = Math.min(1, revealFrames / REVEAL_FRAMES);
+				moving = true;
+			}
 
 			const delta = emphasisTarget - emphasis;
 			if (Math.abs(delta) > 0.005) {
@@ -706,7 +1089,7 @@
 				moving = true;
 			}
 
-			sigma.refresh({ skipIndexation: true });
+			repaintDrawn();
 			if (moving) emphasisFrame = requestAnimationFrame(step);
 		};
 
@@ -738,7 +1121,6 @@
 		return `#${channel(r1, r2)}${channel(g1, g2)}${channel(b1, b2)}${alpha}`;
 	}
 
-	/** Point the emphasis animation at a new focus and start it running. */
 	/**
 	 * What the view is currently emphasising.
 	 *
@@ -756,11 +1138,21 @@
 		const anchor = anchorId();
 		emphasisTarget = anchor || highlight.size > 0 ? 1 : 0;
 		if (anchor && !nodeEmphasis.has(anchor)) nodeEmphasis.set(anchor, 0);
-		startEmphasisTween();
+		startAnimation();
 	}
 
 	function stopLayout(): void {
 		stopTween();
+		stopLayoutWorker();
+	}
+
+	/**
+	 * Stop the cold-fallback simulation, WITHOUT discarding the tween.
+	 *
+	 * Kept separate from `stopLayout` because the two answer different questions:
+	 * one abandons the simulation, the other abandons where it was going too.
+	 */
+	function stopLayoutWorker(): void {
 		if (!worker) return;
 		worker.postMessage({ type: 'stop' });
 		worker.terminate();
@@ -773,36 +1165,73 @@
 	 * after an incremental update, never a rebuild. Positions are not touched.
 	 *
 	 * SIZES are recomputed, not just colours, because both scales are normalised
-	 * against the view (see `scaleDegree`). A memory arriving with three edges
+	 * against the view (see `scaleMagnitude`). A memory arriving with three edges
 	 * changes what "well connected" means for everything already drawn, and
 	 * leaving the old sizes in place meant the graph slowly drifted out of
 	 * agreement with its own data between full rebuilds.
-	 *
-	 * And edges are painted from `edgeColor`, which is what they were meant to
-	 * have all along. This used to flatten every edge to a single slate — undoing
-	 * `syncEdges` a line after it ran, so the community hues survived exactly
-	 * until the first live update and then vanished for the rest of the session.
 	 *
 	 * LABELS are written here too, for the same reason sizes are: they are data,
 	 * not decoration. Editing a memory's title left the old text attached to its
 	 * node for the rest of the session, so the hover pill went on naming something
 	 * the user had already renamed — the one place in this feature where an edit
 	 * appeared not to have been saved.
+	 *
+	 * Both loops are BULK updates. Written as per-attribute setters they emitted
+	 * three events per node and two per edge, each of which sigma answered by
+	 * re-running a reducer — around twenty thousand of them for a graph this size,
+	 * to change colours that a single pass could have carried.
 	 */
-	function repaint(current: GraphView): void {
-		indexView(current);
+	function repaint(scene: Scene): void {
+		indexScene(scene);
 		if (!graph || !sigma) return;
-		for (const node of current.nodes) {
-			if (!graph.hasNode(node.id)) continue;
-			graph.setNodeAttribute(node.id, 'color', nodeColor(node));
-			graph.setNodeAttribute(node.id, 'size', nodeSize(node));
-			graph.setNodeAttribute(node.id, 'label', truncate(node.label));
-		}
-		graph.forEachEdge((edge, _attributes, source, target) => {
-			graph!.setEdgeAttribute(edge, 'color', edgeColor(source, target));
-			graph!.setEdgeAttribute(edge, 'size', edgeSize(source, target));
+
+		// Guarded because of what a renderer invariant COSTS here, not because one
+		// is expected. Sigma raises `can't be repaint` from inside the graphology
+		// event this write emits — it fills its program index only on the frame
+		// after a structural change — and a throw during render in Svelte 5 has no
+		// boundary above it: it propagates out of the component tree and takes the
+		// whole workspace down. A repaint is a frame; it is never worth a session.
+		guardRepaint(() => {
+			graph!.updateEachNodeAttributes(
+				(id, attributes) => {
+					const node = nodeById.get(id);
+					if (!node) return attributes;
+					return {
+						...attributes,
+						color: nodeColor(node),
+						size: nodeSize(node),
+						label: truncate(node.label)
+					};
+				},
+				{ attributes: ['color', 'size', 'label'] }
+			);
+
+			graph!.updateEachEdgeAttributes(
+				(id, attributes, source, target) => ({
+					...attributes,
+					color: edgeColor(source, target),
+					size: edgeSize(source, target)
+				}),
+				{ attributes: ['color', 'size'] }
+			);
 		});
-		sigma.refresh({ skipIndexation: true });
+	}
+
+	/**
+	 * Run a repaint, and turn any renderer invariant it trips into a dropped frame.
+	 *
+	 * Every failure this can catch has the same remedy — sigma's view of the graph
+	 * is behind the graph, and a full refresh rebuilds it — so the recovery is not
+	 * a guess. What it buys is that the NEXT call shape nobody anticipated costs a
+	 * frame instead of the workspace.
+	 */
+	function guardRepaint(paint: () => void): void {
+		try {
+			paint();
+		} catch (error) {
+			debug.warn('memory', 'Memory graph repaint fell back to a full refresh', error);
+			sigma?.refresh();
+		}
 	}
 
 	onMount(() => {
@@ -815,9 +1244,12 @@
 			defaultEdgeType: 'line',
 			minCameraRatio: 0.05,
 			maxCameraRatio: 12,
-			// No labels at rest — only the hover pill below. Thinning them by size and
-			// by grid cell was the earlier compromise and it still left text stacked
-			// over itself wherever the graph was busy.
+			// No captions at rest, at EITHER resolution. Thinning them by size and by
+			// grid cell was the earlier compromise and it still left text stacked over
+			// itself wherever the graph was busy; drawing them only for the merged
+			// marks looked reasonable in principle and, tried, produced the same
+			// overlapping layer over a picture whose whole value is its shape. The
+			// hover pill names one thing at a time, which is what naming is for here.
 			renderLabels: false,
 			/**
 			 * Sigma clamps every edge up to this, and it defaults to 1.7px — which is
@@ -858,7 +1290,16 @@
 				const result = { ...data } as Record<string, unknown>;
 				const colors = palette();
 				const anchor = anchorId();
-				const isAdjacent = !!anchor && !!graph && graph.hasNode(anchor) && graph.areNeighbors(anchor, id);
+				// `id` is checked as well as `anchor`, because sigma can render one
+				// frame against a graph this component has already replaced — and
+				// `areNeighbors` THROWS on an unknown key. See the edge reducer below,
+				// where exactly that took the whole view down.
+				const isAdjacent =
+					!!anchor &&
+					!!graph &&
+					graph.hasNode(anchor) &&
+					graph.hasNode(id) &&
+					graph.areNeighbors(anchor, id);
 				const isHit = highlight.has(id);
 				const own = nodeEmphasis.get(id) ?? 0;
 
@@ -866,12 +1307,19 @@
 				// shrinks while the node being entered grows. The multiplier is larger
 				// than it was because the nodes are smaller: 0.7 on a 22px hub was
 				// obvious, 0.7 on a 2px leaf was not a gesture anyone could see.
+				let size = data.size as number;
 				if (own > 0) {
-					result.size = (data.size as number) * (1 + 1.2 * own);
+					size *= 1 + 1.2 * own;
 					result.zIndex = 2;
 				} else if (isHit) {
 					result.zIndex = 1;
 				}
+
+				// The entrance multiplies whatever the emphasis decided, so a node
+				// hovered mid-entrance grows from where it has got to rather than
+				// snapping to full size and shrinking back.
+				if (reveal < 1) size *= revealOf((data.delay as number) ?? 0);
+				result.size = size;
 
 				const recedes = (anchor && !isAdjacent && id !== anchor) || (!anchor && highlight.size > 0 && !isHit);
 				if (recedes) result.color = mix(data.color as string, colors.dim, emphasis);
@@ -880,20 +1328,45 @@
 
 			edgeReducer: (id, data) => {
 				const result = { ...data } as Record<string, unknown>;
-				if (!graph || emphasis <= 0.001) return result;
+				if (!graph) return result;
+
+				// Edges draw in behind the nodes they connect, by receding from the
+				// colour everything else recedes to rather than by thinning — sigma
+				// clamps thin edges up to `minEdgeThickness`, so animating the width
+				// toward zero would have stopped being visible almost immediately.
+				if (reveal < 1) {
+					const progress = Math.min(
+						1,
+						Math.max(0, (reveal - EDGE_REVEAL_START) / (1 - EDGE_REVEAL_START))
+					);
+					result.color = mix(data.color as string, palette().dim, 1 - progress);
+					if (progress <= 0.001) return result;
+				}
+
+				if (emphasis <= 0.001) return result;
+
+				// `extremities` throws rather than returning null, and sigma can call
+				// this for an edge belonging to a graph this component has already
+				// swapped out — any `setSetting` refreshes synchronously against
+				// whichever graph sigma still holds, while this closure has moved on.
+				// Svelte 5 has no boundary here, so that throw took the entire
+				// workspace down rather than dropping a frame.
+				if (!graph.hasEdge(id)) return result;
 
 				const colors = palette();
 				const [source, target] = graph.extremities(id);
 				const anchor = anchorId();
 
+				const base = result.color as string;
+
 				if (anchor) {
 					if (source === anchor || target === anchor) {
-						result.color = mix(data.color as string, colors.edgeFocus, emphasis);
+						result.color = mix(base, colors.edgeFocus, emphasis);
 						result.size = (data.size as number) + 0.8 * emphasis;
 					} else {
 						// Kept, not hidden — the surrounding structure is context, and
 						// blanking it made the canvas feel broken.
-						result.color = mix(data.color as string, colors.dim, emphasis);
+						result.color = mix(base, colors.dim, emphasis);
 					}
 					return result;
 				}
@@ -907,7 +1380,7 @@
 				// makes it a link out into everything that was just excluded, and lighting
 				// those would redraw the neighbourhood the search asked to filter away.
 				if (highlight.size > 0 && !(highlight.has(source) && highlight.has(target))) {
-					result.color = mix(data.color as string, colors.dim, emphasis);
+					result.color = mix(base, colors.dim, emphasis);
 				}
 				return result;
 			}
@@ -935,155 +1408,27 @@
 		graph = null;
 	});
 
-	// Rebuild ONLY when the dataset actually changed. Without the signature guard,
-	// any store write (a refetch returning identical data) would restart the layout.
-	// "Changed" means anything the canvas draws, attributes included — see
-	// `signatureOf`, where reading too little of the data was itself a stale-view
-	// bug rather than merely a missed optimisation.
+	// Rebuild ONLY when the dataset actually changed. The signature is computed by
+	// the store when a response lands (see `signatureOf` there) rather than here:
+	// it describes a FETCH, and hashing every label again inside a reactive effect
+	// meant paying for it on any store write that happened to invalidate this.
 	//
 	// And when it HAS changed, prefer the incremental path. Memory is written while
 	// the modal is open — that is the whole point of the live refresh — so a full
-	// rebuild would reset the camera and re-run a 400-iteration layout every time a
-	// conversation recorded something, which reads as the view fighting the user.
-	// An attribute-only change lands on the cheapest branch of all: no node churn
-	// means no re-heat, so a rename repaints without moving anything.
+	// rebuild would reset the camera every time a conversation recorded something,
+	// which reads as the view fighting the user. An attribute-only change lands on
+	// the cheapest branch of all: no node churn means no re-heat, so a rename
+	// repaints without moving anything.
 	$effect(() => {
-		const current = view;
+		const signature = memoryGraphStore.viewSignature;
+		const layout = memoryGraphStore.layoutSignature;
 		if (!sigma) return;
+		if (signature === renderedSignature && layout === renderedLayout) return;
 
-		const signature = signatureOf(current);
-		if (signature === renderedSignature) return;
-
-		const incremental = graph !== null && renderedSignature !== '' && applyIncremental(current);
 		renderedSignature = signature;
-		if (!incremental) buildGraph(current);
+		renderedLayout = layout;
+		buildGraph(sceneOf(view));
 	});
-
-	// Theme changes repaint in place; they must never rebuild or re-layout.
-	$effect(() => {
-		const dark = themeStore.isDark;
-		if (dark === isDark) return;
-		isDark = dark;
-		repaint(view);
-	});
-
-	// Selection/search only update the plain mirrors and ask for a repaint.
-	$effect(() => {
-		focusId = selectedId;
-		highlight = new Set(highlightIds);
-		setAnchor();
-	});
-
-	// Hovering a search result hovers its node. Reading the store HERE is safe —
-	// it is the reducers that must never touch a rune, and this is an effect.
-	$effect(() => {
-		setHovered(memoryGraphStore.hoveredId);
-	});
-
-	// The drawable area changed, so sigma's idea of its own size is stale and every
-	// camera operation would be computed against the wrong rectangle.
-	$effect(() => {
-		void bottomInset;
-		sigma?.resize();
-	});
-
-	/**
-	 * Fold a changed dataset into the graph already on screen.
-	 *
-	 * Returns false when the change is too large to be worth patching, in which
-	 * case the caller falls back to a full rebuild. The threshold exists because
-	 * beyond a certain churn the incremental path costs more than it saves and the
-	 * layout would be re-heated so hard that positions become meaningless anyway —
-	 * switching projects, for instance, shares almost nothing with what was drawn.
-	 *
-	 * The camera is deliberately NOT touched. Somebody is looking at this.
-	 */
-	function applyIncremental(current: GraphView): boolean {
-		if (!graph || !sigma) return false;
-
-		const incoming = new Set(current.nodes.map(node => node.id));
-		const existing = new Set(graph.nodes());
-
-		const added = current.nodes.filter(node => !existing.has(node.id));
-		const removed = [...existing].filter(id => !incoming.has(id));
-
-		// More than a third of the view turning over is a different graph, not an
-		// update to this one.
-		const churn = added.length + removed.length;
-		if (existing.size > 0 && churn > Math.max(30, existing.size * 0.34)) return false;
-		if (churn === 0) {
-			// Only edges or attributes moved — repaint without disturbing anything.
-			syncEdges(current);
-			repaint(current);
-			return true;
-		}
-
-		for (const id of removed) {
-			if (graph.hasNode(id)) graph.dropNode(id);
-			targets.delete(id);
-		}
-
-		indexView(current);
-		const communitySizes = communitySizesOf(current);
-		for (const node of added) {
-			// New nodes enter near the centroid of what they connect to, so an
-			// arriving memory appears next to its subject rather than flying in from
-			// a corner of the seed field.
-			const anchors = current.edges
-				.filter(edge => edge.source === node.id || edge.target === node.id)
-				.map(edge => (edge.source === node.id ? edge.target : edge.source))
-				.filter(id => graph!.hasNode(id))
-				.map(id => graph!.getNodeAttributes(id) as { x: number; y: number });
-
-			const seed = anchors.length
-				? {
-						x: anchors.reduce((sum, a) => sum + a.x, 0) / anchors.length,
-						y: anchors.reduce((sum, a) => sum + a.y, 0) / anchors.length
-					}
-				: seedPosition(node, communitySizes);
-
-			graph.addNode(node.id, {
-				x: seed.x,
-				y: seed.y,
-				size: nodeSize(node),
-				label: truncate(node.label),
-				color: nodeColor(node),
-				kind: node.kind
-			});
-		}
-
-		syncEdges(current);
-		repaint(current);
-		// Re-heat briefly rather than re-solving: enough for the new nodes to find a
-		// place, not enough to rearrange the graph the user is reading. Safe to do
-		// with the same settings as a cold run now that the layout is a single phase —
-		// what is on screen is already at equilibrium for them, so this nudges the
-		// arrivals into place instead of restarting anything. Somebody is looking at
-		// this.
-		startLayout(current, { iterations: 90 });
-		return true;
-	}
-
-	/** Bring the drawn edge set in line with the data, in place. */
-	function syncEdges(current: GraphView): void {
-		if (!graph) return;
-
-		const wanted = new Set<string>();
-		for (const edge of current.edges) {
-			if (!graph.hasNode(edge.source) || !graph.hasNode(edge.target)) continue;
-			if (edge.source === edge.target) continue;
-			if (!graph.hasEdge(edge.source, edge.target)) {
-				graph.addUndirectedEdge(edge.source, edge.target, {
-				size: edgeSize(edge.source, edge.target),
-				color: edgeColor(edge.source, edge.target)
-			});
-			}
-			wanted.add(graph.edge(edge.source, edge.target) as string);
-		}
-		for (const key of graph.edges()) {
-			if (!wanted.has(key)) graph.dropEdge(key);
-		}
-	}
 
 	/**
 	 * Hover a node from outside the canvas — driven by the search results list, so
@@ -1114,10 +1459,22 @@
 		{ label: 'Fit', icon: 'lucide:maximize', action: () => resetView() }
 	];
 
-	/** Re-measure after the surrounding layout changes (the inspector sliding in). */
+	/**
+	 * Re-measure after the surrounding layout changes (the inspector sliding in).
+	 *
+	 * The refresh is a FULL one, because a changed container changes the
+	 * normalization every position is drawn through — but it only happens when the
+	 * container really did change size. This used to refresh unconditionally, and
+	 * with the divider drag calling it on every pointer move that was a complete
+	 * re-index of the graph per mouse event.
+	 */
 	export function resize(): void {
-		sigma?.resize();
-		sigma?.refresh({ skipIndexation: true });
+		if (!sigma) return;
+		const before = sigma.getDimensions();
+		sigma.resize();
+		const after = sigma.getDimensions();
+		if (before.width === after.width && before.height === after.height) return;
+		sigma.refresh();
 	}
 
 	export function zoomIn(): void {

--- a/frontend/components/memory/MemoryModal.svelte
+++ b/frontend/components/memory/MemoryModal.svelte
@@ -35,7 +35,7 @@
 		EPISODIC_SUBKINDS,
 		STRUCTURAL_SUBKINDS
 	} from '$frontend/stores/features/memory-graph.svelte';
-	import type { GraphNodeKind, GraphSource } from '$shared/types/memory';
+	import type { GraphNodeKind, GraphRegion, GraphSource } from '$shared/types/memory';
 
 	interface Props {
 		isOpen: boolean;
@@ -47,6 +47,22 @@
 	let canvas = $state<ReturnType<typeof MemoryGraphCanvas> | null>(null);
 	let searchInput = $state('');
 	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	/**
+	 * Whether the graph is allowed to mount yet.
+	 *
+	 * The modal's opening animation is two hundred milliseconds of the main
+	 * thread, and building a graph is the single most expensive thing this app
+	 * mounts. Doing both in the same flush is what made opening Memory stutter
+	 * once there was a lot of it: the store keeps the last view, so every open
+	 * after the first found data already there and built the whole canvas inside
+	 * the first frame of the animation.
+	 *
+	 * The fetch still starts immediately — the network is not the main thread.
+	 * Only the drawing waits.
+	 */
+	let canvasReady = $state(false);
+	let readyFallback: ReturnType<typeof setTimeout> | null = null;
 
 	/** Which secondary panel is open over the graph, if any. */
 	let panel = $state<'none' | 'filters' | 'forgotten'>('none');
@@ -89,7 +105,19 @@
 	const stats = $derived(memoryGraphStore.stats);
 	const selected = $derived(memoryGraphStore.selected);
 	const hits = $derived(memoryGraphStore.searchHits);
+	/**
+	 * Hits always highlight, at either resolution. A memory that survived the grid
+	 * as its own mark lights up exactly as it always did; one that was merged into
+	 * a crowd simply has no mark of its own to light, and the results list is where
+	 * it is reached from. That degrades quietly, which the community grouping did
+	 * not — there every hit was invisible.
+	 */
 	const highlightIds = $derived(hits.map(hit => hit.node.id));
+	const region = $derived(memoryGraphStore.region);
+	/** Marks on the canvas: memories drawn individually, plus the merged ones. */
+	const drawnCount = $derived(view.nodes.length + view.bins.length);
+	/** How many memories the merged marks stand for, for the header's tooltip. */
+	const mergedCount = $derived(view.bins.reduce((sum, bin) => sum + bin.members, 0));
 	const kinds = $derived(memoryGraphStore.filter.kinds);
 	const filter = $derived(memoryGraphStore.filter);
 	const forgotten = $derived(memoryGraphStore.forgotten);
@@ -133,7 +161,7 @@
 		void selected;
 		void sidebarWidth;
 		// After the DOM has actually reflowed, not before.
-		requestAnimationFrame(() => canvas?.resize());
+		scheduleResize();
 	});
 
 	// Load on EVERY open, but never on mount: the modal mounts with the navigator,
@@ -156,6 +184,42 @@
 		void memoryGraphStore.fetchConfig();
 	});
 
+	// Closing has to put the gate back, because the modal is never unmounted — it
+	// lives in the navigator — so without this the second open would mount the
+	// canvas immediately again, which is precisely the case this exists for.
+	$effect(() => {
+		if (isOpen) return;
+		canvasReady = false;
+		if (readyFallback) {
+			clearTimeout(readyFallback);
+			readyFallback = null;
+		}
+	});
+
+	/**
+	 * The animation is over; the graph may have the thread.
+	 *
+	 * The timer is a safety net, not a duplicate: `introend` does not fire if the
+	 * transition is skipped — a browser that honours reduced motion, or a modal
+	 * reopened mid-outro — and a canvas that never mounts is a worse bug than one
+	 * that mounts a beat early.
+	 */
+	function handleOpened(): void {
+		if (readyFallback) {
+			clearTimeout(readyFallback);
+			readyFallback = null;
+		}
+		canvasReady = true;
+	}
+
+	$effect(() => {
+		if (!isOpen || canvasReady || readyFallback) return;
+		readyFallback = setTimeout(() => {
+			readyFallback = null;
+			canvasReady = true;
+		}, 320);
+	});
+
 	// Follow the graph while it is open. Memory is written by conversations
 	// happening in other tabs and by background consolidation, so a view that only
 	// loaded once was stale within a turn — and the only way to see the new state
@@ -172,6 +236,12 @@
 		void memoryGraphStore.refreshForgotten();
 	});
 
+	/** `bin:12:34` — a crowd of memories rather than one of them. */
+	function binRegionOf(nodeId: string): GraphRegion | null {
+		if (!nodeId.startsWith('bin:')) return null;
+		return view.bins.find(bin => bin.id === nodeId)?.region ?? null;
+	}
+
 	function visit(nodeId: string | null): void {
 		if (!nodeId) {
 			history = [];
@@ -179,6 +249,22 @@
 			void memoryGraphStore.select(null);
 			return;
 		}
+
+		// A merged mark has nothing to inspect — it stands for several memories
+		// rather than being one — so choosing it zooms into the patch of the map it
+		// covers.
+		const binRegion = binRegionOf(nodeId);
+		if (binRegion) {
+			history = [];
+			historyIndex = -1;
+			// The inspector is showing a memory from wherever the user was before.
+			// Leaving it open next to a patch that does not contain it is the kind of
+			// stale panel that makes a view feel like it lost track of itself.
+			void memoryGraphStore.select(null);
+			memoryGraphStore.focusRegion(binRegion);
+			return;
+		}
+
 		if (nodeId === selectedId) return;
 
 		// Truncate the forward entries: navigating somewhere new from the middle of
@@ -368,11 +454,26 @@
 		(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
 	}
 
+	/**
+	 * Pointer moves arrive far faster than frames, and a resize is the one canvas
+	 * operation that has to rebuild sigma's indices. Coalescing to one per frame
+	 * is what keeps dragging the divider smooth on a large graph.
+	 */
+	let resizeFrame: number | null = null;
+
+	function scheduleResize(): void {
+		if (resizeFrame !== null) return;
+		resizeFrame = requestAnimationFrame(() => {
+			resizeFrame = null;
+			canvas?.resize();
+		});
+	}
+
 	function onDrag(event: PointerEvent): void {
 		if (!dragging || !body) return;
 		const rect = body.getBoundingClientRect();
 		sidebarWidth = Math.max(260, Math.min(rect.width - 320, rect.right - event.clientX));
-		canvas?.resize();
+		scheduleResize();
 	}
 
 	function endDrag(event: PointerEvent): void {
@@ -385,6 +486,7 @@
 <Modal
 	bind:isOpen
 	{onClose}
+	onOpened={handleOpened}
 	bare
 	mobileFullscreen
 	ariaLabelledBy="memory-title"
@@ -526,16 +628,22 @@
 					matters precisely when the graph is too large to draw. Now it carries an
 					icon, a unit and a title that explains the gap.
 				-->
-				{#if view.nodes.length > 0}
+				{#if drawnCount > 0}
 					<span
 						class="hidden sm:inline-flex items-center gap-1 px-1.5 py-1 rounded-md
 						       text-[10px] text-slate-500 dark:text-slate-400 bg-slate-100/70 dark:bg-slate-800/70"
-						title={view.truncated
-							? `Showing the ${view.nodes.length} most reinforced of ${view.totalNodes} matching memories. Narrow the filter to see the rest.`
-							: `${view.nodes.length} memories and code entities`}
+						title={view.level === 'binned'
+							? `${view.totalNodes} memories and code entities, all of them in the picture. ${mergedCount} sit close enough together to share ${view.bins.length} marks — click one to zoom in.`
+							: view.truncated
+								? `Showing the ${view.nodes.length} most reinforced of ${view.totalNodes} matching memories. Narrow the filter to see the rest.`
+								: `${view.nodes.length} memories and code entities`}
 					>
 						<Icon name="lucide:circle-dot" class="w-3 h-3 opacity-70" />
-						{view.nodes.length}{view.truncated ? ` / ${view.totalNodes}` : ''}
+						{#if view.level === 'binned'}
+							{view.totalNodes}
+						{:else}
+							{view.nodes.length}{view.truncated ? ` / ${view.totalNodes}` : ''}
+						{/if}
 					</span>
 				{/if}
 				{#if stats && !stats.embedding.ready}
@@ -580,9 +688,10 @@
 
 		<div bind:this={body} bind:clientHeight={bodyHeight} class="flex-1 min-h-0 flex relative">
 			<div class="flex-1 min-w-0 flex flex-col relative">
-				{#if memoryGraphStore.loading && view.nodes.length === 0}
+				{#if !canvasReady || (memoryGraphStore.loading && drawnCount === 0)}
+					<!-- Held back until the modal has finished opening; see `canvasReady`. -->
 					<div class="flex-1 flex items-center justify-center"><LoadingSpinner /></div>
-				{:else if view.nodes.length === 0}
+				{:else if drawnCount === 0}
 					<div class="flex-1 flex flex-col items-center justify-center gap-2 text-slate-400 px-6 text-center">
 						<Icon name="lucide:brain" class="w-10 h-10 opacity-25" />
 						<span class="text-sm font-medium">No memories yet</span>
@@ -599,6 +708,34 @@
 						bottomInset={canvasBottomInset}
 						onSelect={visit}
 					/>
+				{/if}
+
+				{#if canvasReady && region}
+					<button
+						onclick={() => memoryGraphStore.clearRegion()}
+						class="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-1.5 px-2.5 py-1
+						       rounded-full border border-slate-200 dark:border-slate-800
+						       bg-white/90 dark:bg-slate-900/90 text-[10px] text-slate-500 dark:text-slate-400
+						       hover:text-slate-800 dark:hover:text-slate-100 shadow-sm backdrop-blur-sm
+						       whitespace-nowrap"
+					>
+						<Icon name="lucide:arrow-left" class="w-3 h-3" />
+						Back to everything
+					</button>
+				{:else if canvasReady && view.level === 'binned'}
+					<!--
+						Said once, quietly, at the bottom of the canvas rather than as a
+						banner. The whole graph is already on screen — this only explains
+						the larger marks, which are the one thing that is not literal.
+					-->
+					<div
+						class="absolute bottom-3 left-1/2 -translate-x-1/2 px-2.5 py-1 rounded-full
+						       border border-slate-200 dark:border-slate-800 bg-white/90 dark:bg-slate-900/90
+						       text-[10px] text-slate-500 dark:text-slate-400 shadow-sm backdrop-blur-sm
+						       pointer-events-none whitespace-nowrap"
+					>
+						{view.bins.length} crowded spots · click one to zoom in
+					</div>
 				{/if}
 
 

--- a/frontend/stores/features/memory-graph.svelte.ts
+++ b/frontend/stores/features/memory-graph.svelte.ts
@@ -20,6 +20,7 @@ import type {
 	MemoryDraft,
 	GraphNode,
 	GraphNodeKind,
+	GraphRegion,
 	GraphScope,
 	GraphSource,
 	GraphView,
@@ -100,13 +101,131 @@ export const EPISODIC_SUBKINDS = [
 
 export const STRUCTURAL_SUBKINDS = ['file', 'symbol', 'module', 'dependency'] as const;
 
-const EMPTY_VIEW: GraphView = { nodes: [], edges: [], totalNodes: 0, truncated: false };
+const EMPTY_VIEW: GraphView = {
+	level: 'flat',
+	nodes: [],
+	edges: [],
+	bins: [],
+	binEdges: [],
+	region: null,
+	totalNodes: 0,
+	truncated: false
+};
+
+/**
+ * A fingerprint of everything the canvas actually DRAWS.
+ *
+ * It lives here rather than in the canvas because it belongs to a FETCH, not to
+ * a render: computed once when a response lands, it used to be recomputed inside
+ * a reactive effect — hashing every label of every node again on any store write
+ * that happened to invalidate the effect.
+ *
+ * Every field that feeds a colour, a size or a caption is folded in, and nothing
+ * else: `weight` and `rel` are absent because no drawn property is derived from
+ * them, and including them would buy repaints that change no pixels. Positions
+ * are absent too, but for a different reason — they move a node without changing
+ * what it IS, so they are watched separately by `layoutSignatureOf` and applied
+ * without a rebuild.
+ *
+ * Hashed rather than concatenated: the ids alone are a string joined from up to
+ * three thousand entries, and adding labels would build a few hundred kilobytes
+ * on every refetch to then throw it away.
+ */
+function signatureOf(view: GraphView): string {
+	let hash = 2166136261;
+	const feed = (value: string | number): void => {
+		const text = typeof value === 'number' ? value.toString(36) : value;
+		for (let i = 0; i < text.length; i++) {
+			hash ^= text.charCodeAt(i);
+			hash = Math.imul(hash, 16777619);
+		}
+		// A field separator, so ("ab","c") and ("a","bc") cannot collide.
+		hash ^= 0x1f;
+		hash = Math.imul(hash, 16777619);
+	};
+
+	for (const node of view.nodes) {
+		feed(node.id);
+		feed(node.label);
+		feed(node.kind);
+		feed(node.community);
+		feed(node.degree);
+	}
+	for (const edge of view.edges) {
+		feed(edge.source);
+		feed(edge.target);
+	}
+	for (const bin of view.bins) {
+		feed(bin.id);
+		feed(bin.label);
+		feed(bin.members);
+		feed(bin.community);
+	}
+	for (const edge of view.binEdges) {
+		feed(edge.source);
+		feed(edge.target);
+	}
+	return `${view.level}:${view.nodes.length}:${view.edges.length}:${view.bins.length}:${(hash >>> 0).toString(36)}`;
+}
+
+/**
+ * A fingerprint of WHERE things are, kept apart from what they are.
+ *
+ * The two change on different schedules and want different responses. A changed
+ * node set has to rebuild the graph; a changed arrangement must not, because a
+ * rebuild resets the camera and replays the entrance — and the arrangement
+ * changes on its own, seconds after any memory is recorded, when the background
+ * layout pass lands.
+ *
+ * Without this the canvas never saw those positions at all: the structural
+ * signature was identical, so a graph the client had laid out for itself stayed
+ * on screen until the modal was closed and reopened.
+ */
+function layoutSignatureOf(view: GraphView): string {
+	let hash = 2166136261;
+	const feed = (value: number): void => {
+		// Rounded, so a position that moved a fraction of a pixel does not read as
+		// news. The layout pass re-settles slightly on every run.
+		const text = Math.round(value).toString(36);
+		for (let i = 0; i < text.length; i++) {
+			hash ^= text.charCodeAt(i);
+			hash = Math.imul(hash, 16777619);
+		}
+		hash ^= 0x1f;
+		hash = Math.imul(hash, 16777619);
+	};
+
+	let placed = 0;
+	for (const node of view.nodes) {
+		if (node.x === undefined || node.y === undefined) continue;
+		placed++;
+		feed(node.x);
+		feed(node.y);
+	}
+	for (const bin of view.bins) {
+		feed(bin.x);
+		feed(bin.y);
+	}
+	return `${placed}:${(hash >>> 0).toString(36)}`;
+}
 
 /** Forgotten memories fetched per page. The list is a review queue, not a feed. */
 const FORGOTTEN_PAGE = 200;
 
 let view = $state<GraphView>(EMPTY_VIEW);
+let viewSignature = $state(signatureOf(EMPTY_VIEW));
+let layoutSignature = $state(layoutSignatureOf(EMPTY_VIEW));
 let loading = $state(false);
+
+/**
+ * The part of the layout being looked at closely, when a crowded mark was opened.
+ *
+ * NAVIGATION, not filtering, which is why it does not live in `filter`: a filter
+ * narrows what exists, this chooses what to look at closely. Changing a filter
+ * clears it, because the rectangle was read off an arrangement the new filter
+ * may not produce.
+ */
+let region = $state<GraphRegion | null>(null);
 let stats = $state<MemoryStats | null>(null);
 let selected = $state<NodeDetail | null>(null);
 let selectedLoading = $state(false);
@@ -152,6 +271,11 @@ let hoveredId = $state<string | null>(null);
 
 export const memoryGraphStore = {
 	get view() { return view; },
+	/** Changes exactly when the drawn graph changes; see `signatureOf`. */
+	get viewSignature() { return viewSignature; },
+	/** Changes when the persisted arrangement moves; see `layoutSignatureOf`. */
+	get layoutSignature() { return layoutSignature; },
+	get region() { return region; },
 	get loading() { return loading; },
 	get stats() { return stats; },
 	get selected() { return selected; },
@@ -192,6 +316,30 @@ export const memoryGraphStore = {
 
 	setFilter(patch: Partial<MemoryFilter>): void {
 		filter = { ...filter, ...patch };
+		// The rectangle was read off an arrangement this filter may not produce, so
+		// keeping it would zoom the new graph to a patch of the old one's plane.
+		region = null;
+		void this.refresh();
+	},
+
+	/**
+	 * Zoom into one crowded mark, drawing the memories it stands for.
+	 *
+	 * REPLACES rather than accumulates. Holding several unrelated rectangles at
+	 * once has no coherent picture to draw and would make "back" undo them one at
+	 * a time — a history nobody asked to build. One region, and the whole graph is
+	 * always one step away.
+	 */
+	focusRegion(next: GraphRegion): void {
+		region = next;
+		void this.refresh();
+	},
+
+	/** Back to the whole graph. */
+	clearRegion(): void {
+		if (!region) return;
+		region = null;
+		selected = null;
 		void this.refresh();
 	},
 
@@ -204,16 +352,25 @@ export const memoryGraphStore = {
 				kinds: filter.kinds,
 				...(filter.subkinds.length > 0 && { subkinds: filter.subkinds }),
 				...(filter.sources.length > 0 && { sources: filter.sources }),
+				...(region !== null && { region }),
 				includeArchived: filter.includeArchived
 			})) as GraphView;
 			// A newer fetch has already been issued, so this answer describes a filter
 			// or a moment the user has moved on from. Dropping it is the whole point.
 			if (seq !== refreshSeq) return;
 			view = next;
+			viewSignature = signatureOf(next);
+			layoutSignature = layoutSignatureOf(next);
+			// The server decides the resolution — a graph can fall back to the flat
+			// view while its arrangement is still being computed — so what it
+			// answered with is the truth about what is drawn, not what was asked.
+			region = next.region;
 		} catch (error) {
 			if (seq !== refreshSeq) return;
 			debug.error('settings', 'Failed to load memory graph:', error);
 			view = EMPTY_VIEW;
+			viewSignature = signatureOf(EMPTY_VIEW);
+			layoutSignature = layoutSignatureOf(EMPTY_VIEW);
 		} finally {
 			// Still loading, as far as the user is concerned — the request that
 			// overtook this one has not answered yet.

--- a/shared/types/memory.ts
+++ b/shared/types/memory.ts
@@ -381,6 +381,15 @@ export interface GraphViewNode {
 	/** Louvain community index — the "lobe" a node belongs to. */
 	community: number;
 	createdAt: string;
+	/**
+	 * Where the persisted layout put this node, when it has been laid out.
+	 *
+	 * Absent means "no position yet" — a memory written since the last layout
+	 * pass — and the client seeds those from their neighbours rather than
+	 * re-solving the whole graph. See `backend/memory/layout.ts`.
+	 */
+	x?: number;
+	y?: number;
 }
 
 export interface GraphViewEdge {
@@ -391,9 +400,70 @@ export interface GraphViewEdge {
 	weight: number;
 }
 
+/** A rectangle in layout space — what a zoomed-in view is scoped to. */
+export interface GraphRegion {
+	minX: number;
+	maxX: number;
+	minY: number;
+	maxY: number;
+}
+
+/**
+ * Several memories that fell in one cell of the layout grid, drawn as one mark.
+ *
+ * This is what keeps the view's cost bounded without taking anything out of the
+ * picture, and the distinction from the alternative matters. Grouping by
+ * COMMUNITY replaces the picture — you see lobes instead of memories, and
+ * reaching a memory means opening one. Grouping by POSITION keeps the picture:
+ * marks merge only where their dots would have overlapped anyway, so the
+ * silhouette, the lobes and the colours are the ones the full graph would have
+ * drawn. Below the render budget nothing merges at all and every memory is its
+ * own mark, exactly as before.
+ *
+ * A bin is not a memory — it has no body, no scope and nothing to inspect —
+ * which is why it travels in its own array rather than as a node wearing a fake
+ * subkind.
+ */
+export interface GraphViewBin {
+	/** `bin:<cellX>:<cellY>` — namespaced so it cannot collide with a node id. */
+	id: string;
+	/** How many memories it stands for; drives its size. */
+	members: number;
+	/** The most reinforced member's summary, for the hover pill. */
+	label: string;
+	/** Community of that same member, so the mark keeps its lobe's colour. */
+	community: number;
+	/** Centroid of its members — not the cell's centre, which would grid the map. */
+	x: number;
+	y: number;
+	/** The cell itself, so opening the mark asks for exactly this rectangle. */
+	region: GraphRegion;
+}
+
+/** A connection between two bins, weighted by the edges that cross between them. */
+export interface GraphViewBinEdge {
+	source: string;
+	target: string;
+	weight: number;
+}
+
 export interface GraphView {
+	/**
+	 * `flat` when every matching memory is drawn individually — the ordinary case,
+	 * and the only one below the render budget. `binned` when some marks stand for
+	 * more than one memory.
+	 *
+	 * Both populate `nodes`: a cell holding a single memory returns that memory,
+	 * not a bin of one. So the two are not alternatives to each other — a binned
+	 * view is a full-fidelity view everywhere it can afford to be.
+	 */
+	level: 'flat' | 'binned';
 	nodes: GraphViewNode[];
 	edges: GraphViewEdge[];
+	bins: GraphViewBin[];
+	binEdges: GraphViewBinEdge[];
+	/** The rectangle this view was scoped to, when the caller zoomed into one. */
+	region: GraphRegion | null;
 	/** Total nodes matching the filter before any display cap was applied. */
 	totalNodes: number;
 	/** True when `totalNodes` exceeded the cap and the view was trimmed. */


### PR DESCRIPTION
## Summary
Persist the Memory graph's communities and layout in the database, bound what the
canvas draws by merging only marks that would have overlapped anyway, let the
arrangement's shape follow the data instead of settling into a circle, and make
every change to the view redraw the graph the way opening the modal does.

## Why
The open animation is 200ms of the main thread and the graph build was landing
inside it. Because the store retains the last view, every open after the first
mounted the canvas with data already present and built the whole graph — then ran
several hundred ForceAtlas2 iterations to arrive at the arrangement it had
arrived at the previous time and thrown away.

The rest of the pipeline was bounded by the store rather than by the view: Louvain
ran on every fetch, `graphQueries.list` had no index for its ORDER BY, and
`count()` was a second full scan feeding one header badge. The 3,000-node cap did
not solve this — it hid it, with no way to reach what it excluded.

And the picture was always a disc with a ring of dots around it, whatever the
graph contained.

## Changes
- **Migration 067** — `graph_layout` (community, x, y, `placed`), the partial index
  `idx_graph_nodes_view` the graph listing's ORDER BY never had, and
  `idx_graph_layout_position` for zooming into part of the map.
- **`backend/memory/layout.ts`** (new) — background pass, debounced off
  `notifyGraphChanged`, chunked so it never holds the event loop. Louvain runs over
  every live node; the force simulation is capped and the rest keep their real
  community with `placed = 0`.
- **Shape follows the data** — components are laid out in their own local space and
  packed, gravity is local rather than global, lone nodes fill the interior gaps,
  and the macro seed is a layout of the community meta-graph instead of a spiral.
  The spiral is deleted from both the backend and the canvas.
- **Deterministic** — a seeded PRNG for Louvain, size-derived FA2 chunking, and an
  `id` tiebreak on the layout listing. Existing components and lone nodes keep
  their places across passes.
- **`placeArrivals`** — the server derives a position for anything the arrangement
  has not reached yet, from the centroid of what it connects to. Read-time only; a
  node with no placed neighbour is deliberately left without one, which is what the
  client's cold fallback keys on.
- **Every change redraws** — the incremental render path is gone (223 lines,
  including where `can't be repaint` came from). A filter change, an arrival, or a
  new arrangement all rebuild the graph with the same entrance and camera fit as
  opening the modal.
- **`backend/memory/view.ts`** — returns `level: 'flat' | 'binned'`; a binned view
  is full-fidelity everywhere the grid did not have to merge, and opening a crowded
  mark asks for its cell.
- **`graph-queries.ts`** — `extent` / `binnedNodes` / `binnedEdges` /
  `listInRegion`; `edgesWithin` driven from `idx_graph_edges_src`; `derivedEdges`
  and `entityNamesFor` build groups by appending rather than spreading per row.
- **`MemoryGraphCanvas.svelte`** — draws server positions and never simulates
  except as a cold fallback; merged marks separated by a collision relaxation with
  an ink-coverage cap; partial refreshes and bulk attribute updates in place of the
  full re-index per frame; `guardRepaint` so a renderer invariant costs a frame
  instead of the workspace.
- **Entrance animation** — nodes grow in from the centre outward, edges draw in
  behind them, through the same partial repaint hovering uses. It animates `size`,
  not position: `x`/`y` are sigma's layout-impacting attributes, and under
  `autoRescale` a positional entrance partly cancels itself out anyway.
- **`Modal.svelte`** — `onOpened`, fired on `introend`, so an expensive modal can
  defer its contents past the animation.

## Test plan
- `bun run check` — 0 errors
- `bun run lint` — clean
- `bun run test` — 464 pass, 0 fail
- Synthetic graphs shaped like a real store, through the real query and layout paths:
  - 1,343 memories → `flat`, all drawn individually, nothing truncated, 11ms a fetch
    (161ms before the `edgesWithin` fix)
  - 20,000 memories → 312 individual + 1,150 merged marks, every memory accounted
    for, 78ms a fetch, 4ms to zoom into a mark
  - cold layout 1.6s at 1,769 nodes / 8.9s at 17,618; warm 0.44s / 2.0s
  - a warm pass moves existing nodes at most 1.8% of the span
  - component extents at aspect 1.47, lone nodes contained inside them, and the
    arrangement byte-identical across two cold passes
  - an arrival with no layout row lands 0.4% of the span from its nearest
    neighbour, and every node in the response carries a position

## Migration
Migration 067 runs automatically. `graph_layout` starts empty, and until the first
background pass lands the view falls back to the flat listing it used before, so
nothing is missing meanwhile. The first pass reshapes the map once — existing users
will see a different arrangement, and then a stable one.

## Notes
- Every change now redraws, which is deliberate and was asked for. One recorded
  memory therefore produces two rebuilds: one when it appears, one a few seconds
  later when the background pass refines the arrangement. Suppressing the second
  when nothing moved much is a one-line guard if the replayed entrance reads as a
  flicker.
- Determinism failed on the first attempt from three independent causes, all worth
  knowing: `graphology-communities-louvain` defaults to `rng: Math.random`; FA2
  re-initialises its per-node convergence factor on every `assign` call, so
  time-adaptive chunking changes the trajectory; and an `ORDER BY` without a
  tiebreak lets SQLite return ties in any order, which decides the order the layout
  graph is built in.
- `edgesWithin` is the find worth carrying elsewhere: `IN (…) AND IN (…)` over a
  large id set uses neither index on the joined table. 220ms against 1ms when driven
  from the index. The placeholder form it replaced was no faster — the cost was the
  plan, not the binding.
- Sigma's program indices are populated only by `process()`, which `refresh()`
  defers to the next frame. Anything that adds graph elements and then issues a
  `skipIndexation` refresh in the same synchronous block will throw.
- `notify.ts` and `layout.ts` import each other. Verified at runtime under Bun, not
  just through the type checker.
- Barnes-Hut is off: measured on this workload it costs more than the naive
  repulsion it replaces at every size that reaches the layout pass — 142ms/iteration
  against 93ms at 5,000 nodes.