### PR TITLE
fix(ui): keep feedback indicators moving under reduced motion

### DIFF
--- a/frontend/app.css
+++ b/frontend/app.css
@@ -70,13 +70,15 @@
 		transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
 	}
 
-	/* Disable transitions during theme switching for performance */
+	/* Disable transitions during theme switching for performance.
+	   Transitions only — killing `animation` here would restart every running
+	   spinner on each theme switch, and the 50ms window is long enough to see
+	   the stutter. */
 	.no-transitions,
 	.no-transitions *,
 	.no-transitions *::before,
 	.no-transitions *::after {
 		transition: none !important;
-		animation: none !important;
 	}
 
 	/* Remove all focus outlines - use custom focus states */
@@ -111,7 +113,18 @@
 		white-space: normal;
 	}
 
-	/* Reduced motion support */
+	/* Reduced motion support.
+	   Windows 11 (Accessibility -> Visual effects -> Animation effects) and
+	   most Linux desktops without a running settings daemon report `reduce`,
+	   which is why a frozen spinner only ever showed up on those machines and
+	   never on macOS, where Reduce motion is off by default.
+
+	   The blanket rule below stays: decorative motion goes away. But feedback
+	   indicators are exempt in the block after it — a spinner that does not
+	   spin reads as a hung app, and WCAG 2.3.3 only asks for *non-essential*
+	   motion to be removed. This exemption list is the single place that
+	   decides what counts as essential; add to it, do not scatter
+	   `prefers-reduced-motion` overrides across components. */
 	@media (prefers-reduced-motion: reduce) {
 
 		*,
@@ -122,13 +135,37 @@
 			transition-duration: 0.01ms !important;
 		}
 
+		/* Class selectors outrank the universal one, so these win the !important
+		   fight above and keep their own timing. */
+
+		/* Indeterminate progress: still spinning, just slower and gentler. */
 		.animate-spin {
-			animation: none;
+			animation-duration: 1.5s !important;
+			animation-iteration-count: infinite !important;
 		}
 
-		.animate-pulse {
-			animation: none;
+		/* Skeleton and status pulses — opacity only, no vestibular motion. */
+		.animate-pulse,
+		.ai-pulse {
+			animation-duration: 2s !important;
+			animation-iteration-count: infinite !important;
 		}
+
+		.ai-thinking-bar::after {
+			animation-duration: 1.5s !important;
+			animation-iteration-count: infinite !important;
+		}
+
+		/* Search-jump highlight fades out over its full 3s instead of snapping
+		   to the end state the moment it is painted. */
+		.line-highlight,
+		.match-highlight {
+			animation-duration: 3s !important;
+		}
+
+		/* Deliberately NOT exempt: `.animate-ping` (a halo behind a dot that is
+		   itself always visible), panel/modal enter animations, and the virtual
+		   cursor float — all decorative, all safe to drop. */
 	}
 
 	button {
@@ -257,7 +294,12 @@
 		}
 	}
 
+	/* The lit state lives on the class, not only inside the keyframes: when the
+	   blink is dropped (reduced motion) the cursor degrades to a solid block
+	   instead of vanishing into the terminal background. */
 	.animate-terminal-cursor {
+		background-color: rgb(124 58 237);
+		color: #000000;
 		animation: terminal-cursor-blink 1s infinite;
 	}
 

--- a/frontend/components/preview/browser/components/Container.svelte
+++ b/frontend/components/preview/browser/components/Container.svelte
@@ -876,8 +876,12 @@
 </div>
 
 <style>
-	/* MCP Control Border Animation */
+	/* MCP Control Border Animation.
+	   The resting glow is declared on the class so "the agent is driving this
+	   browser" stays visible when the pulse is dropped (reduced motion) — the
+	   keyframes only add the breathing on top of it. */
 	.mcp-control-border {
+		box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.5), 0 0 20px rgba(245, 158, 11, 0.3);
 		animation: mcp-border-pulse 2s ease-in-out infinite;
 	}
 


### PR DESCRIPTION
## Summary
Loading spinners and other progress indicators no longer freeze for users whose
system reports `prefers-reduced-motion: reduce`.

## Why
Users on Windows 11 and Linux reported spinners that never spin, while the same
build animates fine on macOS. `frontend/app.css` clamped every animation to
`0.01ms` / one iteration under `prefers-reduced-motion: reduce`, and explicitly
set `animation: none` on `.animate-spin` and `.animate-pulse`. That media query
is true by default on Windows 11 with *Animation effects* off (common on tuned
setups, VMs and RDP) and on Linux desktops with no settings daemon running; it is
false on macOS, where *Reduce motion* is off by default — hence the
device-dependent report.

WCAG 2.3.3 asks for *non-essential* motion to be removed. An indeterminate
spinner is the only signal that the app is still working, so freezing it reads as
a hang.

## Changes
- `frontend/app.css`: keep the blanket reduced-motion rule for decorative motion,
  and add one explicit exemption list beside it for feedback indicators —
  `.animate-spin` (slowed to 1.5s), `.animate-pulse` / `.ai-pulse`,
  `.ai-thinking-bar::after`, and `.line-highlight` / `.match-highlight`. The list
  is commented as the single place that decides what counts as essential.
- `frontend/app.css`: `.animate-terminal-cursor` now carries its lit colours on
  the class instead of only inside the keyframes — the cursor previously *vanished*
  under reduced motion because the animation halted on the transparent keyframe.
- `frontend/app.css`: drop `animation: none !important` from `.no-transitions`;
  the class is applied for 50ms on every theme switch and was restarting every
  running spinner.
- `frontend/components/preview/browser/components/Container.svelte`:
  `.mcp-control-border` gets its resting glow on the class, so the "an agent is
  driving this browser" border stays visible when the pulse is dropped.

## Notes
The last two fixes deliberately add a static base state rather than another
`prefers-reduced-motion` override, so they hold against anything that stops an
animation, not just this media query.

`animate-ping` is intentionally left disabled: every use sits behind a solid
status dot that remains visible on its own.

## Test plan
- [x] `bun run check` — 0 errors
- [x] `bun run lint` — clean
- [x] Manual: DevTools → Rendering → *Emulate CSS media feature
      prefers-reduced-motion: reduce*. Spinners keep turning, skeletons keep
      pulsing, the terminal cursor renders as a solid block, and panel/modal enter
      animations stay disabled.