### PR TITLE
fix(engine): stop only the chat the user stopped

### DIFF
--- a/backend/chat/stream-manager.ts
+++ b/backend/chat/stream-manager.ts
@@ -1535,16 +1535,21 @@ class StreamManager extends EventEmitter {
 			debug.log('mcp', `✅ Auto-released MCP tabs for session ${streamState.chatSessionId.slice(0, 8)} on stream cancellation`);
 		}
 
-		// Cancel the per-project engine with a bounded timeout.
-		// engine.cancel() stops the SDK process (Claude Code: close() kills subprocess,
+		// Stop this stream's run on the engine, with a bounded timeout.
+		// engine.cancel() stops the SDK work (Claude Code: close() kills subprocess,
 		// OpenCode: aborts controller + HTTP abort to server). If cancel() hangs
 		// (e.g. unresponsive SDK), the timeout ensures we always proceed to emit
 		// events and update presence — preventing infinite loader on the frontend.
+		//
+		// The abortController identifies WHICH run to stop. One engine instance is
+		// shared by every chat session of a project, so an untargeted cancel stops
+		// whichever run the instance happened to have on hand — cancelling one chat
+		// would kill another chat of the same project mid-answer.
 		try {
 			const engine = streamState.engineInstance;
-			if (engine?.isActive) {
+			if (engine && streamState.abortController) {
 				await Promise.race([
-					engine.cancel(),
+					engine.cancel(streamState.abortController),
 					new Promise<void>(resolve => setTimeout(resolve, 5000))
 				]);
 			}

--- a/backend/engine/README.md
+++ b/backend/engine/README.md
@@ -66,6 +66,22 @@ stays **agnostic** to the underlying SDK.
 > capture the SDK's real runtime shapes with a throwaway script rather than
 > trusting its `.d.ts`.
 
+> **One instance, many streams.** `getProjectEngine` hands the same adapter
+> instance to every chat session of a project, and Clopen lets those sessions
+> stream at the same time. So per-stream state — abort controller, SDK query or
+> session, session id, pooled server, parked questions — belongs to a **run**,
+> held in the adapter's `EngineRuns` registry
+> ([`adapters/run-registry.ts`](./adapters/run-registry.ts)), never in an
+> instance field. `cancel(owner)` and `interrupt(owner)` take the run to stop
+> and the parameter is required; stopping everything is `dispose()`'s job.
+> Storing a stream's handles on the instance is not a style question — it made
+> Stop in one chat abort another chat of the same project, made `isActive`
+> report idle while a stream was still running (so engine retirement disposed it
+> mid-answer), and leaked a pooled OpenCode server hold per overwritten stream.
+> Read **§10.26** in [lessons-learned](./docs/lessons-learned.md) and invariant 2
+> in [adapter-contract](./docs/adapter-contract.md) before adding state to an
+> adapter class.
+
 > **Background parent tools are a streaming category of their own.** `Agent`
 > receives nested activity from the SDK stream, while Claude's `Workflow`
 > writes agent transcripts to JSONL files outside that stream. Both must obey

--- a/backend/engine/adapters/claude/stream.ts
+++ b/backend/engine/adapters/claude/stream.ts
@@ -36,6 +36,7 @@ import { syncEngineArtifacts } from '$backend/engine/artifact-sync';
 import { artifactFilter } from '$backend/profiles';
 import { resolvePermissionsFromDb, isToolAllowed, hasAnyRestriction, syncPermissions } from '$backend/permissions';
 import type { AIEngine, EngineQueryOptions } from '../../types';
+import { EngineRuns } from '../run-registry';
 import type { EngineModel } from '$shared/types/unified';
 import { CLAUDE_CODE_MODELS } from './models';
 
@@ -46,6 +47,20 @@ interface PendingUserAnswer {
   resolve: (result: PermissionResult) => void;
   removeAbortListener: () => void;
   input: Record<string, unknown>;
+  /** The run that asked — cancelling one run must not abandon another's questions. */
+  run: ClaudeRun;
+}
+
+/**
+ * One stream in flight on this instance. This engine instance is shared by every
+ * chat session of a project, so the SDK query has to be held per run: a single
+ * field holds only the most recently started stream, and cancelling any chat
+ * would then close another chat's query.
+ */
+interface ClaudeRun {
+  /** Identity of the run — the controller the caller passed to streamQuery. */
+  controller: AbortController;
+  query: Query | null;
 }
 
 /** Merge the SDK stream with Workflow transcript polling without blocking either producer. */
@@ -78,8 +93,7 @@ class EventQueue<T> {
 export class ClaudeCodeEngine implements AIEngine {
   readonly name = 'claude-code' as const;
   private _isInitialized = false;
-  private activeController: AbortController | null = null;
-  private activeQuery: Query | null = null;
+  private runs = new EngineRuns<ClaudeRun>();
   private pendingUserAnswers = new Map<string, PendingUserAnswer>();
 
   get isInitialized(): boolean {
@@ -87,7 +101,7 @@ export class ClaudeCodeEngine implements AIEngine {
   }
 
   get isActive(): boolean {
-    return this.activeController !== null;
+    return this.runs.isActive;
   }
 
   async initialize(): Promise<void> {
@@ -101,7 +115,8 @@ export class ClaudeCodeEngine implements AIEngine {
   }
 
   async dispose(): Promise<void> {
-    await this.cancel();
+    // Shutdown/retirement: every run on this instance goes.
+    await this.stopRuns(this.runs.all());
     this.pendingUserAnswers.clear();
     this._isInitialized = false;
   }
@@ -140,10 +155,9 @@ export class ClaudeCodeEngine implements AIEngine {
     debug.log('chat', "Claude Code - Stream Query");
     debug.log('chat', { prompt });
 
-    this.activeController = abortController || new AbortController();
-    // Held locally: cancel() nulls the field, and the checks below still need to
-    // know whether this stream ended because the user cancelled it.
-    const streamController = this.activeController;
+    const streamController = abortController || new AbortController();
+    const run: ClaudeRun = { controller: streamController, query: null };
+    this.runs.add(run);
 
     const resolvedProjectPath = resolveOsPath(projectPath);
 
@@ -244,6 +258,7 @@ export class ClaudeCodeEngine implements AIEngine {
               canUseToolOptions.signal.addEventListener('abort', onAbort, { once: true });
 
               this.pendingUserAnswers.set(canUseToolOptions.toolUseID, {
+                run,
                 resolve: (result: PermissionResult) => {
                   canUseToolOptions.signal.removeEventListener('abort', onAbort);
                   resolve(result);
@@ -289,7 +304,7 @@ export class ClaudeCodeEngine implements AIEngine {
         ...(maxTurns && { maxTurns }),
         ...(includePartialMessages && { includePartialMessages }),
         forwardSubagentText: true,
-        abortController: this.activeController,
+        abortController: streamController,
         ...(Object.keys(mcpServers).length > 0 && { mcpServers }),
         ...(allowedMcpTools.length > 0 && { allowedTools: allowedMcpTools })
       };
@@ -306,7 +321,7 @@ export class ClaudeCodeEngine implements AIEngine {
         options: sdkOptions,
       });
 
-      this.activeQuery = queryInstance;
+      run.query = queryInstance;
 
       // Per-query stateful converter so block-stop reasoning tracking persists
       // across the stream of SDK messages.
@@ -335,9 +350,9 @@ export class ClaudeCodeEngine implements AIEngine {
           const observedVersion = workflowTranscripts.changeVersion;
           for (const output of await workflowTranscripts.drain()) events.push(output);
 
-          if (this.activeController?.signal.aborted) break;
+          if (streamController.signal.aborted) break;
           if (sdkStreamDone && !await workflowTranscripts.hasActiveWorkflows()) break;
-          await workflowTranscripts.waitForChange(observedVersion, this.activeController!.signal);
+          await workflowTranscripts.waitForChange(observedVersion, streamController.signal);
         }
         // The terminal status event is authoritative; drain once more for writes
         // already queued by the filesystem before closing the merged stream.
@@ -363,62 +378,87 @@ export class ClaudeCodeEngine implements AIEngine {
     } catch (error) {
       handleStreamError(error);
     } finally {
-      this.activeController = null;
-      this.activeQuery = null;
+      // Retire THIS run only — a concurrent stream of another chat session in
+      // the same project is still using the instance.
+      this.forgetRun(run);
     }
   }
 
   /**
-   * Cancel active query
+   * Drop a finished run and the questions only it could have answered.
    */
-  async cancel(): Promise<void> {
-    // Remove abort listeners from pending AskUserQuestion promises WITHOUT
-    // resolving them. Resolving causes the SDK to call handleControlRequest →
-    // write() to send the permission result to the subprocess. If close() has
-    // already killed the subprocess, this write throws "Operation aborted" as
-    // an unhandled error, crashing the server. By removing listeners and not
-    // resolving, the promises are safely abandoned when close() terminates the
-    // process and the async generator completes.
-    for (const [, pending] of this.pendingUserAnswers) {
-      pending.removeAbortListener();
+  private forgetRun(run: ClaudeRun): void {
+    this.runs.remove(run);
+    for (const [toolUseId, pending] of this.pendingUserAnswers) {
+      if (pending.run === run) this.pendingUserAnswers.delete(toolUseId);
     }
-    this.pendingUserAnswers.clear();
+    run.query = null;
+  }
 
-    // Use close() to forcefully terminate the query process and clean up
-    // all resources (docs: "Forcefully ends the query and cleans up all
-    // resources"). Unlike interrupt() which can hang indefinitely when the
-    // subprocess is unresponsive, close() is synchronous and guaranteed to
-    // complete — making cancel deterministic.
-    if (this.activeQuery && typeof this.activeQuery.close === 'function') {
-      try {
-        this.activeQuery.close();
-      } catch {
-        // Ignore close errors — process may already be dead
+  /**
+   * Cancel the run whose AbortController is `owner`, and only that run.
+   */
+  async cancel(owner: AbortController): Promise<void> {
+    await this.stopRuns(this.runs.select(owner));
+  }
+
+  /**
+   * Tear down the given runs. `cancel` passes the one run it was asked to
+   * stop; `dispose` passes them all. Nothing else may reach this.
+   */
+  private async stopRuns(targets: ClaudeRun[]): Promise<void> {
+    for (const run of targets) {
+      // Remove abort listeners from this run's pending AskUserQuestion promises
+      // WITHOUT resolving them. Resolving causes the SDK to call
+      // handleControlRequest → write() to send the permission result to the
+      // subprocess. If close() has already killed the subprocess, this write
+      // throws "Operation aborted" as an unhandled error, crashing the server.
+      // By removing listeners and not resolving, the promises are safely
+      // abandoned when close() terminates the process and the async generator
+      // completes. Questions parked by OTHER runs stay put — their subprocess
+      // is still alive and still waiting for an answer.
+      for (const [, pending] of this.pendingUserAnswers) {
+        if (pending.run === run) pending.removeAbortListener();
+      }
+
+      // Use close() to forcefully terminate the query process and clean up
+      // all resources (docs: "Forcefully ends the query and cleans up all
+      // resources"). Unlike interrupt() which can hang indefinitely when the
+      // subprocess is unresponsive, close() is synchronous and guaranteed to
+      // complete — making cancel deterministic.
+      if (run.query && typeof run.query.close === 'function') {
+        try {
+          run.query.close();
+        } catch {
+          // Ignore close errors — process may already be dead
+        }
+      }
+
+      if (!run.controller.signal.aborted) run.controller.abort();
+      this.forgetRun(run);
+    }
+  }
+
+  /**
+   * Interrupt a run (soft stop). Targeted like `cancel`.
+   */
+  async interrupt(owner: AbortController): Promise<void> {
+    const targets = this.runs.select(owner);
+    for (const run of targets) {
+      if (run.query && typeof run.query.interrupt === 'function') {
+        await run.query.interrupt();
       }
     }
-
-    if (this.activeController && !this.activeController.signal.aborted) {
-      this.activeController.abort();
-    }
-    this.activeController = null;
-    this.activeQuery = null;
   }
 
   /**
-   * Interrupt the active query
+   * Change permission mode for one run's query.
    */
-  async interrupt(): Promise<void> {
-    if (this.activeQuery && typeof this.activeQuery.interrupt === 'function') {
-      await this.activeQuery.interrupt();
-    }
-  }
-
-  /**
-   * Change permission mode for active query
-   */
-  async setPermissionMode(mode: PermissionMode): Promise<void> {
-    if (this.activeQuery && typeof this.activeQuery.setPermissionMode === 'function') {
-      await this.activeQuery.setPermissionMode(mode);
+  async setPermissionMode(mode: PermissionMode, owner: AbortController): Promise<void> {
+    for (const run of this.runs.select(owner)) {
+      if (run.query && typeof run.query.setPermissionMode === 'function') {
+        await run.query.setPermissionMode(mode);
+      }
     }
   }
 

--- a/backend/engine/adapters/cline/stream.ts
+++ b/backend/engine/adapters/cline/stream.ts
@@ -34,6 +34,7 @@ import { syncEngineArtifacts, buildArtifactsPromptContext } from '$backend/engin
 import { artifactFilter } from '$backend/profiles';
 import { resolvePermissionsFromDb, isToolAllowed } from '$backend/permissions';
 import { buildJsonPrompt, extractJson } from '../../structured-helpers';
+import { EngineRuns } from '../run-registry';
 import { subagentQueries } from '$backend/database/queries';
 import { readSubagentMd } from '$backend/subagents/store';
 import { getClineAccountForProvider, parseClineCredential, resolveClineAuth } from './credential';
@@ -85,12 +86,24 @@ class EventQueue<T> {
 	}
 }
 
+/**
+ * One stream in flight on this instance. This engine instance is shared by every
+ * chat session of a project, so the agent belongs here, not in an instance field
+ * — a field would hold only the most recently started stream, and cancelling any
+ * chat would then abort another chat's agent.
+ */
+interface ClineRun {
+	/** Identity of the run — the controller the caller passed to streamQuery. */
+	controller: AbortController;
+	agent: ClineAgent | null;
+}
+
 export class ClineEngine implements AIEngine {
 	readonly name = 'cline' as const;
 	private _isInitialized = false;
-	private activeController: AbortController | null = null;
-	private activeAgent: ClineAgent | null = null;
-	private pendingAsks = new Map<string, PendingAsk>();
+	private runs = new EngineRuns<ClineRun>();
+	/** Parked AskUserQuestion callbacks → the run that asked. */
+	private pendingAsks = new Map<string, PendingAsk & { owner: ClineRun }>();
 	/**
 	 * In-memory transcript keyed by the SDK session id EMITTED for each turn.
 	 * Every turn stores its resulting transcript under a fresh id and never
@@ -101,7 +114,7 @@ export class ClineEngine implements AIEngine {
 	private sessions = new Map<string, AgentMessage[]>();
 
 	get isInitialized(): boolean { return this._isInitialized; }
-	get isActive(): boolean { return this.activeController !== null; }
+	get isActive(): boolean { return this.runs.isActive; }
 
 	async initialize(): Promise<void> {
 		if (this._isInitialized) return;
@@ -110,7 +123,7 @@ export class ClineEngine implements AIEngine {
 	}
 
 	async dispose(): Promise<void> {
-		await this.cancel();
+		await this.stopRuns(this.runs.all());
 		this.pendingAsks.clear();
 		this.sessions.clear();
 		this._isInitialized = false;
@@ -145,7 +158,9 @@ export class ClineEngine implements AIEngine {
 		const provider = parseClineCredential(account.credential)?.provider ?? providerSlug;
 		const auth = await resolveClineAuth(account);
 
-		this.activeController = abortController || new AbortController();
+		const controller = abortController || new AbortController();
+		const run: ClineRun = { controller, agent: null };
+		this.runs.add(run);
 		const resolvedProjectPath = resolveOsPath(projectPath);
 
 		// ── Active Profile scoping + artifact materialization ──
@@ -169,7 +184,7 @@ export class ClineEngine implements AIEngine {
 			enableSubmitAndExit: false,
 		});
 		const askTool = await createAskUserQuestionTool({
-			register: (id, entry) => this.pendingAsks.set(id, entry),
+			register: (id, entry) => this.pendingAsks.set(id, { ...entry, owner: run }),
 			unregister: (id) => this.pendingAsks.delete(id),
 		});
 		const mcpTools = await buildClineMcpTools(options.mcpContext, mcpProfileFilter);
@@ -278,7 +293,7 @@ export class ClineEngine implements AIEngine {
 			toolPolicies,
 			maxIterations: options.maxTurns ?? 100,
 		});
-		this.activeAgent = agent;
+		run.agent = agent;
 		if (priorMessages?.length) agent.restore(priorMessages);
 
 		const engineMeta: MessageEngine = {
@@ -300,7 +315,7 @@ export class ClineEngine implements AIEngine {
 
 		// Abort wiring: cancelling the stream aborts the Cline run.
 		const onAbort = () => { agent.abort('Cancelled'); };
-		this.activeController.signal.addEventListener('abort', onAbort, { once: true });
+		controller.signal.addEventListener('abort', onAbort, { once: true });
 
 		// Build the user turn (text + image attachments).
 		const promptText = prompt.content.filter(b => b.type === 'text').map(b => (b.type === 'text' ? b.text : '')).join('\n');
@@ -348,29 +363,52 @@ export class ClineEngine implements AIEngine {
 		} catch (error) {
 			handleStreamError(error);
 		} finally {
-			this.activeController?.signal.removeEventListener('abort', onAbort);
+			controller.signal.removeEventListener('abort', onAbort);
 			unsubscribe();
-			this.activeAgent = null;
-			this.activeController = null;
-			this.pendingAsks.clear();
+			// Retire THIS run only — another chat session of the same project may
+			// still be streaming on this instance.
+			this.forgetRun(run);
 		}
 	}
 
-	async cancel(): Promise<void> {
-		if (this.activeController && !this.activeController.signal.aborted) {
-			this.activeController.abort();
+	/** Drop a finished run and the asks only it could answer. */
+	private forgetRun(run: ClineRun): void {
+		this.runs.remove(run);
+		for (const [id, pending] of this.pendingAsks) {
+			if (pending.owner === run) this.pendingAsks.delete(id);
 		}
-		if (this.activeAgent) {
-			try { this.activeAgent.abort('Cancelled'); } catch { /* may already be idle */ }
-		}
-		this.pendingAsks.clear();
-		this.activeAgent = null;
-		this.activeController = null;
+		run.agent = null;
 	}
 
-	async interrupt(): Promise<void> {
-		if (this.activeAgent) {
-			try { this.activeAgent.abort('Interrupted'); } catch { /* ignore */ }
+	/**
+	 * Cancel the run whose AbortController is `owner`, and only that run.
+	 */
+	async cancel(owner: AbortController): Promise<void> {
+		await this.stopRuns(this.runs.select(owner));
+	}
+
+	/**
+	 * Tear down the given runs. `cancel` passes the one run it was asked to
+	 * stop; `dispose` passes them all. Nothing else may reach this.
+	 */
+	private async stopRuns(targets: ClineRun[]): Promise<void> {
+		for (const run of targets) {
+			if (!run.controller.signal.aborted) run.controller.abort();
+			const agent = run.agent;
+			// Drop only this run's parked asks; another run's are still live.
+			this.forgetRun(run);
+			if (agent) {
+				try { agent.abort('Cancelled'); } catch { /* may already be idle */ }
+			}
+		}
+	}
+
+	async interrupt(owner: AbortController): Promise<void> {
+		const targets = this.runs.select(owner);
+		for (const run of targets) {
+			if (run.agent) {
+				try { run.agent.abort('Interrupted'); } catch { /* ignore */ }
+			}
 		}
 	}
 

--- a/backend/engine/adapters/codex/stream.ts
+++ b/backend/engine/adapters/codex/stream.ts
@@ -29,6 +29,7 @@ import { resolveOsPath } from '$backend/utils/paths';
 import { resolveEngineCli } from '$backend/engine/engine-cli';
 import { getCleanSpawnEnv } from '$backend/utils/index.js';
 import { getCodexMcpConfig } from '../../../mcp';
+import { EngineRuns } from '../run-registry';
 import { artifactFilter } from '$backend/profiles';
 import { syncSkills } from '$backend/skills';
 import { syncEngineArtifacts, buildArtifactsPromptContext } from '$backend/engine/artifact-sync';
@@ -56,13 +57,26 @@ import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs';
 
+/** One stream in flight on this instance. */
+interface CodexRun {
+	/** Identity of the run — the controller the caller passed to streamQuery. */
+	controller: AbortController;
+	thread: Thread | null;
+}
+
 export class CodexEngine implements AIEngine {
 	readonly name = 'codex' as const;
 
 	private _isInitialized = false;
 	private codex: Codex | null = null;
-	private activeThread: Thread | null = null;
-	private activeController: AbortController | null = null;
+	/**
+	 * Every stream in flight, keyed by the AbortController its caller passed to
+	 * streamQuery. One instance serves all chat sessions of a project, so the
+	 * thread and controller of a stream belong to the run, not the instance — a
+	 * field would hold only the most recent one and cancelling any chat would
+	 * abort another chat's turn.
+	 */
+	private runs = new EngineRuns<CodexRun>();
 	/** Account ID currently baked into `this.codex`. Same trade-off as Copilot. */
 	private currentAccountId: number | null = null;
 	/**
@@ -78,7 +92,7 @@ export class CodexEngine implements AIEngine {
 	}
 
 	get isActive(): boolean {
-		return this.activeController !== null;
+		return this.runs.isActive;
 	}
 
 	async initialize(accountId?: number, mcpProfileFilter?: Set<string>): Promise<void> {
@@ -140,7 +154,7 @@ export class CodexEngine implements AIEngine {
 	}
 
 	async dispose(): Promise<void> {
-		await this.cancel();
+		await this.stopRuns(this.runs.all());
 		this.codex = null;
 		this.currentAccountId = null;
 		this.currentMcpFilterKey = null;
@@ -197,7 +211,9 @@ export class CodexEngine implements AIEngine {
 			applyAccountAuth(activeAccount);
 		}
 
-		this.activeController = abortController || new AbortController();
+		const controller = abortController || new AbortController();
+		const run: CodexRun = { controller, thread: null };
+		this.runs.add(run);
 
 		const resolvedProjectPath = resolveOsPath(projectPath);
 		const state = createCodexState('', modelId);
@@ -237,7 +253,7 @@ export class CodexEngine implements AIEngine {
 				thread = this.codex.startThread(threadOptions);
 			}
 
-			this.activeThread = thread;
+			run.thread = thread;
 
 			// Prompt-scoped engine: advertise the profile-scoped Skills/Commands/
 			// Subagents PER-SESSION via the prompt (not the shared global AGENTS.md /
@@ -245,11 +261,11 @@ export class CodexEngine implements AIEngine {
 			const artifactsContext = buildArtifactsPromptContext(profileId);
 			const input = await buildCodexInput(prompt, artifactsContext || undefined);
 			const { events } = await thread.runStreamed(input, {
-				signal: this.activeController.signal,
+				signal: controller.signal,
 			});
 
 			for await (const event of events) {
-				if (this.activeController.signal.aborted) break;
+				if (controller.signal.aborted) break;
 
 				switch (event.type) {
 					case 'thread.started':
@@ -284,7 +300,7 @@ export class CodexEngine implements AIEngine {
 				}
 			}
 
-			yield buildResultEvent(state, this.activeController.signal.aborted);
+			yield buildResultEvent(state, controller.signal.aborted);
 		} catch (error) {
 			handleStreamError(error);
 		} finally {
@@ -295,23 +311,34 @@ export class CodexEngine implements AIEngine {
 			} catch (snapshotErr) {
 				debug.warn('engine', 'Codex: post-stream auth.json snapshot failed (non-fatal):', snapshotErr);
 			}
-			this.activeThread = null;
-			this.activeController = null;
+			// Retire THIS run only — another chat session of the same project may
+			// still be streaming on this instance.
+			this.runs.remove(run);
 		}
 	}
 
-	async cancel(): Promise<void> {
+	/**
+	 * Cancel the run whose AbortController is `owner`, and only that run.
+	 */
+	async cancel(owner: AbortController): Promise<void> {
+		await this.stopRuns(this.runs.select(owner));
+	}
+
+	/**
+	 * Tear down the given runs. `cancel` passes the one run it was asked to
+	 * stop; `dispose` passes them all. Nothing else may reach this.
+	 */
+	private async stopRuns(targets: CodexRun[]): Promise<void> {
 		// Abort the local controller so the for-await loop exits even if the
 		// SDK's signal propagation hangs.
-		if (this.activeController && !this.activeController.signal.aborted) {
-			this.activeController.abort();
+		for (const run of targets) {
+			if (!run.controller.signal.aborted) run.controller.abort();
+			this.runs.remove(run);
 		}
-		this.activeController = null;
-		this.activeThread = null;
 	}
 
-	async interrupt(): Promise<void> {
-		await this.cancel();
+	async interrupt(owner: AbortController): Promise<void> {
+		await this.stopRuns(this.runs.select(owner));
 	}
 
 	/**

--- a/backend/engine/adapters/copilot/stream.ts
+++ b/backend/engine/adapters/copilot/stream.ts
@@ -24,6 +24,7 @@ import { engineQueries } from '$backend/database/queries/engine-queries';
 import { resolveOsPath, getEngineUserConfigDir } from '$backend/utils/paths';
 import { debug } from '$shared/utils/logger';
 import { getCopilotMcpConfig } from '../../../mcp';
+import { EngineRuns } from '../run-registry';
 import { artifactFilter } from '$backend/profiles';
 import { syncSkills } from '$backend/skills';
 import { syncEngineArtifacts, buildArtifactsPromptContext } from '$backend/engine/artifact-sync';
@@ -107,13 +108,30 @@ interface PendingCopilotUserAnswer {
 	choices?: string[];
 }
 
+/**
+ * One stream in flight on this instance.
+ */
+interface CopilotRun {
+	/** Identity of the run — the controller the caller passed to streamQuery. */
+	controller: AbortController;
+	session: CopilotSession | null;
+	/** Correlates `onUserInputRequest` with the toolCallId seen on the event stream. */
+	pendingAskUserToolCallId: string | null;
+}
+
 export class CopilotEngine implements AIEngine {
 	readonly name = 'copilot' as const;
 
 	private _isInitialized = false;
 	private client: CopilotClient | null = null;
-	private activeSession: CopilotSession | null = null;
-	private activeController: AbortController | null = null;
+	/**
+	 * Every stream in flight, keyed by the AbortController its caller passed to
+	 * streamQuery. One instance serves all chat sessions of a project, so the
+	 * Copilot session of a stream belongs to the run — a field would hold only
+	 * the most recent one and cancelling any chat would abort another chat's
+	 * session.
+	 */
+	private runs = new EngineRuns<CopilotRun>();
 	private modelsCache: ModelInfo[] | null = null;
 	/**
 	 * Account ID currently baked into `this.client`. The Copilot SDK takes the
@@ -132,20 +150,20 @@ export class CopilotEngine implements AIEngine {
 	 *     NOT the toolCallId (see `node_modules/@github/copilot-sdk/dist/client.js::handleUserInputRequest`)
 	 *
 	 * To correlate the two we capture the most recent `toolCallId` from
-	 * those events into `pendingAskUserToolCallId`, then read it inside
-	 * the callback. Only one `ask_user` can be outstanding per session at
-	 * a time (the SDK blocks the agent's turn until the callback returns),
-	 * so a single-slot variable is sufficient.
+	 * those events into the run's `pendingAskUserToolCallId`, then read it
+	 * inside the callback. Only one `ask_user` can be outstanding per session
+	 * at a time (the SDK blocks the agent's turn until the callback returns),
+	 * so a single slot PER RUN is sufficient — but it cannot be a single slot
+	 * per instance, which two concurrent chats of a project would share.
 	 */
-	private pendingUserAnswers = new Map<string, PendingCopilotUserAnswer>();
-	private pendingAskUserToolCallId: string | null = null;
+	private pendingUserAnswers = new Map<string, PendingCopilotUserAnswer & { owner: CopilotRun }>();
 
 	get isInitialized(): boolean {
 		return this._isInitialized;
 	}
 
 	get isActive(): boolean {
-		return this.activeController !== null;
+		return this.runs.isActive;
 	}
 
 	async initialize(accountId?: number): Promise<void> {
@@ -178,7 +196,7 @@ export class CopilotEngine implements AIEngine {
 	}
 
 	async dispose(): Promise<void> {
-		await this.cancel();
+		await this.stopRuns(this.runs.all());
 
 		if (this.client) {
 			try {
@@ -242,7 +260,9 @@ export class CopilotEngine implements AIEngine {
 			throw new Error('Copilot client unavailable.');
 		}
 
-		this.activeController = abortController || new AbortController();
+		const controller = abortController || new AbortController();
+		const run: CopilotRun = { controller, session: null, pendingAskUserToolCallId: null };
+		this.runs.add(run);
 
 		// Active Profile for this stream — scopes artifacts + connectors.
 		const profileId = options.mcpContext?.profileId;
@@ -299,13 +319,13 @@ export class CopilotEngine implements AIEngine {
 			if (event.type === 'assistant.message' && event.data.toolRequests) {
 				for (const req of event.data.toolRequests) {
 					if (req.name === 'ask_user') {
-						this.pendingAskUserToolCallId = req.toolCallId;
+						run.pendingAskUserToolCallId = req.toolCallId;
 					}
 				}
 			} else if (event.type === 'tool.execution_start' && event.data.toolName === 'ask_user') {
-				this.pendingAskUserToolCallId = event.data.toolCallId;
+				run.pendingAskUserToolCallId = event.data.toolCallId;
 			} else if (event.type === 'user_input.requested' && event.data.toolCallId) {
-				this.pendingAskUserToolCallId = event.data.toolCallId;
+				run.pendingAskUserToolCallId = event.data.toolCallId;
 			}
 			pushEvent(event);
 		};
@@ -314,7 +334,7 @@ export class CopilotEngine implements AIEngine {
 			finished = true;
 			pushEvent(null);
 		};
-		this.activeController.signal.addEventListener('abort', onAbort, { once: true });
+		controller.signal.addEventListener('abort', onAbort, { once: true });
 
 		const { approveAll } = await loadEngineSdk<typeof import('@github/copilot-sdk')>('copilot', '@github/copilot-sdk');
 
@@ -343,8 +363,8 @@ export class CopilotEngine implements AIEngine {
 					// to a synthetic id so `cancel()` can still release the
 					// Promise — but log loudly because the chat UI's answer
 					// submission won't reach this entry.
-					const captured = this.pendingAskUserToolCallId;
-					this.pendingAskUserToolCallId = null;
+					const captured = run.pendingAskUserToolCallId;
+					run.pendingAskUserToolCallId = null;
 					const toolCallId = captured ?? `copilot-ask-user-${crypto.randomUUID()}`;
 
 					if (captured) {
@@ -357,6 +377,7 @@ export class CopilotEngine implements AIEngine {
 						this.pendingUserAnswers.set(toolCallId, {
 							resolve,
 							choices: request.choices,
+							owner: run,
 						});
 					});
 				},
@@ -413,7 +434,7 @@ export class CopilotEngine implements AIEngine {
 				session = await this.client.createSession({ ...baseConfig } as SessionConfig);
 			}
 
-			this.activeSession = session;
+			run.session = session;
 			state.sessionId = session.sessionId;
 
 			// Send the prompt — fire-and-forget; events arrive via the queue.
@@ -440,7 +461,7 @@ export class CopilotEngine implements AIEngine {
 
 			// Drain the event queue.
 			while (!finished) {
-				if (this.activeController.signal.aborted) break;
+				if (controller.signal.aborted) break;
 
 				const event: SessionEvent | null = queue.length > 0
 					? queue.shift()!
@@ -448,7 +469,7 @@ export class CopilotEngine implements AIEngine {
 						waiter = resolve;
 					});
 
-				if (!event || this.activeController.signal.aborted) break;
+				if (!event || controller.signal.aborted) break;
 
 				// Resolve the parent Agent (`task`) tool call id for events
 				// originating inside a sub-agent. Null for the root agent and
@@ -582,54 +603,77 @@ export class CopilotEngine implements AIEngine {
 		} catch (error) {
 			handleStreamError(error);
 		} finally {
-			this.activeController.signal.removeEventListener('abort', onAbort);
+			controller.signal.removeEventListener('abort', onAbort);
 
-			if (this.activeSession) {
+			if (run.session) {
 				try {
-					await this.activeSession.disconnect();
+					await run.session.disconnect();
 				} catch (error) {
 					debug.warn('engine', 'Copilot session.disconnect failed (non-fatal):', error);
 				}
 			}
-			this.activeSession = null;
-			this.activeController = null;
+			// Retire THIS run only — another chat session of the same project may
+			// still be streaming on this instance.
+			this.forgetRun(run);
 		}
 	}
 
-	async cancel(): Promise<void> {
-		// 1. Release any parked `onUserInputRequest` callbacks with an empty
-		// answer so the SDK isn't left blocked on a Promise that will never
-		// resolve. Empty `answer` + `wasFreeform: false` is the SDK-safe way
-		// to unblock without injecting fake user input.
-		for (const [, pending] of this.pendingUserAnswers) {
-			pending.resolve({ answer: '', wasFreeform: false });
+	/** Drop a finished run and the questions only it could answer. */
+	private forgetRun(run: CopilotRun): void {
+		this.runs.remove(run);
+		for (const [toolCallId, pending] of this.pendingUserAnswers) {
+			if (pending.owner === run) this.pendingUserAnswers.delete(toolCallId);
 		}
-		this.pendingUserAnswers.clear();
-		this.pendingAskUserToolCallId = null;
+		run.session = null;
+		run.pendingAskUserToolCallId = null;
+	}
 
-		// 2. Abort the local stream first so the loop exits even if RPC hangs.
-		const session = this.activeSession;
-		if (this.activeController && !this.activeController.signal.aborted) {
-			this.activeController.abort();
-		}
-		this.activeController = null;
+	/**
+	 * Cancel the run whose AbortController is `owner`, and only that run.
+	 */
+	async cancel(owner: AbortController): Promise<void> {
+		await this.stopRuns(this.runs.select(owner));
+	}
 
-		// 3. Tell the Copilot server to stop processing (with timeout).
-		if (session) {
-			try {
-				await Promise.race([
-					session.abort(),
-					new Promise<void>(resolve => setTimeout(resolve, ABORT_TIMEOUT_MS)),
-				]);
-				debug.log('engine', 'Copilot session aborted:', session.sessionId);
-			} catch (error) {
-				debug.warn('engine', 'Copilot session.abort failed (non-fatal):', error);
+	/**
+	 * Tear down the given runs. `cancel` passes the one run it was asked to
+	 * stop; `dispose` passes them all. Nothing else may reach this.
+	 */
+	private async stopRuns(targets: CopilotRun[]): Promise<void> {
+		for (const run of targets) {
+			// 1. Release THIS run's parked `onUserInputRequest` callbacks with an
+			// empty answer so the SDK isn't left blocked on a Promise that will
+			// never resolve. Empty `answer` + `wasFreeform: false` is the SDK-safe
+			// way to unblock without injecting fake user input. Another run's
+			// parked callback stays — its session is still live.
+			for (const [toolCallId, pending] of this.pendingUserAnswers) {
+				if (pending.owner !== run) continue;
+				pending.resolve({ answer: '', wasFreeform: false });
+				this.pendingUserAnswers.delete(toolCallId);
+			}
+
+			// 2. Abort the local stream first so the loop exits even if RPC hangs.
+			const session = run.session;
+			if (!run.controller.signal.aborted) run.controller.abort();
+			this.forgetRun(run);
+
+			// 3. Tell the Copilot server to stop processing (with timeout).
+			if (session) {
+				try {
+					await Promise.race([
+						session.abort(),
+						new Promise<void>(resolve => setTimeout(resolve, ABORT_TIMEOUT_MS)),
+					]);
+					debug.log('engine', 'Copilot session aborted:', session.sessionId);
+				} catch (error) {
+					debug.warn('engine', 'Copilot session.abort failed (non-fatal):', error);
+				}
 			}
 		}
 	}
 
-	async interrupt(): Promise<void> {
-		await this.cancel();
+	async interrupt(owner: AbortController): Promise<void> {
+		await this.stopRuns(this.runs.select(owner));
 	}
 
 	/**

--- a/backend/engine/adapters/cursor/stream.ts
+++ b/backend/engine/adapters/cursor/stream.ts
@@ -35,6 +35,7 @@ import { getCursorMcpConfig } from '../../../mcp';
 import { subagentQueries } from '$backend/database/queries';
 import { readSubagentMd } from '$backend/subagents/store';
 import { buildJsonPrompt, extractJson } from '../../structured-helpers';
+import { EngineRuns } from '../run-registry';
 import { getActiveCursorAccount, resolveCursorApiKey } from './credential';
 import { getCursorStore } from './environment';
 import { forkCursorAgent } from './session-fork';
@@ -97,16 +98,28 @@ function buildCursorModelSelection(modelId: string, reasoningEffort?: string): M
 	return { id: modelId, params: [{ id: paramId, value }] };
 }
 
+/**
+ * One stream in flight on this instance. This engine instance is shared by every
+ * chat session of a project, so the run and agent belong here, not in instance
+ * fields — those would hold only the most recently started stream, and
+ * cancelling any chat would then cancel another chat's Cursor run.
+ */
+interface CursorRunState {
+	/** Identity of the run — the controller the caller passed to streamQuery. */
+	controller: AbortController;
+	run: Run | null;
+	agent: SDKAgent | null;
+}
+
 export class CursorEngine implements AIEngine {
 	readonly name = 'cursor' as const;
 	private _isInitialized = false;
-	private activeController: AbortController | null = null;
-	private activeRun: Run | null = null;
-	private activeAgent: SDKAgent | null = null;
-	private pendingAsks = new Map<string, PendingAsk>();
+	private runs = new EngineRuns<CursorRunState>();
+	/** Parked AskUserQuestion callbacks → the run that asked. */
+	private pendingAsks = new Map<string, PendingAsk & { owner: CursorRunState }>();
 
 	get isInitialized(): boolean { return this._isInitialized; }
-	get isActive(): boolean { return this.activeController !== null; }
+	get isActive(): boolean { return this.runs.isActive; }
 
 	async initialize(): Promise<void> {
 		if (this._isInitialized) return;
@@ -115,7 +128,7 @@ export class CursorEngine implements AIEngine {
 	}
 
 	async dispose(): Promise<void> {
-		await this.cancel();
+		await this.stopRuns(this.runs.all());
 		this.pendingAsks.clear();
 		this._isInitialized = false;
 	}
@@ -153,7 +166,9 @@ export class CursorEngine implements AIEngine {
 		}
 		const apiKey = resolveCursorApiKey(account);
 
-		this.activeController = abortController || new AbortController();
+		const controller = abortController || new AbortController();
+		const runState: CursorRunState = { controller, run: null, agent: null };
+		this.runs.add(runState);
 		const resolvedProjectPath = resolveOsPath(projectPath);
 
 		// ── Active Profile scoping + artifact materialization ──
@@ -168,7 +183,7 @@ export class CursorEngine implements AIEngine {
 
 		// ── Tools: AskUserQuestion (in-process custom tool) + MCP (native config) ──
 		const askTool: SDKCustomTool = createAskUserQuestionTool({
-			register: (id, entry) => this.pendingAsks.set(id, entry),
+			register: (id, entry) => this.pendingAsks.set(id, { ...entry, owner: runState }),
 			unregister: (id) => this.pendingAsks.delete(id),
 			// Emit the tool_use with the COMPLETE questions from execute's args.
 			emit: (id, questions) => {
@@ -220,11 +235,11 @@ export class CursorEngine implements AIEngine {
 					...(agents ? { agents } : {}),
 				});
 		} catch (error) {
-			this.activeController = null;
+			this.runs.remove(runState);
 			handleStreamError(error);
 			return;
 		}
-		this.activeAgent = agent;
+		runState.agent = agent;
 		const sessionId = agent.agentId;
 
 		const converter = createCursorMessageConverter({ engine: engineMeta, sessionId });
@@ -260,11 +275,11 @@ export class CursorEngine implements AIEngine {
 					}
 				},
 			});
-			this.activeRun = run;
+			runState.run = run;
 
 			// Abort wiring: cancelling the stream cancels the Cursor run.
 			onAbort = () => { run.cancel().catch(() => { /* already terminal */ }); };
-			this.activeController.signal.addEventListener('abort', onAbort, { once: true });
+			controller.signal.addEventListener('abort', onAbort, { once: true });
 
 			// Drive the pull stream + result in the background, funnelling into the queue.
 			const settle = (async () => {
@@ -287,38 +302,63 @@ export class CursorEngine implements AIEngine {
 		} catch (error) {
 			handleStreamError(error);
 		} finally {
-			if (onAbort) this.activeController?.signal.removeEventListener('abort', onAbort);
+			if (onAbort) controller.signal.removeEventListener('abort', onAbort);
 			try { agent.close(); } catch { /* fire-and-forget */ }
-			this.activeRun = null;
-			this.activeAgent = null;
-			this.activeController = null;
-			this.pendingAsks.clear();
+			// Retire THIS run only — another chat session of the same project may
+			// still be streaming on this instance.
+			this.forgetRun(runState);
 		}
 	}
 
-	async cancel(): Promise<void> {
-		// Release any parked AskUserQuestion callbacks so a blocked run can settle.
-		for (const [, pending] of this.pendingAsks) {
-			pending.resolve('User did not answer the question.');
+	/** Drop a finished run and the asks only it could answer. */
+	private forgetRun(runState: CursorRunState): void {
+		this.runs.remove(runState);
+		for (const [id, pending] of this.pendingAsks) {
+			if (pending.owner === runState) this.pendingAsks.delete(id);
 		}
-		this.pendingAsks.clear();
-
-		// Abort the local controller first (cuts the for-await loop), then RPC.
-		if (this.activeController && !this.activeController.signal.aborted) {
-			this.activeController.abort();
-		}
-		this.activeController = null;
-
-		if (this.activeRun) {
-			try { await this.activeRun.cancel(); } catch { /* may already be terminal */ }
-		}
-		this.activeRun = null;
-		this.activeAgent = null;
+		runState.run = null;
+		runState.agent = null;
 	}
 
-	async interrupt(): Promise<void> {
-		if (this.activeRun) {
-			try { await this.activeRun.cancel(); } catch { /* ignore */ }
+	/**
+	 * Cancel the run whose AbortController is `owner`, and only that run.
+	 */
+	async cancel(owner: AbortController): Promise<void> {
+		await this.stopRuns(this.runs.select(owner));
+	}
+
+	/**
+	 * Tear down the given runs. `cancel` passes the one run it was asked to
+	 * stop; `dispose` passes them all. Nothing else may reach this.
+	 */
+	private async stopRuns(targets: CursorRunState[]): Promise<void> {
+		for (const runState of targets) {
+			// Release the parked AskUserQuestion callbacks of THIS run so it can
+			// settle. Another run's parked ask is left alone — it is still live and
+			// still waiting for a real answer.
+			for (const [id, pending] of this.pendingAsks) {
+				if (pending.owner !== runState) continue;
+				pending.resolve('User did not answer the question.');
+				this.pendingAsks.delete(id);
+			}
+
+			// Abort the local controller first (cuts the for-await loop), then RPC.
+			if (!runState.controller.signal.aborted) runState.controller.abort();
+
+			const run = runState.run;
+			this.forgetRun(runState);
+			if (run) {
+				try { await run.cancel(); } catch { /* may already be terminal */ }
+			}
+		}
+	}
+
+	async interrupt(owner: AbortController): Promise<void> {
+		const targets = this.runs.select(owner);
+		for (const runState of targets) {
+			if (runState.run) {
+				try { await runState.run.cancel(); } catch { /* ignore */ }
+			}
 		}
 	}
 

--- a/backend/engine/adapters/opencode/stream.ts
+++ b/backend/engine/adapters/opencode/stream.ts
@@ -51,6 +51,7 @@ import { getOpenCodeProfileDisabledToolIds } from '$backend/mcp';
 import { resolvePermissionsFromDb, matchesAny, type ResolvedPermissions } from '$backend/permissions';
 import { formatSessionError, handleStreamError } from './error-handler';
 import { buildJsonPrompt, extractJson } from '../../structured-helpers';
+import { EngineRuns } from '../run-registry';
 import { debug } from '$shared/utils/logger';
 
 /**
@@ -99,26 +100,49 @@ function buildOpenCodeToolDisableMap(permissions: ResolvedPermissions): Record<s
 // OpenCode Engine (per-project instance)
 // ============================================================================
 
+/**
+ * One stream in flight on this instance. Everything here used to be an instance
+ * field, which only worked while a project never had two chats streaming at once.
+ */
+interface OpenCodeRun {
+	/** Identity of the run — the controller the caller passed to streamQuery. */
+	controller: AbortController;
+	projectPath: string;
+	/** The pooled per-Profile server this run is bound to. */
+	server: ServerInstance | null;
+	/** The pool hold taken for this run, released when it ends. */
+	holder: { key: string; holderId: string } | null;
+	sessionId: string | null;
+}
+
+interface PendingQuestion {
+	requestId: string;
+	questions: Array<{ question: string }>;
+	/** The run that asked — its server is where the answer has to be posted. */
+	run: OpenCodeRun;
+}
+
 export class OpenCodeEngine implements AIEngine {
 	readonly name = 'opencode' as const;
 	private _isInitialized = false;
-	private _isActive = false;
-	private activeAbortController: AbortController | null = null;
-	private activeSessionId: string | null = null;
-	private activeProjectPath: string | null = null;
-	/** The pooled per-Profile server this instance's active stream is bound to. */
-	private activeServer: ServerInstance | null = null;
-	/** The pool hold taken for the running stream, released when it ends. */
-	private activeHolder: { key: string; holderId: string } | null = null;
-	/** Pending question requests keyed by tool callID → { requestId, questions } */
-	private pendingQuestions = new Map<string, { requestId: string; questions: Array<{ question: string }> }>();
+	/**
+	 * Every stream running on this instance, keyed by the AbortController its
+	 * caller passed to streamQuery. This instance is shared by all chat sessions
+	 * of a project, so anything a single stream owns — its session id, its pooled
+	 * server, its pool hold — belongs here and not in an instance field. A field
+	 * would hold only the most recent stream, and cancelling any chat would then
+	 * abort another chat's session and leak the hold of the one it overwrote.
+	 */
+	private runs = new EngineRuns<OpenCodeRun>();
+	/** Pending question requests keyed by tool callID → the asking run's reply target. */
+	private pendingQuestions = new Map<string, PendingQuestion>();
 
 	get isInitialized(): boolean {
 		return this._isInitialized;
 	}
 
 	get isActive(): boolean {
-		return this._isActive;
+		return this.runs.isActive;
 	}
 
 	/**
@@ -138,15 +162,11 @@ export class OpenCodeEngine implements AIEngine {
 	 * Does NOT dispose the shared client — that's handled by disposeOpenCodeClient().
 	 */
 	async dispose(): Promise<void> {
-		await this.cancel();
+		// Shutdown/retirement: every run on this instance goes, and each releases
+		// its own hold. An instance retired mid-stream still owes the pool those holds;
+		// without them the servers it was using would never become reapable.
+		await this.stopRuns(this.runs.all());
 		this.pendingQuestions.clear();
-		// An instance retired mid-stream still owes the pool its hold; without this
-		// the server it was using would never become reapable.
-		if (this.activeHolder) {
-			releaseServer(this.activeHolder.key, this.activeHolder.holderId);
-			this.activeHolder = null;
-		}
-		this.activeServer = null;
 		this._isInitialized = false;
 		debug.log('engine', 'Open Code engine instance disposed');
 	}
@@ -176,9 +196,15 @@ export class OpenCodeEngine implements AIEngine {
 			abortController
 		} = options;
 
-		this.activeAbortController = abortController || new AbortController();
-		this._isActive = true;
-		this.activeProjectPath = projectPath;
+		const controller = abortController || new AbortController();
+		const run: OpenCodeRun = {
+			controller,
+			projectPath,
+			server: null,
+			holder: null,
+			sessionId: null,
+		};
+		this.runs.add(run);
 
 		// Active Profile for this stream. Skills go into the prompt and commands
 		// into shared dirs; materialize those first, then bind to the per-Profile
@@ -203,8 +229,8 @@ export class OpenCodeEngine implements AIEngine {
 		// stream id is what makes that safe: a held server is never reaped.
 		const holderId = options.mcpContext?.streamId;
 		const server = await acquireServer({ mcpProfileFilter, subagentFilter, inlineAgents }, holderId);
-		this.activeServer = server;
-		this.activeHolder = holderId ? { key: server.key, holderId } : null;
+		run.server = server;
+		run.holder = holderId ? { key: server.key, holderId } : null;
 		const client = server.client;
 
 		// Resolve the permission policy once per stream; the permission event
@@ -255,7 +281,7 @@ export class OpenCodeEngine implements AIEngine {
 				sessionId = sessionResult.data?.id || crypto.randomUUID();
 			}
 
-			this.activeSessionId = sessionId;
+			run.sessionId = sessionId;
 
 			yield convertSystemInitMessage(sessionId, modelId);
 			yield convertStreamStart(sessionId);
@@ -263,7 +289,7 @@ export class OpenCodeEngine implements AIEngine {
 			// 1. Subscribe to event stream FIRST (before sending prompt)
 			const eventResult = await client.event.subscribe({
 				query: { directory: projectPath },
-				signal: this.activeAbortController.signal
+				signal: controller.signal
 			});
 
 			// 2. Send prompt asynchronously (non-blocking). Disabled tools enforce
@@ -385,7 +411,7 @@ export class OpenCodeEngine implements AIEngine {
 
 			if (eventResult?.stream) {
 				for await (const event of eventResult.stream) {
-					if (this.activeAbortController?.signal.aborted) break;
+					if (controller.signal.aborted) break;
 
 					const evt = event as { type: string; properties: Record<string, unknown> };
 					debug.log('engine', `[OC] event: ${evt.type}`);
@@ -760,6 +786,7 @@ export class OpenCodeEngine implements AIEngine {
 								this.pendingQuestions.set(props.tool.callID, {
 									requestId: props.id,
 									questions: props.questions,
+									run,
 								});
 								debug.log('engine', `[OC] question.asked: stored question ${props.id} for callID ${props.tool.callID}`);
 							}
@@ -785,7 +812,7 @@ export class OpenCodeEngine implements AIEngine {
 							if (blocked) {
 								debug.log('permissions', `⛔ Blocked tool "${rawTool}" (Clopen permission policy)`);
 							}
-							this.replyPermission(props.id, props.sessionID, blocked ? 'reject' : 'once');
+							this.replyPermission(run, props.id, props.sessionID, blocked ? 'reject' : 'once');
 							break;
 						}
 
@@ -804,45 +831,65 @@ export class OpenCodeEngine implements AIEngine {
 		} catch (error) {
 			handleStreamError(error);
 		} finally {
-			this._isActive = false;
-			this.activeAbortController = null;
-			this.activeSessionId = null;
-			this.activeProjectPath = null;
-			this.pendingQuestions.clear();
-			// Hand the server back. Until this runs the server is pinned, which is
-			// exactly what keeps a settings change from cutting this turn short.
-			if (this.activeHolder) {
-				releaseServer(this.activeHolder.key, this.activeHolder.holderId);
-				this.activeHolder = null;
-			}
+			// Retire THIS run only — a concurrent stream of another chat session in
+			// the same project is still using the instance.
+			this.forgetRun(run);
 		}
 	}
 
-	async cancel(): Promise<void> {
-		// Capture refs before clearing — needed for server-side abort below
-		const sessionId = this.activeSessionId;
-		const projectPath = this.activeProjectPath;
+	/**
+	 * Drop a finished run: unregister it, discard the questions only it could
+	 * answer, and hand its pooled server back. Until the hold is released the
+	 * server is pinned, which is exactly what keeps a settings change from
+	 * cutting that turn short.
+	 */
+	private forgetRun(run: OpenCodeRun): void {
+		this.runs.remove(run);
+		for (const [callId, pending] of this.pendingQuestions) {
+			if (pending.run === run) this.pendingQuestions.delete(callId);
+		}
+		if (run.holder) {
+			releaseServer(run.holder.key, run.holder.holderId);
+			run.holder = null;
+		}
+	}
 
+	/**
+	 * Cancel one run — the one whose AbortController is `owner` — or every run
+	 * when no owner is given (dispose/shutdown).
+	 *
+	 * Targeting matters here: an untargeted abort would tear down whichever
+	 * session id and hold this instance had on hand, which is another chat's as
+	 * soon as two sessions of the project stream at once.
+	 */
+	async cancel(owner: AbortController): Promise<void> {
+		await this.stopRuns(this.runs.select(owner));
+	}
+
+	/**
+	 * Tear down the given runs. `cancel` passes the one run it was asked to
+	 * stop; `dispose` passes them all. Nothing else may reach this.
+	 */
+	private async stopRuns(targets: OpenCodeRun[]): Promise<void> {
 		// 1. FIRST: Abort local stream processing immediately.
 		//    This breaks the SSE event stream and causes the for-await loop
 		//    in processStream() to throw AbortError, stopping all local processing.
 		//    Must happen BEFORE the HTTP call because client.session.abort() can
 		//    hang indefinitely if the OpenCode server is busy/unresponsive.
-		if (this.activeAbortController) {
-			this.activeAbortController.abort();
-			this.activeAbortController = null;
+		for (const run of targets) {
+			if (!run.controller.signal.aborted) run.controller.abort();
 		}
-		this._isActive = false;
-		this.activeSessionId = null;
-		this.activeProjectPath = null;
-		this.pendingQuestions.clear();
 
 		// 2. THEN: Tell the OpenCode server to stop processing (with timeout).
 		//    This is a courtesy cleanup — local processing is already stopped.
 		//    The server-side session would otherwise keep running (consuming
 		//    LLM API calls and compute resources) until it naturally completes.
-		const client = this.activeServer?.client ?? getClient();
-		if (client && sessionId) {
+		//    The pool hold is still held here on purpose — handing the server back
+		//    first could let it be reaped out from under this very call.
+		for (const run of targets) {
+			const client = run.server?.client ?? getClient();
+			const { sessionId, projectPath } = run;
+			if (!client || !sessionId) continue;
 			try {
 				await Promise.race([
 					client.session.abort({
@@ -856,32 +903,15 @@ export class OpenCodeEngine implements AIEngine {
 				debug.warn('engine', 'Failed to abort Open Code session (non-fatal):', error);
 			}
 		}
+
+		// 3. Retire the runs. Each hands its own pooled server back; a run that
+		//    never got as far as binding one simply has nothing to release.
+		for (const run of targets) this.forgetRun(run);
 	}
 
-	/**
-	 * Cancel a specific session on the OpenCode server.
-	 * Used by stream-manager for per-project isolation (instead of global cancel).
-	 */
-	async cancelSession(sessionId: string, projectPath?: string): Promise<void> {
-		const client = this.activeServer?.client ?? getClient();
-		if (!client || !sessionId) return;
-		try {
-			await Promise.race([
-				client.session.abort({
-					path: { id: sessionId },
-					...(projectPath && { query: { directory: projectPath } }),
-				}),
-				new Promise<void>(resolve => setTimeout(resolve, 5000))
-			]);
-			debug.log('engine', 'Open Code session aborted (per-stream):', sessionId);
-		} catch (error) {
-			debug.warn('engine', 'Failed to abort Open Code session (non-fatal):', error);
-		}
-	}
-
-	async interrupt(): Promise<void> {
+	async interrupt(owner: AbortController): Promise<void> {
 		// Open Code SDK doesn't have a separate interrupt — use cancel
-		await this.cancel();
+		await this.stopRuns(this.runs.select(owner));
 	}
 
 	/**
@@ -903,7 +933,7 @@ export class OpenCodeEngine implements AIEngine {
 				const answer = answers[q.question];
 				return answer ? [answer] : [];
 			});
-			this.replyToQuestion(pending.requestId, orderedAnswers);
+			this.replyToQuestion(pending.run, pending.requestId, orderedAnswers);
 			this.pendingQuestions.delete(toolUseId);
 			return true;
 		}
@@ -917,14 +947,18 @@ export class OpenCodeEngine implements AIEngine {
 	/**
 	 * POST /question/{requestID}/reply to send user answers back to the OpenCode server.
 	 */
-	private replyToQuestion(requestId: string, orderedAnswers: string[][]): void {
-		const serverUrl = this.activeServer?.url ?? getServerUrl();
+	private replyToQuestion(run: OpenCodeRun | null, requestId: string, orderedAnswers: string[][]): void {
+		const serverUrl = run?.server?.url ?? getServerUrl();
 		if (!serverUrl) {
 			debug.warn('engine', 'replyToQuestion: Server URL not available');
 			return;
 		}
 
-		const dirParam = this.activeProjectPath ? `?directory=${encodeURIComponent(this.activeProjectPath)}` : '';
+		// The answer must go back to the server that asked. Concurrent streams of
+		// one project can sit on different pooled servers (different Profiles), so
+		// a shared "current server" would post this reply into the wrong one and
+		// leave the asking session waiting forever.
+		const dirParam = run?.projectPath ? `?directory=${encodeURIComponent(run.projectPath)}` : '';
 		const url = `${serverUrl}/question/${requestId}/reply${dirParam}`;
 		debug.log('engine', `Replying to question ${requestId}:`, orderedAnswers);
 
@@ -948,14 +982,18 @@ export class OpenCodeEngine implements AIEngine {
 	 * Fallback: GET /question to list pending questions, find the matching one, and reply.
 	 */
 	private async fetchAndReplyToQuestion(toolUseId: string, answers: Record<string, string>): Promise<void> {
-		const serverUrl = this.activeServer?.url ?? getServerUrl();
+		// No stored question means no known run — fall back to the single
+		// still-running one when there is exactly one, else the shared client.
+		const running = this.runs.all();
+		const run = running.length === 1 ? running[0] : null;
+		const serverUrl = run?.server?.url ?? getServerUrl();
 		if (!serverUrl) {
 			debug.warn('engine', 'fetchAndReplyToQuestion: Server URL not available');
 			return;
 		}
 
 		try {
-			const dirParam = this.activeProjectPath ? `?directory=${encodeURIComponent(this.activeProjectPath)}` : '';
+			const dirParam = run?.projectPath ? `?directory=${encodeURIComponent(run.projectPath)}` : '';
 			const res = await fetch(`${serverUrl}/question${dirParam}`);
 			if (!res.ok) {
 				debug.error('engine', `Failed to list pending questions: ${res.status}`);
@@ -978,7 +1016,7 @@ export class OpenCodeEngine implements AIEngine {
 				const answer = answers[q.question];
 				return answer ? [answer] : [];
 			});
-			this.replyToQuestion(matching.id, orderedAnswers);
+			this.replyToQuestion(run, matching.id, orderedAnswers);
 		} catch (error) {
 			debug.error('engine', 'Failed to fetch and reply to question:', error);
 		}
@@ -990,8 +1028,8 @@ export class OpenCodeEngine implements AIEngine {
 	 * by the permission policy. Uses direct HTTP since the v1 client may not have
 	 * the v2 permission.reply method.
 	 */
-	private replyPermission(permissionId: string, sessionId: string, response: 'once' | 'reject'): void {
-		const serverUrl = this.activeServer?.url ?? getServerUrl();
+	private replyPermission(run: OpenCodeRun, permissionId: string, sessionId: string, response: 'once' | 'reject'): void {
+		const serverUrl = run.server?.url ?? getServerUrl();
 		if (!serverUrl) return;
 		const verb = response === 'reject' ? 'rejected' : 'approved';
 
@@ -1006,12 +1044,12 @@ export class OpenCodeEngine implements AIEngine {
 				return;
 			}
 			// v2 endpoint not available — try v1
-			const client = this.activeServer?.client ?? getClient();
+			const client = run.server?.client ?? getClient();
 			if (client) {
 				client.postSessionIdPermissionsPermissionId({
 					path: { id: sessionId, permissionID: permissionId },
 					body: { response },
-					...(this.activeProjectPath && { query: { directory: this.activeProjectPath } }),
+					...(run.projectPath && { query: { directory: run.projectPath } }),
 				}).then(() => {
 					debug.log('engine', `[OC] ${verb} permission ${permissionId} (v1)`);
 				}).catch(err => {

--- a/backend/engine/adapters/pi/stream.ts
+++ b/backend/engine/adapters/pi/stream.ts
@@ -39,6 +39,7 @@ import { syncEngineArtifacts } from '$backend/engine/artifact-sync';
 import { artifactFilter } from '$backend/profiles';
 import { resolvePermissionsFromDb, isToolAllowed } from '$backend/permissions';
 import { buildJsonPrompt, extractJson } from '../../structured-helpers';
+import { EngineRuns } from '../run-registry';
 import { DbCredentialStore, getPiAccountForProvider, parsePiCredential } from './credential';
 import { createPiRuntime } from './presets';
 import { getPiAgentDir } from './environment';
@@ -88,15 +89,27 @@ class EventQueue<T> {
 	}
 }
 
+/**
+ * One stream in flight on this instance. This engine instance is shared by every
+ * chat session of a project, so the Pi session belongs here, not in an instance
+ * field — a field would hold only the most recently started stream, and
+ * cancelling any chat would then abort another chat's session.
+ */
+interface PiRun {
+	/** Identity of the run — the controller the caller passed to streamQuery. */
+	controller: AbortController;
+	session: AgentSession | null;
+}
+
 export class PiEngine implements AIEngine {
 	readonly name = 'pi' as const;
 	private _isInitialized = false;
-	private activeController: AbortController | null = null;
-	private activeSession: AgentSession | null = null;
-	private pendingAsks = new Map<string, PendingAsk>();
+	private runs = new EngineRuns<PiRun>();
+	/** Parked AskUserQuestion callbacks → the run that asked. */
+	private pendingAsks = new Map<string, PendingAsk & { owner: PiRun }>();
 
 	get isInitialized(): boolean { return this._isInitialized; }
-	get isActive(): boolean { return this.activeController !== null; }
+	get isActive(): boolean { return this.runs.isActive; }
 
 	async initialize(): Promise<void> {
 		if (this._isInitialized) return;
@@ -105,7 +118,8 @@ export class PiEngine implements AIEngine {
 	}
 
 	async dispose(): Promise<void> {
-		await this.cancel();
+		// Shutdown/retirement: every run on this instance goes.
+		await this.stopRuns(this.runs.all());
 		this.pendingAsks.clear();
 		this._isInitialized = false;
 	}
@@ -139,7 +153,9 @@ export class PiEngine implements AIEngine {
 			throw new Error(`Pi could not resolve model "${modelId}" for provider "${provider}".`);
 		}
 
-		this.activeController = abortController || new AbortController();
+		const controller = abortController || new AbortController();
+		const run: PiRun = { controller, session: null };
+		this.runs.add(run);
 		const resolvedProjectPath = resolveOsPath(projectPath);
 		const agentDir = getPiAgentDir();
 
@@ -168,7 +184,7 @@ export class PiEngine implements AIEngine {
 		// ── Tools: builtins (permission-filtered) + AskUserQuestion + MCP bridge + subagents ──
 		const allowedBuiltins = PI_BUILTIN_TOOLS.filter((name) => isToolAllowed(permissions, name));
 		const askTool = createAskUserQuestionTool({
-			register: (id, entry) => this.pendingAsks.set(id, entry),
+			register: (id, entry) => this.pendingAsks.set(id, { ...entry, owner: run }),
 			unregister: (id) => this.pendingAsks.delete(id),
 		});
 		const mcpTools = await buildPiMcpTools(options.mcpContext, mcpProfileFilter);
@@ -272,7 +288,7 @@ export class PiEngine implements AIEngine {
 			sessionManager,
 			settingsManager: SettingsManager.inMemory({ retry: PI_RETRY }),
 		});
-		this.activeSession = session;
+		run.session = session;
 
 		const engineMeta: MessageEngine = {
 			type: 'pi',
@@ -295,7 +311,7 @@ export class PiEngine implements AIEngine {
 
 		// Abort wiring: cancelling the stream aborts the Pi session.
 		const onAbort = () => { void session.abort(); };
-		this.activeController.signal.addEventListener('abort', onAbort, { once: true });
+		controller.signal.addEventListener('abort', onAbort, { once: true });
 
 		// Prompt text + image attachments.
 		const promptText = prompt.content.filter((b) => b.type === 'text').map((b) => b.text).join('\n');
@@ -340,30 +356,53 @@ export class PiEngine implements AIEngine {
 		} catch (error) {
 			handleStreamError(error);
 		} finally {
-			this.activeController?.signal.removeEventListener('abort', onAbort);
+			controller.signal.removeEventListener('abort', onAbort);
 			unsubscribe();
 			try { session.dispose(); } catch { /* already disposed */ }
-			this.activeSession = null;
-			this.activeController = null;
-			this.pendingAsks.clear();
+			// Retire THIS run only — another chat session of the same project may
+			// still be streaming on this instance.
+			this.forgetRun(run);
 		}
 	}
 
-	async cancel(): Promise<void> {
-		if (this.activeController && !this.activeController.signal.aborted) {
-			this.activeController.abort();
+	/** Drop a finished run and the asks only it could answer. */
+	private forgetRun(run: PiRun): void {
+		this.runs.remove(run);
+		for (const [id, pending] of this.pendingAsks) {
+			if (pending.owner === run) this.pendingAsks.delete(id);
 		}
-		if (this.activeSession) {
-			try { await this.activeSession.abort(); } catch { /* may already be idle */ }
-		}
-		this.pendingAsks.clear();
-		this.activeSession = null;
-		this.activeController = null;
+		run.session = null;
 	}
 
-	async interrupt(): Promise<void> {
-		if (this.activeSession) {
-			try { await this.activeSession.abort(); } catch { /* ignore */ }
+	/**
+	 * Cancel the run whose AbortController is `owner`, and only that run.
+	 */
+	async cancel(owner: AbortController): Promise<void> {
+		await this.stopRuns(this.runs.select(owner));
+	}
+
+	/**
+	 * Tear down the given runs. `cancel` passes the one run it was asked to
+	 * stop; `dispose` passes them all. Nothing else may reach this.
+	 */
+	private async stopRuns(targets: PiRun[]): Promise<void> {
+		for (const run of targets) {
+			if (!run.controller.signal.aborted) run.controller.abort();
+			const session = run.session;
+			// Drop only this run's parked asks; another run's are still live.
+			this.forgetRun(run);
+			if (session) {
+				try { await session.abort(); } catch { /* may already be idle */ }
+			}
+		}
+	}
+
+	async interrupt(owner: AbortController): Promise<void> {
+		const targets = this.runs.select(owner);
+		for (const run of targets) {
+			if (run.session) {
+				try { await run.session.abort(); } catch { /* ignore */ }
+			}
 		}
 	}
 

--- a/backend/engine/adapters/qwen/stream.ts
+++ b/backend/engine/adapters/qwen/stream.ts
@@ -3,9 +3,10 @@
  *
  * Wraps `@qwen-code/sdk` into the AIEngine interface. The SDK manages a
  * `qwen` subprocess per `query()` call (CLI is bundled with the SDK from
- * v0.1.1+). We only own the per-project `Query` lifecycle, an
- * `AbortController`, and the single-slot `pendingAskUserQuestion` for the
- * blocking AskUserQuestion flow.
+ * v0.1.1+). We own the `Query` lifecycle, an `AbortController` and the
+ * `pendingAskUserQuestion` slot of the blocking AskUserQuestion flow — all of
+ * it per RUN, since one instance serves every chat session of a project and
+ * several of them can be streaming at the same time.
  *
  * Auth: paste-token only. `engine_accounts.credential` stores the
  * OpenAI-compatible API key; the active account is read on every stream
@@ -46,6 +47,7 @@ import { handleStreamError } from './error-handler';
 import { createSdkMessageConverter, toSdkUserMessage, type SdkMessageConverter } from './message-converter';
 import { fetchQwenModels } from './models';
 import { getQwenMcpConfig } from '../../../mcp';
+import { EngineRuns } from '../run-registry';
 import { artifactFilter } from '$backend/profiles';
 import { syncSkills } from '$backend/skills';
 import { syncEngineArtifacts } from '$backend/engine/artifact-sync';
@@ -65,29 +67,40 @@ interface PendingAskUserQuestion {
 	toolUseId: string | null;
 }
 
+/**
+ * One stream in flight on this instance. All of it used to be instance fields,
+ * which only held the most recently started stream — so a second chat in the
+ * same project silently took over the first one's query, converter and parked
+ * question, and cancelling either one tore down the wrong stream.
+ */
+interface QwenRun {
+	/** Identity of the run — the controller the caller passed to streamQuery. */
+	controller: AbortController;
+	query: Query | null;
+	/**
+	 * Live converter for this run — used by `resolveUserAnswer` to push the
+	 * user's answers into the converter state so the eventual AUQ tool_result
+	 * can be rewritten with the actual answers (the Qwen SDK's `canUseTool` →
+	 * AUQ tool execution path drops `answers` on the floor; see the comment
+	 * block at the top of `message-converter.ts` and the analysis in
+	 * `qwen/stream.ts::canUseTool` for AskUserQuestion).
+	 */
+	converter: SdkMessageConverter | null;
+	pendingAskUserQuestion: PendingAskUserQuestion | null;
+}
+
 export class QwenEngine implements AIEngine {
 	readonly name = 'qwen' as const;
 
 	private _isInitialized = false;
-	private activeController: AbortController | null = null;
-	private activeQuery: Query | null = null;
-	private pendingAskUserQuestion: PendingAskUserQuestion | null = null;
-	/**
-	 * Live converter for the current stream — used by `resolveUserAnswer` to
-	 * push the user's answers into the converter state so the eventual AUQ
-	 * tool_result can be rewritten with the actual answers (the Qwen SDK's
-	 * `canUseTool` → AUQ tool execution path drops `answers` on the floor; see
-	 * the comment block at the top of `message-converter.ts` and the analysis
-	 * in `qwen/stream.ts::canUseTool` for AskUserQuestion).
-	 */
-	private activeConverter: SdkMessageConverter | null = null;
+	private runs = new EngineRuns<QwenRun>();
 
 	get isInitialized(): boolean {
 		return this._isInitialized;
 	}
 
 	get isActive(): boolean {
-		return this.activeController !== null;
+		return this.runs.isActive;
 	}
 
 	async initialize(): Promise<void> {
@@ -97,8 +110,8 @@ export class QwenEngine implements AIEngine {
 	}
 
 	async dispose(): Promise<void> {
-		await this.cancel();
-		this.pendingAskUserQuestion = null;
+		// Shutdown/retirement: every run on this instance goes.
+		await this.stopRuns(this.runs.all());
 		this._isInitialized = false;
 	}
 
@@ -139,7 +152,9 @@ export class QwenEngine implements AIEngine {
 		}
 		const { env } = resolution;
 
-		this.activeController = abortController || new AbortController();
+		const controller = abortController || new AbortController();
+		const run: QwenRun = { controller, query: null, converter: null, pendingAskUserQuestion: null };
+		this.runs.add(run);
 		const resolvedProjectPath = resolveOsPath(projectPath);
 		// Active Profile for this stream — scopes artifacts + connectors.
 		const profileId = options.mcpContext?.profileId;
@@ -194,7 +209,7 @@ export class QwenEngine implements AIEngine {
 				// "Qwen OAuth free tier was discontinued" even though we've
 				// supplied OPENAI_API_KEY / OPENAI_BASE_URL.
 				authType: 'openai',
-				abortController: this.activeController,
+				abortController: controller,
 				includePartialMessages,
 				stderr: (msg: string) => {
 					const trimmed = msg.replace(/\s+$/, '');
@@ -273,11 +288,11 @@ export class QwenEngine implements AIEngine {
 								// Claude (see claude/stream.ts cancel()). Resolving
 								// would prompt the SDK to write the result to a
 								// subprocess that's about to die.
-								this.pendingAskUserQuestion = null;
+								run.pendingAskUserQuestion = null;
 							};
 							ctx.signal.addEventListener('abort', onAbort, { once: true });
 
-							this.pendingAskUserQuestion = {
+							run.pendingAskUserQuestion = {
 								resolve: (result) => {
 									ctx.signal.removeEventListener('abort', onAbort);
 									resolve(result);
@@ -308,7 +323,7 @@ export class QwenEngine implements AIEngine {
 
 			const { query } = await loadEngineSdk<typeof import('@qwen-code/sdk')>('qwen', '@qwen-code/sdk');
 			const queryInstance = query({ prompt: promptIterable, options: sdkOptions });
-			this.activeQuery = queryInstance;
+			run.query = queryInstance;
 
 			const converter = createSdkMessageConverter(modelId, {
 				onAskUserQuestionEmitted: (toolUseId: string) => {
@@ -317,55 +332,68 @@ export class QwenEngine implements AIEngine {
 					// the pending slot here unblocks `resolveUserAnswer` even
 					// when the frontend gets the toolUseId before our slot was
 					// populated (rare but possible if the SDK queues events).
-					if (this.pendingAskUserQuestion && this.pendingAskUserQuestion.toolUseId === null) {
-						this.pendingAskUserQuestion.toolUseId = toolUseId;
+					if (run.pendingAskUserQuestion && run.pendingAskUserQuestion.toolUseId === null) {
+						run.pendingAskUserQuestion.toolUseId = toolUseId;
 					}
 				},
 			});
-			this.activeConverter = converter;
+			run.converter = converter;
 			for await (const sdkMessage of queryInstance) {
 				yield* converter.convert(sdkMessage);
 			}
 		} catch (error) {
 			handleStreamError(error, stderrLines.join('\n'));
 		} finally {
-			this.activeController = null;
-			this.activeQuery = null;
-			this.activeConverter = null;
+			// Retire THIS run only — another chat session of the same project may
+			// still be streaming on this instance.
+			this.runs.remove(run);
 		}
 	}
 
-	async cancel(): Promise<void> {
-		// Drop the pending AskUserQuestion handler — same pattern as Claude
-		// (don't resolve, just abandon, otherwise the SDK tries to write to
-		// a subprocess that's about to die).
-		if (this.pendingAskUserQuestion) {
-			this.pendingAskUserQuestion.removeAbortListener();
-			this.pendingAskUserQuestion = null;
-		}
+	/**
+	 * Cancel the run whose AbortController is `owner`, and only that run.
+	 */
+	async cancel(owner: AbortController): Promise<void> {
+		await this.stopRuns(this.runs.select(owner));
+	}
 
-		if (this.activeQuery && typeof this.activeQuery.close === 'function') {
-			try {
-				await this.activeQuery.close();
-			} catch {
-				/* subprocess may already be dead */
+	/**
+	 * Tear down the given runs. `cancel` passes the one run it was asked to
+	 * stop; `dispose` passes them all. Nothing else may reach this.
+	 */
+	private async stopRuns(targets: QwenRun[]): Promise<void> {
+		for (const run of targets) {
+			// Drop this run's pending AskUserQuestion handler — same pattern as
+			// Claude (don't resolve, just abandon, otherwise the SDK tries to write
+			// to a subprocess that's about to die). Another run's parked question
+			// is left alone; its subprocess is still alive and still waiting.
+			if (run.pendingAskUserQuestion) {
+				run.pendingAskUserQuestion.removeAbortListener();
+				run.pendingAskUserQuestion = null;
 			}
-		}
 
-		if (this.activeController && !this.activeController.signal.aborted) {
-			this.activeController.abort();
+			if (run.query && typeof run.query.close === 'function') {
+				try {
+					await run.query.close();
+				} catch {
+					/* subprocess may already be dead */
+				}
+			}
+
+			if (!run.controller.signal.aborted) run.controller.abort();
+			this.runs.remove(run);
 		}
-		this.activeController = null;
-		this.activeQuery = null;
-		this.activeConverter = null;
 	}
 
-	async interrupt(): Promise<void> {
-		if (this.activeQuery && typeof this.activeQuery.interrupt === 'function') {
-			try {
-				await this.activeQuery.interrupt();
-			} catch {
-				/* fall through to cancel */
+	async interrupt(owner: AbortController): Promise<void> {
+		const targets = this.runs.select(owner);
+		for (const run of targets) {
+			if (run.query && typeof run.query.interrupt === 'function') {
+				try {
+					await run.query.interrupt();
+				} catch {
+					/* fall through to cancel */
+				}
 			}
 		}
 	}
@@ -453,8 +481,13 @@ export class QwenEngine implements AIEngine {
 	}
 
 	resolveUserAnswer(toolUseId: string, answers: Record<string, string>): boolean {
-		const pending = this.pendingAskUserQuestion;
-		if (!pending) {
+		// Find the run that parked this question: the one that already recorded
+		// this toolUseId, else the one still waiting for its id to arrive.
+		const running = this.runs.all();
+		const run = running.find(r => r.pendingAskUserQuestion?.toolUseId === toolUseId)
+			?? running.find(r => r.pendingAskUserQuestion && r.pendingAskUserQuestion.toolUseId === null);
+		const pending = run?.pendingAskUserQuestion ?? null;
+		if (!run || !pending) {
 			debug.warn('engine', 'Qwen resolveUserAnswer: no pending question');
 			return false;
 		}
@@ -474,13 +507,13 @@ export class QwenEngine implements AIEngine {
 		// tool_result body is `"User has provided the following answers:\n\n"`
 		// (empty). The converter intercepts that tool_result and replaces its
 		// content with the proper formatted answers we just stored.
-		this.activeConverter?.recordUserAnswer(toolUseId, answers);
+		run.converter?.recordUserAnswer(toolUseId, answers);
 
 		pending.resolve({
 			behavior: 'allow',
 			updatedInput: { ...pending.input, answers },
 		});
-		this.pendingAskUserQuestion = null;
+		run.pendingAskUserQuestion = null;
 		return true;
 	}
 }

--- a/backend/engine/adapters/run-registry.test.ts
+++ b/backend/engine/adapters/run-registry.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+
+import { EngineRuns } from './run-registry';
+
+// One engine instance serves every chat session of a project, so a cancel has to
+// name the stream it means. These cases are the difference between "Stop this
+// chat" and "Stop whatever this engine happens to be doing" — the second one
+// interrupted a different chat mid-answer.
+
+interface Run {
+	controller: AbortController;
+	label: string;
+}
+
+function registry(...labels: string[]) {
+	const runs = new EngineRuns<Run>();
+	const byLabel: Record<string, Run> = {};
+	for (const label of labels) {
+		byLabel[label] = runs.add({ controller: new AbortController(), label });
+	}
+	return { runs, byLabel };
+}
+
+describe('EngineRuns', () => {
+	test('an owner selects its own run and leaves the others alone', () => {
+		const { runs, byLabel } = registry('a', 'b');
+
+		expect(runs.select(byLabel.a.controller).map(r => r.label)).toEqual(['a']);
+		expect(runs.select(byLabel.b.controller).map(r => r.label)).toEqual(['b']);
+	});
+
+	test('an owner that already finished selects nothing', () => {
+		const { runs, byLabel } = registry('a', 'b');
+		runs.remove(byLabel.a);
+
+		// The tempting fallback — "target not found, so stop what's left" — is
+		// exactly the bug: it would take down 'b', a chat the user never stopped.
+		expect(runs.select(byLabel.a.controller)).toEqual([]);
+	});
+
+	test('all() returns every run, for dispose and shutdown', () => {
+		const { runs } = registry('a', 'b');
+
+		expect(runs.all().map(r => r.label).sort()).toEqual(['a', 'b']);
+	});
+
+	test('isActive stays true until the LAST run ends', () => {
+		const { runs, byLabel } = registry('a', 'b');
+
+		expect(runs.isActive).toBe(true);
+		runs.remove(byLabel.a);
+		// An engine retired mid-stream is disposed once it goes idle. Reporting
+		// idle here would dispose it out from under 'b'.
+		expect(runs.isActive).toBe(true);
+		runs.remove(byLabel.b);
+		expect(runs.isActive).toBe(false);
+	});
+
+	test('removing a run twice is not an error', () => {
+		const { runs, byLabel } = registry('a');
+
+		// cancel() and the stream's own `finally` both retire the run.
+		runs.remove(byLabel.a);
+		runs.remove(byLabel.a);
+		expect(runs.isActive).toBe(false);
+	});
+
+	test('an empty registry is not an error', () => {
+		const runs = new EngineRuns<Run>();
+
+		expect(runs.all()).toEqual([]);
+		expect(runs.select(new AbortController())).toEqual([]);
+		expect(runs.isActive).toBe(false);
+	});
+});

--- a/backend/engine/adapters/run-registry.ts
+++ b/backend/engine/adapters/run-registry.ts
@@ -1,0 +1,63 @@
+/**
+ * The runs an engine instance is currently serving.
+ *
+ * One instance is shared by every chat session of a project (see
+ * `getProjectEngine`), so at any moment it can be streaming several chats at
+ * once. Everything a single stream owns — its abort controller, its SDK query
+ * or session, its pooled server, its parked questions — therefore belongs to a
+ * RUN and not to the instance. An instance field holds only the most recently
+ * started stream, which is how "Stop this chat" came to abort a different chat
+ * of the same project.
+ *
+ * A run is identified by the AbortController its caller passed to
+ * `streamQuery`. That is the same object `StreamState.abortController` holds,
+ * so it is the one handle the stream-manager and the adapter already agree on —
+ * no ids to mint, no bookkeeping to keep in sync.
+ *
+ * Adapters own the SHAPE of a run (each SDK exposes different handles) and this
+ * class owns the BOOKKEEPING, so the targeting rules live in one place instead
+ * of eight.
+ */
+
+/** The one field every adapter's run state must expose: its own controller. */
+export interface EngineRun {
+	controller: AbortController;
+}
+
+export class EngineRuns<T extends EngineRun> {
+	private byController = new Map<AbortController, T>();
+
+	/** True while at least ONE run is in flight — the answer `AIEngine.isActive` owes its callers. */
+	get isActive(): boolean {
+		return this.byController.size > 0;
+	}
+
+	/** Register a run for the duration of one `streamQuery` call. */
+	add(run: T): T {
+		this.byController.set(run.controller, run);
+		return run;
+	}
+
+	/** Unregister a finished run. Idempotent — cancel and the stream's own `finally` both call it. */
+	remove(run: T): void {
+		this.byController.delete(run.controller);
+	}
+
+	/**
+	 * The run a targeted `cancel` / `interrupt` applies to.
+	 *
+	 * An owner that has already finished selects NOTHING. Falling back to "the
+	 * runs that are left" is what made Stop in one chat kill another chat of the
+	 * same project: the caller named a stream that had ended, and the engine
+	 * helpfully tore down whichever one it still had.
+	 */
+	select(owner: AbortController): T[] {
+		const run = this.byController.get(owner);
+		return run ? [run] : [];
+	}
+
+	/** Every run — for `dispose()` and shutdown, the only places that may stop them all. */
+	all(): T[] {
+		return [...this.byController.values()];
+	}
+}

--- a/backend/engine/docs/adapter-contract.md
+++ b/backend/engine/docs/adapter-contract.md
@@ -12,8 +12,8 @@ export interface AIEngine {
 
   initialize(accountId?: number): Promise<void>;  // lazy; idempotent
   dispose(): Promise<void>;           // called per-project & on shutdown
-  cancel(): Promise<void>;            // hard cancel
-  interrupt(): Promise<void>;         // soft stop
+  cancel(owner: AbortController): Promise<void>;     // hard cancel, ONE run
+  interrupt(owner: AbortController): Promise<void>;  // soft stop, ONE run
 
   streamQuery(options: EngineQueryOptions):
     AsyncGenerator<EngineOutput, void, unknown>;
@@ -31,10 +31,35 @@ Four invariants:
 1. **`streamQuery` is the only streaming output path.** It is an
    `AsyncGenerator<EngineOutput>`. The adapter translates SDK events into
    `EngineOutput` — that is all.
-2. **Streaming state lives on the instance.** Because `getProjectEngine`
-   returns one instance per `(projectId, engineType)`, the abort controller,
-   active query, `pendingUserAnswers`, and session ID are automatically
-   isolated per-project.
+2. **Streaming state lives on the RUN, never on the instance.**
+   `getProjectEngine` returns one instance per `(projectId, engineType)`, so an
+   instance is isolated from other *projects* — and shared by every chat session
+   *within* one project. Several of them stream at the same time. An
+   `activeController` / `activeQuery` / `activeSessionId` field therefore holds
+   whichever chat started last, and the earlier one silently loses its handles.
+   That is not theoretical: it is how `cancel()` came to abort a different chat
+   than the one the user stopped, how a finished stream made `isActive` report
+   idle while another was still running (letting engine retirement dispose it
+   mid-answer), and how OpenCode leaked a pooled-server hold per overwritten
+   stream.
+
+   So every adapter keeps a `private runs = new EngineRuns<XxxRun>()`
+   ([`adapters/run-registry.ts`](../adapters/run-registry.ts)) and puts each
+   stream's controller, SDK handle, session id, server binding and parked
+   questions in its own `XxxRun`. The registry keys runs by the AbortController
+   the caller passed to `streamQuery` — the same object
+   `StreamState.abortController` holds, so no id has to be minted or kept in
+   sync. `isActive` is `this.runs.isActive` (any run, not the latest one), the
+   stream's `finally` retires only its own run, and anything keyed by tool id
+   (`pendingUserAnswers`, `pendingAsks`, `pendingQuestions`) records which run
+   parked it so a cancel drops that run's entries alone.
+
+   `cancel(owner)` and `interrupt(owner)` take the run to stop, and the
+   parameter is required on purpose — there is no "cancel whatever you are
+   doing" for callers outside the adapter. Adapters implement the teardown once
+   in a private `stopRuns(targets)`, called with `this.runs.select(owner)` from
+   `cancel` and with `this.runs.all()` from `dispose()`. Stopping everything is
+   `dispose()`'s job; only shutdown and engine retirement get to ask for it.
 3. **Init is lazy & concurrency-safe.** The first `streamQuery` /
    `getAvailableModels` call triggers `initialize()`. Multiple parallel
    callers **must** share a single init promise. See:
@@ -61,7 +86,7 @@ share one instance instead of racing to build two.
 | Accessor                             | Kind  | Used for                                      |
 |--------------------------------------|-------|-----------------------------------------------|
 | `getEngine(type)`                    | async | Global singleton — `models:list`, settings    |
-| `getProjectEngine(projectId, type)`  | async | Streaming chat — isolated per-project         |
+| `getProjectEngine(projectId, type)`  | async | Streaming chat — one instance per project, shared by its chat sessions |
 | `findProjectEngine(projectId, type)` | sync  | An engine that must already exist — cancel, answer routing |
 
 `findProjectEngine` returns `undefined` rather than creating one: cancelling a
@@ -280,10 +305,16 @@ Important conventions:
 - Tool names **must** be canonicalised via `toCanonicalToolName(...)`
   (`shared/types/unified/tool.ts`) so the frontend renders the same UI for
   tools that have different names across SDKs.
+- `cancel()` targeting: act **only** on `this.runs.select(owner)`. Never fall
+  back to "the runs that are left" when the owner is gone — the caller named a
+  stream that already ended, and the runs that are left belong to other chats
+  (see invariant 2 and `adapters/run-registry.test.ts`).
 - `cancel()` ordering: **abort the local controller first**, **then** RPC
   to the SDK/server. RPCs can hang; the local abort cuts the `for await`
-  loop deterministically. See `OpenCodeEngine.cancel`,
-  `ClaudeCodeEngine.cancel`, `CopilotEngine.cancel`.
+  loop deterministically. Release shared resources (OpenCode's pool hold)
+  **after** the RPC, or the server can be reaped mid-call. See
+  `OpenCodeEngine.stopRuns`, `ClaudeCodeEngine.stopRuns`,
+  `CopilotEngine.stopRuns`.
 - Dynamic-catalog fetchers in `models.ts` MUST return `EngineModel[]` and
   use `[]` as the failure sentinel (network, auth, parse error). Do **not**
   return `null` — both `fetchOpenCodeModels` and `fetchQwenModels` return

--- a/backend/engine/docs/adding-an-engine.md
+++ b/backend/engine/docs/adding-an-engine.md
@@ -298,6 +298,14 @@ Then the minimum UI scenarios that must pass:
       Active account: <name>`.
 - [ ] Chat input → pick NewEngine + model → send a message → assistant
       replies → cancel mid-stream → idle → send again → resume works.
+- [ ] **Two chats of the SAME project streaming at once.** Start one, start a
+      second, switch back to the first and Stop it: only that one stops, the
+      other keeps streaming and keeps rendering. Then Stop the second. One
+      instance serves both, so per-stream state on the adapter class shows up
+      here and nowhere else (§10.26).
+- [ ] With those two chats still streaming, change the engine's account or
+      config in Settings. Neither chat may be cut short — retirement waits for
+      `isActive`, which must count every run and not just the newest one.
 - [ ] AskUserQuestion (if the SDK supports it) → appears in UI → submit
       answer → stream continues.
 - [ ] Reasoning effort (if the engine has a knob) → the pill appears for

--- a/backend/engine/docs/frontend-and-chat.md
+++ b/backend/engine/docs/frontend-and-chat.md
@@ -299,6 +299,33 @@ Backend `chat:stream` then `streamManager.startStream(...)`, which:
 > (`claude`, `copilot`) read this and override their per-stream credential
 > accordingly.
 
+### 6.3a Stop path → backend
+
+Stop is `chatService.cancelRequest()` → `ws.emit('chat:cancel', { chatSessionId })`
+→ `streamManager.cancelStream(streamId)` → `engine.cancel(streamState.abortController)`.
+
+Every hop names a session or a run explicitly, because both halves once
+resolved it from ambient state and both stopped the wrong chat:
+
+- **The target is the session on screen** — `sessionState.currentSession`,
+  nothing else. The service used to prefer a `currentSessionId` remembered from
+  the last message this client *sent*, which is a different session the moment
+  two chats stream at once.
+- **Stream bookkeeping is per session.** `processId`, `streamCompleted`, the
+  cancelled-processId set and the cancel safety timer live in a
+  `Map<sessionId, …>` inside `chat.service.ts`. Stream events carry no
+  `chatSessionId` — they are routed by chat-session room and a client is joined
+  to exactly the room it is viewing, so the viewed session is the authoritative
+  owner of every incoming event.
+- **The backend cancels one run**, identified by `StreamState.abortController`.
+  See invariant 2 in [adapter-contract](./adapter-contract.md) and §10.26 in
+  [lessons-learned](./lessons-learned.md).
+
+Catchup (`ChatInput.svelte::catchupActiveStream` → `chatService.reconnectToStream`)
+is keyed by `projectId:sessionId` for the same reason: a project-only key made an
+intra-project session switch skip catchup, so the session switched to never
+re-attached to its own live stream.
+
 ### 6.4 Reasoning, attachments, AskUserQuestion
 
 - **Reasoning (output)**: an adapter must emit

--- a/backend/engine/docs/lessons-learned.md
+++ b/backend/engine/docs/lessons-learned.md
@@ -1508,3 +1508,73 @@ The mechanical part of an upgrade is cheap; budget the time for the union
 diffs. `/tmp`-installing the old and new versions side by side and diffing the
 `type: "…"` literals in each SDK's event declarations found every item above in
 minutes.
+
+---
+
+### 10.26 One engine instance, many chats — per-stream state cannot live on it
+
+A user with two chats streaming in one project pressed **Stop** in one of them.
+Both stopped.
+
+`getProjectEngine(projectId, type)` returns one instance per project, and the
+adapters read that as "one stream at a time". Every one of the eight kept the
+running stream's handles in instance fields:
+
+```ts
+private activeController: AbortController | null = null;
+private activeQuery: Query | null = null;          // opencode: activeSessionId,
+                                                   // activeServer, activeHolder
+```
+
+Clopen's stream-manager has always allowed concurrent streams — one per
+`(project, chat session)`, not one per project. So the second chat to start
+overwrote the first chat's handles, and `cancel()` operated on whatever was in
+the fields:
+
+- **Stop hit the wrong chat.** With chats A and B streaming, cancelling A ran
+  `client.session.abort(activeSessionId)` — B's id. Both died. Before a
+  frontend fix that made Stop target the *viewed* session, the mis-target on
+  each side cancelled out and the bug read as "Stop needs two presses".
+- **`isActive` lied.** The first stream's `finally` nulled the shared fields,
+  so the instance reported idle while the second was still running. Engine
+  retirement (§10.14's successor: evict now, dispose once idle) took that at
+  face value and disposed the engine mid-answer — the exact bug retirement was
+  built to prevent.
+- **Resources leaked.** OpenCode's `activeHolder` is the pool hold that keeps a
+  per-Profile server from being reaped. The second stream overwrote it, so the
+  first stream's hold was never released and that server was pinned forever.
+- **Replies went to the wrong server.** Two chats on different Profiles sit on
+  different pooled servers; permission and question replies read
+  `this.activeServer`, so one chat's approval was POSTed into the other's
+  server and its own tool call sat waiting.
+
+The fix is structural, not a guard: per-stream state moved into an
+`EngineRuns<XxxRun>` registry ([`adapters/run-registry.ts`](../adapters/run-registry.ts))
+keyed by the AbortController the caller passed to `streamQuery` — the same
+object `StreamState.abortController` holds, so the stream-manager and the
+adapter already agree on it without minting an id. `isActive` counts runs, the
+stream's `finally` retires only its own, and each adapter implements teardown
+once in `stopRuns(targets)`.
+
+Three details worth keeping:
+
+- **`cancel(owner)` takes a required parameter.** An optional one invites
+  `cancel()` at a call site that has a specific stream in mind, which is the
+  original bug with a nicer signature. Stopping every run is `dispose()`'s job.
+- **An owner that has already finished cancels nothing.** The tempting fallback
+  — "not found, so stop what's left" — reproduces the bug exactly: the runs that
+  are left belong to other chats. This is the case `run-registry.test.ts` pins.
+- **Release shared resources after the RPC, not before.** OpenCode's hold is
+  handed back only once `session.abort()` has returned; releasing first can let
+  the server be reaped out from under that very call.
+
+One boundary this does **not** cover: `isActive` counts streaming runs, so a
+`generateStructured` call in flight still reads as idle. Those run on the global
+singleton tier (`initializeEngine`), not the per-project one, so they are a
+separate problem — but if a future engine routes one-shot generation through a
+project engine, it has to register a run like everything else.
+
+What made this survive so long is that the contract doc *taught* it: invariant 2
+used to read "Streaming state lives on the instance … automatically isolated
+per-project". It was true about projects and silently wrong about chat sessions.
+When an invariant is scoped, write down what it does **not** cover.

--- a/backend/engine/docs/quick-reference.md
+++ b/backend/engine/docs/quick-reference.md
@@ -19,7 +19,9 @@
 | Usage backfill (once-per-turn engines)      | `backend/chat/stream-manager.ts::backfillUsageForStream` (Codex + Cursor; §10.20-I) |
 | Context window unknown → "?" not 100%       | `frontend/utils/context-manager.ts` (`unknown`) + `frontend/components/chat/widgets/ContextIndicator.svelte` (§10.20-J) |
 | Reasoning stream lifecycle                  | `opencode/stream.ts::flushReasoning`, `copilot/message-converter.ts::convertReasoningDelta` |
-| Cancel-before-RPC ordering                  | `opencode/stream.ts::cancel`, `claude/stream.ts::cancel`, `copilot/stream.ts::cancel`  |
+| Per-stream state on a shared instance       | `adapters/run-registry.ts::EngineRuns` (+ each adapter's `XxxRun`; §10.26) |
+| Cancel exactly one chat's stream            | `adapters/run-registry.ts::select` → `stream.ts::stopRuns`; stream-manager passes `streamState.abortController` |
+| Cancel-before-RPC ordering                  | `opencode/stream.ts::stopRuns`, `claude/stream.ts::stopRuns`, `copilot/stream.ts::stopRuns`  |
 | Fork session (native vs. on-disk vs. in-memory) | `claude/stream.ts` (`forkSession: true`), `opencode/stream.ts` (`client.session.fork`), `copilot/stream.ts` (`client.rpc.sessions.fork`), `codex/session-fork.ts` + `qwen/session-fork.ts` (copy disk state), `pi/session-fork.ts` (`SessionManager.forkFrom`), `cline/stream.ts` (**session-less** — fresh id per turn + in-memory copy-on-branch; see §10.10) |
 | Sub-agent (`Task`/`Agent`) routing          | `claude/message-converter.ts` (`parent_tool_use_id`), `opencode/message-converter.ts::convertSubtaskToolUseOnly`, `copilot/message-converter.ts::resolveParentToolUseId` + `agentParentMap`; **synthesized** `Agent` tool for bare-loop SDKs in `cline/agent-tool.ts` + `pi/agent-tool.ts` (see §10.15) |
 | File-backed Workflow activity (event-driven) | `claude/workflow-transcript.ts` (filesystem watchers, byte offsets, terminal status) + `claude/stream.ts::EventQueue` merge; no interval polling (§10.15) |

--- a/backend/engine/index.ts
+++ b/backend/engine/index.ts
@@ -8,10 +8,16 @@
  *   Used for non-streaming operations like models:list, settings, etc.
  *
  * - Per-project instances (getProjectEngine / initializeProjectEngine):
- *   Used by stream-manager for chat streaming.
- *   Each project gets its own engine instance so abort controllers,
- *   active queries, and session IDs are fully isolated.
- *   Cancelling Project A's stream never affects Project B.
+ *   Used by stream-manager for chat streaming. Cancelling Project A's stream
+ *   never affects Project B.
+ *
+ *   Per project, NOT per chat session: every chat session of a project shares
+ *   one instance, and several of them stream at once. Isolation between those
+ *   streams is the adapter's job, not this cache's — each keeps its per-stream
+ *   state in an `EngineRuns` registry (backend/engine/adapters/run-registry.ts)
+ *   and `cancel(owner)` stops exactly the run it was handed. Adding per-stream
+ *   state to an adapter INSTANCE reintroduces "Stop this chat" stopping a
+ *   different one.
  *
  * Adapters are loaded on first use, never at boot. This registry used to import
  * all eight statically, which coupled every user's startup to every adapter: one
@@ -238,8 +244,10 @@ const projectEngines = new Map<string, Map<EngineType, EngineSlot>>();
 
 /**
  * Get (or create) an engine instance scoped to a specific project.
- * Each project gets its own engine with independent state (abort controllers,
- * active queries, session IDs), ensuring complete stream isolation.
+ *
+ * Scoped per project, so one project's streams never reach another's. Within a
+ * project the instance is SHARED by every chat session — see the note at the
+ * top of this file for what that means for adapters.
  */
 export async function getProjectEngine(projectId: string, type: EngineType): Promise<AIEngine> {
 	let engines = projectEngines.get(projectId);

--- a/backend/engine/types.ts
+++ b/backend/engine/types.ts
@@ -81,13 +81,25 @@ export interface AIEngine {
 	 */
 	streamQuery(options: EngineQueryOptions): AsyncGenerator<EngineOutput, void, unknown>;
 
-	/** Cancel the active query */
-	cancel(): Promise<void>;
+	/**
+	 * Cancel ONE run — the stream whose AbortController is `owner`.
+	 *
+	 * One engine instance is shared by every chat session of a project, so it can
+	 * be streaming several chats at once. `owner` is the controller that stream
+	 * passed to `streamQuery`, and the same object `StreamState.abortController`
+	 * holds — the handle both sides already agree on. Adapters must stop that run
+	 * alone and leave the others streaming.
+	 *
+	 * The parameter is deliberately required: there is no "cancel whatever you
+	 * are doing" for callers. Stopping every run is `dispose()`'s job, and only
+	 * shutdown and engine retirement get to ask for it.
+	 */
+	cancel(owner: AbortController): Promise<void>;
 
-	/** Interrupt the active query (soft stop) */
-	interrupt(): Promise<void>;
+	/** Interrupt one run (soft stop). Targeted like `cancel`. */
+	interrupt(owner: AbortController): Promise<void>;
 
-	/** Check if a query is currently active */
+	/** True while at least ONE run is in flight — not just the most recent one. */
 	readonly isActive: boolean;
 
 	/** Return the list of models this engine supports */

--- a/frontend/components/chat/input/ChatInput.svelte
+++ b/frontend/components/chat/input/ChatInput.svelte
@@ -271,18 +271,22 @@
 
 	// Sync appState.isLoading from presence data (single source of truth for all users)
 	// Also fetch partial text and reconnect to stream for late-joining users / refresh
-	let lastCatchupProjectId: string | undefined;
+	// Keyed by project + session: two sessions of the same project can stream at
+	// once, so a project-only key made an intra-project session switch skip
+	// catchup entirely — the switched-to session never re-attached to its live
+	// stream and its output stopped updating.
+	let lastCatchupKey: string | undefined;
 	let lastPresenceProjectId: string | undefined;
 
 	// Reset catchup tracking on WS reconnect so catchupActiveStream re-runs.
 	// When WS briefly disconnects, the server-side cleanup removes the stream
 	// EventEmitter subscription. Without resetting, catchup won't fire again
-	// (guarded by lastCatchupProjectId) and the stream subscription is never
+	// (guarded by lastCatchupKey) and the stream subscription is never
 	// re-established — causing stream output to silently stop in the UI.
 	onWsReconnect(() => {
-		if (lastCatchupProjectId) {
+		if (lastCatchupKey) {
 			debug.log('chat', 'WS reconnected — resetting stream catchup tracking');
-			lastCatchupProjectId = undefined;
+			lastCatchupKey = undefined;
 		}
 	});
 
@@ -302,6 +306,7 @@
 			lastPresenceProjectId = projectId;
 		}
 
+		const catchupKey = sessionId ? `${projectId}:${sessionId}` : undefined;
 		const status = presenceState.statuses.get(projectId);
 		// Check if the active stream is for the CURRENT session (not just any session in the project)
 		const hasActiveForSession = status?.streams?.some(
@@ -314,28 +319,29 @@
 			appState.isLoading = true;
 
 			// Catch up on active stream's partial text for late-joining users
-			// Only do this once per project switch to avoid repeated fetches
+			// Only do this once per project+session switch to avoid repeated fetches
 			// Only attempt if session is available (may not be on initial load)
-			if (projectId !== lastCatchupProjectId && sessionId) {
-				lastCatchupProjectId = projectId;
+			if (catchupKey && catchupKey !== lastCatchupKey) {
+				lastCatchupKey = catchupKey;
 				catchupActiveStream(status);
 			}
-		} else if (hasActiveForSession && appState.isLoading && sessionId && projectId !== lastCatchupProjectId) {
-			// Session became available after loading was already set (e.g. page refresh)
-			// The first run set isLoading=true but couldn't catch up because session wasn't loaded yet
-			lastCatchupProjectId = projectId;
+		} else if (hasActiveForSession && appState.isLoading && catchupKey && catchupKey !== lastCatchupKey) {
+			// Session became available after loading was already set (e.g. page refresh),
+			// or the user switched to another session of this project that is still
+			// streaming — either way this session must re-attach to its live stream.
+			lastCatchupKey = catchupKey;
 			catchupActiveStream(status);
 		} else if (!hasActiveForSession && appState.isLoading && !appState.isCancelling) {
 			// Only clear loading if not in the middle of a cancel operation
 			appState.isLoading = false;
-			lastCatchupProjectId = undefined;
+			lastCatchupKey = undefined;
 		} else if (!hasActiveForSession && !appState.isLoading) {
 			// No active streams for this session — clear cancelling state and reset catchup tracking.
 			// This is the authoritative signal that the cancel is fully complete (presence confirmed).
 			if (appState.isCancelling) {
 				appState.isCancelling = false;
 			}
-			lastCatchupProjectId = undefined;
+			lastCatchupKey = undefined;
 		}
 	});
 

--- a/frontend/services/chat/chat.service.ts
+++ b/frontend/services/chat/chat.service.ts
@@ -11,7 +11,7 @@
  * - Proper presence synchronization
  */
 
-import { appState, updateSessionProcessState } from '$frontend/stores/core/app.svelte';
+import { appState, updateSessionProcessState, getSessionProcessState } from '$frontend/stores/core/app.svelte';
 import type { SessionProcessState } from '$frontend/stores/core/app.svelte';
 import { chatModelState } from '$frontend/stores/ui/chat-model.svelte';
 import { projectState } from '$frontend/stores/core/projects.svelte';
@@ -34,14 +34,28 @@ interface ChatServiceOptions {
 }
 import ws from '$frontend/utils/ws';
 
+/**
+ * Stream bookkeeping for ONE chat session.
+ *
+ * Streams run concurrently across sessions, so every piece of stream identity
+ * has to be keyed by chat session. A single global "current stream" pins itself
+ * to whichever session last sent a message and then mis-targets every later
+ * action — most visibly, Stop in session A cancelling session B's stream.
+ */
+interface SessionStreamState {
+  /** processId of this session's in-flight stream; null when idle. */
+  processId: string | null;
+  /** True once this session's stream ended locally (complete/error/cancel). */
+  streamCompleted: boolean;
+  /** Streams of THIS session that were cancelled/abandoned locally — their late events are dropped. */
+  cancelledProcessIds: Set<string>;
+  /** Fallback timer that clears a stuck `isCancelling` for this session. */
+  cancelSafetyTimer: ReturnType<typeof setTimeout> | null;
+}
+
 class ChatService {
-  private activeProcessId: string | null = null;
-  private streamCompleted: boolean = false;
-  private currentSessionId: string | null = null;
-  private lastEventSeq = new Map<string, number>(); // Sequence-based deduplication
-  private cancelledProcessIds = new Set<string>(); // Track ALL cancelled streams to ignore late events
-  private reconnected: boolean = false; // Whether we've reconnected to an active stream
-  private cancelSafetyTimer: ReturnType<typeof setTimeout> | null = null;
+  private streams = new Map<string, SessionStreamState>();
+  private lastEventSeq = new Map<string, number>(); // Sequence-based deduplication (processId → last seq)
 
   static loadingTexts: string[] = [
     'thinking', 'processing', 'analyzing', 'calculating', 'computing',
@@ -112,18 +126,50 @@ class ChatService {
   }
 
   /**
+   * Get (creating if needed) the stream bookkeeping for a chat session.
+   */
+  private streamFor(sessionId: string): SessionStreamState {
+    let state = this.streams.get(sessionId);
+    if (!state) {
+      state = {
+        processId: null,
+        streamCompleted: false,
+        cancelledProcessIds: new Set<string>(),
+        cancelSafetyTimer: null
+      };
+      this.streams.set(sessionId, state);
+    }
+    return state;
+  }
+
+  /**
+   * The session that owns the stream events currently arriving.
+   *
+   * Stream events (chat:connection/message/partial/complete/error/cancelled)
+   * carry no chatSessionId — the backend routes them by chat session room, and
+   * a client is only ever joined to the room of the session on screen (see
+   * setCurrentSession). So the viewed session IS the owner of every incoming
+   * stream event, and the only correct key for this bookkeeping.
+   */
+  private viewedStream(): { sessionId: string; state: SessionStreamState } | null {
+    const sessionId = sessionState.currentSession?.id;
+    if (!sessionId) return null;
+    return { sessionId, state: this.streamFor(sessionId) };
+  }
+
+  /**
    * Update process state for a session.
    * Writes to both the per-session map (for multi-session support)
    * and global convenience flags (for backward-compatible single-session components).
    *
    * @param update - Partial state to merge
-   * @param sessionId - Override session ID (defaults to this.currentSessionId or current session)
+   * @param sessionId - Target session ID (defaults to the session on screen)
    */
   private setProcessState(
     update: Partial<SessionProcessState>,
     sessionId?: string | null
   ): void {
-    const resolvedId = sessionId ?? this.currentSessionId ?? sessionState.currentSession?.id;
+    const resolvedId = sessionId ?? sessionState.currentSession?.id;
     if (resolvedId) {
       updateSessionProcessState(resolvedId, update);
     }
@@ -174,30 +220,36 @@ class ChatService {
 
     // Connection event - received by ALL users in the project
     ws.on('chat:connection', (data) => {
+      const ctx = this.viewedStream();
+      if (!ctx) return;
       if (this.shouldSkipEvent(data.processId, data.seq)) return;
       // Ignore events from a locally cancelled stream
-      if (data.processId && this.cancelledProcessIds.has(data.processId)) return;
+      if (data.processId && ctx.state.cancelledProcessIds.has(data.processId)) return;
 
-      this.activeProcessId = data.processId;
-      this.streamCompleted = false;
+      ctx.state.processId = data.processId;
+      ctx.state.streamCompleted = false;
     });
 
     // Message event
     ws.on('chat:message', (data) => {
+      const ctx = this.viewedStream();
+      if (!ctx) return;
       if (this.shouldSkipEvent(data.processId, data.seq)) return;
       // Ignore events from a locally cancelled stream
-      if (data.processId && this.cancelledProcessIds.has(data.processId)) return;
+      if (data.processId && ctx.state.cancelledProcessIds.has(data.processId)) return;
 
-      this.handleMessageEvent(data);
+      this.handleMessageEvent(data, ctx.state);
     });
 
     // Partial message event (streaming)
     ws.on('chat:partial', (data) => {
+      const ctx = this.viewedStream();
+      if (!ctx) return;
       if (this.shouldSkipEvent(data.processId, data.seq)) return;
       // Ignore events from a locally cancelled stream
-      if (data.processId && this.cancelledProcessIds.has(data.processId)) return;
+      if (data.processId && ctx.state.cancelledProcessIds.has(data.processId)) return;
 
-      this.handlePartialEvent(data);
+      this.handlePartialEvent(data, ctx.state);
     });
 
     // Notification event
@@ -235,21 +287,24 @@ class ChatService {
 
     // Complete event
     ws.on('chat:complete', async (data) => {
+      const ctx = this.viewedStream();
+      if (!ctx) return;
       if (this.shouldSkipEvent(data.processId, data.seq)) return;
       // Ignore late events from a locally cancelled stream
-      if (data.processId && this.cancelledProcessIds.has(data.processId)) return;
+      if (data.processId && ctx.state.cancelledProcessIds.has(data.processId)) return;
 
-      this.streamCompleted = true;
-      this.reconnected = false;
-      this.clearCancelSafetyTimer();
-      this.setProcessState({ isLoading: false, isWaitingInput: false, isCancelling: false });
+      ctx.state.streamCompleted = true;
+      ctx.state.processId = null;
+      this.clearCancelSafetyTimer(ctx.sessionId);
+      this.setProcessState({ isLoading: false, isWaitingInput: false, isCancelling: false }, ctx.sessionId);
 
       // Mark any tool_use blocks that never got a tool_result
       this.markInterruptedTools();
 
-      // Stream completed successfully — all old cancelled streams' events
-      // have definitely been delivered by now, so clear the blacklist.
-      this.cancelledProcessIds.clear();
+      // A completed stream means every late event of THIS session's older
+      // cancelled streams has been delivered, so its blacklist can go. Other
+      // sessions keep theirs — their streams may still be running.
+      ctx.state.cancelledProcessIds.clear();
 
       // Don't reload messages - they're already added via chat:message events
       // Reloading would cause duplicates
@@ -259,22 +314,23 @@ class ChatService {
 
     // Cancelled event - broadcast to ALL collaborators when any user cancels
     ws.on('chat:cancelled', async (data) => {
+      const ctx = this.viewedStream();
+      if (!ctx) return;
       // Track the cancelled processId so late-arriving events are blocked.
       // This handles the case where a collaborator initiated the cancel
       // (so our local cancelRequest was not called).
       if (data.processId) {
-        this.cancelledProcessIds.add(data.processId);
+        ctx.state.cancelledProcessIds.add(data.processId);
       }
-      this.streamCompleted = true;
-      this.reconnected = false;
-      this.activeProcessId = null;
-      this.clearCancelSafetyTimer();
+      ctx.state.streamCompleted = true;
+      ctx.state.processId = null;
+      this.clearCancelSafetyTimer(ctx.sessionId);
       // Don't clear isCancelling here — it causes a race with presence.
       // The chat:cancelled WS event arrives before broadcastPresence() updates,
       // so clearing isCancelling lets the presence $effect re-enable isLoading
       // (because hasActiveForSession is still true). The presence $effect will
       // clear isCancelling once the stream is actually gone from presence.
-      this.setProcessState({ isLoading: false, isWaitingInput: false });
+      this.setProcessState({ isLoading: false, isWaitingInput: false }, ctx.sessionId);
 
       // Mark any tool_use blocks that never got a tool_result
       this.markInterruptedTools();
@@ -284,16 +340,19 @@ class ChatService {
 
     // Error event
     ws.on('chat:error', async (data) => {
+      const ctx = this.viewedStream();
+      if (!ctx) return;
       if (this.shouldSkipEvent(data.processId, data.seq)) return;
-      if (this.streamCompleted) return;
+      if (ctx.state.streamCompleted) return;
       // Ignore late error events from a locally cancelled stream
-      if (data.processId && this.cancelledProcessIds.has(data.processId)) return;
+      if (data.processId && ctx.state.cancelledProcessIds.has(data.processId)) return;
 
       // Mark completed immediately to block any duplicate error events that may arrive
       // (e.g. from multiple subscriptions or late-arriving events with different processId/seq)
-      this.streamCompleted = true;
-      this.reconnected = false;
-      this.setProcessState({ isLoading: false, isWaitingInput: false, isCancelling: false });
+      ctx.state.streamCompleted = true;
+      ctx.state.processId = null;
+      this.clearCancelSafetyTimer(ctx.sessionId);
+      this.setProcessState({ isLoading: false, isWaitingInput: false, isCancelling: false }, ctx.sessionId);
 
       // Mark any tool_use blocks that never got a tool_result
       this.markInterruptedTools();
@@ -327,12 +386,13 @@ class ChatService {
   reconnectToStream(chatSessionId: string, processId: string): void {
     debug.log('chat', 'Reconnecting to active stream:', { chatSessionId, processId });
 
-    // Set up local state so events are processed and cancel works
-    this.activeProcessId = processId;
-    this.currentSessionId = chatSessionId;
-    this.streamCompleted = false;
-    this.cancelledProcessIds.clear();
-    this.reconnected = true;
+    // Set up this session's stream state so its events are processed again.
+    // Re-attaching is deliberate, so any block placed on this stream by a
+    // previous switch-away (resetForSessionSwitch) is lifted here.
+    const state = this.streamFor(chatSessionId);
+    state.processId = processId;
+    state.streamCompleted = false;
+    state.cancelledProcessIds.clear();
 
     // Tell backend to re-subscribe this connection to the stream
     ws.emit('chat:reconnect', {
@@ -392,15 +452,18 @@ class ChatService {
       return;
     }
 
-    // Set loading state
-    this.streamCompleted = false;
-    this.reconnected = false;
-    this.currentSessionId = sessionState.currentSession.id;
-    this.setProcessState({ isLoading: true, isWaitingInput: false, isCancelling: false });
-    // DON'T clear cancelledProcessIds — late events from previously cancelled
-    // streams must still be blocked. The set is cleared on stream complete.
-    // Clear sequence tracking for new stream
-    this.lastEventSeq.clear();
+    // Set loading state for the session being sent to
+    const targetSessionId = sessionState.currentSession.id;
+    const targetStream = this.streamFor(targetSessionId);
+    targetStream.streamCompleted = false;
+    this.setProcessState({ isLoading: true, isWaitingInput: false, isCancelling: false }, targetSessionId);
+    // DON'T clear this session's cancelledProcessIds — late events from its
+    // previously cancelled streams must still be blocked. The set is cleared
+    // when one of its streams completes.
+    // Drop sequence tracking for THIS session's previous stream only; other
+    // sessions may still be streaming and need theirs to deduplicate.
+    if (targetStream.processId) this.lastEventSeq.delete(targetStream.processId);
+    targetStream.processId = null;
 
     // Clean up stale stream_events from any previous cancelled streams.
     // These linger because cancel doesn't remove them, and they cause
@@ -549,32 +612,35 @@ class ChatService {
   }
 
   /**
-   * Cancel the current request - works for ANY collaborator, not just the sender
-   * Also works after browser refresh since it uses sessionState as fallback
+   * Cancel the stream of the session on screen — works for ANY collaborator,
+   * not just the sender, and after a browser refresh.
+   *
+   * The session being VIEWED is the only valid target: Stop is rendered inside
+   * that session's chat. Resolving it from remembered sender state instead
+   * would cancel whichever session this client last sent to, which is a
+   * different session as soon as two chats stream at once.
    */
   cancelRequest(): void {
-    // Use currentSessionId (set by sender) OR sessionState (available to all collaborators)
-    const chatSessionId = this.currentSessionId || sessionState.currentSession?.id;
+    const chatSessionId = sessionState.currentSession?.id;
+    if (!chatSessionId) return;
 
-    if (chatSessionId) {
-      ws.emit('chat:cancel', {
-        sessionId: crypto.randomUUID(),
-        chatSessionId
-      });
-    }
+    const state = this.streamFor(chatSessionId);
 
-    // Track cancelled processId so late-arriving events are ignored.
-    // Use a Set to track ALL cancelled streams (not just the last one),
-    // preventing late events from any previously cancelled stream from leaking through.
-    if (this.activeProcessId) {
-      this.cancelledProcessIds.add(this.activeProcessId);
+    ws.emit('chat:cancel', {
+      sessionId: crypto.randomUUID(),
+      chatSessionId
+    });
+
+    // Track this session's cancelled processId so its late-arriving events are
+    // ignored. The set holds ALL of this session's cancelled streams, so late
+    // events from an earlier cancel can't leak through either.
+    if (state.processId) {
+      state.cancelledProcessIds.add(state.processId);
     }
-    this.activeProcessId = null;
-    this.currentSessionId = null;
-    this.streamCompleted = true;
-    this.reconnected = false;
-    // Update per-session map with captured ID (before it was nulled above)
-    // and global flags — cancel sets isCancelling=true to prevent presence re-enabling
+    state.processId = null;
+    state.streamCompleted = true;
+    // Update per-session map and (when this session is on screen) the global
+    // flags — cancel sets isCancelling=true to prevent presence re-enabling
     this.setProcessState({ isLoading: false, isWaitingInput: false, isCancelling: true }, chatSessionId);
 
     // Convert stream_events to finalized assistant messages on cancel.
@@ -587,10 +653,10 @@ class ChatService {
     // arrive within 10 seconds, force-clear isCancelling to prevent infinite loader.
     // This catches edge cases: WS disconnect during cancel, engine.cancel() timeout,
     // or race conditions between presence update and chat:cancelled event ordering.
-    this.clearCancelSafetyTimer();
-    this.cancelSafetyTimer = setTimeout(() => {
-      this.cancelSafetyTimer = null;
-      if (appState.isCancelling) {
+    this.clearCancelSafetyTimer(chatSessionId);
+    state.cancelSafetyTimer = setTimeout(() => {
+      state.cancelSafetyTimer = null;
+      if (getSessionProcessState(chatSessionId).isCancelling) {
         debug.warn('chat', 'Cancel safety timeout: force-clearing isCancelling after 10s');
         this.setProcessState({ isCancelling: false, isLoading: false }, chatSessionId);
       }
@@ -598,28 +664,35 @@ class ChatService {
   }
 
   /**
-   * Clear the cancel safety timer (called when cancel completes normally)
+   * Clear a session's cancel safety timer (called when its cancel completes normally)
    */
-  private clearCancelSafetyTimer(): void {
-    if (this.cancelSafetyTimer) {
-      clearTimeout(this.cancelSafetyTimer);
-      this.cancelSafetyTimer = null;
+  private clearCancelSafetyTimer(sessionId: string): void {
+    const state = this.streams.get(sessionId);
+    if (state?.cancelSafetyTimer) {
+      clearTimeout(state.cancelSafetyTimer);
+      state.cancelSafetyTimer = null;
     }
   }
 
   /**
-   * Reset stream state when switching sessions (e.g. collaborator receiving new-chat).
-   * Blocks all stale events from the old stream.
+   * Stop tracking the viewed session's stream before switching away from it
+   * (e.g. New Chat). The backend stream keeps running; this only blocks stale
+   * events from reaching the session that replaces it on screen.
+   *
+   * Coming back to this session re-attaches via catchupActiveStream →
+   * reconnectToStream, which lifts the block again.
    */
   resetForSessionSwitch(): void {
-    if (this.activeProcessId) {
-      this.cancelledProcessIds.add(this.activeProcessId);
+    const sessionId = sessionState.currentSession?.id;
+    if (sessionId) {
+      const state = this.streamFor(sessionId);
+      if (state.processId) {
+        state.cancelledProcessIds.add(state.processId);
+        this.lastEventSeq.delete(state.processId);
+      }
+      state.processId = null;
+      state.streamCompleted = true;
     }
-    this.activeProcessId = null;
-    this.currentSessionId = null;
-    this.streamCompleted = true;
-    this.reconnected = false;
-    this.lastEventSeq.clear();
     appState.isLoading = false;
     appState.isWaitingInput = false;
     appState.isCancelling = false;
@@ -643,19 +716,14 @@ class ChatService {
   /**
    * Handle message events from stream
    */
-  private handleMessageEvent(data: any): void {
+  private handleMessageEvent(data: any, stream: SessionStreamState): void {
     const rawMessage = data.message as UnifiedMessage | undefined;
 
     // Early return if no message
     if (!rawMessage) return;
 
     // Ignore messages from a completed/cancelled stream
-    if (this.streamCompleted) return;
-
-    // Early return if no valid session
-    if (!sessionState.currentSession?.id) {
-      return;
-    }
+    if (stream.streamCompleted) return;
 
     // Enrich with transport metadata (DB id, parent, sender)
     const message = this.enrichMessage(rawMessage, data);
@@ -758,14 +826,9 @@ class ChatService {
   /**
    * Handle partial message events (streaming)
    */
-  private handlePartialEvent(data: any): void {
+  private handlePartialEvent(data: any, stream: SessionStreamState): void {
     // Ignore partials from a completed/cancelled stream
-    if (this.streamCompleted) return;
-
-    // Early return if no valid session
-    if (!sessionState.currentSession?.id) {
-      return;
-    }
+    if (stream.streamCompleted) return;
 
     const isReasoning = data.reasoning === true;
     const { eventType, partialText } = data;


### PR DESCRIPTION
## Summary
Stop now interrupts exactly the chat it was pressed in, on the first press,
while other chats of the same project keep streaming.

## Why
With two chats streaming in one project, switching to chat A and pressing Stop
interrupted chat B; a second press interrupted A. Two defects lined up, and the
first hid the second:

1. `ChatService` resolved the cancel target from `currentSessionId` — remembered
   from the last message this client *sent*, never updated on a session switch —
   instead of the session on screen.
2. Every engine adapter kept per-stream state in instance fields, while
   `getProjectEngine` hands one instance to every chat session of a project. The
   second stream overwrote the first's handles, so `engine.cancel()` stopped
   whichever stream the instance had on hand.

Fixing only the frontend made Stop kill both chats, which is what surfaced (2).

Beyond the reported symptom, the same fields meant `isActive` reported idle once
the first of two streams ended — so an engine retired after a config or account
change was disposed while the other chat was still answering, the exact failure
engine retirement was built to prevent (#488) — and OpenCode leaked one pooled
server hold per overwritten stream, plus posted permission/question replies to
another chat's server when the two sat on different Profiles.

## Changes
**Engine layer**
- `adapters/run-registry.ts` (new): `EngineRuns<T>` owns run bookkeeping —
  `add`/`remove`/`select(owner)`/`all()`/`isActive` — keyed by the
  AbortController the caller passed to `streamQuery`.
- All eight adapters (claude, opencode, qwen, codex, copilot, cursor, pi, cline):
  per-stream state moves into an `XxxRun`; `isActive` counts runs; each stream's
  `finally` retires only its own; teardown consolidated into one private
  `stopRuns()` reached by `cancel` (one run) and `dispose` (all runs).
- `types.ts`: `cancel(owner)` / `interrupt(owner)` take a required
  AbortController — there is no untargeted cancel for callers.
- `chat/stream-manager.ts`: passes `streamState.abortController`.
- opencode: each run releases its own pool hold — after the server-side abort,
  not before — and replies through its own pooled server. Removed the unused
  `cancelSession()`.

**Frontend**
- `services/chat/chat.service.ts`: stream bookkeeping keyed by chat session;
  `cancelRequest()` targets `sessionState.currentSession`.
- `components/chat/input/ChatInput.svelte`: catchup guard keyed by
  `projectId:sessionId`, so switching between sessions of one project re-attaches
  to that session's live stream.

**Docs** — the contract doc taught the broken pattern, so it is corrected rather
than merely contradicted: `docs/adapter-contract.md` invariant 2, `README.md`
callout, `index.ts` header, `docs/adding-an-engine.md` QA checklist,
`docs/frontend-and-chat.md` §6.3a (stop path), `docs/lessons-learned.md` §10.26,
`docs/quick-reference.md`.

## Test plan
- `bun run check` — 0 errors
- `bun run lint` — clean
- `bun run test` — 482 pass, 17 skip, 0 fail (6 new in `run-registry.test.ts`,
  covering the two rules that caused the bug: an owner that already finished
  cancels nothing, and `isActive` stays true until the last run ends)
- Manual, per engine: two chats of one project streaming; Stop in each stops that
  chat on the first press and leaves the other streaming and rendering.
- Manual: change an engine account/config while both stream — neither is cut short.
- Manual: AskUserQuestion pending in one chat while the other is cancelled — the
  question stays answerable.

## Notes
Verified end-to-end against opencode, the engine in the report. The other seven
adapters share the identical defect and the identical fix shape, but their SDK
teardown paths were reasoned about and type-checked, not exercised at runtime —
the new QA checklist items in `adding-an-engine.md` are the standing way to
close that.

Pre-existing and unchanged: a stream that throws during setup, after its run is
registered, leaves the entry behind and `isActive` stays true for that instance
— the same way `activeController` used to be left set. `isActive` also does not
count `generateStructured` calls; those run on the global singleton tier. Both
are recorded in §10.26.