### PR TITLE
fix(git): stop reporting package-manager checkouts as sub-repos

### DIFF
--- a/backend/git/git-executor.ts
+++ b/backend/git/git-executor.ts
@@ -13,14 +13,30 @@ export interface GitExecResult {
 	exitCode: number;
 }
 
+export interface GitExecOptions {
+	/** Milliseconds before the process is killed. */
+	timeout?: number;
+	/** Piped to the command's stdin (e.g. `check-ignore --stdin` path lists). */
+	stdin?: string;
+	/**
+	 * Exit codes that are a normal answer rather than a failure, so they are
+	 * not logged as one — `check-ignore` exits 1 to say "nothing matched".
+	 */
+	okExitCodes?: number[];
+}
+
 /**
- * Execute a git command in the given working directory
+ * Execute a git command in the given working directory.
+ * The third argument accepts a timeout in ms (legacy form) or an options object.
  */
 export async function execGit(
 	args: string[],
 	cwd: string,
-	timeout = 30000
+	timeoutOrOptions: number | GitExecOptions = 30000
 ): Promise<GitExecResult> {
+	const options: GitExecOptions =
+		typeof timeoutOrOptions === 'number' ? { timeout: timeoutOrOptions } : timeoutOrOptions;
+	const { timeout = 30000, stdin, okExitCodes = [] } = options;
 	debug.log('git', `Executing: git ${args.join(' ')} in ${cwd}`);
 
 	const gitPath = resolveBinary('git');
@@ -29,6 +45,9 @@ export async function execGit(
 	const safeCwd = cwd.replace(/\\/g, '/');
 	const proc = Bun.spawn([gitPath, '-c', `safe.directory=${safeCwd}`, ...args], {
 		cwd,
+		// Commands that read a path list (`check-ignore --stdin`) get it here —
+		// far safer than argv, which has a length limit and quoting pitfalls.
+		stdin: stdin === undefined ? 'ignore' : new TextEncoder().encode(stdin),
 		stdout: 'pipe',
 		stderr: 'pipe',
 		env: {
@@ -63,7 +82,7 @@ export async function execGit(
 		const exitCode = await proc.exited;
 		clearTimeout(timeoutId);
 
-		if (exitCode !== 0) {
+		if (exitCode !== 0 && !okExitCodes.includes(exitCode)) {
 			debug.warn('git', `Command failed (exit ${exitCode}): git ${args.join(' ')}\n${stderr}`);
 		}
 

--- a/backend/git/git-service.ts
+++ b/backend/git/git-service.ts
@@ -36,7 +36,7 @@ import {
 	assertSafeGitRevish,
 	assertSafeGitShowRef
 } from './git-spawn-validation';
-import { findNestedRepoPaths, findSubmodulePaths } from '../snapshot/gitignore';
+import { findNestedRepoPaths, findSubmodulePaths } from './nested-repos';
 import path from 'node:path';
 
 export class GitService {

--- a/backend/git/nested-repos.test.ts
+++ b/backend/git/nested-repos.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execGit } from './git-executor';
+import { findNestedRepoPaths, findRepoForFile } from './nested-repos';
+
+/**
+ * Sub-repo detection used to walk the whole tree and report every directory
+ * with a `.git` inside it. On an iOS project that meant Swift Package
+ * Manager's `build/…/SourcePackages/checkouts/*` — thousands of foreign
+ * changes in the Changes tab. These cover both sides of the policy: package
+ * caches stay out, repos the user actually embedded stay in.
+ */
+
+let root: string;
+
+async function git(cwd: string, ...args: string[]) {
+	const result = await execGit(args, cwd);
+	if (result.exitCode !== 0 && args[0] !== 'check-ignore') {
+		throw new Error(`git ${args.join(' ')}: ${result.stderr}`);
+	}
+	return result.stdout;
+}
+
+async function initRepo(dir: string) {
+	await mkdir(dir, { recursive: true });
+	await git(dir, 'init', '-b', 'main', '.');
+	await git(dir, 'config', 'user.email', 'test@example.com');
+	await git(dir, 'config', 'user.name', 'Test');
+	await git(dir, 'config', 'commit.gpgsign', 'false');
+}
+
+/** Paths relative to the project root, for readable assertions. */
+async function detected(): Promise<string[]> {
+	const paths = await findNestedRepoPaths(root);
+	return paths.map((p) => path.relative(root, p).replace(/\\/g, '/')).sort();
+}
+
+beforeEach(async () => {
+	root = await mkdtemp(path.join(tmpdir(), 'clopen-nested-'));
+	await initRepo(root);
+});
+
+afterEach(async () => {
+	await rm(root, { recursive: true, force: true });
+});
+
+describe('findNestedRepoPaths', () => {
+	test('ignores package-manager checkouts under an ignored build dir', async () => {
+		await writeFile(path.join(root, '.gitignore'), 'build/\n');
+		for (const name of ['abseil-cpp-binary', 'firebase-ios-sdk', 'leveldb']) {
+			await initRepo(path.join(root, 'build/ios/SourcePackages/checkouts', name));
+		}
+
+		expect(await detected()).toEqual([]);
+	});
+
+	test('ignores dependency dirs by name even when they are committed', async () => {
+		// No .gitignore at all — the name alone must be enough.
+		await initRepo(path.join(root, 'node_modules/some-pkg'));
+		await initRepo(path.join(root, 'ios/Pods/SomePod'));
+		await initRepo(path.join(root, '.build/checkouts/some-dep'));
+
+		expect(await detected()).toEqual([]);
+	});
+
+	test('detects a repo embedded in the project tree', async () => {
+		await initRepo(path.join(root, 'packages/widget'));
+
+		expect(await detected()).toEqual(['packages/widget']);
+	});
+
+	test('detects a repo the outer repo ignores', async () => {
+		await writeFile(path.join(root, '.gitignore'), 'wp-content/themes/mytheme/\n');
+		await initRepo(path.join(root, 'wp-content/themes/mytheme'));
+
+		expect(await detected()).toEqual(['wp-content/themes/mytheme']);
+	});
+
+	test('detects a repo sitting directly under an ignored parent', async () => {
+		await writeFile(path.join(root, '.gitignore'), 'themes/\n');
+		await initRepo(path.join(root, 'themes/mytheme'));
+
+		expect(await detected()).toEqual(['themes/mytheme']);
+	});
+
+	test('does not report repos generated deep inside an ignored tree', async () => {
+		await writeFile(path.join(root, '.gitignore'), 'themes/\n');
+		await initRepo(path.join(root, 'themes/mytheme'));
+		await initRepo(path.join(root, 'themes/cache/vendor/dep/checkout'));
+
+		expect(await detected()).toEqual(['themes/mytheme']);
+	});
+
+	test('a nested repo is judged by its own ignore rules', async () => {
+		await initRepo(path.join(root, 'packages/widget'));
+		await writeFile(path.join(root, 'packages/widget/.gitignore'), 'build/\n');
+		await initRepo(path.join(root, 'packages/widget/build/x/y/dep'));
+		await initRepo(path.join(root, 'packages/widget/plugins/helper'));
+
+		expect(await detected()).toEqual(['packages/widget', 'packages/widget/plugins/helper']);
+	});
+});
+
+describe('findRepoForFile', () => {
+	test('routes a file to the deepest owning repo', async () => {
+		await initRepo(path.join(root, 'packages/widget'));
+		await initRepo(path.join(root, 'packages/widget/plugins/helper'));
+
+		const owner = await findRepoForFile(root, 'packages/widget/plugins/helper/src/a.ts');
+		expect(owner?.repoPath).toBe(path.join(root, 'packages/widget/plugins/helper'));
+		expect(owner?.relativeFilePath).toBe('src/a.ts');
+	});
+
+	test('leaves outer-repo files alone', async () => {
+		await initRepo(path.join(root, 'packages/widget'));
+
+		expect(await findRepoForFile(root, 'src/main.ts')).toBeNull();
+	});
+});

--- a/backend/git/nested-repos.ts
+++ b/backend/git/nested-repos.ts
@@ -1,0 +1,301 @@
+/**
+ * Nested git repo discovery — the single source of truth for "which sub-repos
+ * live inside this project".
+ *
+ * Used by the Git panel (status/branches/conflicts aggregation), by the file
+ * handlers that must run git inside the owning repo, and by the snapshot
+ * scanner. Every caller MUST go through `findNestedRepoPaths` so they all agree
+ * on what counts as a sub-repo.
+ *
+ * ## What counts as a sub-repo
+ *
+ * A directory with its own `.git` that the user actually works in — a theme or
+ * plugin extracted into its own repo, a submodule, a worktree.
+ *
+ * What does NOT count: the hundreds of repos a package manager clones into a
+ * build or cache directory (Swift Package Manager's
+ * `build/…/SourcePackages/checkouts/*`, Carthage, Go module caches, …). They
+ * are machine-generated, the user never commits them, and listing them floods
+ * the Changes tab with thousands of foreign files.
+ *
+ * Two signals separate the two, both applied while walking:
+ *
+ * 1. **Name** — directories in `HARD_SKIP_DIRS` are dependency/build caches by
+ *    definition; never descend into them.
+ * 2. **Ignore state** — a directory the enclosing repo ignores is not part of
+ *    the project's own structure. We still peek `IGNORED_DESCENT_LEVELS` level
+ *    into it, because an embedded repo is commonly placed directly under an
+ *    ignored parent (`wp-content/themes/` ignored, the theme repo inside it),
+ *    but generated checkouts always sit much deeper.
+ *
+ * A repo found this way resets the ignore budget: its own contents are then
+ * judged by its own `.gitignore`, not the outer repo's.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { debug } from '$shared/utils/logger';
+import { execGit } from './git-executor';
+
+/**
+ * Directories that never hold a user's own repo — VCS internals, dependency
+ * caches, and package-manager checkout dirs. Pruned by name at any depth,
+ * whether or not the enclosing repo ignores them (a project may well commit
+ * its `Pods/`, and it still isn't where sub-repos live).
+ */
+const HARD_SKIP_DIRS = new Set([
+	'.git', '.svn', '.hg',
+	'node_modules', 'bower_components', '.yarn', '.pnpm-store',
+	'Pods', 'Carthage', 'DerivedData', 'SourcePackages', '.build',
+	'.gradle', '.m2', '.cargo', '.pub-cache', '.dart_tool', '.expo',
+	'.venv', 'venv', '__pycache__', '.tox', '.stack-work',
+	'.next', '.nuxt', '.svelte-kit', '.turbo', '.angular', '.parcel-cache',
+	'.terraform', '.serverless', '.vercel', '.netlify', '.cache'
+]);
+
+/** How many levels below an ignored directory we still look for a repo. */
+const IGNORED_DESCENT_LEVELS = 1;
+
+/** Depth limit below the project root — a runaway walk helps nobody. */
+const MAX_DEPTH = 12;
+
+/**
+ * Upper bound on reported sub-repos. A project with more than this is either
+ * pathological or hit a detection hole; either way the UI cannot usefully show
+ * them, so we stop and log instead of flooding it.
+ */
+const MAX_REPOS = 50;
+
+/** One directory queued for inspection during the breadth-first walk. */
+interface WalkEntry {
+	/** Absolute path of the directory whose children we will inspect. */
+	dirPath: string;
+	/** Absolute path of the nearest enclosing git repo (for ignore checks). */
+	repoRoot: string;
+	/**
+	 * Remaining levels we may descend while inside an ignored tree, or `null`
+	 * when this directory is part of the enclosing repo's own structure.
+	 */
+	ignoredBudget: number | null;
+}
+
+/**
+ * Ask the enclosing repo which of `relPaths` it ignores. Returns the ignored
+ * subset. Batched so a walk costs one git call per repo per depth level, not
+ * one per directory.
+ */
+async function filterIgnored(repoRoot: string, relPaths: string[]): Promise<Set<string>> {
+	const ignored = new Set<string>();
+	if (relPaths.length === 0) return ignored;
+
+	try {
+		// Paths go in over stdin: no argv limit, no quoting rules. Exit 1 just
+		// means "none of these are ignored" — not a failure.
+		const result = await execGit(['check-ignore', '-z', '--stdin'], repoRoot, {
+			stdin: relPaths.join('\0'),
+			okExitCodes: [1]
+		});
+		if (result.exitCode === 0) {
+			for (const p of result.stdout.split('\0')) {
+				if (p) ignored.add(p.replace(/\\/g, '/'));
+			}
+		}
+	} catch {
+		// Not a repo, or git unavailable — treat as "nothing ignored" and let
+		// the name-based prune carry the walk.
+	}
+
+	return ignored;
+}
+
+/** Whether `dirPath` is a git repo (`.git` is a dir for clones, a file for worktrees/submodules). */
+async function isRepoDir(dirPath: string): Promise<boolean> {
+	try {
+		await fs.access(path.join(dirPath, '.git'));
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Find every nested git repo under `rootPath`, skipping dependency caches and
+ * ignored trees (see the module comment for the exact policy). Does NOT scan
+ * the repos — just returns their absolute paths, sorted for stable UI order.
+ */
+export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
+	const found: string[] = [];
+	let level: WalkEntry[] = [{ dirPath: rootPath, repoRoot: rootPath, ignoredBudget: null }];
+	let truncated = false;
+
+	for (let depth = 0; depth < MAX_DEPTH && level.length > 0 && !truncated; depth++) {
+		// Collect this level's candidate children, grouped by enclosing repo so
+		// the ignore check can be batched per repo.
+		const candidates: Array<{ parent: WalkEntry; fullPath: string; relPath: string }> = [];
+		for (const entry of level) {
+			let entries;
+			try {
+				entries = await fs.readdir(entry.dirPath, { withFileTypes: true });
+			} catch {
+				continue; // unreadable dir — skip, never fail the whole walk
+			}
+			for (const child of entries) {
+				// `isDirectory()` is false for symlinks, which also keeps the
+				// walk free of symlink cycles.
+				if (!child.isDirectory()) continue;
+				if (HARD_SKIP_DIRS.has(child.name)) continue;
+				const fullPath = path.join(entry.dirPath, child.name);
+				candidates.push({
+					parent: entry,
+					fullPath,
+					relPath: path.relative(entry.repoRoot, fullPath).replace(/\\/g, '/')
+				});
+			}
+		}
+		if (candidates.length === 0) break;
+
+		// Ignore state is only needed for candidates that are not repos
+		// themselves and whose parent isn't already inside an ignored tree.
+		const repoFlags = await Promise.all(candidates.map((c) => isRepoDir(c.fullPath)));
+		const needIgnoreCheck = new Map<string, string[]>();
+		candidates.forEach((c, i) => {
+			if (repoFlags[i] || c.parent.ignoredBudget !== null) return;
+			const list = needIgnoreCheck.get(c.parent.repoRoot) ?? [];
+			list.push(c.relPath);
+			needIgnoreCheck.set(c.parent.repoRoot, list);
+		});
+		const ignoredByRepo = new Map<string, Set<string>>();
+		for (const [repoRoot, relPaths] of needIgnoreCheck) {
+			ignoredByRepo.set(repoRoot, await filterIgnored(repoRoot, relPaths));
+		}
+
+		const next: WalkEntry[] = [];
+		candidates.forEach((c, i) => {
+			if (repoFlags[i]) {
+				if (found.length >= MAX_REPOS) {
+					truncated = true;
+					return;
+				}
+				found.push(c.fullPath);
+				// Inside a repo, its own ignore rules apply from scratch.
+				next.push({ dirPath: c.fullPath, repoRoot: c.fullPath, ignoredBudget: null });
+				return;
+			}
+
+			let budget = c.parent.ignoredBudget;
+			if (budget === null) {
+				const ignored = ignoredByRepo.get(c.parent.repoRoot);
+				if (!ignored?.has(c.relPath)) {
+					// Part of the project's own structure — descend freely.
+					next.push({ dirPath: c.fullPath, repoRoot: c.parent.repoRoot, ignoredBudget: null });
+					return;
+				}
+				budget = IGNORED_DESCENT_LEVELS;
+			} else {
+				budget -= 1;
+			}
+			// Inside an ignored tree: keep looking only while the budget lasts.
+			if (budget > 0) {
+				next.push({ dirPath: c.fullPath, repoRoot: c.parent.repoRoot, ignoredBudget: budget });
+			}
+		});
+
+		level = next;
+	}
+
+	if (truncated) {
+		debug.warn('git', `Nested repo scan of ${rootPath} stopped at ${MAX_REPOS} repos`);
+	}
+
+	found.sort();
+	return found;
+}
+
+/**
+ * Read the outer repo's `.gitmodules` file and return the set of relative
+ * submodule paths. Returns an empty set when the file is missing or unreadable
+ * (e.g. the project isn't a git repo at all, or has no submodules).
+ *
+ * The format is INI-like:
+ *   [submodule "vendor/foo"]
+ *           path = vendor/foo
+ *           url = git@example.com:vendor/foo.git
+ *
+ * The `path =` value is what we return — the directory inside the project root
+ * where the submodule is checked out. If a section omits `path =`, git falls
+ * back to the section name; we mirror that.
+ */
+export async function findSubmodulePaths(rootPath: string): Promise<Set<string>> {
+	const out = new Set<string>();
+	let raw: string;
+	try {
+		raw = await fs.readFile(path.join(rootPath, '.gitmodules'), 'utf8');
+	} catch {
+		return out; // file missing → no submodules
+	}
+
+	// Two-pass parse: collect per-section { name, path? } then resolve.
+	// Single-pass is simpler but needs careful handling of the implicit
+	// section-name fallback; the two-pass version reads more clearly.
+	const sections: Array<{ name: string; path?: string }> = [];
+	let current: { name: string; path?: string } | null = null;
+	for (const line of raw.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith('#')) continue;
+
+		const sectionMatch = trimmed.match(/^\[submodule\s+"([^"]+)"\]\s*$/);
+		if (sectionMatch) {
+			if (current) sections.push(current);
+			current = { name: sectionMatch[1] };
+			continue;
+		}
+		if (!current) continue;
+
+		const pathMatch = trimmed.match(/^path\s*=\s*(.+?)\s*$/);
+		if (pathMatch) current.path = pathMatch[1].replace(/\\/g, '/');
+	}
+	if (current) sections.push(current);
+
+	for (const s of sections) {
+		out.add(s.path ?? s.name);
+	}
+	return out;
+}
+
+/**
+ * Given a file path relative to the project root, find the deepest nested
+ * git repo that contains it. Returns the repo's absolute path and the file
+ * path relative to that repo, or `null` if the file lives in the outer repo.
+ *
+ * Used by git staging/discard handlers so that `git add` / `git restore` /
+ * `git rm` run inside the correct repo (the outer repo's `git` would skip
+ * or fail on files that are tracked by a nested repo).
+ */
+export async function findRepoForFile(
+	projectPath: string,
+	filePath: string
+): Promise<{ repoPath: string; relativeFilePath: string } | null> {
+	const normalizedFilePath = filePath.replace(/\\/g, '/');
+	const nestedRepoPaths = await findNestedRepoPaths(projectPath);
+
+	let bestMatch: { repoPath: string; relativeFilePath: string } | null = null;
+	let bestRepoRelLen = -1;
+
+	for (const repoPath of nestedRepoPaths) {
+		const repoRel = path.relative(projectPath, repoPath).replace(/\\/g, '/');
+		// File is inside this repo if its path starts with `repoRel/`
+		if (normalizedFilePath === repoRel || normalizedFilePath.startsWith(repoRel + '/')) {
+			if (repoRel.length > bestRepoRelLen) {
+				bestMatch = {
+					repoPath,
+					relativeFilePath: normalizedFilePath === repoRel
+						? ''
+						: normalizedFilePath.substring(repoRel.length + 1)
+				};
+				bestRepoRelLen = repoRel.length;
+			}
+		}
+	}
+
+	return bestMatch;
+}

--- a/backend/snapshot/gitignore.ts
+++ b/backend/snapshot/gitignore.ts
@@ -12,6 +12,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { debug } from '$shared/utils/logger';
 import { execGit } from '../git/git-executor';
+import { findNestedRepoPaths } from '../git/nested-repos';
 
 /**
  * Safety-net directories to always exclude regardless of .gitignore.
@@ -22,137 +23,6 @@ const ALWAYS_EXCLUDE_DIRS = new Set([
 	'node_modules',
 ]);
 
-/**
- * Find paths of all nested git repos (directories with their own `.git`) at any
- * depth under `rootPath`. Walks into nested repos to find deeply nested ones.
- * Does NOT scan the repos — just returns their absolute paths.
- *
- * Used by callers that need to run git commands inside each nested repo
- * (e.g. `git:status` aggregating changes from nested repos into the Changes
- * tab of the Git panel).
- */
-export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
-	const paths: string[] = [];
-
-	const walk = async (currentPath: string): Promise<void> => {
-		let entries;
-		try {
-			entries = await fs.readdir(currentPath, { withFileTypes: true });
-		} catch {
-			return;
-		}
-
-		for (const entry of entries) {
-			if (!entry.isDirectory()) continue;
-			if (ALWAYS_EXCLUDE_DIRS.has(entry.name)) continue;
-
-			const fullPath = path.join(currentPath, entry.name);
-
-			// Check if this directory is itself a git repo
-			try {
-				await fs.access(path.join(fullPath, '.git'));
-				paths.push(fullPath);
-				// Fall through to also walk into it for deeper nested repos
-			} catch {
-				// Not a git repo
-			}
-
-			await walk(fullPath);
-		}
-	};
-
-	await walk(rootPath);
-	return paths;
-}
-
-/**
- * Read the outer repo's `.gitmodules` file and return the set of relative
- * submodule paths. Returns an empty set when the file is missing or unreadable
- * (e.g. the project isn't a git repo at all, or has no submodules).
- *
- * The format is INI-like:
- *   [submodule "vendor/foo"]
- *           path = vendor/foo
- *           url = git@example.com:vendor/foo.git
- *
- * The `path =` value is what we return — the directory inside the project root
- * where the submodule is checked out. If a section omits `path =`, git falls
- * back to the section name; we mirror that.
- */
-export async function findSubmodulePaths(rootPath: string): Promise<Set<string>> {
-	const out = new Set<string>();
-	let raw: string;
-	try {
-		raw = await fs.readFile(path.join(rootPath, '.gitmodules'), 'utf8');
-	} catch {
-		return out; // file missing → no submodules
-	}
-
-	// Two-pass parse: collect per-section { name, path? } then resolve.
-	// Single-pass is simpler but needs careful handling of the implicit
-	// section-name fallback; the two-pass version reads more clearly.
-	const sections: Array<{ name: string; path?: string }> = [];
-	let current: { name: string; path?: string } | null = null;
-	for (const line of raw.split(/\r?\n/)) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith('#')) continue;
-
-		const sectionMatch = trimmed.match(/^\[submodule\s+"([^"]+)"\]\s*$/);
-		if (sectionMatch) {
-			if (current) sections.push(current);
-			current = { name: sectionMatch[1] };
-			continue;
-		}
-		if (!current) continue;
-
-		const pathMatch = trimmed.match(/^path\s*=\s*(.+?)\s*$/);
-		if (pathMatch) current.path = pathMatch[1].replace(/\\/g, '/');
-	}
-	if (current) sections.push(current);
-
-	for (const s of sections) {
-		out.add(s.path ?? s.name);
-	}
-	return out;
-}
-
-/**
- * Given a file path relative to the project root, find the deepest nested
- * git repo that contains it. Returns the repo's absolute path and the file
- * path relative to that repo, or `null` if the file lives in the outer repo.
- *
- * Used by git staging/discard handlers so that `git add` / `git restore` /
- * `git rm` run inside the correct repo (the outer repo's `git` would skip
- * or fail on files that are tracked by a nested repo).
- */
-export async function findRepoForFile(
-	projectPath: string,
-	filePath: string
-): Promise<{ repoPath: string; relativeFilePath: string } | null> {
-	const normalizedFilePath = filePath.replace(/\\/g, '/');
-	const nestedRepoPaths = await findNestedRepoPaths(projectPath);
-
-	let bestMatch: { repoPath: string; relativeFilePath: string } | null = null;
-	let bestRepoRelLen = -1;
-
-	for (const repoPath of nestedRepoPaths) {
-		const repoRel = path.relative(projectPath, repoPath).replace(/\\/g, '/');
-		// File is inside this repo if its path starts with `repoRel/`
-		if (normalizedFilePath === repoRel || normalizedFilePath.startsWith(repoRel + '/')) {
-			if (repoRel.length > bestRepoRelLen) {
-				bestMatch = {
-					repoPath,
-					relativeFilePath: normalizedFilePath === repoRel
-						? ''
-						: normalizedFilePath.substring(repoRel.length + 1)
-				};
-				bestRepoRelLen = repoRel.length;
-			}
-		}
-	}
-
-	return bestMatch;
-}
 
 /**
  * Get list of snapshot-eligible files using git (preferred) or manual scan.
@@ -236,52 +106,18 @@ async function scanSingleGitRepo(dirPath: string): Promise<string[]> {
 }
 
 /**
- * Walk the project tree to find nested git repos (directories with their own
- * `.git`) and scan each one independently. This catches nested repos that are
- * gitignored by the parent — they'd otherwise be invisible to the outer repo's
- * `git ls-files --exclude-standard`.
- *
- * The walk respects ALWAYS_EXCLUDE_DIRS (skips `.git`, `node_modules`) but does
- * NOT respect .gitignore, because the nested repo we're looking for may itself
- * be gitignored by the parent. Once a nested repo is found, its own
- * `git ls-files --exclude-standard` handles its .gitignore rules.
+ * Scan every nested git repo inside the project and return their files.
+ * Discovery is delegated to `findNestedRepoPaths` — the same source of truth
+ * the Git panel uses — so a repo the panel shows is a repo the snapshot
+ * captures, and a package-manager checkout neither of them touches. Each repo
+ * is then scanned with its own `git ls-files --exclude-standard`, which applies
+ * that repo's .gitignore rules.
  */
 async function findAndScanNestedRepos(rootPath: string): Promise<string[]> {
 	const files: string[] = [];
-
-	const walk = async (currentPath: string): Promise<void> => {
-		let entries;
-		try {
-			entries = await fs.readdir(currentPath, { withFileTypes: true });
-		} catch {
-			return;
-		}
-
-		for (const entry of entries) {
-			if (!entry.isDirectory()) continue;
-			if (ALWAYS_EXCLUDE_DIRS.has(entry.name)) continue;
-
-			const fullPath = path.join(currentPath, entry.name);
-
-			// Check if this directory is itself a git repo (`.git` can be a
-			// directory or a file — the latter for worktrees/submodules).
-			try {
-				await fs.access(path.join(fullPath, '.git'));
-				// Nested repo found — scan it independently, then continue
-				// walking into it to find even deeper nested repos.
-				const nestedFiles = await scanSingleGitRepo(fullPath);
-				files.push(...nestedFiles);
-				await walk(fullPath);
-				continue;
-			} catch {
-				// Not a git repo — recurse to find deeper nested repos
-			}
-
-			await walk(fullPath);
-		}
-	};
-
-	await walk(rootPath);
+	for (const repoPath of await findNestedRepoPaths(rootPath)) {
+		files.push(...await scanSingleGitRepo(repoPath));
+	}
 	return files;
 }
 

--- a/backend/ws/files/read.ts
+++ b/backend/ws/files/read.ts
@@ -19,7 +19,7 @@ import {
 } from '../../files/file-reading';
 import { handlePathBrowsing } from '../../files/path-browsing';
 import { gitService } from '../../git/git-service';
-import { findRepoForFile } from '../../snapshot/gitignore';
+import { findRepoForFile } from '../../git/nested-repos';
 import { projectQueries } from '../../database/queries/project-queries';
 import { isAbsolute, relative } from 'node:path';
 import { requireProjectAccess } from '../access';

--- a/backend/ws/git/conflict.ts
+++ b/backend/ws/git/conflict.ts
@@ -6,7 +6,7 @@ import { t } from 'elysia';
 import path from 'node:path';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { findNestedRepoPaths, findRepoForFile } from '../../snapshot/gitignore';
+import { findNestedRepoPaths, findRepoForFile } from '../../git/nested-repos';
 import { requireProjectAccess } from '../access';
 import { debug } from '$shared/utils/logger';
 

--- a/backend/ws/git/diff.ts
+++ b/backend/ws/git/diff.ts
@@ -6,7 +6,7 @@ import { t } from 'elysia';
 import path from 'node:path';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { findRepoForFile } from '../../snapshot/gitignore';
+import { findRepoForFile } from '../../git/nested-repos';
 import { requireProjectAccess } from '../access';
 import { debug } from '$shared/utils/logger';
 

--- a/backend/ws/git/staging.ts
+++ b/backend/ws/git/staging.ts
@@ -6,7 +6,7 @@ import { t } from 'elysia';
 import path from 'node:path';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { findRepoForFile } from '../../snapshot/gitignore';
+import { findRepoForFile } from '../../git/nested-repos';
 import { requireProjectAccess } from '../access';
 import { debug } from '$shared/utils/logger';
 

--- a/backend/ws/git/status.ts
+++ b/backend/ws/git/status.ts
@@ -5,7 +5,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { findNestedRepoPaths } from '../../snapshot/gitignore';
+import { findNestedRepoPaths } from '../../git/nested-repos';
 import { requireProjectAccess } from '../access';
 import { relative as pathRelative } from 'path';
 


### PR DESCRIPTION
## Summary
Nested git repo detection no longer reports package-manager checkouts (Swift
Package Manager, Carthage, and friends) as project sub-repos, and all callers
now share one discovery implementation.

## Why
Detection walked the whole tree and accepted any directory with a `.git`,
excluding only `.git` and `node_modules`. On an iOS project, SPM's
`app/build/ios/SourcePackages/checkouts/*` clones were all classified as
sub-repos, so `git:status` aggregated them and the Changes tab showed 6324
foreign changes. The snapshot scanner had a duplicate walk with the same flaw,
so checkpoints captured those dependency trees as well.

## Changes
- Add `backend/git/nested-repos.ts` — single source of truth for nested repo
  discovery (`findNestedRepoPaths`, `findSubmodulePaths`, `findRepoForFile`),
  moved out of `backend/snapshot/gitignore.ts`
- Prune by directory name (dependency and build caches) and by ignore state,
  keeping a one-level peek inside ignored directories so an embedded repo under
  an ignored parent is still found
- Batch ignore checks into one `git check-ignore -z --stdin` call per repo per
  depth level; cap walk depth at 12 and reported repos at 50 with a warning
- Replace the duplicate walk in `backend/snapshot/gitignore.ts` with a call into
  the shared discovery
- Give `execGit` an options form (`stdin`, `okExitCodes`, `timeout`); the
  numeric-timeout form still works
- Point `ws/git/{status,diff,staging,conflict}`, `ws/files/read` and
  `git-service` at the new module

## Test plan
- `backend/git/nested-repos.test.ts` (new, 9 cases): SPM checkouts under an
  ignored `build/`, dependency dirs by name even when committed, an embedded
  repo, an ignored embedded repo, a repo directly under an ignored parent, a
  generated repo deep inside an ignored tree, a sub-repo judged by its own
  `.gitignore`, plus `findRepoForFile` routing
- Fixture reproducing the report: before, 8 SPM checkouts plus the real
  sub-repo; after, only the real sub-repo
- `bun run check` (0 errors), `bun run lint` (clean), `bun run test`
  (491 pass, 0 fail)

## Notes
The one-level peek inside ignored directories is the deliberate trade-off: a
repo placed deeper than one level below an ignored parent is no longer listed.
That shape is what generated checkouts look like, and the name-based prune plus
the repo-count cap keep the failure mode loud rather than silent.