### PR TITLE
fix(db-client): resolve every statement against the database it names

### DIFF
--- a/backend/db-client/drivers/mssql.ts
+++ b/backend/db-client/drivers/mssql.ts
@@ -126,6 +126,18 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 		return this.pool;
 	}
 
+	/**
+	 * The database a statement should run in.
+	 *
+	 * Most DDL here is three-part qualified and so needs no context, but the
+	 * statements that cannot be (`sp_rename`, `CREATE VIEW`) must name one —
+	 * falling back to the connection's configured database rather than trusting
+	 * whichever database the pooled connection was last left in.
+	 */
+	private scopeDb(opts?: SchemaOpts): string | undefined {
+		return opts?.database || this.conn?.database || undefined;
+	}
+
 	async health(): Promise<DbClientHealth> {
 		if (!this.pool) return notConnected();
 		const start = performance.now();
@@ -218,9 +230,14 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 	async executeRead(q: string, params: unknown[] = [], opts?: { database?: string; limit?: number }): Promise<DbClientQueryResult> {
 		const pool = this.requirePool();
 		const start = performance.now();
-		const needUse = opts?.database && opts.database.toLowerCase() !== this.conn?.database?.toLowerCase();
+		// Always switch when a database is named — never skip because it matches
+		// the connection's configured one. `USE` is per-connection session state
+		// and the driver hands pooled connections back without resetting it, so a
+		// connection an earlier request left on another database would otherwise
+		// silently serve this one.
+		const database = opts?.database;
 
-		if (needUse && isBatchSensitive(q)) {
+		if (database && isBatchSensitive(q)) {
 			// Batch-sensitive DDL (CREATE PROCEDURE, …) can't share a batch with
 			// `USE`, so run the database switch as a separate request first, wrapped
 			// in a transaction for atomicity.
@@ -228,7 +245,7 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 			await transaction.begin();
 			try {
 				const useRequest = new sql.Request(transaction);
-				await useRequest.query(`USE ${Q(opts!.database as string)}`);
+				await useRequest.query(`USE ${Q(database)}`);
 
 				const request = new sql.Request(transaction);
 				this.bindParams(request, params);
@@ -247,7 +264,7 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 
 		const request = pool.request();
 		this.bindParams(request, params);
-		const finalQuery = needUse ? `USE ${Q(opts!.database as string)};\n${q}` : q;
+		const finalQuery = database ? `USE ${Q(database)};\n${q}` : q;
 		const result = await request.query(finalQuery);
 		return this.buildResult(result, q, Math.round(performance.now() - start));
 	}
@@ -265,15 +282,19 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 		await transaction.begin();
 
 		const txDb = opts?.database;
+		// The transaction owns one connection for its whole lifetime, so the
+		// database it was switched to holds until we switch it again — track it
+		// and skip the redundant `USE` on every statement of a batch.
+		let txCurrentDb: string | null = null;
 
 		try {
 			const txContext: DbClientTxContext = {
 				executeRead: async (q, params, txOpts) => {
 					const db = txOpts?.database || txDb;
-					const needUse = db && db.toLowerCase() !== this.conn?.database?.toLowerCase();
-					if (needUse) {
+					if (db && db !== txCurrentDb) {
 						const useRequest = new sql.Request(transaction);
-						await useRequest.query(`USE ${Q(db as string)}`);
+						await useRequest.query(`USE ${Q(db)}`);
+						txCurrentDb = db;
 					}
 					const request = new sql.Request(transaction);
 					this.bindParams(request, params ?? []);
@@ -295,10 +316,10 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 				},
 				executeWrite: async (q, params, txOpts) => {
 					const db = txOpts?.database || txDb;
-					const needUse = db && db.toLowerCase() !== this.conn?.database?.toLowerCase();
-					if (needUse) {
+					if (db && db !== txCurrentDb) {
 						const useRequest = new sql.Request(transaction);
-						await useRequest.query(`USE ${Q(db as string)}`);
+						await useRequest.query(`USE ${Q(db)}`);
+						txCurrentDb = db;
 					}
 					const request = new sql.Request(transaction);
 					this.bindParams(request, params ?? []);
@@ -347,15 +368,18 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 		`, [db]);
 		const sizeBytes = Number(sizeRes.rows[0]?.size_bytes ?? 0);
 
-		// Tables and views count
+		// Tables and views count. `sys.tables`/`sys.views` are per-database
+		// catalogs, so these have to run against the database being reported on —
+		// otherwise the panel shows the counts of whatever database the pooled
+		// connection happened to sit on (usually `master`).
 		const tablesRes = await this.executeRead(`
 			SELECT COUNT(*) AS tables_count
 			FROM sys.tables
-		`);
+		`, [], { database: db });
 		const viewsRes = await this.executeRead(`
 			SELECT COUNT(*) AS views_count
 			FROM sys.views
-		`);
+		`, [], { database: db });
 
 		return {
 			serverVersion: health.serverVersion,
@@ -561,17 +585,20 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 
 	// ── Structure ─────────────────────────────────────────────────────────
 
+	// Database-level DDL runs from `master`: SQL Server refuses to drop or rename
+	// a database the connection is sitting in, and a pooled connection may well
+	// be sitting in the one being changed.
 	async createDatabase(name: string): Promise<string> {
 		assertSafeIdentifier(name);
 		const ddl = `CREATE DATABASE ${Q(name)}`;
-		await this.executeWrite(ddl);
+		await this.executeWrite(ddl, [], { database: 'master' });
 		return ddl;
 	}
 
 	async dropDatabase(name: string): Promise<string> {
 		assertSafeIdentifier(name);
 		const ddl = `DROP DATABASE ${Q(name)}`;
-		await this.executeWrite(ddl);
+		await this.executeWrite(ddl, [], { database: 'master' });
 		return ddl;
 	}
 
@@ -579,7 +606,7 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 		assertSafeIdentifier(name);
 		assertSafeIdentifier(newName);
 		const ddl = `ALTER DATABASE ${Q(name)} MODIFY NAME = ${Q(newName)}`;
-		await this.executeWrite(ddl);
+		await this.executeWrite(ddl, [], { database: 'master' });
 		return ddl;
 	}
 
@@ -616,7 +643,7 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 		}
 
 		const fullQuery = ddls.join(';\n');
-		await this.executeWrite(fullQuery);
+		await this.executeWrite(fullQuery, [], { database: this.scopeDb(opts) });
 		return fullQuery;
 	}
 
@@ -652,6 +679,9 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 				case 'rename-column':
 					assertSafeIdentifier(op.name);
 					assertSafeIdentifier(op.newName);
+					// sp_rename cannot cross databases — it resolves its argument in
+					// the connection's current database, which is why this batch is
+					// sent with the target database attached below.
 					const objectPath = `${schema}.${name}.${op.name}`;
 					ddls.push(`EXEC sp_rename '${objectPath}', '${op.newName}', 'COLUMN'`);
 					break;
@@ -666,7 +696,7 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 		}
 
 		const fullQuery = ddls.join(';\n');
-		await this.executeWrite(fullQuery);
+		await this.executeWrite(fullQuery, [], { database: this.scopeDb(opts) });
 		return fullQuery;
 	}
 
@@ -694,8 +724,10 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 		assertSafeIdentifier(newName);
 		const schema = opts?.schema || 'dbo';
 		const objectPath = `${schema}.${name}`;
+		// sp_rename takes a two-part name and resolves it in the current database,
+		// so the target database has to be selected for the statement.
 		const ddl = `EXEC sp_rename '${objectPath}', '${newName}'`;
-		await this.executeWrite(ddl);
+		await this.executeWrite(ddl, [], { database: this.scopeDb(opts) });
 		return ddl;
 	}
 
@@ -753,9 +785,12 @@ export class MssqlAdapter implements DbClientDriverAdapter {
 
 	async createView(name: string, query: string, opts?: SchemaOpts): Promise<string> {
 		assertSafeIdentifier(name);
-		const fqt = qualified(Q, [opts?.database, opts?.schema || 'dbo', name]);
+		// T-SQL rejects a database prefix on CREATE VIEW, and the statement must be
+		// alone in its batch — name it two-part and let the batch-sensitive path
+		// select the database in a separate request.
+		const fqt = qualified(Q, [opts?.schema || 'dbo', name]);
 		const ddl = `CREATE VIEW ${fqt} AS ${query}`;
-		await this.executeWrite(ddl);
+		await this.executeWrite(ddl, [], { database: this.scopeDb(opts) });
 		return ddl;
 	}
 

--- a/backend/db-client/drivers/mysql.ts
+++ b/backend/db-client/drivers/mysql.ts
@@ -3,6 +3,7 @@
  */
 
 import { SQL } from 'bun';
+import type { ReservedSQL } from 'bun';
 import type {
 	DbClientConnection,
 	DbClientHealth,
@@ -45,13 +46,10 @@ export class MysqlAdapter implements DbClientDriverAdapter {
 
 	private sql: SQL | null = null;
 	private alive = false;
-	// The session's currently-USEd database (mutated by ensureDatabase).
-	private defaultDb: string | null = null;
 	// The connection's configured database — immutable, used as the scope
 	// fallback so a connection-level overview never resolves to the last-browsed
-	// database that only the session happens to be sitting on.
+	// database, and as the state every pooled socket is restored to.
 	private configuredDb: string | null = null;
-	private ensureLock = Promise.resolve();
 
 	async connect(conn: DbClientConnection, tunnelPort?: number): Promise<void> {
 		const host = tunnelPort ? '127.0.0.1' : (conn.host ?? '127.0.0.1');
@@ -64,26 +62,16 @@ export class MysqlAdapter implements DbClientDriverAdapter {
 		const url = `mysql://${auth}${host}:${port}${db}`;
 		this.sql = new SQL(url, BUN_SQL_POOL_OPTIONS);
 		await this.sql.connect();
-		this.defaultDb = conn.database || null;
 		this.configuredDb = conn.database || null;
 		this.alive = true;
 	}
 
 	async close(): Promise<void> {
-		let release: () => void;
-		const prev = this.ensureLock;
-		this.ensureLock = new Promise<void>((resolve) => { release = resolve; });
-		await prev;
-
-		try {
-			this.alive = false;
-			this.defaultDb = null;
-			if (!this.sql) return;
-			await this.sql.close().catch((err) => debug.warn('db-client', 'MySQL close error:', err));
-			this.sql = null;
-		} finally {
-			release!();
-		}
+		this.alive = false;
+		if (!this.sql) return;
+		const sql = this.sql;
+		this.sql = null;
+		await sql.close().catch((err) => debug.warn('db-client', 'MySQL close error:', err));
 	}
 
 	isAlive(): boolean {
@@ -123,32 +111,53 @@ export class MysqlAdapter implements DbClientDriverAdapter {
 		return opts?.database || this.configuredDb || undefined;
 	}
 
-	private async ensureDatabase(database?: string): Promise<void> {
-		if (!database) return;
-		if (database === this.defaultDb) return;
+	/**
+	 * Restore a socket to the connection's configured database.
+	 *
+	 * Every pooled socket is opened on the configured database (it is in the
+	 * connection URL), so putting it back there before releasing keeps an idle
+	 * socket's session state predictable for statements that carry their own
+	 * qualification instead of naming a database.
+	 */
+	private async restoreConfigured(sql: SQL, current: string): Promise<void> {
+		if (!this.configuredDb || this.configuredDb === current) return;
+		await sql
+			.unsafe(`USE ${quoteMysql(this.configuredDb)}`)
+			.catch((err) => debug.warn('db-client', 'MySQL restore database failed:', err));
+	}
 
-		let release: () => void;
-		const prev = this.ensureLock;
-		this.ensureLock = new Promise<void>((resolve) => { release = resolve; });
-		await prev;
-
+	/**
+	 * Run `fn` on a socket pinned to `database`.
+	 *
+	 * `USE` is per-connection session state while the adapter holds a *pool*, so
+	 * a `USE` sent on one pooled socket says nothing about the socket the next
+	 * query lands on — that is why browsing a database other than the configured
+	 * one intermittently failed with "Table 'configured_db.x' doesn't exist".
+	 * Reserving a connection makes the switch and the query share one socket.
+	 */
+	private async withDatabase<T>(
+		database: string | undefined,
+		fn: (sql: SQL | ReservedSQL) => Promise<T>
+	): Promise<T> {
+		const sql = this.requireSql();
+		if (!database) return fn(sql);
+		assertSafeIdentifier(database);
+		const reserved = await sql.reserve();
 		try {
-			if (database === this.defaultDb) return;
-			const sql = this.requireSql();
-			assertSafeIdentifier(database);
-			await sql.unsafe(`USE ${quoteMysql(database)}`);
-			this.defaultDb = database;
+			await reserved.unsafe(`USE ${quoteMysql(database)}`);
+			return await fn(reserved);
 		} finally {
-			release!();
+			await this.restoreConfigured(reserved, database);
+			reserved.release();
 		}
 	}
 
 	async executeRead(q: string, params: unknown[] = [], opts?: { database?: string }): Promise<DbClientQueryResult> {
-		await this.ensureDatabase(opts?.database);
-		const sql = this.requireSql();
-		const start = performance.now();
-		const raw = await sql.unsafe(q, params as never);
-		return normalizeBunSqlResult(raw, Math.round(performance.now() - start));
+		return this.withDatabase(opts?.database, async (sql) => {
+			const start = performance.now();
+			const raw = await sql.unsafe(q, params as never);
+			return normalizeBunSqlResult(raw, Math.round(performance.now() - start));
+		});
 	}
 
 	async executeWrite(q: string, params: unknown[] = [], opts?: { database?: string }): Promise<DbClientQueryResult> {
@@ -160,22 +169,33 @@ export class MysqlAdapter implements DbClientDriverAdapter {
 	}
 
 	async withTransaction<T>(fn: (tx: DbClientTxContext) => Promise<T>, opts?: { database?: string }): Promise<T> {
-		await this.ensureDatabase(opts?.database);
 		const sql = this.requireSql();
-		// Bun.sql reserves one connection for the `begin` block. Note: MySQL
+		const database = opts?.database;
+		if (database) assertSafeIdentifier(database);
+		// Bun.sql reserves one connection for the `begin` block, so the batch's
+		// database has to be selected inside it — a `USE` sent anywhere else
+		// belongs to a different socket. `USE` is not an implicit-commit
+		// statement, so it is safe within the transaction. Note: MySQL
 		// implicitly commits on DDL (CREATE/ALTER/DROP/…), so a batch that
 		// mixes DDL with later failures cannot fully roll back the DDL — a
 		// server limitation, not an app one.
 		return sql.begin(async (tx) => {
+			if (database) await tx.unsafe(`USE ${quoteMysql(database)}`);
 			const run = async (q: string, params: unknown[] = []): Promise<DbClientQueryResult> => {
 				const start = performance.now();
 				const raw = await tx.unsafe(q, params as never);
 				return normalizeBunSqlResult(raw, Math.round(performance.now() - start));
 			};
-			return fn({
-				executeRead: (q, params) => run(q, params ?? []),
-				executeWrite: (q, params) => run(q, params ?? [])
-			});
+			try {
+				return await fn({
+					executeRead: (q, params) => run(q, params ?? []),
+					executeWrite: (q, params) => run(q, params ?? [])
+				});
+			} finally {
+				// The transaction's socket goes back to the pool once the block
+				// ends, and a rollback does not undo `USE`.
+				if (database) await this.restoreConfigured(tx, database);
+			}
 		}) as Promise<T>;
 	}
 
@@ -358,7 +378,8 @@ export class MysqlAdapter implements DbClientDriverAdapter {
 		assertSafeIdentifier(name);
 		const ddl = `DROP DATABASE ${Q(name)}`;
 		await this.requireSql().unsafe(ddl);
-		if (this.defaultDb === name) this.defaultDb = null;
+		// Nothing to fall back to or restore sockets into once it is gone.
+		if (this.configuredDb === name) this.configuredDb = null;
 		return ddl;
 	}
 
@@ -379,8 +400,8 @@ export class MysqlAdapter implements DbClientDriverAdapter {
 			await sql.unsafe(`RENAME TABLE ${qualified(Q, [name, r.TABLE_NAME])} TO ${qualified(Q, [newName, r.TABLE_NAME])}`);
 		}
 		await sql.unsafe(`DROP DATABASE ${Q(name)}`);
-		// Force a fresh `USE` on next access — the session's selected db is gone.
-		if (this.defaultDb === name) this.defaultDb = null;
+		// The connection's scope database no longer exists under that name.
+		if (this.configuredDb === name) this.configuredDb = null;
 		return `CREATE DATABASE ${Q(newName)}; RENAME TABLE …; DROP DATABASE ${Q(name)}`;
 	}
 

--- a/backend/db-client/drivers/postgres.ts
+++ b/backend/db-client/drivers/postgres.ts
@@ -47,7 +47,7 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 	private sql: SQL | null = null;
 	private alive = false;
 	// The database the active connection currently points at (switched by
-	// reconnecting in ensureDatabase).
+	// reconnecting in acquire).
 	private defaultDb: string | null = null;
 	// The connection's home database — what we revert to when no specific
 	// database is requested, so a connection-level overview doesn't keep
@@ -92,10 +92,19 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 		this.alive = true;
 	}
 
-	private async ensureDatabase(database?: string): Promise<void> {
-		if (!this.conn) return;
+	/**
+	 * Return the client connected to `database`, switching if needed.
+	 *
+	 * Postgres cannot cross databases within a session, so a switch means a new
+	 * client on a rewritten URL. Callers must run their statement on the client
+	 * this returns rather than re-reading `this.sql`: a concurrent switch can
+	 * land between the two, and the query would then silently run against
+	 * whichever database the shared field points at by then.
+	 */
+	private async acquire(database?: string): Promise<SQL> {
+		if (!this.conn) return this.requireSql();
 		const target = database || this.homeDb;
-		if (target === this.defaultDb) return;
+		if (target === this.defaultDb) return this.requireSql();
 
 		let release: () => void;
 		const prev = this.ensureLock;
@@ -103,7 +112,7 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 		await prev;
 
 		try {
-			if (target === this.defaultDb) return;
+			if (target === this.defaultDb) return this.requireSql();
 			const newConn = { ...this.conn, database: target };
 			const url = this.buildUrl(newConn, this.tunnelPort);
 			const next = new SQL(url, BUN_SQL_POOL_OPTIONS);
@@ -113,7 +122,10 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 			this.defaultDb = target;
 			this.conn = newConn;
 			this.alive = true;
+			// The old client closes gracefully, so queries already running on it
+			// finish before its sockets go away.
 			if (prevSql) await prevSql.close().catch((err) => debug.warn('db-client', 'pg switch close error:', err));
+			return next;
 		} finally {
 			release!();
 		}
@@ -173,8 +185,7 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 	}
 
 	async executeRead(q: string, params: unknown[] = [], opts?: { database?: string }): Promise<DbClientQueryResult> {
-		await this.ensureDatabase(opts?.database);
-		const sql = this.requireSql();
+		const sql = await this.acquire(opts?.database);
 		const start = performance.now();
 		const raw = await sql.unsafe(q, params as never);
 		return normalizeBunSqlResult(raw, Math.round(performance.now() - start));
@@ -189,8 +200,7 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 	}
 
 	async withTransaction<T>(fn: (tx: DbClientTxContext) => Promise<T>, opts?: { database?: string }): Promise<T> {
-		await this.ensureDatabase(opts?.database);
-		const sql = this.requireSql();
+		const sql = await this.acquire(opts?.database);
 		// Bun.sql reserves a single connection for the duration of `begin`, so
 		// every statement below shares one transaction. Postgres wraps DDL in
 		// the transaction too, so a mid-batch failure rolls everything back.
@@ -210,8 +220,7 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 	// ── Overview ──────────────────────────────────────────────────────────
 
 	async overview(opts?: SchemaOpts): Promise<DbClientOverview> {
-		await this.ensureDatabase(opts?.database);
-		const sql = this.requireSql();
+		const sql = await this.acquire(opts?.database);
 		const start = performance.now();
 		const verRows = (await sql.unsafe('SELECT version() AS v')) as Array<{ v: string }>;
 		const latencyMs = Math.round(performance.now() - start);
@@ -252,7 +261,9 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 			tableCount: c.tables === undefined ? null : Number(c.tables),
 			viewCount: c.views === undefined ? null : Number(c.views),
 			extra: [
-				{ label: 'Database', value: this.defaultDb ?? 'postgres' },
+				// Report what was asked for, not the shared "currently connected"
+				// field — a switch for another panel could have moved it by now.
+				{ label: 'Database', value: opts?.database || this.homeDb },
 				{ label: 'Schema', value: schema }
 			]
 		};
@@ -267,8 +278,12 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 		return rows.map((r) => ({ name: r.datname, type: 'database' as const }));
 	}
 
-	async listSchemas(): Promise<DbClientSchemaNode[]> {
-		const rows = (await this.requireSql().unsafe(
+	async listSchemas(database?: string): Promise<DbClientSchemaNode[]> {
+		// Schemas live inside a database, so this has to run on the browsed one —
+		// the caller passes it and the tree would otherwise show the home
+		// database's schemas under every database node.
+		const sql = await this.acquire(database);
+		const rows = (await sql.unsafe(
 			`SELECT schema_name FROM information_schema.schemata
 			 WHERE schema_name NOT IN ('pg_catalog','information_schema','pg_toast')
 			 ORDER BY schema_name`
@@ -277,9 +292,9 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 	}
 
 	async listObjects(database?: string, schema?: string): Promise<DbClientSchemaNode[]> {
-		await this.ensureDatabase(database);
+		const sql = await this.acquire(database);
 		const target = this.targetSchema({ schema });
-		const tables = (await this.requireSql().unsafe(
+		const tables = (await sql.unsafe(
 			`SELECT table_name, table_type FROM information_schema.tables
 			 WHERE table_schema = $1 ORDER BY table_name`,
 			[target] as never
@@ -289,7 +304,7 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 		// on prokind: keep plain functions ('f') and procedures ('p'), but exclude
 		// aggregates ('a') and window functions ('w') — those (e.g. avg/sum) have no
 		// pg_get_functiondef and would error when their DDL is opened.
-		const routines = (await this.requireSql().unsafe(
+		const routines = (await sql.unsafe(
 			`SELECT p.proname AS routine_name, p.prokind
 			 FROM pg_proc p
 			 JOIN pg_namespace n ON p.pronamespace = n.oid
@@ -328,9 +343,8 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 		database?: string,
 		schema?: string
 	): Promise<DbClientObjectDetails> {
-		await this.ensureDatabase(database);
+		const sql = await this.acquire(database);
 		const target = this.targetSchema({ schema });
-		const sql = this.requireSql();
 
 		if (_type === 'function' || _type === 'procedure') {
 			const routineRows = (await sql.unsafe(
@@ -438,25 +452,24 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 		assertSafeIdentifier(name);
 		// Postgres refuses to drop the database the session is connected to —
 		// hop to the maintenance database first when needed.
-		if (this.defaultDb === name) await this.ensureDatabase('postgres');
+		const sql = this.defaultDb === name ? await this.acquire('postgres') : this.requireSql();
 		const ddl = `DROP DATABASE ${Q(name)}`;
-		await this.requireSql().unsafe(ddl);
+		await sql.unsafe(ddl);
 		return ddl;
 	}
 
 	async renameDatabase(name: string, newName: string): Promise<string> {
 		assertSafeIdentifier(name);
 		assertSafeIdentifier(newName);
-		if (this.defaultDb === name) await this.ensureDatabase('postgres');
+		const sql = this.defaultDb === name ? await this.acquire('postgres') : this.requireSql();
 		const ddl = `ALTER DATABASE ${Q(name)} RENAME TO ${Q(newName)}`;
-		await this.requireSql().unsafe(ddl);
+		await sql.unsafe(ddl);
 		return ddl;
 	}
 
 	async resetDatabase(opts?: SchemaOpts): Promise<string> {
-		await this.ensureDatabase(opts?.database);
+		const sql = await this.acquire(opts?.database);
 		const target = this.targetSchema(opts);
-		const sql = this.requireSql();
 		const rows = (await sql.unsafe(
 			`SELECT table_name FROM information_schema.tables
 			 WHERE table_schema = $1 AND table_type = 'BASE TABLE' ORDER BY table_name`,
@@ -471,21 +484,20 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 	}
 
 	async resetTable(name: string, opts?: SchemaOpts): Promise<string> {
-		await this.ensureDatabase(opts?.database);
+		const sql = await this.acquire(opts?.database);
 		assertSafeIdentifier(name);
 		const ddl = `TRUNCATE TABLE ${qualified(Q, [this.targetSchema(opts), name])} RESTART IDENTITY`;
-		await this.requireSql().unsafe(ddl);
+		await sql.unsafe(ddl);
 		return ddl;
 	}
 
 	async duplicateTable(name: string, newName: string, opts?: (SchemaOpts & { withData?: boolean })): Promise<string> {
-		await this.ensureDatabase(opts?.database);
+		const sql = await this.acquire(opts?.database);
 		assertSafeIdentifier(name);
 		assertSafeIdentifier(newName);
 		const schema = this.targetSchema(opts);
 		const src = qualified(Q, [schema, name]);
 		const dst = qualified(Q, [schema, newName]);
-		const sql = this.requireSql();
 		const create = `CREATE TABLE ${dst} (LIKE ${src} INCLUDING ALL)`;
 		await sql.unsafe(create);
 		const statements = [create];
@@ -515,7 +527,7 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 	}
 
 	async createTable(definition: TableDefinition, opts?: SchemaOpts): Promise<string> {
-		await this.ensureDatabase(opts?.database);
+		const sql = await this.acquire(opts?.database);
 		assertSafeIdentifier(definition.name);
 		const ddl = renderCreateTable({
 			quote: Q,
@@ -523,12 +535,12 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 			schema: this.targetSchema(opts),
 			driver: 'postgres'
 		});
-		await this.requireSql().unsafe(ddl);
+		await sql.unsafe(ddl);
 		return ddl;
 	}
 
 	async alterTable(name: string, operations: AlterOperation[], opts?: SchemaOpts): Promise<string> {
-		await this.ensureDatabase(opts?.database);
+		const sql = await this.acquire(opts?.database);
 		assertSafeIdentifier(name);
 		const fqt = qualified(Q, [this.targetSchema(opts), name]);
 		const parts: string[] = [];
@@ -554,73 +566,75 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 			}
 		}
 		const ddl = `ALTER TABLE ${fqt} ${parts.join(', ')}`;
-		await this.requireSql().unsafe(ddl);
+		await sql.unsafe(ddl);
 		return ddl;
 	}
 
 	async dropTable(name: string, opts?: SchemaOpts): Promise<string> {
-		await this.ensureDatabase(opts?.database);
+		const sql = await this.acquire(opts?.database);
 		assertSafeIdentifier(name);
 		const ddl = `DROP TABLE ${qualified(Q, [this.targetSchema(opts), name])}`;
-		await this.requireSql().unsafe(ddl);
+		await sql.unsafe(ddl);
 		return ddl;
 	}
 
 	async truncateTable(name: string, opts?: SchemaOpts): Promise<string> {
-		await this.ensureDatabase(opts?.database);
+		const sql = await this.acquire(opts?.database);
 		assertSafeIdentifier(name);
 		const ddl = `TRUNCATE TABLE ${qualified(Q, [this.targetSchema(opts), name])}`;
-		await this.requireSql().unsafe(ddl);
+		await sql.unsafe(ddl);
 		return ddl;
 	}
 
 	async renameTable(name: string, newName: string, opts?: SchemaOpts): Promise<string> {
-		await this.ensureDatabase(opts?.database);
+		const sql = await this.acquire(opts?.database);
 		assertSafeIdentifier(name);
 		assertSafeIdentifier(newName);
 		const ddl = `ALTER TABLE ${qualified(Q, [this.targetSchema(opts), name])} RENAME TO ${Q(newName)}`;
-		await this.requireSql().unsafe(ddl);
+		await sql.unsafe(ddl);
 		return ddl;
 	}
 
 	async createIndex(tableName: string, def: IndexDefinition, opts?: SchemaOpts): Promise<string> {
-		await this.ensureDatabase(opts?.database);
+		const sql = await this.acquire(opts?.database);
 		assertSafeIdentifier(tableName);
 		assertSafeIdentifier(def.name);
 		def.columns.forEach(assertSafeIdentifier);
 		const ddl = renderCreateIndex({ quote: Q, tableName, def, schema: this.targetSchema(opts) });
-		await this.requireSql().unsafe(ddl);
+		await sql.unsafe(ddl);
 		return ddl;
 	}
 
 	async dropIndex(_tableName: string, indexName: string, opts?: SchemaOpts): Promise<string> {
-		await this.ensureDatabase(opts?.database);
+		const sql = await this.acquire(opts?.database);
 		assertSafeIdentifier(indexName);
 		const ddl = `DROP INDEX ${qualified(Q, [this.targetSchema(opts), indexName])}`;
-		await this.requireSql().unsafe(ddl);
+		await sql.unsafe(ddl);
 		return ddl;
 	}
 
 	async createView(name: string, query: string, opts?: SchemaOpts): Promise<string> {
-		await this.ensureDatabase(opts?.database);
+		const sql = await this.acquire(opts?.database);
 		assertSafeIdentifier(name);
 		const ddl = `CREATE VIEW ${qualified(Q, [this.targetSchema(opts), name])} AS ${query}`;
-		await this.requireSql().unsafe(ddl);
+		await sql.unsafe(ddl);
 		return ddl;
 	}
 
 	async dropView(name: string, opts?: SchemaOpts): Promise<string> {
-		await this.ensureDatabase(opts?.database);
+		const sql = await this.acquire(opts?.database);
 		assertSafeIdentifier(name);
 		const ddl = `DROP VIEW ${qualified(Q, [this.targetSchema(opts), name])}`;
-		await this.requireSql().unsafe(ddl);
+		await sql.unsafe(ddl);
 		return ddl;
 	}
 
 	// ── Data CRUD ─────────────────────────────────────────────────────────
 
+	// Postgres statements can only be schema-qualified, never database-qualified,
+	// so the target database has to ride along to `executeWrite` — without it the
+	// write resolves against the connection's home database instead.
 	async insertRow(table: string, row: Record<string, unknown>, opts?: SchemaOpts): Promise<DbClientQueryResult> {
-		await this.ensureDatabase(opts?.database);
 		assertSafeIdentifier(table);
 		Object.keys(row).forEach(assertSafeIdentifier);
 		const { sql, params } = buildInsert({
@@ -630,7 +644,7 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 			schema: this.targetSchema(opts),
 			placeholder: PG_PLACEHOLDER
 		});
-		return this.executeWrite(sql, params);
+		return this.executeWrite(sql, params, { database: opts?.database });
 	}
 
 	async updateRow(
@@ -639,7 +653,6 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 		changes: Record<string, unknown>,
 		opts?: SchemaOpts
 	): Promise<DbClientQueryResult> {
-		await this.ensureDatabase(opts?.database);
 		assertSafeIdentifier(table);
 		[...Object.keys(pk), ...Object.keys(changes)].forEach(assertSafeIdentifier);
 		const { sql, params } = buildUpdate({
@@ -650,11 +663,10 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 			schema: this.targetSchema(opts),
 			placeholder: PG_PLACEHOLDER
 		});
-		return this.executeWrite(sql, params);
+		return this.executeWrite(sql, params, { database: opts?.database });
 	}
 
 	async deleteRows(table: string, pks: Record<string, unknown>[], opts?: SchemaOpts): Promise<DbClientQueryResult> {
-		await this.ensureDatabase(opts?.database);
 		assertSafeIdentifier(table);
 		if (pks.length > 0) Object.keys(pks[0]).forEach(assertSafeIdentifier);
 		const { sql, params } = buildDelete({
@@ -664,7 +676,7 @@ export class PostgresAdapter implements DbClientDriverAdapter {
 			schema: this.targetSchema(opts),
 			placeholder: PG_PLACEHOLDER
 		});
-		return this.executeWrite(sql, params);
+		return this.executeWrite(sql, params, { database: opts?.database });
 	}
 }
 


### PR DESCRIPTION
## Summary
Make every db-client statement resolve against the database it was issued for, across the MySQL, Postgres and SQL Server drivers.

## Why
A connection browses databases the connection itself was not opened on, and each driver tracked that context in a way its own connection pool could invalidate.

- **MySQL** cached a single `USE` sent through a pool of three sockets. Only the socket that served it switched, so a query landing elsewhere resolved unqualified names against the socket's own database — the reported "Table '<other_db>.<table>' doesn't exist", intermittent because it depended on which socket the pool handed out.
- **Postgres** was worse because it failed silently. `insertRow`/`updateRow`/`deleteRows` switched to the target database and then called `executeWrite()` without passing it — and `ensureDatabase(undefined)` reconnects to the *home* database. Every row edit made while browsing another database was applied to the home one, and Postgres statements cannot be database-qualified, so nothing caught it. `listSchemas` ignored the database argument the WS handler passes, and each method re-read the shared client after awaiting the switch.
- **SQL Server** skipped the `USE` when the requested database matched the configured one, but node-mssql releases pooled connections without resetting session state, so a connection an earlier request left elsewhere could serve them. Separately, the overview counted `sys.tables`/`sys.views` with no database context, `sp_rename` (rename table/column) ran outside its target database, and `CREATE VIEW` was emitted with a three-part name T-SQL rejects.

## Changes
- `mysql.ts`: `withDatabase()` reserves a connection, sends `USE`, runs the query on that socket, and restores the configured database before release; transactions select inside the `begin` block; the `defaultDb`/`ensureDatabase`/`ensureLock` session state is gone.
- `postgres.ts`: `ensureDatabase` becomes `acquire()`, returning the client for the target database so the callers never re-read `this.sql`; row CRUD passes its database down to `executeWrite`; `listSchemas(database)` honors the argument; the overview reports the requested database rather than the shared "currently connected" field.
- `mssql.ts`: always `USE` when a database is named; the transaction path tracks its own selected database so batches skip redundant switches; overview counts run against the reported database; `sp_rename` and `CREATE VIEW` (now two-part named) run under `scopeDb()`; database-level DDL runs from `master`.

## Test plan
- MySQL, against a throwaway MySQL 9.7 instance: 15 concurrent reads → 10 failed with the reported error before, 0 after; cross-database concurrency, 12 concurrent queries over a pool of 3, transaction batches, unnamed statements, cross-database CRUD/DDL/index/duplicate/reset, and 20 consecutive failures without a socket leak.
- Postgres, against a local PostgreSQL 17: a row written while browsing another database landed in the home database before the fix and in the browsed one after; no leak into home; `listSchemas` now returns the browsed database's schemas; cross-database CRUD, DDL, index, duplicate, reset, object details, batch/transaction, overview, and six alternating database switches with zero mismatches.
- `bun run check` (0 errors), `bun run lint` (clean), `bun run test` (464 pass, 17 skip, 0 fail).

## Notes
The SQL Server changes are **review-verified only** — no SQL Server instance was reachable here (no local server, Docker daemon down), so they were derived from the driver source (`node_modules/mssql` releases connections without a `reset()`) and T-SQL rules rather than from a run. Worth extra eyes, especially the `CREATE VIEW` path, which now relies on `isBatchSensitive()` routing it to the separate-`USE` request.

MongoDB, SQLite and Redis were checked and need no change: Mongo resolves `client.db(name)` per call, SQLite is a single file, and Redis holds one connection whose logical DB comes from the URL. Redis's `listDatabases()` advertises indexes 0–15, but `useDatabaseTree` (SchemaTree.svelte:48) excludes redis, so the UI never offers them and nothing can target the wrong one; giving Redis real per-index browsing would be a feature, not part of this fix.