### PR TITLE
fix(engine): install and resolve engine clis from the managed stack dir

### DIFF
--- a/backend/chat/stream-manager.ts
+++ b/backend/chat/stream-manager.ts
@@ -815,7 +815,7 @@ class StreamManager extends EventEmitter {
 			// exact fix (Stack to install/update, Engines to sign in). Thrown here
 			// so the processStream catch surfaces it as a chat error, which the
 			// ErrorMessage renderer turns into a one-click action.
-			const setupIssue = checkEngineSetup(requestEngine.type, requestEngine.account.id);
+			const setupIssue = await checkEngineSetup(requestEngine.type, requestEngine.account.id);
 			if (setupIssue) throw new Error(setupIssue.message);
 
 			// Stream EngineOutput events through the engine adapter

--- a/backend/engine/adapters/codex/stream.ts
+++ b/backend/engine/adapters/codex/stream.ts
@@ -26,7 +26,7 @@ import type { AIEngine, EngineQueryOptions, StructuredGenerationOptions } from '
 import { extractJson } from '../../structured-helpers';
 import { engineQueries } from '$backend/database/queries/engine-queries';
 import { resolveOsPath } from '$backend/utils/paths';
-import { resolveBinary } from '$backend/utils/cli';
+import { resolveEngineCli } from '$backend/engine/engine-cli';
 import { getCleanSpawnEnv } from '$backend/utils/index.js';
 import { getCodexMcpConfig } from '../../../mcp';
 import { artifactFilter } from '$backend/profiles';
@@ -104,7 +104,10 @@ export class CodexEngine implements AIEngine {
 		// option is passed directly; no filesystem mutation.
 		applyAccountAuth(account);
 
-		const codexBinary = resolveBinary('codex');
+		// Prefer the binary clopen manages (vendored in the SDK's platform package
+		// inside the stack dir) over an older copy on the user's PATH — the SDK
+		// would otherwise be pinned while the process it spawns drifts.
+		const codexCli = await resolveEngineCli('codex');
 		const mcpConfig = getCodexMcpConfig(mcpProfileFilter);
 
 		// Codex SDK takes config at construction. We pass `show_raw_agent_reasoning`
@@ -123,7 +126,7 @@ export class CodexEngine implements AIEngine {
 		const { Codex } = await loadEngineSdk<typeof import('@openai/codex-sdk')>('codex', '@openai/codex-sdk');
 		this.codex = new Codex({
 			apiKey: credential.kind === 'api_key' ? credential.apiKey : undefined,
-			...(codexBinary ? { codexPathOverride: codexBinary } : {}),
+			...(codexCli ? { codexPathOverride: codexCli.path } : {}),
 			env: { ...getCleanSpawnEnv(), CODEX_HOME: getCodexHomeDir() },
 			config: {
 				show_raw_agent_reasoning: true,

--- a/backend/engine/adapters/opencode/server.ts
+++ b/backend/engine/adapters/opencode/server.ts
@@ -28,7 +28,7 @@ import { getOpenCodeMcpConfig } from '../../../mcp';
 import { engineQueries, settingsQueries } from '../../../database/queries';
 import { generateOpenCodeProviderConfig, parseCredentialMap } from './config';
 import type { OpenCodeInlineAgent } from '$backend/subagents';
-import { resolveBinaryWithRefresh } from '$backend/utils/cli';
+import { resolveEngineCli } from '$backend/engine/engine-cli';
 import { loadEngineSdk } from '$backend/engine/sdk-loader';
 import { getEngineUserConfigDir } from '$backend/utils/paths';
 import { debug } from '$shared/utils/logger';
@@ -164,9 +164,18 @@ async function spawnServer(key: string, spec: ServerConfigSpec): Promise<ServerI
 		? configDir
 		: join(configDir, 'pool', Buffer.from(key).toString('base64url'));
 
-	const command = await resolveBinaryWithRefresh('opencode');
-	if (!command) throw new Error('opencode binary not found on PATH');
-	const args = [command, 'serve', `--hostname=${OPENCODE_HOST}`, '--port=0'];
+	// The CLI lives in clopen's managed stack dir (or, failing that, on the
+	// user's PATH); `resolveEngineCli` is the same lookup Settings → Stack
+	// reports, so an engine shown as installed is always one we can spawn.
+	// The literal "Settings → Stack" routes the chat/model-picker error to the
+	// one place that fixes it.
+	const cli = await resolveEngineCli('opencode');
+	if (!cli) {
+		throw new Error(
+			'Open Code is missing its CLI. Open Settings → Stack to install it before using this engine.'
+		);
+	}
+	const args = [cli.path, 'serve', `--hostname=${OPENCODE_HOST}`, '--port=0'];
 
 	// MCP: only inject remote servers whose endpoint is reachable — an unreachable
 	// remote can stall startup. stdio/local servers (no `url`) always survive.

--- a/backend/engine/bootstrap-default-engine.ts
+++ b/backend/engine/bootstrap-default-engine.ts
@@ -1,20 +1,36 @@
 /**
- * Fresh-install default engine bootstrap.
+ * Fresh-install default engine bootstrap & repair.
  *
- * On a machine where NO engine SDK is installed yet, auto-install OpenCode —
- * the one free, no-account engine — into the managed stack dir so first-time
- * users have a working default without any manual setup (wizard or otherwise).
- * Runs in the background at startup; failures are non-fatal (engines remain
- * installable from Settings → Stack). Skipped as soon as ANY engine is present,
- * so it never fights a user who intentionally removed OpenCode.
+ * Two jobs, both aimed at a user who should never have to know any of this
+ * exists:
+ *
+ *  1. Bootstrap — on a machine where NO engine SDK is installed yet,
+ *     auto-install OpenCode (the one free, no-account engine) into the managed
+ *     stack dir so first-time users have a working default without any manual
+ *     setup. Skipped as soon as ANY engine is present, so it never fights a
+ *     user who intentionally removed OpenCode.
+ *
+ *  2. Repair — OpenCode needs an external CLI binary on top of its SDK
+ *     (see engine-cli.ts). Earlier builds installed only the SDK, so machines
+ *     bootstrapped by them carry a half-installed engine: Settings → Stack
+ *     reported it as ready while the adapter could not spawn it at all. Those
+ *     installs are clopen's own doing, so clopen finishes them rather than
+ *     asking the user to. The repair is deliberately narrow — the SDK must
+ *     already be there and only its CLI missing — so it never pulls in an
+ *     engine nobody asked for.
+ *
+ * Both run in the background at startup through the normal install runner, so
+ * the work shows up as a live session in Settings → Stack instead of a silent
+ * download; failures are non-fatal (engines stay installable by hand).
  */
 
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { debug } from '$shared/utils/logger';
-import { getCleanSpawnEnv } from '$backend/utils/env';
 import { isEngineSdkInstalled } from './sdk-loader';
-import { resolveRecipe } from './install-recipes';
+import { ENGINE_PACKAGES } from './install-recipes';
+import { getRequiredEngineCliSpec, resolveEngineCli } from './engine-cli';
+import { awaitInstall, InstallAlreadyRunningError, startInstall, SYSTEM_INSTALL_USER } from './install-runner';
+
+const DEFAULT_ENGINE = 'opencode' as const;
 
 const ENGINE_SDK_PACKAGES = [
 	'@anthropic-ai/claude-agent-sdk',
@@ -37,9 +53,10 @@ const ENGINE_SDK_PACKAGES = [
 let inFlight: Promise<void> | null = null;
 
 /**
- * Install OpenCode on a fresh machine (no engine SDK present). Idempotent and
- * safe to call at every startup and after a data wipe; it no-ops once any engine
- * exists, and de-dupes concurrent calls via the in-flight promise.
+ * Install the default engine on a fresh machine, or finish a half-installed one.
+ * Idempotent and safe to call at every startup and after a data wipe; it no-ops
+ * once the default engine is fully usable, and de-dupes concurrent calls via the
+ * in-flight promise.
  */
 export function ensureDefaultEngineInstalled(): Promise<void> {
 	if (inFlight) return inFlight;
@@ -49,34 +66,46 @@ export function ensureDefaultEngineInstalled(): Promise<void> {
 	return inFlight;
 }
 
+/**
+ * Why the default engine needs installing, or null when nothing is to be done.
+ * "repair" covers the SDK-without-CLI state older builds left behind.
+ */
+async function pendingInstallReason(): Promise<'bootstrap' | 'repair' | null> {
+	if (!ENGINE_SDK_PACKAGES.some(isEngineSdkInstalled)) return 'bootstrap';
+
+	// Some engine is installed, so the fresh-machine bootstrap is done. The
+	// default engine may still be half-installed, though — and only its own SDK
+	// tells us whether clopen ever installed it in the first place.
+	const sdkPkg = ENGINE_PACKAGES[DEFAULT_ENGINE]?.[0];
+	if (!sdkPkg || !isEngineSdkInstalled(sdkPkg)) return null;
+	if (!getRequiredEngineCliSpec(DEFAULT_ENGINE)) return null;
+
+	return (await resolveEngineCli(DEFAULT_ENGINE)) ? null : 'repair';
+}
+
 async function runDefaultEngineInstall(): Promise<void> {
-	if (ENGINE_SDK_PACKAGES.some(isEngineSdkInstalled)) return;
+	const reason = await pendingInstallReason();
+	if (!reason) return;
 
-	const recipe = await resolveRecipe('opencode');
-	if (!recipe.command || !recipe.cwd) return;
+	debug.log(
+		'engine',
+		reason === 'bootstrap'
+			? `No engine installed — auto-installing the default engine (${DEFAULT_ENGINE})`
+			: `Default engine (${DEFAULT_ENGINE}) is missing its CLI — repairing the install`
+	);
 
-	// Ensure the managed dir is a minimal bun project before `bun add` runs.
-	mkdirSync(recipe.cwd, { recursive: true });
-	const pkgJsonPath = join(recipe.cwd, 'package.json');
-	if (!existsSync(pkgJsonPath)) {
-		writeFileSync(
-			pkgJsonPath,
-			JSON.stringify({ name: 'clopen-stack-engines', private: true, version: '0.0.0' }, null, 2) + '\n'
-		);
-	}
-
-	debug.log('engine', `Auto-installing default engine (OpenCode): ${recipe.displayCommand}`);
 	try {
-		const proc = Bun.spawn(recipe.command, {
-			cwd: recipe.cwd,
-			env: getCleanSpawnEnv(),
-			stdout: 'ignore',
-			stderr: 'ignore',
-			stdin: 'ignore',
-		});
-		const code = await proc.exited;
-		debug.log('engine', `Default engine (OpenCode) auto-install exited with code ${code}`);
+		const session = await startInstall(DEFAULT_ENGINE, SYSTEM_INSTALL_USER);
+		// Callers chain work that needs a usable engine (memory picks its
+		// extraction model from the engine's catalog), so wait for the run to
+		// settle rather than returning as soon as it is spawned.
+		await awaitInstall(session.id);
+		debug.log('engine', `Default engine ${reason} finished with status "${session.status}"`);
 	} catch (error) {
-		debug.warn('engine', 'Default engine auto-install failed (non-fatal)', error);
+		if (error instanceof InstallAlreadyRunningError) {
+			debug.log('engine', `Default engine ${reason} skipped — an install is already running`);
+			return;
+		}
+		debug.warn('engine', `Default engine ${reason} failed (non-fatal)`, error);
 	}
 }

--- a/backend/engine/engine-cli.ts
+++ b/backend/engine/engine-cli.ts
@@ -1,0 +1,313 @@
+/**
+ * Engine CLI binaries
+ *
+ * Several engines are not pure SDKs: behind the npm package sits a real
+ * executable that clopen (or the SDK itself) has to spawn. Those binaries live
+ * inside the managed stack dir — never on PATH — which is where clopen kept
+ * getting this wrong. Code that needed one reached for `Bun.which`, found
+ * nothing on a machine without a global install, and reported an engine as
+ * missing that Settings → Stack had just installed:
+ *
+ *   - Open Code: `@opencode-ai/sdk` is an HTTP client with no binary at all, so
+ *     the adapter could not spawn `opencode serve` and NO model could be picked.
+ *     Its CLI ships as a separate package, installed alongside the SDK.
+ *   - Codex and Claude Code: their SDKs bundle a CLI as an optional platform
+ *     dependency and locate it themselves, so streaming works — but clopen's own
+ *     sign-in flows (`codex login`, `claude setup-token`) and the Codex engine
+ *     status card looked on PATH and declared the CLI missing.
+ *
+ * This module is the single source of truth for that second artifact: which
+ * package carries the binary, where it lands, and which version it must match.
+ * Status, the readiness gate, the adapters and the sign-in flows all resolve
+ * through `resolveEngineCli`, so what clopen reports is what clopen can run.
+ *
+ * Resolution order (first candidate that actually runs wins):
+ *   1. the binary inside the managed stack dir — version-matched to the pinned
+ *      SDK, so it is preferred over anything else,
+ *   2. the platform package one level down — the same binary, reached when a
+ *      postinstall was blocked and the package's own `bin/` holds a stub,
+ *   3. whatever is on PATH — a CLI the user installed themselves.
+ *
+ * Every candidate is verified by running `--version` before it is handed out:
+ * a postinstall stub exits 1, and a plain x64 build on a pre-AVX2 CPU dies on
+ * startup. Both must fall through rather than reach a spawn site.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { debug } from '$shared/utils/logger';
+import { resolveBinaryWithRefresh } from '$backend/utils/cli';
+import { getStackEnginesDir, getRequiredSdkVersion } from './sdk-loader';
+import type { ToolId } from './install-recipes';
+
+/** How long a candidate gets to answer `--version` before it is discarded. */
+const PROBE_TIMEOUT_MS = 15_000;
+
+export interface EngineCliSpec {
+	/** Binary name as it appears on PATH. */
+	binaryName: string;
+	/**
+	 * Package whose pinned version governs this CLI's version. For a bundled CLI
+	 * that is the SDK itself; for Open Code it is the SDK the separate CLI
+	 * package is released in lockstep with.
+	 */
+	versionSource: string;
+	/**
+	 * Extra package `bun add` must install for this CLI, when the SDK does not
+	 * bring the binary itself. Omitted for CLIs bundled as a platform optional
+	 * dependency of the SDK — those arrive with the engine install already.
+	 */
+	installPackage?: string;
+	/**
+	 * True when the engine cannot run at all without this binary. Such an engine
+	 * counts as installed only once the CLI resolves. A bundled CLI is false:
+	 * the SDK locates it internally through its own module graph, so a failure
+	 * to find it here only affects clopen's own spawn sites.
+	 */
+	required: boolean;
+	/** Candidate paths inside the stack dir's node_modules, best first. */
+	candidates: (modulesDir: string) => string[];
+}
+
+const isWindows = process.platform === 'win32';
+
+/** `<name>` on posix, `<name>.exe` on Windows. */
+function exe(name: string): string {
+	return isWindows ? `${name}.exe` : name;
+}
+
+// ─── Open Code ───────────────────────────────────────────────────────────────
+
+const OPENCODE_PLATFORMS: Record<string, string> = {
+	darwin: 'darwin',
+	linux: 'linux',
+	win32: 'windows'
+};
+
+/**
+ * Open Code's platform packages, in the order its own postinstall would pick
+ * them. bun installs the plain build matching our `os`/`cpu`/`libc`, so that is
+ * normally the only one present; the `-baseline` (no AVX2) and `-musl` variants
+ * are listed because the postinstall pulls them in on hosts where the plain
+ * build cannot run, and we must find them there too.
+ */
+function opencodePlatformPackages(): string[] {
+	const platform = OPENCODE_PLATFORMS[process.platform] ?? process.platform;
+	const arch = process.arch;
+	const base = `opencode-${platform}-${arch}`;
+
+	if (platform === 'linux') {
+		return arch === 'x64'
+			? [base, `${base}-baseline`, `${base}-musl`, `${base}-baseline-musl`]
+			: [base, `${base}-musl`];
+	}
+	return arch === 'x64' ? [base, `${base}-baseline`] : [base];
+}
+
+// ─── Codex ───────────────────────────────────────────────────────────────────
+
+/** Rust target triples Codex vendors its binary under, keyed by platform-arch. */
+const CODEX_TARGET_TRIPLES: Record<string, string> = {
+	'linux-x64': 'x86_64-unknown-linux-musl',
+	'linux-arm64': 'aarch64-unknown-linux-musl',
+	'darwin-x64': 'x86_64-apple-darwin',
+	'darwin-arm64': 'aarch64-apple-darwin',
+	'win32-x64': 'x86_64-pc-windows-msvc',
+	'win32-arm64': 'aarch64-pc-windows-msvc'
+};
+
+/** `@openai/codex-<platform>-<arch>/vendor/<triple>/bin/codex` — the CLI's own layout. */
+function codexCandidates(modules: string): string[] {
+	const key = `${process.platform}-${process.arch}`;
+	const triple = CODEX_TARGET_TRIPLES[key];
+	if (!triple) return [];
+	return [join(modules, '@openai', `codex-${key}`, 'vendor', triple, 'bin', exe('codex'))];
+}
+
+// ─── Claude Code ─────────────────────────────────────────────────────────────
+
+/**
+ * `@anthropic-ai/claude-agent-sdk-<platform>-<arch>[-musl]/claude`. The musl
+ * build is a separate package on Linux and is the one bun installs on Alpine,
+ * so both names are tried.
+ */
+function claudeCandidates(modules: string): string[] {
+	const base = `claude-agent-sdk-${process.platform}-${process.arch}`;
+	const names = process.platform === 'linux' ? [base, `${base}-musl`] : [base];
+	return names.map(name => join(modules, '@anthropic-ai', name, exe('claude')));
+}
+
+/**
+ * Engines whose runtime needs an executable, and where to find it. Engines
+ * absent from this registry run entirely in process (Cline, Pi, Cursor) or let
+ * their SDK spawn a bundled entrypoint clopen never has to locate (Copilot,
+ * Qwen, both resolved module-relative inside the stack dir).
+ */
+export const ENGINE_CLI: Partial<Record<ToolId, EngineCliSpec>> = {
+	opencode: {
+		binaryName: 'opencode',
+		versionSource: '@opencode-ai/sdk',
+		installPackage: 'opencode-ai',
+		// Without it the adapter cannot spawn `opencode serve`, so the engine is
+		// unusable — this is the one CLI that gates the engine's install state.
+		required: true,
+		candidates: modules => [
+			// The postinstall writes `bin/opencode.exe` on every platform, not just
+			// Windows — the extension is part of the shipped layout, not a guess.
+			join(modules, 'opencode-ai', 'bin', 'opencode.exe'),
+			...opencodePlatformPackages().map(pkg => join(modules, pkg, 'bin', exe('opencode')))
+		]
+	},
+	codex: {
+		binaryName: 'codex',
+		versionSource: '@openai/codex-sdk',
+		required: false,
+		candidates: codexCandidates
+	},
+	claude: {
+		binaryName: 'claude',
+		versionSource: '@anthropic-ai/claude-agent-sdk',
+		required: false,
+		candidates: claudeCandidates
+	}
+};
+
+/** The CLI spec for a tool, or null when the engine needs no external binary. */
+export function getEngineCliSpec(tool: ToolId): EngineCliSpec | null {
+	return ENGINE_CLI[tool] ?? null;
+}
+
+/** The CLI spec only when a missing binary makes the engine unusable. */
+export function getRequiredEngineCliSpec(tool: ToolId): EngineCliSpec | null {
+	const spec = ENGINE_CLI[tool];
+	return spec?.required ? spec : null;
+}
+
+/**
+ * Packages whose postinstall must be allowed to run inside the managed stack
+ * dir. bun blocks lifecycle scripts for untrusted dependencies, and a CLI
+ * package can ship a stub whose postinstall copies the real binary into place.
+ */
+export function engineCliTrustedPackages(): string[] {
+	return Object.values(ENGINE_CLI)
+		.map(spec => spec.installPackage)
+		.filter((pkg): pkg is string => pkg !== undefined);
+}
+
+/** Version this CLI must match — the pin its version source carries. */
+export function getRequiredCliVersion(spec: EngineCliSpec): string | null {
+	return getRequiredSdkVersion(spec.versionSource);
+}
+
+/** `<package>@<version>` install argument, or null when the SDK bundles the CLI. */
+export function engineCliInstallArg(spec: EngineCliSpec): string | null {
+	if (!spec.installPackage) return null;
+	const version = getRequiredCliVersion(spec);
+	return version ? `${spec.installPackage}@${version}` : spec.installPackage;
+}
+
+export interface ResolvedEngineCli {
+	/** Absolute path of a binary that answered `--version`. */
+	path: string;
+	/** Version it reported, or null when the output was unparseable. */
+	version: string | null;
+	/** Where it came from: clopen's managed stack dir, or the user's PATH. */
+	source: 'stack' | 'path';
+}
+
+const resolved = new Map<ToolId, ResolvedEngineCli>();
+const inFlight = new Map<ToolId, Promise<ResolvedEngineCli | null>>();
+
+/**
+ * Drop cached resolutions. Only needed when a binary is replaced in place at a
+ * path that already resolved — a missing file is detected on the next call.
+ */
+export function invalidateEngineCliCache(tool?: ToolId): void {
+	if (tool) resolved.delete(tool);
+	else resolved.clear();
+}
+
+/** Run `<binary> --version`; returns null when it cannot run or exits non-zero. */
+async function probeBinary(path: string): Promise<{ version: string | null } | null> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+	try {
+		const proc = Bun.spawn([path, '--version'], {
+			stdout: 'pipe',
+			stderr: 'ignore',
+			stdin: 'ignore',
+			signal: controller.signal
+		});
+		const [stdout, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			proc.exited
+		]);
+		if (exitCode !== 0) return null;
+		const first = stdout.trim().split('\n')[0]?.trim() ?? '';
+		return { version: first || null };
+	} catch {
+		return null;
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+async function doResolve(tool: ToolId, spec: EngineCliSpec): Promise<ResolvedEngineCli | null> {
+	const modules = join(getStackEnginesDir(), 'node_modules');
+
+	const candidates: ResolvedEngineCli[] = spec.candidates(modules).map(path => ({
+		path,
+		version: null,
+		source: 'stack' as const
+	}));
+
+	const onPath = await resolveBinaryWithRefresh(spec.binaryName);
+	if (onPath) candidates.push({ path: onPath, version: null, source: 'path' });
+
+	for (const candidate of candidates) {
+		if (!existsSync(candidate.path)) continue;
+		const probe = await probeBinary(candidate.path);
+		if (!probe) {
+			debug.warn('engine', `${spec.binaryName} candidate did not run, skipping: ${candidate.path}`);
+			continue;
+		}
+		const hit: ResolvedEngineCli = { ...candidate, version: probe.version };
+		resolved.set(tool, hit);
+		debug.log(
+			'engine',
+			`Resolved ${spec.binaryName} CLI from ${hit.source}: ${hit.path}` +
+			(hit.version ? ` (v${hit.version})` : '')
+		);
+		return hit;
+	}
+
+	debug.warn('engine', `No usable ${spec.binaryName} CLI found (stack dir or PATH)`);
+	return null;
+}
+
+/**
+ * Resolve a runnable CLI for an engine, or null when none is usable. Returns
+ * null immediately for engines that need no external binary — callers can treat
+ * "no spec" and "spec satisfied" alike by checking `getEngineCliSpec` first.
+ *
+ * Successful resolutions are cached (probing spawns a large binary) and
+ * revalidated by existence on every call; failures are not cached, so a repair
+ * install becomes visible as soon as it lands.
+ */
+export async function resolveEngineCli(tool: ToolId): Promise<ResolvedEngineCli | null> {
+	const spec = ENGINE_CLI[tool];
+	if (!spec) return null;
+
+	const cached = resolved.get(tool);
+	if (cached) {
+		if (existsSync(cached.path)) return cached;
+		resolved.delete(tool);
+	}
+
+	const pending = inFlight.get(tool);
+	if (pending) return pending;
+
+	const p = doResolve(tool, spec).finally(() => { inFlight.delete(tool); });
+	inFlight.set(tool, p);
+	return p;
+}

--- a/backend/engine/engine-setup.ts
+++ b/backend/engine/engine-setup.ts
@@ -7,14 +7,21 @@
  *   - required account not set up        → Settings → Engines (sign in)
  *
  * SDK readiness is checked first, so a not-installed engine is fixed before an
- * account is asked for. The message text embeds the literal "Settings → Stack" /
- * "Settings → Engines" phrases; the chat error renderer
+ * account is asked for. Engines that also need an external CLI binary (Open
+ * Code) are only ready once that binary resolves too — the SDK alone cannot run
+ * them, and waving them through would send the user off to sign in for an engine
+ * that fails at spawn.
+ *
+ * The message text embeds the literal "Settings → Stack" / "Settings → Engines"
+ * phrases; the chat error renderer
  * (`frontend/components/chat/formatters/ErrorMessage.svelte`) turns those into
  * clickable buttons that open the matching settings section.
  */
 
 import type { EngineType } from '$shared/types/unified';
 import { readEngineSdkVersion, getRequiredSdkVersion } from './sdk-loader';
+import { getRequiredEngineCliSpec, resolveEngineCli } from './engine-cli';
+import type { ToolId } from './install-recipes';
 
 /** Primary SDK package clopen imports for each engine. */
 export const ENGINE_SDK: Record<EngineType, string> = {
@@ -26,6 +33,22 @@ export const ENGINE_SDK: Record<EngineType, string> = {
 	pi: '@earendil-works/pi-coding-agent',
 	cline: '@cline/sdk',
 	cursor: '@cursor/sdk',
+};
+
+/**
+ * Engine identity in the Stack's id space. The two namespaces exist because
+ * Stack also manages non-engine tools (git, chrome) and spells Claude Code
+ * "claude"; `install-recipes.test.ts` guards this mapping against drift.
+ */
+export const TOOL_FOR_ENGINE: Record<EngineType, ToolId> = {
+	'claude-code': 'claude',
+	opencode: 'opencode',
+	copilot: 'copilot',
+	codex: 'codex',
+	qwen: 'qwen',
+	pi: 'pi',
+	cline: 'cline',
+	cursor: 'cursor',
 };
 
 /**
@@ -43,7 +66,7 @@ export interface EngineSetupIssue {
  * Returns null when the engine is ready to stream, or an actionable issue.
  * @param accountId the resolved account id for this request (0 = none selected).
  */
-export function checkEngineSetup(engine: EngineType, accountId: number): EngineSetupIssue | null {
+export async function checkEngineSetup(engine: EngineType, accountId: number): Promise<EngineSetupIssue | null> {
 	const sdkPkg = ENGINE_SDK[engine];
 	const installed = readEngineSdkVersion(sdkPkg);
 	const required = getRequiredSdkVersion(sdkPkg);
@@ -62,6 +85,20 @@ export function checkEngineSetup(engine: EngineType, accountId: number): EngineS
 				`Open Settings → Stack to update it before using this engine.`
 		};
 	}
+
+	// A CLI the engine cannot run without is installed by the same Stack action
+	// as the SDK, so a missing one is the same fix for the user: install the
+	// engine. CLIs the SDK bundles and locates itself are not checked here.
+	const tool = TOOL_FOR_ENGINE[engine];
+	if (getRequiredEngineCliSpec(tool) && !(await resolveEngineCli(tool))) {
+		return {
+			reason: 'not-installed',
+			message:
+				`Engine "${engine}" is missing its CLI. ` +
+				`Open Settings → Stack to install it before using this engine.`
+		};
+	}
+
 	if (!ENGINES_WITHOUT_ACCOUNT.has(engine) && accountId === 0) {
 		return {
 			reason: 'needs-account',

--- a/backend/engine/install-recipes.test.ts
+++ b/backend/engine/install-recipes.test.ts
@@ -15,15 +15,24 @@
  * `readEngineSdkVersion` compounds it: `loadEngineSdk` only enforces a version
  * match when a required version exists, so an unpinned package also loses the
  * "needs update" check that would otherwise surface the drift in Settings → Stack.
+ *
+ * Engine CLIs (engine-cli.ts) are pinned one step removed — through their SDK's
+ * version, since a platform binary has no business in devDependencies — and
+ * they only work if bun is allowed to run their postinstall. Both of those are
+ * silent failures too: an unpinned CLI floats to @latest, and an untrusted one
+ * installs a stub that fails at the first spawn.
  */
 
 import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { EngineType } from '$shared/types/unified';
-import { ENGINE_PACKAGES, type ToolId } from './install-recipes';
-import { ENGINE_SDK } from './engine-setup';
+import { ENGINE_PACKAGES, engineInstallArgs, type ToolId } from './install-recipes';
+import { ENGINE_SDK, TOOL_FOR_ENGINE } from './engine-setup';
 import { getRequiredSdkVersion } from './sdk-loader';
+import { ENGINE_CLI, engineCliTrustedPackages, getRequiredCliVersion } from './engine-cli';
+import { ensureStackProject } from './stack-project';
 
 const pkg = JSON.parse(
 	readFileSync(join(import.meta.dir, '..', '..', 'package.json'), 'utf8')
@@ -71,7 +80,7 @@ describe('on-demand engine SDKs', () => {
 		// would probe a package nobody installs — reporting an installed engine as
 		// missing, or worse, waving through one that cannot load. TypeScript only
 		// forces the keys to exist; the values have to be checked.
-		const TOOL_FOR_ENGINE: Record<EngineType, ToolId> = {
+		const expectedToolForEngine: Record<EngineType, ToolId> = {
 			'claude-code': 'claude',
 			opencode: 'opencode',
 			copilot: 'copilot',
@@ -82,7 +91,11 @@ describe('on-demand engine SDKs', () => {
 			cursor: 'cursor',
 		};
 
-		const drift = Object.entries(TOOL_FOR_ENGINE).flatMap(([engine, tool]) => {
+		// The mapping ships in engine-setup (readiness and status both resolve a
+		// tool id through it); this independent copy is what detects a silent edit.
+		expect(TOOL_FOR_ENGINE).toEqual(expectedToolForEngine);
+
+		const drift = Object.entries(expectedToolForEngine).flatMap(([engine, tool]) => {
 			const probed = ENGINE_SDK[engine as EngineType];
 			const installed = ENGINE_PACKAGES[tool]?.[0];
 			if (installed === undefined) return [`${engine}: no install recipe for tool "${tool}"`];
@@ -100,6 +113,87 @@ describe('on-demand engine SDKs', () => {
 		// silently floated again.
 		for (const { name } of enginePackages) {
 			expect(getRequiredSdkVersion(name)).toBe(declared[name]!);
+		}
+	});
+});
+
+describe('on-demand engine CLIs', () => {
+	const cliEntries = Object.entries(ENGINE_CLI).map(([tool, spec]) => ({ tool: tool as ToolId, spec }));
+
+	test('the registry is non-empty', () => {
+		// Open Code is the one engine that needs a CLI; an emptied registry would
+		// make every check below vacuous and re-open the bug it exists to prevent.
+		expect(cliEntries.length).toBeGreaterThan(0);
+	});
+
+	test('every CLI is pinned through a declared, exact SDK version', () => {
+		// A CLI is not in package.json (it is a platform binary weighing hundreds
+		// of megabytes), so its version rides on the SDK it ships with or is
+		// released in lockstep with. If that source is missing or floated, a
+		// separately-installed CLI lands at @latest against a pinned SDK.
+		const unpinned = cliEntries
+			.filter(({ spec }) => !/^\d+\.\d+\.\d+/.test(declared[spec.versionSource] ?? ''))
+			.map(({ tool, spec }) => `${tool}: pins via "${spec.versionSource}" (${declared[spec.versionSource]})`);
+
+		expect(unpinned).toEqual([]);
+
+		for (const { spec } of cliEntries) {
+			expect(getRequiredCliVersion(spec)).toBe(declared[spec.versionSource]!);
+		}
+	});
+
+	test('the installer installs a separate CLI alongside the SDK', () => {
+		// Installing the SDK alone is exactly the half-install that reported
+		// "installed" in Settings → Stack and then failed at the first spawn.
+		// CLIs bundled with their SDK need no extra package and must not add one.
+		for (const { tool, spec } of cliEntries) {
+			const args = engineInstallArgs(tool);
+			if (spec.installPackage) {
+				expect(args).toContain(`${spec.installPackage}@${declared[spec.versionSource]}`);
+			} else {
+				expect(args).toEqual(ENGINE_PACKAGES[tool]!.map(name => `${name}@${declared[name]}`));
+			}
+		}
+	});
+
+	test('only an engine-blocking CLI gates the install state', () => {
+		// `required` decides whether a missing binary makes Settings → Stack report
+		// the engine as not installed. Marking a bundled CLI required would flip a
+		// working engine to "not installed" the moment our own path guess drifts
+		// from the SDK's; leaving Open Code's optional would restore the original
+		// bug, where an unspawnable engine reported itself ready.
+		const required = cliEntries.filter(({ spec }) => spec.required).map(({ tool }) => tool);
+		expect(required).toEqual(['opencode']);
+	});
+
+	test('the managed dir trusts every CLI postinstall', () => {
+		// bun blocks postinstall scripts for untrusted packages, and these CLIs
+		// ship a stub whose postinstall copies the real binary into place.
+		const dir = mkdtempSync(join(tmpdir(), 'clopen-stack-'));
+		ensureStackProject(dir);
+
+		const created = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as { trustedDependencies?: string[] };
+		expect(created.trustedDependencies).toEqual(engineCliTrustedPackages().sort());
+	});
+
+	test('an older managed dir is upgraded in place', () => {
+		// Machines bootstrapped by earlier builds already have a package.json
+		// without the field; merging (not just creating) is what repairs them.
+		const dir = mkdtempSync(join(tmpdir(), 'clopen-stack-'));
+		writeFileSync(
+			join(dir, 'package.json'),
+			JSON.stringify({ name: 'clopen-stack-engines', private: true, version: '0.0.0', dependencies: { '@opencode-ai/sdk': '1.18.18' } })
+		);
+
+		ensureStackProject(dir);
+
+		const merged = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as {
+			dependencies?: Record<string, string>;
+			trustedDependencies?: string[];
+		};
+		expect(merged.dependencies).toEqual({ '@opencode-ai/sdk': '1.18.18' });
+		for (const pkg of engineCliTrustedPackages()) {
+			expect(merged.trustedDependencies).toContain(pkg);
 		}
 	});
 });

--- a/backend/engine/install-recipes.ts
+++ b/backend/engine/install-recipes.ts
@@ -20,6 +20,7 @@ import { getClopenDir } from '$backend/utils/paths';
 import { resolveBinary, resolveBinaryWithRefresh } from '$backend/utils/cli';
 import { resolveStaticCurlAsset } from '$backend/utils/static-curl';
 import { getStackEnginesDir, readEngineSdkVersion, getRequiredSdkVersion } from './sdk-loader';
+import { engineCliInstallArg, getEngineCliSpec, getRequiredEngineCliSpec, resolveEngineCli } from './engine-cli';
 
 export type ToolId = 'git' | 'claude' | 'opencode' | 'copilot' | 'codex' | 'qwen' | 'pi' | 'cline' | 'cursor' | 'chrome';
 
@@ -123,13 +124,23 @@ function isEngineTool(tool: ToolId): boolean {
 	return tool in ENGINE_PACKAGES;
 }
 
-/** `bun add` arg vector for an engine: each package pinned to its package.json version. */
-function engineInstallArgs(tool: ToolId): string[] {
+/**
+ * `bun add` arg vector for an engine: each package pinned to its package.json
+ * version, plus the engine's CLI package when it needs one (see engine-cli.ts).
+ * The CLI is pinned through its SDK's version instead of a package.json entry
+ * of its own — it is a platform binary, not something to put in devDependencies.
+ */
+export function engineInstallArgs(tool: ToolId): string[] {
 	const packages = ENGINE_PACKAGES[tool] ?? [];
-	return packages.map(name => {
+	const args = packages.map(name => {
 		const v = getRequiredSdkVersion(name);
 		return v ? `${name}@${v}` : name;
 	});
+
+	const cli = getEngineCliSpec(tool);
+	const cliArg = cli ? engineCliInstallArg(cli) : null;
+	if (cliArg) args.push(cliArg);
+	return args;
 }
 
 
@@ -269,14 +280,38 @@ export async function getToolStatus(tool: ToolId): Promise<ToolStatus> {
 
 	if (isEngineTool(tool)) {
 		// Engines are detected by the presence of their SDK in the clopen-managed
-		// stack dir (installed on demand there), NOT by a CLI binary on PATH — the
-		// SDK is what the engine adapter actually needs.
+		// stack dir (installed on demand there) — that is what the adapter loads.
 		const sdkPkg = ENGINE_PACKAGES[tool]![0];
-		const version = readEngineSdkVersion(sdkPkg);
+		const sdkVersion = readEngineSdkVersion(sdkPkg);
 		const requiredVersion = getRequiredSdkVersion(sdkPkg);
-		if (!version) return { tool, installed: false, version: null, source: null, requiredVersion, needsUpdate: false };
-		const needsUpdate = requiredVersion !== null && version !== requiredVersion;
-		return { tool, installed: true, version, source: getStackEnginesDir(), requiredVersion, needsUpdate };
+		if (!sdkVersion) return { tool, installed: false, version: null, source: null, requiredVersion, needsUpdate: false };
+		const sdkNeedsUpdate = requiredVersion !== null && sdkVersion !== requiredVersion;
+
+		// Only a CLI the engine cannot run without gates its install state; a CLI
+		// the SDK bundles and locates itself arrives with the engine anyway.
+		const cliSpec = getRequiredEngineCliSpec(tool);
+		if (!cliSpec) {
+			return { tool, installed: true, version: sdkVersion, source: getStackEnginesDir(), requiredVersion, needsUpdate: sdkNeedsUpdate };
+		}
+
+		// Engines that cannot run without an external CLI (Open Code) count as
+		// installed only when a runnable binary exists. Reporting the SDK alone is
+		// what let Stack show "installed" for an engine nothing could spawn.
+		const cli = await resolveEngineCli(tool);
+		if (!cli) return { tool, installed: false, version: null, source: null, requiredVersion, needsUpdate: false };
+
+		// The CLI is the artifact that actually runs, so it decides the reported
+		// version — a user's own older copy on PATH surfaces as "needs update"
+		// instead of hiding behind the pinned SDK version.
+		const cliNeedsUpdate = requiredVersion !== null && cli.version !== null && cli.version !== requiredVersion;
+		return {
+			tool,
+			installed: true,
+			version: cli.version ?? sdkVersion,
+			source: cli.path,
+			requiredVersion,
+			needsUpdate: sdkNeedsUpdate || cliNeedsUpdate
+		};
 	}
 
 	const resolved = await resolveBinaryWithRefresh(tool);
@@ -421,8 +456,9 @@ function attachCurlRequirement(base: Recipe, toolLabel: string): boolean {
  * Engine install recipe — installs the exact engine SDK package(s) declared in
  * package.json (the single source of truth) into the clopen-managed stack dir
  * (`~/.clopen/stack/engines`), NOT the user's global bun store. Installing the
- * SDK also pulls whatever CLI binary the SDK bundles. Versions are pinned,
- * never floated to `latest`.
+ * SDK also pulls whatever CLI binary the SDK bundles, plus — for engines whose
+ * SDK bundles none (Open Code) — the separate package that carries the CLI.
+ * Versions are pinned, never floated to `latest`.
  */
 function resolveEngineRecipe(tool: ToolId): Recipe {
 	const args = engineInstallArgs(tool);

--- a/backend/engine/install-runner.ts
+++ b/backend/engine/install-runner.ts
@@ -18,8 +18,6 @@
  */
 
 import { freemem, totalmem } from 'node:os';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { debug } from '$shared/utils/logger';
 import { ws } from '$backend/utils/ws';
 import { getCleanSpawnEnv } from '$backend/utils/env';
@@ -27,26 +25,21 @@ import { refreshProcessPath } from '$backend/utils/path-enrich';
 import { ensureCurlAvailable } from '$backend/utils/static-curl';
 import type { Recipe, ToolId } from './install-recipes';
 import { resolveRecipe } from './install-recipes';
+import { ensureStackProject } from './stack-project';
+import { invalidateEngineCliCache } from './engine-cli';
 
 const RING_BUFFER_LINES = 10_000;
 const RETENTION_MS = 5 * 60 * 1000;
 
 /**
- * Ensure a recipe's working directory exists as a minimal bun project before
- * `bun add` runs there. Engine recipes install into the clopen-managed stack
- * dir (`~/.clopen/stack/engines`); a package.json must exist so `bun add`
- * treats it as a project root instead of walking up to some parent.
+ * Ensure a recipe's working directory is ready before `bun add` runs there.
+ * Engine recipes install into the clopen-managed stack dir
+ * (`~/.clopen/stack/engines`), whose package.json both roots the install and
+ * carries the `trustedDependencies` that let engine CLI postinstalls run.
  */
 function ensureRecipeCwd(recipe: Recipe): void {
 	if (!recipe.cwd) return;
-	mkdirSync(recipe.cwd, { recursive: true });
-	const pkgJsonPath = join(recipe.cwd, 'package.json');
-	if (!existsSync(pkgJsonPath)) {
-		writeFileSync(
-			pkgJsonPath,
-			JSON.stringify({ name: 'clopen-stack-engines', private: true, version: '0.0.0' }, null, 2) + '\n'
-		);
-	}
+	ensureStackProject(recipe.cwd);
 }
 
 export type SessionStatus = 'running' | 'success' | 'failed' | 'cancelled';
@@ -74,6 +67,8 @@ interface Session {
 
 const sessions = new Map<string, Session>();
 const activeByTool = new Map<ToolId, string>();
+/** Run promise per session, so callers can await an install they didn't start. */
+const runs = new Map<string, Promise<void>>();
 
 function newRingBuffer(): RingBuffer {
 	return { lines: [], total: 0 };
@@ -91,6 +86,7 @@ function scheduleRetention(session: Session): void {
 	if (session.retentionTimer) clearTimeout(session.retentionTimer);
 	session.retentionTimer = setTimeout(() => {
 		sessions.delete(session.id);
+		runs.delete(session.id);
 		if (activeByTool.get(session.tool) === session.id) {
 			activeByTool.delete(session.tool);
 		}
@@ -188,6 +184,11 @@ function finalizeSession(session: Session, preferredStatus: SessionStatus, exitC
 	session.exitCode = exitCode;
 	session.endedAt = Date.now();
 	session.proc = null;
+
+	// An install can replace the binary a previous resolution cached (a user's
+	// own older copy on PATH, or a stub swapped for the real thing at the same
+	// path), so the next lookup must probe again rather than trust the cache.
+	invalidateEngineCliCache(session.tool);
 
 	debug.log('path', `[install:${session.id}] Finished status=${session.status} exit=${exitCode}`);
 
@@ -307,6 +308,14 @@ async function runInstall(session: Session, env: Record<string, string>): Promis
 	finalizeSession(session, exitCode === 0 ? 'success' : 'failed', exitCode);
 }
 
+/**
+ * Owner id for installs clopen starts itself (startup repair), rather than a
+ * user clicking Install. Sessions carry an owner so one admin cannot drive
+ * another's install; system-owned sessions are readable by any admin instead
+ * (see `requireInstallSessionAccess`) so the repair is visible and cancellable.
+ */
+export const SYSTEM_INSTALL_USER = 'system';
+
 export async function startInstall(tool: ToolId, userId: string): Promise<Session> {
 	await refreshProcessPath();
 
@@ -356,13 +365,22 @@ export async function startInstall(tool: ToolId, userId: string): Promise<Sessio
 		startedAt: session.startedAt
 	});
 
-	runInstall(session, env).catch((err) => {
+	runs.set(id, runInstall(session, env).catch((err) => {
 		debug.error('path', `[install:${id}] runner crash:`, err);
 		emitStream(session, 'stderr', `runner crash: ${err instanceof Error ? err.message : String(err)}\n`);
 		finalizeSession(session, 'failed', -1);
-	});
+	}));
 
 	return session;
+}
+
+/**
+ * Resolve once the install has finished (success, failure or cancellation).
+ * Resolves immediately for an unknown or already-collected session, so callers
+ * can await without racing session retention.
+ */
+export function awaitInstall(sessionId: string): Promise<void> {
+	return runs.get(sessionId) ?? Promise.resolve();
 }
 
 export function cancelInstall(sessionId: string): boolean {

--- a/backend/engine/stack-project.ts
+++ b/backend/engine/stack-project.ts
@@ -1,0 +1,72 @@
+/**
+ * Managed stack project bootstrap
+ *
+ * `~/.clopen/stack/engines` is a minimal bun project. A package.json must exist
+ * there before `bun add` runs, or bun walks up the tree and installs into
+ * whatever project happens to contain the directory.
+ *
+ * It must also declare `trustedDependencies`. bun blocks postinstall scripts
+ * for untrusted packages, and an engine CLI package ships only a stub — its
+ * real binary is copied into place by exactly that postinstall. Without the
+ * entry the install still reports success and leaves behind a shell script that
+ * prints "postinstall script was not run", which is precisely the half-installed
+ * state that used to reach the adapter.
+ *
+ * Both install paths (the user-triggered runner and the startup bootstrap) go
+ * through here, and the file is MERGED rather than only created, so a stack dir
+ * written by an older clopen picks the field up on its next install.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { debug } from '$shared/utils/logger';
+import { engineCliTrustedPackages } from './engine-cli';
+
+interface StackPackageJson {
+	name?: string;
+	private?: boolean;
+	version?: string;
+	trustedDependencies?: string[];
+	[key: string]: unknown;
+}
+
+const BASE: StackPackageJson = {
+	name: 'clopen-stack-engines',
+	private: true,
+	version: '0.0.0'
+};
+
+function readExisting(path: string): StackPackageJson | null {
+	if (!existsSync(path)) return null;
+	try {
+		const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+		if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+			return parsed as StackPackageJson;
+		}
+	} catch {
+		// Corrupt file: fall through and rewrite from the base template rather
+		// than leaving a package.json bun will choke on.
+	}
+	return null;
+}
+
+/**
+ * Ensure `dir` is a bun project that trusts every engine CLI package. Safe to
+ * call repeatedly; writes only when the file is missing or would change.
+ */
+export function ensureStackProject(dir: string): void {
+	mkdirSync(dir, { recursive: true });
+	const path = join(dir, 'package.json');
+
+	const existing = readExisting(path);
+	const merged: StackPackageJson = { ...BASE, ...(existing ?? {}) };
+
+	const trusted = new Set([...(merged.trustedDependencies ?? []), ...engineCliTrustedPackages()]);
+	merged.trustedDependencies = [...trusted].sort();
+
+	const next = JSON.stringify(merged, null, 2) + '\n';
+	if (existing !== null && readFileSync(path, 'utf8') === next) return;
+
+	writeFileSync(path, next);
+	debug.log('engine', `Stack project package.json ${existing ? 'updated' : 'created'}: ${path}`);
+}

--- a/backend/utils/path-enrich.ts
+++ b/backend/utils/path-enrich.ts
@@ -84,6 +84,8 @@ function windowsKnownDirs(): string[] {
 		join(home, '.bun', 'bin'),
 		join(home, '.deno', 'bin'),
 		join(home, '.cargo', 'bin'),
+		// install-script target (Open Code), the Windows twin of the posix entry
+		join(home, '.opencode', 'bin'),
 		join(home, 'scoop', 'shims'),
 		join(localAppData, 'Microsoft', 'WinGet', 'Links'),
 		join(localAppData, 'Programs', 'Git', 'cmd'),

--- a/backend/ws/engine/claude/accounts.ts
+++ b/backend/ws/engine/claude/accounts.ts
@@ -19,7 +19,7 @@ import { createRouter } from '$shared/utils/ws-server';
 import { ws } from '$backend/utils/ws';
 import { engineQueries } from '../../../database/queries';
 import { resetEnvironment, getClaudeUserConfigDir } from '../../../engine/adapters/claude/environment';
-import { resolveBinaryWithRefresh } from '../../../utils/cli';
+import { resolveEngineCli } from '$backend/engine/engine-cli';
 import { debug } from '$shared/utils/logger';
 import { getCleanSpawnEnv } from '../../../utils/env';
 import { requireSetupSessionAccess } from '../access';
@@ -209,11 +209,16 @@ export const accountsHandler = createRouter()
 		ptyEnv['CLAUDE_CONFIG_DIR'] = getClaudeUserConfigDir();
 		ptyEnv['BROWSER'] = 'false';
 
-		const claudeCmd = await resolveBinaryWithRefresh('claude');
-		if (!claudeCmd) throw new Error('claude binary not found on PATH');
+		// The CLI ships inside the Claude Agent SDK's platform package in the
+		// managed stack dir, so sign-in must not demand a global install the way
+		// it used to — `resolveEngineCli` prefers that copy and falls back to PATH.
+		const claudeCli = await resolveEngineCli('claude');
+		if (!claudeCli) {
+			throw new Error('Claude Code CLI not found. Open Settings → Stack to install the engine.');
+		}
 		let pty: ReturnType<typeof spawn>;
 		try {
-			pty = spawn(claudeCmd, ['setup-token'], {
+			pty = spawn(claudeCli.path, ['setup-token'], {
 				name: 'xterm-256color',
 				cols: 1000,
 				rows: 30,

--- a/backend/ws/engine/codex/accounts.ts
+++ b/backend/ws/engine/codex/accounts.ts
@@ -48,7 +48,7 @@ import {
 	serializeCodexCredential,
 	getCodexHomeDir,
 } from '../../../engine/adapters/codex/credential';
-import { resolveBinaryWithRefresh } from '../../../utils/cli';
+import { resolveEngineCli } from '$backend/engine/engine-cli';
 import { getCleanSpawnEnv } from '../../../utils/env';
 import { debug } from '$shared/utils/logger';
 import { requireSetupSessionAccess } from '../access';
@@ -328,11 +328,14 @@ export const codexAccountsHandler = createRouter()
 		const existing = userSetups.get(userId);
 		if (existing) cleanupSetup(existing);
 
-		const codexCmd = await resolveBinaryWithRefresh('codex');
-		if (!codexCmd) {
+		// The CLI is vendored inside the Codex SDK's platform package in the
+		// managed stack dir; resolving through `resolveEngineCli` means sign-in
+		// works off a Stack install instead of demanding a global one.
+		const codexCli = await resolveEngineCli('codex');
+		if (!codexCli) {
 			ws.emit.user(userId, 'engine:codex-account-setup-error', {
 				setupId,
-				message: 'Codex CLI not found on PATH. Install it via Settings → Stack.'
+				message: 'Codex CLI not found. Install the engine via Settings → Stack.'
 			});
 			return;
 		}
@@ -352,7 +355,7 @@ export const codexAccountsHandler = createRouter()
 
 			let pty: ReturnType<typeof spawn>;
 			try {
-				pty = spawn(codexCmd, args, {
+				pty = spawn(codexCli.path, args, {
 					name: 'xterm-256color',
 					cols: 1000,
 					rows: 30,

--- a/backend/ws/engine/codex/status.ts
+++ b/backend/ws/engine/codex/status.ts
@@ -1,33 +1,26 @@
 /**
  * OpenAI Codex Engine Status Handler
  *
- * Reports SDK availability + active account state. Codex differs from
- * Copilot in that the SDK does NOT bundle a CLI internally — the CLI must
- * be installed on PATH (Stack → Codex CLI). `installed` reflects
- * whether the `codex` binary resolves on the host's PATH.
+ * Reports SDK availability + active account state. `installed` tracks the SDK;
+ * `version` is the CLI's, since that is the process Codex actually runs. That
+ * binary is vendored inside the SDK's platform package in the managed stack dir
+ * (or comes from PATH when the user installed Codex themselves) — reading it
+ * off PATH alone left the version blank on a Stack-only install.
  */
 
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { engineQueries } from '../../../database/queries';
-import { resolveBinaryWithRefresh } from '../../../utils/cli';
+import { resolveEngineCli } from '$backend/engine/engine-cli';
 import { getBackendOS } from '../../../utils/os';
 import { debug } from '$shared/utils/logger';
 import { readEngineSdkVersion } from '$backend/engine/sdk-loader';
 
 async function readCliVersion(): Promise<string | null> {
-	const bin = await resolveBinaryWithRefresh('codex');
-	if (!bin) return null;
-	try {
-		const proc = Bun.spawn([bin, '--version'], { stdout: 'pipe', stderr: 'pipe' });
-		const exitCode = await proc.exited;
-		if (exitCode !== 0) return null;
-		const stdout = await new Response(proc.stdout).text();
-		const first = stdout.trim().split('\n')[0]?.trim() ?? '';
-		return first || null;
-	} catch {
-		return null;
-	}
+	// `resolveEngineCli` already ran `--version` on the binary it handed back,
+	// so the version comes for free with the resolution.
+	const cli = await resolveEngineCli('codex');
+	return cli?.version ?? null;
 }
 
 export const codexStatusHandler = createRouter()

--- a/backend/ws/settings/crud.ts
+++ b/backend/ws/settings/crud.ts
@@ -133,7 +133,7 @@ export const crudHandler = createRouter()
 		// account and has none (→ Engines). Mirrors the chat pre-stream gate so
 		// the model picker reflects the same install/sign-in state as chat.
 		const activeAccount = engineQueries.getActiveAccountForEngine(engineType);
-		const setupIssue = checkEngineSetup(engineType, activeAccount?.id ?? 0);
+		const setupIssue = await checkEngineSetup(engineType, activeAccount?.id ?? 0);
 		if (setupIssue) throw new Error(setupIssue.message);
 
 		// Uniform path for every engine. Each adapter's getAvailableModels()

--- a/backend/ws/stack/access.ts
+++ b/backend/ws/stack/access.ts
@@ -9,7 +9,7 @@
 
 import type { WSConnection } from '$shared/utils/ws-server';
 import { ws } from '$backend/utils/ws';
-import { getSession, getSessionOwner } from '$backend/engine/install-runner';
+import { getSession, getSessionOwner, SYSTEM_INSTALL_USER } from '$backend/engine/install-runner';
 
 type InstallSession = NonNullable<ReturnType<typeof getSession>>;
 
@@ -21,7 +21,10 @@ type InstallSession = NonNullable<ReturnType<typeof getSession>>;
 export function requireInstallSessionAccess(conn: WSConnection, sessionId: string): InstallSession | null {
 	const userId = ws.getUserId(conn);
 	const owner = getSessionOwner(sessionId);
-	if (owner && owner !== userId) {
+	// Installs clopen starts itself belong to no user; any admin reaching this
+	// guard may watch or cancel them, otherwise a startup repair would show up
+	// in Settings → Stack as a running session nobody is allowed to touch.
+	if (owner && owner !== SYSTEM_INSTALL_USER && owner !== userId) {
 		throw new Error('Install session not found');
 	}
 	return getSession(sessionId);


### PR DESCRIPTION
## Summary
OpenCode was reported as installed in Settings → Stack while the engine could not
run: the model picker failed with `opencode binary not found on PATH` and no model
could be selected. Stack now tracks the binary each engine actually spawns,
installs it, and repairs machines already left half-installed. The same PATH
assumption was breaking Codex and Claude Code sign-in, and is fixed with it.

## Why
Two code paths disagreed about what "installed" means. `getToolStatus` checked for
the SDK package in the managed stack dir; the adapter needs the `opencode` CLI to
spawn `opencode serve`. `@opencode-ai/sdk` is a pure HTTP client and ships no
binary, so installing it satisfied the check and left the engine unusable. Machines
that already had the CLI from OpenCode's own installer masked the gap — a fresh
Windows 11 box, auto-bootstrapped by clopen at startup, did not.

Auditing the other seven engines turned up the same mistake in two more places.
Codex and Claude Code bundle their CLI as a platform dependency of the SDK, which
finds it module-relative, so streaming worked; but `codex login`, `claude
setup-token` and the Codex status card looked on PATH and declared the CLI missing
on a Stack-only install. Copilot and Qwen resolve their entrypoint inside the stack
dir on their own, and Cursor, Pi and Cline run in process — those are unaffected.

## Changes
- `backend/engine/engine-cli.ts` (new): registry + resolver for engines whose
  runtime needs an executable — stack package → platform package → PATH, each
  candidate verified with `--version` so a postinstall stub or a build the host CPU
  cannot run falls through instead of reaching a spawn site. Versions are pinned
  through the SDK's package.json entry; a CLI is a platform binary weighing
  hundreds of megabytes and has no business in devDependencies.
- The registry separates a CLI that needs its own install (`installPackage`,
  OpenCode only) from one bundled with its SDK, and a CLI the engine cannot run
  without (`required`, OpenCode only) from one the SDK locates itself. Only the
  latter gates install state — marking a bundled CLI required would flip a working
  engine to "not installed" the moment our path guess drifted from the SDK's.
- `backend/engine/stack-project.ts` (new): shared bootstrap for the managed
  `package.json`, merging `trustedDependencies` so bun runs the CLI postinstall.
  Merging (not just creating) is what upgrades existing stack dirs.
- `install-recipes.ts`: the OpenCode recipe installs `opencode-ai` alongside the
  SDK; `getToolStatus` requires a runnable binary and reports its version and path.
- `engine-setup.ts`: readiness gate covers a required CLI (now async) and exports
  `TOOL_FOR_ENGINE`; `adapters/opencode/server.ts` spawns the resolved binary and
  its error routes to Settings → Stack.
- `ws/engine/claude/accounts.ts`, `ws/engine/codex/accounts.ts`,
  `ws/engine/codex/status.ts`, `adapters/codex/stream.ts`: sign-in, status and the
  SDK path override resolve the bundled CLI in the stack dir instead of requiring a
  global install; the managed copy now wins over an older one on PATH.
- `bootstrap-default-engine.ts`: startup repair for the SDK-without-CLI state, run
  through the install runner so it appears as a live session; `install-runner.ts`
  gains `awaitInstall`, a system install owner, and CLI cache invalidation.
- `path-enrich.ts`: `%USERPROFILE%\.opencode\bin` on Windows.

## Test plan
- `bun run check`, `bun run lint`, `bun run test` (470 pass, 0 fail)
- New tests: CLI pinning through the SDK version, the installer adding a separate
  CLI (and not adding one for a bundled CLI), `required` limited to the
  engine-blocking case, `trustedDependencies` on both a new and a pre-existing
  managed dir
- Manual, against an isolated `CLOPEN_DATA_DIR`:
  - full install → postinstall runs, status reports the stack binary at 1.18.18
  - SDK present, no CLI, empty PATH (the reported state) → status flips to
    not installed
  - postinstall blocked → stub rejected, platform package resolved instead
  - user's own older CLI on PATH → used as-is and surfaced as needing an update
  - half-installed machine → startup repair completes and the CLI resolves
- Resolved the Codex and Claude CLIs against the real stack dir: both come from the
  managed platform packages, no global install involved
- Audited all eight engines; no engine binary is looked up on PATH any more

## Notes
Verified separately that bun blocks the postinstall without `trustedDependencies`
(leaving the stub behind) and supplies its own `node` shim when it does run, so the
install needs no Node.js on the host. Windows behaviour is derived from the
packages' shipped layout and bun's platform resolution rather than a Windows run —
worth a confirmation on the reporter's machine.