### PR TITLE
fix(markdown): render images that point at local file paths

### DIFF
--- a/frontend/components/common/display/Markdown.svelte
+++ b/frontend/components/common/display/Markdown.svelte
@@ -2,11 +2,18 @@
 	// Single, shared markdown surface for the whole app. Renders content via renderMarkdown, wires
 	// the data-md-* link clicks via dispatchMarkdownClick, and owns the markdown CSS. Visual scale is
 	// selected with `variant`; consumers pass only their content and a couple of flags.
-	import { renderMarkdown, dispatchMarkdownClick } from '$frontend/utils/markdown-renderer';
+	import { onDestroy } from 'svelte';
+	import {
+		renderMarkdown,
+		dispatchMarkdownClick,
+		resolveLocalImageSrc
+	} from '$frontend/utils/markdown-renderer';
 	import { revealFile } from '$frontend/stores/ui/file-peek.svelte';
 	import { initMonaco } from '$frontend/components/common/editor/monaco-loader';
 	import { getThemeName, registerThemes } from '$frontend/components/common/editor/monaco-themes';
 	import { themeStore } from '$frontend/stores/ui/theme.svelte';
+	import ws from '$frontend/utils/ws';
+	import { debug } from '$shared/utils/logger';
 
 	interface Props {
 		content: string;
@@ -38,6 +45,85 @@
 		// when that panel isn't part of the current layout.
 		dispatchMarkdownClick(event, { onFileLink: onFileLink ?? revealFile });
 	}
