### PR TITLE
fix(chat): attribute stream events to the chat that owns them

### DIFF
--- a/backend/engine/docs/frontend-and-chat.md
+++ b/backend/engine/docs/frontend-and-chat.md
@@ -313,10 +313,22 @@ resolved it from ambient state and both stopped the wrong chat:
   two chats stream at once.
 - **Stream bookkeeping is per session.** `processId`, `streamCompleted`, the
   cancelled-processId set and the cancel safety timer live in a
-  `Map<sessionId, …>` inside `chat.service.ts`. Stream events carry no
-  `chatSessionId` — they are routed by chat-session room and a client is joined
-  to exactly the room it is viewing, so the viewed session is the authoritative
-  owner of every incoming event.
+  `Map<sessionId, …>` inside `chat.service.ts`.
+- **Every stream event carries its own `chatSessionId`** — `chat:connection`,
+  `chat:message`, `chat:partial`, `chat:complete`, `chat:error`,
+  `chat:cancelled` — and `chat.service.ts::ownerOf` credits it to that session.
+  Room membership looks like it would do the job (a client joins the room of the
+  session it views) but it does not: a switch points `currentSession` at the new
+  chat immediately, while the leave/join and the transcript reload are still in
+  flight. Attributing by "whatever is on screen" put the chat being left's
+  pending question onto the chat being opened, which then showed
+  "Waiting for your input..." while it was still working.
+- **`sessionState.messagesSessionId` says whose transcript is loaded.**
+  `sessionState.messages` holds one session's messages, and `currentSession`
+  moves a round trip before they arrive. Anything that writes to the transcript
+  or derives from it — event handlers, `catchupActiveStream`,
+  `detectPendingInteractiveTools`, the cancel-time `finalizeStreamEvents` —
+  checks this marker, not `currentSession`.
 - **The backend cancels one run**, identified by `StreamState.abortController`.
   See invariant 2 in [adapter-contract](./adapter-contract.md) and §10.26 in
   [lessons-learned](./lessons-learned.md).