+
+	// --- Local images ---
+	// Images that point at a path on the backend's disk carry [data-md-local-src] instead of a src
+	// (see resolveLocalImageSrc). Their bytes are read over the file WS API — the same channel the
+	// media preview uses — and handed to the <img> as a blob URL, so they render identically for a
+	// local browser and for someone viewing the workspace from another device.
+	const localImageUrls = new Map<string, string>();
+	const localImageLoads = new Map<string, Promise<string | null>>();
+	const localImageFailures = new Set<string>();
+
+	function loadLocalImage(path: string): Promise<string | null> {
+		const cached = localImageUrls.get(path);
+		if (cached) return Promise.resolve(cached);
+		const inFlight = localImageLoads.get(path);
+		if (inFlight) return inFlight;
+
+		const load = (async () => {
+			try {
+				const response = await ws.http('files:read-content', { path });
+				if (!response.content) return null;
+				const binary = atob(response.content);
+				const bytes = new Uint8Array(binary.length);
+				for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+				const blob = new Blob([bytes], {
+					type: response.contentType || 'application/octet-stream'
+				});
+				const url = URL.createObjectURL(blob);
+				localImageUrls.set(path, url);
+				return url;
+			} catch (err) {
+				debug.error('file', 'Failed to load markdown image:', path, err);
+				return null;
+			} finally {
+				localImageLoads.delete(path);
+			}
+		})();
+		localImageLoads.set(path, load);
+		return load;
+	}
+
+	$effect(() => {
+		void rendered; // re-run when the rendered HTML changes
+		const el = root;
+		if (!el) return;
+
+		const present = new Set<string>();
+		for (const img of Array.from(el.querySelectorAll('img'))) {
+			// Sanitized raw <img src="/Users/..."> goes through the same resolution, so inline HTML
+			// in a file preview behaves like markdown image syntax.
+			const path =
+				img.getAttribute('data-md-local-src') || resolveLocalImageSrc(img.getAttribute('src') || '');
+			if (!path) continue;
+			// Stamp the resolved path so the next pass still recognizes the element after its src
+			// has been swapped for a blob URL (matters for the raw-HTML case).
+			img.setAttribute('data-md-local-src', path);
+			present.add(path);
+			// A failed read is remembered so a streaming message doesn't retry it on every chunk.
+			if (localImageFailures.has(path)) continue;
+			void loadLocalImage(path).then((url) => {
+				if (!url) {
+					localImageFailures.add(path);
+					return;
+				}
+				if (img.isConnected) img.src = url;
+			});
+		}
+
+		// Release blobs for images the current content no longer references.
+		for (const [path, url] of localImageUrls) {
+			if (present.has(path)) continue;
+			URL.revokeObjectURL(url);
+			localImageUrls.delete(path);
+		}
+	});
+
+	onDestroy(() => {
+		for (const url of localImageUrls.values()) URL.revokeObjectURL(url);
+		localImageUrls.clear();
+	});
 
 	// Fence language → Monaco language id (aliases Monaco doesn't resolve itself).
 	const MONACO_LANG: Record<string, string> = {

--- a/frontend/utils/markdown-renderer.test.ts
+++ b/frontend/utils/markdown-renderer.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { renderMarkdown, resolveLocalImageSrc } from './markdown-renderer';
+
+// resolveLocalImageSrc consults window.location for same-host URLs; the rest of the module works
+// without a DOM.
+const hadWindow = 'window' in globalThis;
+
+beforeAll(() => {
+	(globalThis as { window?: unknown }).window = {
+		location: { origin: 'http://localhost:9141', hostname: 'localhost' }
+	};
+});
+
+afterAll(() => {
+	if (!hadWindow) delete (globalThis as { window?: unknown }).window;
+});
+
+describe('resolveLocalImageSrc', () => {
+	test('resolves bare absolute paths', () => {
+		expect(resolveLocalImageSrc('/Users/me/shots/cover.png')).toBe('/Users/me/shots/cover.png');
+		expect(resolveLocalImageSrc('/home/me/shots/cover.png')).toBe('/home/me/shots/cover.png');
+	});
+
+	test('resolves file:// URLs, decoding escapes', () => {
+		expect(resolveLocalImageSrc('file:///Users/me/my%20shots/cover.png')).toBe(
+			'/Users/me/my shots/cover.png'
+		);
+	});
+
+	test('resolves same-host URLs that carry an absolute path', () => {
+		expect(resolveLocalImageSrc('http://localhost:9141/Users/me/shots/cover.png')).toBe(
+			'/Users/me/shots/cover.png'
+		);
+	});
+
+	test('resolves Windows paths', () => {
+		expect(resolveLocalImageSrc('C:\\Users\\me\\cover.png')).toBe('C:/Users/me/cover.png');
+		expect(resolveLocalImageSrc('file:///C:/Users/me/cover.png')).toBe('C:/Users/me/cover.png');
+	});
+
+	test('leaves remote, inline and relative sources alone', () => {
+		expect(resolveLocalImageSrc('https://example.com/cover.png')).toBeNull();
+		expect(resolveLocalImageSrc('data:image/png;base64,AAAA')).toBeNull();
+		expect(resolveLocalImageSrc('blob:http://localhost:9141/abc')).toBeNull();
+		expect(resolveLocalImageSrc('evidence/cover.png')).toBeNull();
+		expect(resolveLocalImageSrc('/assets/cover.png')).toBeNull();
+		expect(resolveLocalImageSrc('')).toBeNull();
+	});
+});
+
+describe('renderMarkdown images', () => {
+	test('marks a local image instead of emitting a doomed src', () => {
+		const html = renderMarkdown('![Cover](/Users/me/shots/cover.png)');
+		expect(html).toContain('data-md-local-src="/Users/me/shots/cover.png"');
+		expect(html).toContain('alt="Cover"');
+		expect(html).not.toContain(' src=');
+	});
+
+	test('keeps a remote image src', () => {
+		const html = renderMarkdown('![Cover](https://example.com/cover.png "Title")');
+		expect(html).toContain('src="https://example.com/cover.png"');
+		expect(html).toContain('title="Title"');
+		expect(html).not.toContain('data-md-local-src');
+	});
+});

--- a/frontend/utils/markdown-renderer.ts
+++ b/frontend/utils/markdown-renderer.ts
@@ -70,6 +70,17 @@ function isExternalUrl(href: string): boolean {
 	return PROTOCOL_RE.test(href) || href.startsWith('//') || href.startsWith('mailto:');
 }
 
+// Recognize an absolute filesystem path (as it appears in a URL pathname or bare in markdown).
+// Returns the file path if matched, otherwise null.
+function matchAbsoluteFilePath(path: string): string | null {
+	// Unix-style absolute file path
+	if (/^\/(Users|home|tmp|opt|var|root|mnt|private|etc)\//.test(path)) return path;
+	// Windows-style, either as a URL pathname (/C:/...) or bare (C:\... / C:/...)
+	const winMatch = path.match(/^\/?([A-Za-z]):[/\\](.*)$/);
+	if (winMatch) return `${winMatch[1]}:/${winMatch[2].replace(/\\/g, '/')}`;
+	return null;
+}
+
 // Detect URLs that point to a local absolute file path served by the current host (e.g.
 // http://localhost/Users/...). Returns the resolved file path if matched, otherwise null, so
 // same-host file links resolve to a Files-panel target instead of opening a new tab.
@@ -81,16 +92,37 @@ function matchLocalFilePath(href: string): string | null {
 			url.hostname === 'localhost' ||
 			url.hostname === '127.0.0.1';
 		if (!sameHost) return null;
-		const path = decodeURIComponent(url.pathname);
-		// Unix-style absolute file path
-		if (/^\/(Users|home|tmp|opt|var|root|mnt|private|etc)\//.test(path)) return path;
-		// Windows-style /C:/...
-		const winMatch = path.match(/^\/([A-Za-z]):\/(.*)$/);
-		if (winMatch) return `${winMatch[1]}:/${winMatch[2]}`;
-		return null;
+		return matchAbsoluteFilePath(decodeURIComponent(url.pathname));
 	} catch {
 		return null;
 	}
+}
+
+// Classify an image source: returns the absolute filesystem path when the source points at a
+// file on the machine running the backend, otherwise null (leave the src alone).
+//
+// Assistants routinely reference screenshots by absolute path (`![shot](/Users/me/x.png)`), which
+// the browser would resolve against the app origin — http://localhost:9141/Users/me/x.png — and
+// fail. A `file://` URL is no fix either: browsers refuse file subresources inside an http page,
+// and for someone viewing the app from another device the path isn't on their disk at all. The
+// bytes have to come from the backend, so these sources are handed to Markdown.svelte, which
+// fetches them over the file WS API. Everything else (http(s), data:, blob:, relative) passes
+// through untouched.
+export function resolveLocalImageSrc(src: string): string | null {
+	const href = src.trim();
+	if (!href) return null;
+	if (href.startsWith('file:')) {
+		try {
+			return matchAbsoluteFilePath(decodeURIComponent(new URL(href).pathname));
+		} catch {
+			return null;
+		}
+	}
+	// A Windows drive letter (C:\...) looks like a URL scheme, so it has to be settled before the
+	// protocol check.
+	if (/^[A-Za-z]:[/\\]/.test(href)) return matchAbsoluteFilePath(href);
+	if (PROTOCOL_RE.test(href) || href.startsWith('//')) return matchLocalFilePath(href);
+	return matchAbsoluteFilePath(href);
 }
 
 // --- Heading id generation (used for in-document scroll anchors) ---
@@ -178,6 +210,20 @@ export function renderMarkdown(content: string, options: RenderMarkdownOptions =
 			return `<a href="${safeHref}" data-md-file="${safeHref}"${titleAttr}>${text}</a>`;
 		}
 		return `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer"${titleAttr}>${text}</a>`;
+	};
+
+	renderer.image = function (token) {
+		const href = token.href || '';
+		const altAttr = ` alt="${escapeHtml(token.text || '')}"`;
+		const titleAttr = token.title ? ` title="${escapeHtml(token.title)}"` : '';
+		const localPath = resolveLocalImageSrc(href);
+		if (localPath) {
+			// Deliberately no src — an http://<origin>/Users/... request would only 404. The
+			// element is marked instead, and Markdown.svelte fills in a blob URL once it has
+			// read the file from the backend.
+			return `<img data-md-local-src="${escapeHtml(localPath)}"${altAttr}${titleAttr}>`;
+		}
+		return `<img src="${escapeHtml(href)}"${altAttr}${titleAttr}>`;
 	};
 
 	renderer.table = function (token) {


### PR DESCRIPTION
## Summary
Markdown images that point at a local file path now render, instead of turning into a broken `http://localhost:9141/Users/...` request.

## Why
Assistant messages routinely reference screenshots by absolute path (`![Cover](/Users/me/project/evidence/cover.png)`). The browser resolved that against the app origin and requested a path the server doesn't serve, so the image was always broken.

`file://` is not an alternative: browsers block file subresources inside an http page, and for a viewer on another device the path isn't on their disk. The bytes have to be read by the backend, which also keeps the existing per-user path access check in force.

## Changes
- `frontend/utils/markdown-renderer.ts`: new `resolveLocalImageSrc()` — classifies bare absolute paths, `file://` URLs, same-host URLs carrying an absolute path, and Windows drive paths; leaves http(s), `data:`, `blob:` and relative sources untouched. Absolute-path matching is factored into `matchAbsoluteFilePath()` and shared with the existing link classifier.
- `frontend/utils/markdown-renderer.ts`: `renderer.image` emits `<img data-md-local-src="...">` with no `src` for local sources, so the failing origin request never happens.
- `frontend/components/common/display/Markdown.svelte`: loads those paths over the `files:read-content` WS API and assigns a blob URL — per-path blob cache, in-flight dedupe, revoke on content change and destroy, and failed reads remembered so streaming messages don't retry each chunk. Sanitized raw `<img src="/Users/...">` in file previews is resolved the same way.
- `frontend/utils/markdown-renderer.test.ts`: new coverage for source classification and the emitted image HTML.

## Test plan
- `bun run check` — 0 errors
- `bun run lint` — clean
- `bun run test` — 498 pass, 0 fail (7 new)
- Manual: chat message with `![alt](/absolute/path.png)` renders the image; remote/`data:` images unaffected; markdown file preview with an absolute-path image renders.

## Notes
Loading goes through `requireFilePathAccess`, so a non-admin viewer only sees images inside projects they have access to — a path outside them fails to load rather than leaking bytes. Relative image paths (`![](evidence/x.png)`) are still left alone; resolving those needs a base directory per consumer and is a separate change.