--- a/backend/ws/chat/stream.ts
+++ b/backend/ws/chat/stream.ts
@@ -253,6 +253,7 @@ export const streamHandler = createRouter()
 			const stream = streamManager.getStream(streamId);
 			if (stream) {
 				ws.emit.chatSession(data.chatSessionId, 'chat:connection', {
+					chatSessionId: data.chatSessionId,
 					processId: stream.processId,
 					timestamp: stream.startedAt.toISOString(),
 					seq: 1
@@ -273,6 +274,7 @@ export const streamHandler = createRouter()
 					switch (event.type) {
 						case 'connection':
 							ws.emit.chatSession(chatSessionId, 'chat:connection', {
+								chatSessionId,
 								processId: event.data.processId,
 								timestamp: event.data.timestamp,
 								seq: event.seq
@@ -284,6 +286,7 @@ export const streamHandler = createRouter()
 
 						case 'message': {
 							ws.emit.chatSession(chatSessionId, 'chat:message', {
+								chatSessionId,
 								processId: event.processId,
 								message: trimSubAgentForWire(event.data.message),
 								usage: event.data.usage,
@@ -302,6 +305,7 @@ export const streamHandler = createRouter()
 
 						case 'partial':
 							ws.emit.chatSession(chatSessionId, 'chat:partial', {
+								chatSessionId,
 								processId: event.processId,
 								eventType: event.data.eventType as any,
 								partialText: event.data.partialText || '',
@@ -336,6 +340,7 @@ export const streamHandler = createRouter()
 
 						case 'complete':
 							ws.emit.chatSession(chatSessionId, 'chat:complete', {
+								chatSessionId,
 								processId: event.processId,
 								timestamp: event.data.timestamp,
 								seq: event.seq
@@ -347,6 +352,7 @@ export const streamHandler = createRouter()
 
 						case 'error':
 							ws.emit.chatSession(chatSessionId, 'chat:error', {
+								chatSessionId,
 								processId: event.processId,
 								error: event.data.error,
 								timestamp: event.data.timestamp,
@@ -358,6 +364,7 @@ export const streamHandler = createRouter()
 
 						case 'cancelled':
 							ws.emit.chatSession(chatSessionId, 'chat:error', {
+								chatSessionId,
 								processId: event.processId,
 								error: 'Stream cancelled',
 								timestamp: event.data.timestamp,
@@ -387,6 +394,7 @@ export const streamHandler = createRouter()
 			debug.error('chat', 'WS chat:stream error:', errorMessage);
 
 			ws.emit.chatSession(data.chatSessionId, 'chat:error', {
+				chatSessionId: data.chatSessionId,
 				processId: crypto.randomUUID(),
 				error: errorMessage,
 				timestamp: new Date().toISOString()
@@ -420,6 +428,7 @@ export const streamHandler = createRouter()
 					switch (event.type) {
 						case 'connection':
 							ws.emit.chatSession(chatSessionId, 'chat:connection', {
+								chatSessionId,
 								processId: event.data.processId,
 								timestamp: event.data.timestamp,
 								seq: event.seq
@@ -428,6 +437,7 @@ export const streamHandler = createRouter()
 
 						case 'message': {
 							ws.emit.chatSession(chatSessionId, 'chat:message', {
+								chatSessionId,
 								processId: event.processId,
 								message: trimSubAgentForWire(event.data.message),
 								usage: event.data.usage,
@@ -446,6 +456,7 @@ export const streamHandler = createRouter()
 
 						case 'partial':
 							ws.emit.chatSession(chatSessionId, 'chat:partial', {
+								chatSessionId,
 								processId: event.processId,
 								eventType: event.data.eventType as any,
 								partialText: event.data.partialText || '',
@@ -480,6 +491,7 @@ export const streamHandler = createRouter()
 
 						case 'complete':
 							ws.emit.chatSession(chatSessionId, 'chat:complete', {
+								chatSessionId,
 								processId: event.processId,
 								timestamp: event.data.timestamp,
 								seq: event.seq
@@ -490,6 +502,7 @@ export const streamHandler = createRouter()
 
 						case 'error':
 							ws.emit.chatSession(chatSessionId, 'chat:error', {
+								chatSessionId,
 								processId: event.processId,
 								error: event.data.error,
 								timestamp: event.data.timestamp,
@@ -501,6 +514,7 @@ export const streamHandler = createRouter()
 
 						case 'cancelled':
 							ws.emit.chatSession(chatSessionId, 'chat:error', {
+								chatSessionId,
 								processId: event.processId,
 								error: 'Stream cancelled',
 								timestamp: event.data.timestamp,
@@ -523,6 +537,7 @@ export const streamHandler = createRouter()
 
 			// Send current state snapshot to chat session room so frontend can catch up
 			ws.emit.chatSession(chatSessionId, 'chat:connection', {
+				chatSessionId,
 				processId: streamState.processId,
 				timestamp: streamState.startedAt.toISOString(),
 				seq: streamState.eventSeq
@@ -657,6 +672,7 @@ export const streamHandler = createRouter()
 				// Stream not found - could already be completed/cleaned up
 				// Send cancellation to chat session room so frontend stops loading
 				ws.emit.chatSession(chatSessionId, 'chat:cancelled', {
+					chatSessionId,
 					status: 'cancelled',
 					processId: ''
 				});
@@ -669,6 +685,7 @@ export const streamHandler = createRouter()
 			await streamManager.cancelStream(streamState.streamId);
 			// Always send cancelled to chat session room to clear UI
 			ws.emit.chatSession(chatSessionId, 'chat:cancelled', {
+				chatSessionId,
 				status: 'cancelled',
 				processId: streamState.processId
 			});
@@ -679,6 +696,7 @@ export const streamHandler = createRouter()
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 			ws.emit.chatSession(chatSessionId, 'chat:error', {
+				chatSessionId,
 				processId: '',
 				error: errorMessage,
 				timestamp: new Date().toISOString()
@@ -966,12 +984,14 @@ export const streamHandler = createRouter()
 	}))
 
 	.emit('chat:connection', t.Object({
+		chatSessionId: t.String(),
 		processId: t.String(),
 		timestamp: t.String(),
 		seq: t.Optional(t.Number())
 	}))
 
 	.emit('chat:message', t.Object({
+		chatSessionId: t.String(),
 		processId: t.String(),
 		message: t.Any(), // SDKMessage
 		usage: t.Optional(t.Any()),
@@ -985,6 +1005,7 @@ export const streamHandler = createRouter()
 	}))
 
 	.emit('chat:partial', t.Object({
+		chatSessionId: t.String(),
 		processId: t.String(),
 		eventType: t.Union([
 			t.Literal('start'),
@@ -1030,12 +1051,14 @@ export const streamHandler = createRouter()
 	}))
 
 	.emit('chat:complete', t.Object({
+		chatSessionId: t.String(),
 		processId: t.String(),
 		timestamp: t.String(),
 		seq: t.Optional(t.Number())
 	}))
 
 	.emit('chat:error', t.Object({
+		chatSessionId: t.String(),
 		processId: t.String(),
 		error: t.String(),
 		timestamp: t.String(),
@@ -1043,6 +1066,7 @@ export const streamHandler = createRouter()
 	}))
 
 	.emit('chat:cancelled', t.Object({
+		chatSessionId: t.String(),
 		status: t.Literal('cancelled'),
 		processId: t.Optional(t.String()),
 		seq: t.Optional(t.Number())

--- a/frontend/components/chat/input/ChatInput.svelte
+++ b/frontend/components/chat/input/ChatInput.svelte
@@ -306,7 +306,13 @@
 			lastPresenceProjectId = projectId;
 		}
 
-		const catchupKey = sessionId ? `${projectId}:${sessionId}` : undefined;
+		// Catchup reads and writes this session's transcript, so it may only run
+		// once that transcript is the one loaded — `currentSession` moves on
+		// switch, `messagesSessionId` a round trip later. Leaving the key
+		// undefined until then means the attempt is not marked as done, so this
+		// effect retries the moment the messages land.
+		const transcriptReady = !!sessionId && sessionState.messagesSessionId === sessionId;
+		const catchupKey = transcriptReady ? `${projectId}:${sessionId}` : undefined;
 		const status = presenceState.statuses.get(projectId);
 		// Check if the active stream is for the CURRENT session (not just any session in the project)
 		const hasActiveForSession = status?.streams?.some(
@@ -350,18 +356,27 @@
 	 * for late-joining users (browser refresh, project switch, long absence)
 	 */
 	async function catchupActiveStream(status: any) {
-		if (!status?.streams?.length || !sessionState.currentSession?.id) return;
+		// Pin the session this catchup is for. Everything below runs after an
+		// await, and `sessionState.messages` always holds whichever session is on
+		// screen *now* — so a catchup that resolves after the user switched away
+		// would inject one chat's partial text into another's transcript and read
+		// that transcript to decide whether to show "Waiting for your input".
+		const chatSessionId = sessionState.currentSession?.id;
+		if (!status?.streams?.length || !chatSessionId) return;
+		// `messagesSessionId` — not `currentSession` — is what says the transcript
+		// on screen is this session's; the switch moves one a round trip before
+		// the other.
+		const holdsThisSession = () => sessionState.messagesSessionId === chatSessionId;
 
 		// Find the active stream for the current session
 		const activeStream = status.streams.find(
-			(s: any) => s.status === 'active' && s.chatSessionId === sessionState.currentSession?.id
+			(s: any) => s.status === 'active' && s.chatSessionId === chatSessionId
 		);
 		if (!activeStream) return;
 
 		try {
-			const streamState = await ws.http('chat:stream-state', {
-				chatSessionId: sessionState.currentSession.id
-			});
+			const streamState = await ws.http('chat:stream-state', { chatSessionId });
+			if (!holdsThisSession()) return;
 
 			if (streamState && streamState.status === 'active' && streamState.processId) {
 				// ── Inject reasoning stream_event (if available) ──
@@ -420,13 +435,10 @@
 				}
 
 				// Reconnect to live stream events so future partials/messages/complete flow in
-				chatService.reconnectToStream(
-					sessionState.currentSession.id,
-					streamState.processId
-				);
+				chatService.reconnectToStream(chatSessionId, streamState.processId);
 
 				// Detect if an interactive tool (e.g. AskUserQuestion) is pending in existing messages
-				chatService.detectPendingInteractiveTools();
+				chatService.detectPendingInteractiveTools(chatSessionId);
 
 				debug.log('chat', 'Caught up with active stream:', {
 					processId: streamState.processId,

--- a/frontend/components/chat/tools/variants/classic/AskUserQuestionTool.svelte
+++ b/frontend/components/chat/tools/variants/classic/AskUserQuestionTool.svelte
@@ -2,7 +2,7 @@
 	import type { ToolUseBlock, AskUserQuestionInput } from '$shared/types/unified';
 	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import ws from '$frontend/utils/ws';
-	import { currentSessionId } from '$frontend/stores/core/sessions.svelte';
+	import { renderedSessionId, sessionState } from '$frontend/stores/core/sessions.svelte';
 	import { appState, updateSessionProcessState } from '$frontend/stores/core/app.svelte';
 	import { debug } from '$shared/utils/logger';
 
@@ -127,13 +127,15 @@
 			}
 			debug.log('chat', 'Submitting AskUserQuestion answers:', answers);
 			ws.emit('chat:ask-user-answer', {
-				chatSessionId: currentSessionId(),
+				chatSessionId: renderedSessionId(),
 				toolUseId: toolInput.id,
 				answers
 			});
-			const sessId = currentSessionId();
+			const sessId = renderedSessionId();
 			if (sessId) updateSessionProcessState(sessId, { isWaitingInput: false });
-			appState.isWaitingInput = false;
+			// Only mirror to the global flag when this transcript is also the one
+			// the rest of the UI is pointed at.
+			if (sessId === sessionState.currentSession?.id) appState.isWaitingInput = false;
 			hasSubmitted = true;
 		} catch (error) {
 			debug.error('chat', 'Failed to submit answers:', error);

--- a/frontend/components/chat/tools/variants/compact/AskUserQuestionTool.svelte
+++ b/frontend/components/chat/tools/variants/compact/AskUserQuestionTool.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { ToolUseBlock, AskUserQuestionInput } from '$shared/types/unified';
 	import ws from '$frontend/utils/ws';
-	import { currentSessionId } from '$frontend/stores/core/sessions.svelte';
+	import { renderedSessionId, sessionState } from '$frontend/stores/core/sessions.svelte';
 	import { appState, updateSessionProcessState } from '$frontend/stores/core/app.svelte';
 	import { debug } from '$shared/utils/logger';
 
@@ -108,10 +108,12 @@
 				}
 			}
 			debug.log('chat', 'Submitting AskUserQuestion answers:', answers);
-			ws.emit('chat:ask-user-answer', { chatSessionId: currentSessionId(), toolUseId: toolInput.id, answers });
-			const sessId = currentSessionId();
+			ws.emit('chat:ask-user-answer', { chatSessionId: renderedSessionId(), toolUseId: toolInput.id, answers });
+			const sessId = renderedSessionId();
 			if (sessId) updateSessionProcessState(sessId, { isWaitingInput: false });
-			appState.isWaitingInput = false;
+			// Only mirror to the global flag when this transcript is also the one
+			// the rest of the UI is pointed at.
+			if (sessId === sessionState.currentSession?.id) appState.isWaitingInput = false;
 			hasSubmitted = true;
 		} catch (error) {
 			debug.error('chat', 'Failed to submit answers:', error);

--- a/frontend/services/chat/chat.service.ts
+++ b/frontend/services/chat/chat.service.ts
@@ -42,6 +42,14 @@ import ws from '$frontend/utils/ws';
  * to whichever session last sent a message and then mis-targets every later
  * action — most visibly, Stop in session A cancelling session B's stream.
  */
+/** A stream event resolved to the session that owns it. */
+interface OwnedStream {
+  sessionId: string;
+  state: SessionStreamState;
+  /** True when `sessionState.messages` is this session's transcript. */
+  ownsTranscript: boolean;
+}
+
 interface SessionStreamState {
   /** processId of this session's in-flight stream; null when idle. */
   processId: string | null;
@@ -143,18 +151,29 @@ class ChatService {
   }
 
   /**
-   * The session that owns the stream events currently arriving.
+   * The session a stream event belongs to, and whether that session is on screen.
    *
-   * Stream events (chat:connection/message/partial/complete/error/cancelled)
-   * carry no chatSessionId — the backend routes them by chat session room, and
-   * a client is only ever joined to the room of the session on screen (see
-   * setCurrentSession). So the viewed session IS the owner of every incoming
-   * stream event, and the only correct key for this bookkeeping.
+   * Every stream event (chat:connection/message/partial/complete/error/cancelled)
+   * carries its own `chatSessionId`. The session on screen is NOT a safe
+   * substitute: a session switch points `sessionState.currentSession` at the new
+   * chat immediately, while the room leave/join and the message reload are still
+   * in flight — so an event of the chat being left would be credited to the chat
+   * being opened. That is how one chat's "Waiting for your input" appeared over
+   * another chat that was still working.
    */
-  private viewedStream(): { sessionId: string; state: SessionStreamState } | null {
-    const sessionId = sessionState.currentSession?.id;
+  private ownerOf(data: { chatSessionId?: string }): OwnedStream | null {
+    const sessionId = data.chatSessionId;
     if (!sessionId) return null;
-    return { sessionId, state: this.streamFor(sessionId) };
+    return {
+      sessionId,
+      state: this.streamFor(sessionId),
+      // `sessionState.messages` may only be touched by the session that array
+      // actually holds. Checking the viewed session alone is not enough: the
+      // switch points `currentSession` at the new chat a round trip before its
+      // transcript arrives, so for that window the array still belongs to the
+      // chat being left.
+      ownsTranscript: sessionState.messagesSessionId === sessionId,
+    };
   }
 
   /**
@@ -220,7 +239,7 @@ class ChatService {
 
     // Connection event - received by ALL users in the project
     ws.on('chat:connection', (data) => {
-      const ctx = this.viewedStream();
+      const ctx = this.ownerOf(data);
       if (!ctx) return;
       if (this.shouldSkipEvent(data.processId, data.seq)) return;
       // Ignore events from a locally cancelled stream
@@ -232,22 +251,26 @@ class ChatService {
 
     // Message event
     ws.on('chat:message', (data) => {
-      const ctx = this.viewedStream();
+      const ctx = this.ownerOf(data);
       if (!ctx) return;
       if (this.shouldSkipEvent(data.processId, data.seq)) return;
       // Ignore events from a locally cancelled stream
       if (data.processId && ctx.state.cancelledProcessIds.has(data.processId)) return;
+      // A message for a chat that is not on screen has no message list to land
+      // in — that session's status comes from presence until it is opened.
+      if (!ctx.ownsTranscript) return;
 
-      this.handleMessageEvent(data, ctx.state);
+      this.handleMessageEvent(data, ctx);
     });
 
     // Partial message event (streaming)
     ws.on('chat:partial', (data) => {
-      const ctx = this.viewedStream();
+      const ctx = this.ownerOf(data);
       if (!ctx) return;
       if (this.shouldSkipEvent(data.processId, data.seq)) return;
       // Ignore events from a locally cancelled stream
       if (data.processId && ctx.state.cancelledProcessIds.has(data.processId)) return;
+      if (!ctx.ownsTranscript) return;
 
       this.handlePartialEvent(data, ctx.state);
     });
@@ -287,7 +310,7 @@ class ChatService {
 
     // Complete event
     ws.on('chat:complete', async (data) => {
-      const ctx = this.viewedStream();
+      const ctx = this.ownerOf(data);
       if (!ctx) return;
       if (this.shouldSkipEvent(data.processId, data.seq)) return;
       // Ignore late events from a locally cancelled stream
@@ -299,7 +322,7 @@ class ChatService {
       this.setProcessState({ isLoading: false, isWaitingInput: false, isCancelling: false }, ctx.sessionId);
 
       // Mark any tool_use blocks that never got a tool_result
-      this.markInterruptedTools();
+      if (ctx.ownsTranscript) this.markInterruptedTools();
 
       // A completed stream means every late event of THIS session's older
       // cancelled streams has been delivered, so its blacklist can go. Other
@@ -314,7 +337,7 @@ class ChatService {
 
     // Cancelled event - broadcast to ALL collaborators when any user cancels
     ws.on('chat:cancelled', async (data) => {
-      const ctx = this.viewedStream();
+      const ctx = this.ownerOf(data);
       if (!ctx) return;
       // Track the cancelled processId so late-arriving events are blocked.
       // This handles the case where a collaborator initiated the cancel
@@ -333,14 +356,14 @@ class ChatService {
       this.setProcessState({ isLoading: false, isWaitingInput: false }, ctx.sessionId);
 
       // Mark any tool_use blocks that never got a tool_result
-      this.markInterruptedTools();
+      if (ctx.ownsTranscript) this.markInterruptedTools();
 
       // Notifications handled by GlobalStreamMonitor via chat:stream-finished
     });
 
     // Error event
     ws.on('chat:error', async (data) => {
-      const ctx = this.viewedStream();
+      const ctx = this.ownerOf(data);
       if (!ctx) return;
       if (this.shouldSkipEvent(data.processId, data.seq)) return;
       if (ctx.state.streamCompleted) return;
@@ -355,7 +378,7 @@ class ChatService {
       this.setProcessState({ isLoading: false, isWaitingInput: false, isCancelling: false }, ctx.sessionId);
 
       // Mark any tool_use blocks that never got a tool_result
-      this.markInterruptedTools();
+      if (ctx.ownsTranscript) this.markInterruptedTools();
 
       // Don't show notification for cancel-triggered errors
       if (data.error === 'Stream cancelled') return;
@@ -363,9 +386,11 @@ class ChatService {
       // Remove any remaining stream_event messages (streaming placeholders that won't be finalized).
       // The actual error bubble is now emitted as a chat:message from the backend and saved to DB,
       // so it persists across browser refresh. No need to inject a synthetic bubble here.
-      for (let i = sessionState.messages.length - 1; i >= 0; i--) {
-        if (sessionState.messages[i].type === 'stream_event') {
-          sessionState.messages.splice(i, 1);
+      if (ctx.ownsTranscript) {
+        for (let i = sessionState.messages.length - 1; i >= 0; i--) {
+          if (sessionState.messages[i].type === 'stream_event') {
+            sessionState.messages.splice(i, 1);
+          }
         }
       }
 
@@ -646,8 +671,11 @@ class ChatService {
     // Convert stream_events to finalized assistant messages on cancel.
     // This preserves partial reasoning/text that was visible to the user.
     // Empty stream_events are removed. The backend saves partial text to DB
-    // independently, so on refresh the DB version takes over.
-    this.finalizeStreamEvents();
+    // independently, so on refresh the DB version takes over. Only touch the
+    // transcript when it is the one belonging to the cancelled session.
+    if (sessionState.messagesSessionId === chatSessionId) {
+      this.finalizeStreamEvents();
+    }
 
     // Safety timeout: if backend events (chat:cancelled + presence update) don't
     // arrive within 10 seconds, force-clear isCancelling to prevent infinite loader.
@@ -716,14 +744,14 @@ class ChatService {
   /**
    * Handle message events from stream
    */
-  private handleMessageEvent(data: any, stream: SessionStreamState): void {
+  private handleMessageEvent(data: any, ctx: OwnedStream): void {
     const rawMessage = data.message as UnifiedMessage | undefined;
 
     // Early return if no message
     if (!rawMessage) return;
 
     // Ignore messages from a completed/cancelled stream
-    if (stream.streamCompleted) return;
+    if (ctx.state.streamCompleted) return;
 
     // Enrich with transport metadata (DB id, parent, sender)
     const message = this.enrichMessage(rawMessage, data);
@@ -754,7 +782,7 @@ class ChatService {
         const msg = sessionState.messages[i];
         if (msg.type === 'stream_event' && !(msg as StreamingMessage).reasoning) {
           sessionState.messages[i] = message;
-          this.checkInteractiveTools(message);
+          this.checkInteractiveTools(message, ctx.sessionId);
           return;
         }
       }
@@ -796,14 +824,14 @@ class ChatService {
 
     // Detect interactive tool_use blocks (e.g., AskUserQuestion) and set waiting status
     if (message.type === 'assistant') {
-      this.checkInteractiveTools(message);
+      this.checkInteractiveTools(message, ctx.sessionId);
     }
 
     // When a user message with tool_result arrives, the SDK is unblocked — clear waiting status
     if (message.type === 'user') {
       const hasToolResult = message.content.some((item) => item.type === 'tool_result');
-      if (hasToolResult && appState.isWaitingInput) {
-        this.setProcessState({ isWaitingInput: false });
+      if (hasToolResult) {
+        this.setProcessState({ isWaitingInput: false }, ctx.sessionId);
       }
     }
 
@@ -814,12 +842,12 @@ class ChatService {
   /**
    * Check for interactive tool_use blocks and set waiting status
    */
-  private checkInteractiveTools(message: AssistantMessage): void {
+  private checkInteractiveTools(message: AssistantMessage, sessionId: string): void {
     const hasInteractiveTool = message.content.some(
       (item) => item.type === 'tool_use' && INTERACTIVE_TOOLS.has(item.name)
     );
     if (hasInteractiveTool) {
-      this.setProcessState({ isWaitingInput: true });
+      this.setProcessState({ isWaitingInput: true }, sessionId);
     }
   }
 
@@ -952,16 +980,23 @@ class ChatService {
   }
 
   /**
-   * Detect whether any interactive tool (e.g. AskUserQuestion) is pending in the current messages.
-   * Used after browser refresh / catchup to restore the isWaitingInput state.
+   * Detect whether an interactive tool (e.g. AskUserQuestion) is pending for
+   * `chatSessionId`. Used after browser refresh / catchup to restore the
+   * isWaitingInput state.
+   *
+   * The answer is derived from `sessionState.messages`, which holds the VIEWED
+   * session — so a stale caller (catchup resolving after the user moved on)
+   * would read one chat's transcript and write the verdict onto another. The
+   * session is therefore named by the caller and checked here.
    */
-  detectPendingInteractiveTools(): void {
-    if (!appState.isLoading) return;
+  detectPendingInteractiveTools(chatSessionId: string): void {
+    if (sessionState.messagesSessionId !== chatSessionId) return;
+    if (!getSessionProcessState(chatSessionId).isLoading) return;
 
     // Delegate to the shared derivation so this can never disagree with the
     // backend presence layer (both read the same message-ordering rules).
     if (isWaitingForInteractiveInput(sessionState.messages)) {
-      this.setProcessState({ isWaitingInput: true });
+      this.setProcessState({ isWaitingInput: true }, chatSessionId);
     }
   }
 

--- a/frontend/stores/core/sessions.svelte.ts
+++ b/frontend/stores/core/sessions.svelte.ts
@@ -48,6 +48,17 @@ interface SessionState {
 	sessions: ChatSession[];
 	currentSession: ChatSession | null;
 	messages: FrontendMessage[];
+	/**
+	 * Which session `messages` currently holds.
+	 *
+	 * `currentSession` moves the instant the user switches, while the transcript
+	 * arrives one round trip later — so for that window the two disagree, and
+	 * anything that reads `messages` "for the current session" is reading the
+	 * previous chat. Live stream events and stream catchup both check this
+	 * before they write, which is what stops one chat's pending question from
+	 * being reported against another (see chat.service.ts::ownerOf).
+	 */
+	messagesSessionId: string | null;
 	isLoading: boolean;
 	error: string | null;
 	/** True if the current session has message history (even if HEAD is null after restore to initial) */
@@ -59,6 +70,7 @@ export const sessionState = $state<SessionState>({
 	sessions: [],
 	currentSession: null,
 	messages: [],
+	messagesSessionId: null,
 	isLoading: false,
 	error: null,
 	hasMessageHistory: false
@@ -74,6 +86,19 @@ export function hasSessions() {
 
 export function currentSessionId() {
 	return sessionState.currentSession?.id || '';
+}
+
+/**
+ * The session that owns the transcript on screen.
+ *
+ * Anything acting on a rendered message — answering its AskUserQuestion,
+ * clearing the waiting flag it set — belongs to THIS session, not to
+ * `currentSession`: a switch moves that one a round trip before the new
+ * transcript replaces the old one, and in that window the messages still being
+ * rendered are the previous chat's.
+ */
+export function renderedSessionId() {
+	return sessionState.messagesSessionId || '';
 }
 
 export function messageCount() {
@@ -128,8 +153,11 @@ export async function setCurrentSession(session: ChatSession | null, skipLoadMes
 			// Ignore - proceed with existing session data
 		}
 
-		// Load messages for this session (skip if we're restoring and already have messages)
-		if (!skipLoadMessages) {
+		// Load messages for this session (skip if we're restoring and already have
+		// messages — those already belong to this session, so claim them).
+		if (skipLoadMessages) {
+			sessionState.messagesSessionId = session.id;
+		} else {
 			await loadMessagesForSession(session.id);
 		}
 
@@ -137,6 +165,7 @@ export async function setCurrentSession(session: ChatSession | null, skipLoadMes
 	} else {
 		// Clear messages when no session
 		sessionState.messages = [];
+		sessionState.messagesSessionId = null;
 		syncAiChangesFromMessages();
 		debug.log('session', 'Session cleared');
 	}
@@ -206,6 +235,7 @@ export function removeSession(sessionId: string) {
 	if (sessionState.currentSession?.id === sessionId) {
 		sessionState.currentSession = null;
 		sessionState.messages = [];
+		sessionState.messagesSessionId = null;
 		syncAiChangesFromMessages();
 	}
 }
@@ -258,6 +288,7 @@ export function updateMessages(messages: FrontendMessage[]) {
 
 export function clearMessages() {
 	sessionState.messages = [];
+	sessionState.messagesSessionId = null;
 	sessionState.hasMessageHistory = false;
 	syncAiChangesFromMessages();
 }
@@ -269,6 +300,7 @@ export async function loadMessagesForSession(sessionId: string) {
 		if (response && Array.isArray(response)) {
 			// Messages from server already have correct UnifiedMessage shape
 			sessionState.messages = response as UnifiedMessage[];
+			sessionState.messagesSessionId = sessionId;
 
 			if (response.length > 0) {
 				sessionState.hasMessageHistory = true;
@@ -279,11 +311,13 @@ export async function loadMessagesForSession(sessionId: string) {
 			}
 		} else {
 			sessionState.messages = [];
+			sessionState.messagesSessionId = sessionId;
 			sessionState.hasMessageHistory = false;
 		}
 	} catch (error) {
 		debug.error('session', 'Error loading messages:', error);
 		sessionState.messages = [];
+		sessionState.messagesSessionId = null;
 		sessionState.hasMessageHistory = false;
 	} finally {
 		// Re-derive AI-change indicators for whatever is now loaded (incl. after a


### PR DESCRIPTION
## Summary
A chat that is still working no longer shows another chat's
"Waiting for your input..." — stream events are credited to the chat that
actually produced them.

## Why
With chats A and B both streaming in one project, B parking on an
AskUserQuestion, and the user switching back to A, A displayed
"Waiting for your input..." instead of its own loading text.

Stream events carried no `chatSessionId`, so the client attributed each one to
the chat on screen. A session switch breaks that assumption in two ways:
`sessionState.currentSession` moves immediately, while the room leave/join and
the transcript reload are still in flight, and `sessionState.messages` holds a
single session's messages — so for that window the transcript on screen is the
chat being left. `catchupActiveStream` for the newly opened chat therefore read
the previous chat's transcript, found its pending question, and wrote
`isWaitingInput` onto the chat it was catching up.

## Changes
**Backend**
- `ws/chat/stream.ts`: `chat:connection`, `chat:message`, `chat:partial`,
  `chat:complete`, `chat:error` and `chat:cancelled` carry `chatSessionId` — in
  the emit schemas and at all 18 emit sites.

**Frontend**
- `services/chat/chat.service.ts`: `ownerOf(data)` resolves each event to its own
  session; handlers touch the transcript only when it belongs to that session;
  `checkInteractiveTools` and `detectPendingInteractiveTools` take the session
  they are deciding for.
- `stores/core/sessions.svelte.ts`: `sessionState.messagesSessionId` records
  whose transcript is loaded, plus `renderedSessionId()` for components acting on
  a rendered message.
- `components/chat/input/ChatInput.svelte`: catchup pins the session it started
  for, re-checks after its await, and does not mark itself done when it bails —
  so it retries once the transcript lands.
- `components/chat/tools/variants/*/AskUserQuestionTool.svelte`: the answer and
  the flag it clears go to the session that owns the rendered question.

**Docs**
- `backend/engine/docs/frontend-and-chat.md` §6.3a: the previous text claimed
  room routing made the viewed session the authoritative owner of every event.
  That assumption is what this PR fixes, so it is corrected rather than left to
  mislead the next reader.

## Test plan
- `bun run check` — 0 errors
- `bun run lint` — clean
- `bun run test` — 482 pass, 17 skip, 0 fail
- Manual: chat A streaming → new chat B streaming → B parks on an
  AskUserQuestion → switch to A. A must show the rotating loading text, not
  "Waiting for your input...", and B must still show the amber state when
  reopened.
- Manual: answer B's question after switching back and forth — the answer
  reaches B, and A's state is untouched.
- Manual: switch to a chat that IS waiting — the amber label appears after its
  transcript loads.

## Notes
Depends on #489 (per-session stream state and per-run engine cancel); this builds
on the `SessionStreamState` map that PR introduced.

The guard is UI state, so it is not covered by a unit test — the verification is
the manual switch sequence above. What is enforceable is now enforced by shape:
events carry their own session id, and the transcript has a named owner.