### PR TITLE
fix(preview): recover stuck previews and bind MCP calls to their project

### DIFF
--- a/backend/chat/stream-manager.ts
+++ b/backend/chat/stream-manager.ts
@@ -439,7 +439,10 @@ class StreamManager extends EventEmitter {
 		// Register session -> projectId mapping for MCP context
 		if (request.projectId) {
 			projectContextService.registerSession(request.chatSessionId, request.projectId);
-			projectContextService.registerStream(streamId, request.projectId, request.chatSessionId);
+			// The engine goes with it: the remote HTTP MCP bridge cannot always
+			// name the calling stream, and knowing which engine asked is what
+			// keeps a fallback from reaching across into another engine's project.
+			projectContextService.registerStream(streamId, request.projectId, request.chatSessionId, request.engine.type);
 		}
 		// Hand the AbortSignal to MCP so tool handlers can fast-fail on
 		// cancellation. Without this, the engine subprocess dies on cancel

--- a/backend/engine/adapters/codex/stream.ts
+++ b/backend/engine/adapters/codex/stream.ts
@@ -86,6 +86,24 @@ export class CodexEngine implements AIEngine {
 	 * `'*'` = unfiltered (no profile constraint). `null` = not initialized.
 	 */
 	private currentMcpFilterKey: string | null = null;
+	/**
+	 * Project baked into `this.codex`'s MCP bridge URL.
+	 *
+	 * Codex takes its MCP set at construction, so the URL — and with it the
+	 * identity the bridge binds tool calls to — is fixed for the life of the
+	 * client. An instance serves exactly one project (see the per-project engine
+	 * cache in `backend/engine/index.ts`), so the project is a safe thing to bake;
+	 * the chat session is not, because the same client serves all of them.
+	 * `null` = built without a project, which a later stream re-initialises.
+	 */
+	private currentProjectId: string | null = null;
+	/**
+	 * Project for the client `initialize()` is about to build. Carried in a field
+	 * rather than an argument because `initialize` is part of the `AIEngine`
+	 * interface and adding a parameter to the implementation would stop it
+	 * satisfying that type.
+	 */
+	private pendingProjectId: string | null = null;
 
 	get isInitialized(): boolean {
 		return this._isInitialized;
@@ -100,6 +118,8 @@ export class CodexEngine implements AIEngine {
 		if (this._isInitialized && (accountId == null || accountId === this.currentAccountId) && mcpKey === this.currentMcpFilterKey) {
 			return;
 		}
+
+		const projectId = this.pendingProjectId;
 
 		const account = accountId != null
 			? engineQueries.getAccount(accountId)
@@ -122,7 +142,7 @@ export class CodexEngine implements AIEngine {
 		// inside the stack dir) over an older copy on the user's PATH — the SDK
 		// would otherwise be pinned while the process it spawns drifts.
 		const codexCli = await resolveEngineCli('codex');
-		const mcpConfig = getCodexMcpConfig(mcpProfileFilter);
+		const mcpConfig = getCodexMcpConfig(mcpProfileFilter, projectId ? { projectId } : undefined);
 
 		// Codex SDK takes config at construction. We pass `show_raw_agent_reasoning`
 		// (so the SDK forwards reasoning text events) and forward the Clopen MCP
@@ -149,8 +169,9 @@ export class CodexEngine implements AIEngine {
 		});
 		this.currentAccountId = account.id;
 		this.currentMcpFilterKey = mcpKey;
+		this.currentProjectId = projectId;
 		this._isInitialized = true;
-		debug.log('engine', `Codex engine initialized (account ${account.id}, mode=${credential.kind}, mcpFilter=${mcpKey})`);
+		debug.log('engine', `Codex engine initialized (account ${account.id}, mode=${credential.kind}, mcpFilter=${mcpKey}, project=${projectId ?? 'none'})`);
 	}
 
 	async dispose(): Promise<void> {
@@ -158,6 +179,7 @@ export class CodexEngine implements AIEngine {
 		this.codex = null;
 		this.currentAccountId = null;
 		this.currentMcpFilterKey = null;
+		this.currentProjectId = null;
 		this._isInitialized = false;
 		debug.log('engine', 'Codex engine disposed');
 	}
@@ -191,10 +213,17 @@ export class CodexEngine implements AIEngine {
 		const mcpKey = mcpProfileFilter ? [...mcpProfileFilter].sort().join(',') : '*';
 		const accountChanged = this._isInitialized && accountId != null && accountId !== this.currentAccountId;
 		const mcpChanged = this._isInitialized && mcpKey !== this.currentMcpFilterKey;
-		if (accountChanged || mcpChanged) {
-			debug.log('engine', `Codex re-initialising (accountChanged=${accountChanged}, mcpChanged=${mcpChanged})`);
+		// A client built without a project (the bare `initialize()` the engine
+		// registry does) addresses the bridge anonymously, and its tool calls fall
+		// back to whichever stream started last — the way an agent in one project
+		// ended up opening tabs in another.
+		const streamProjectId = options.mcpContext?.projectId ?? null;
+		const projectChanged = this._isInitialized && streamProjectId !== null && streamProjectId !== this.currentProjectId;
+		if (accountChanged || mcpChanged || projectChanged) {
+			debug.log('engine', `Codex re-initialising (accountChanged=${accountChanged}, mcpChanged=${mcpChanged}, projectChanged=${projectChanged})`);
 			await this.dispose();
 		}
+		this.pendingProjectId = streamProjectId;
 		if (!this._isInitialized || !this.codex) {
 			await this.initialize(accountId, mcpProfileFilter);
 		}

--- a/backend/engine/adapters/copilot/stream.ts
+++ b/backend/engine/adapters/copilot/stream.ts
@@ -339,7 +339,7 @@ export class CopilotEngine implements AIEngine {
 		const { approveAll } = await loadEngineSdk<typeof import('@github/copilot-sdk')>('copilot', '@github/copilot-sdk');
 
 		try {
-			const mcpConfig = getCopilotMcpConfig(mcpProfileFilter);
+			const mcpConfig = getCopilotMcpConfig(mcpProfileFilter, options.mcpContext);
 
 			const baseConfig: ResumeSessionConfig = {
 				onPermissionRequest: (request, invocation) =>

--- a/backend/engine/adapters/cursor/stream.ts
+++ b/backend/engine/adapters/cursor/stream.ts
@@ -192,7 +192,7 @@ export class CursorEngine implements AIEngine {
 			},
 		});
 		const customTools: Record<string, SDKCustomTool> = { AskUserQuestion: askTool };
-		const mcpServers = getCursorMcpConfig(mcpProfileFilter);
+		const mcpServers = getCursorMcpConfig(mcpProfileFilter, options.mcpContext);
 		const agents = await this.buildAgents();
 
 		const { Agent } = await loadEngineSdk<typeof import('@cursor/sdk')>('cursor', '@cursor/sdk');

--- a/backend/engine/adapters/qwen/stream.ts
+++ b/backend/engine/adapters/qwen/stream.ts
@@ -162,7 +162,7 @@ export class QwenEngine implements AIEngine {
 		// Refresh the synthetic skills preamble in the Qwen memory file.
 		await syncSkills('qwen', profileId);
 		await syncEngineArtifacts('qwen', profileId);
-		const mcpConfig = getQwenMcpConfig(mcpProfileFilter);
+		const mcpConfig = getQwenMcpConfig(mcpProfileFilter, options.mcpContext);
 
 		// Resolve the permission policy once per stream; canUseTool enforces it
 		// (Qwen otherwise auto-allows everything). Tool names arrive snake_cased.

--- a/backend/engine/docs/adapter-contract.md
+++ b/backend/engine/docs/adapter-contract.md
@@ -190,6 +190,13 @@ interface EngineQueryOptions {
 **cannot** write into project B. Always forward it: see `claude/stream.ts`
 calling `getEnabledMcpServers(options.mcpContext)`.
 
+Engines that reach MCP over the HTTP bridge instead of in-process forward the
+same context to their config builder — `getCodexMcpConfig(filter, mcpContext)`
+and friends — which writes it into the bridge URL for `handleMcpRequest` to bind.
+Skipping it does not fail loudly: the handler falls back to the most recently
+started stream, so tool calls land in whichever project the user most recently
+prompted in. See `backend/mcp/README.md` → "Who is calling".
+
 `reasoningEffort` is an **opaque, native-per-engine token** — there is no
 cross-engine normalization. The adapter that produced the level in
 `models.ts` is the one that consumes it in `stream.ts`; every other layer

--- a/backend/mcp/README.md
+++ b/backend/mcp/README.md
@@ -284,7 +284,7 @@ servers/browser-automation/
    └─> Mounted at /mcp on the main Elysia server
         ↓
 3. Open Code engine (opencode/stream.ts)
-   └─> Uses getOpenCodeMcpConfig() → { type: 'remote', url: '/mcp' }
+   └─> Uses getOpenCodeMcpConfig() → { type: 'remote', url: '/mcp?engine=opencode' }
         ↓
 4. Open Code connects via Streamable HTTP transport
    └─> Sends JSON-RPC tool calls to /mcp endpoint
@@ -612,8 +612,33 @@ Returns MCP configuration for Open Code engine (remote HTTP MCP server).
 import { getOpenCodeMcpConfig } from '$backend/mcp';
 
 const mcpConfig = getOpenCodeMcpConfig();
-// Returns: { 'clopen-mcp': { type: 'remote', url: 'http://localhost:9151/mcp', ... } }
+// Returns: { 'clopen-mcp': { type: 'remote', url: 'http://localhost:9151/mcp?engine=opencode', ... } }
 ```
+
+##### Who is calling: the bridge URL carries the caller
+
+The in-process engines (Claude, Pi, Cline) wrap every tool handler in the
+stream's `McpExecutionContext`, so a handler that asks "which project is this?"
+always gets the right answer. An HTTP request carries no such context, and the
+fallback — the most recently *started* stream anywhere in the app — is the
+project the **user** last prompted in, not the one the agent is working in. An
+agent driving the Preview Browser in project A opened its tabs in project B the
+moment the user switched over there.
+
+So each config builder addresses the bridge with as much identity as its own
+lifetime allows, and `handleMcpRequest` binds that for the MCP session:
+
+| Engine        | Query string                            | Why not more |
+| ------------- | --------------------------------------- | ------------ |
+| Copilot, Cursor, Qwen | `engine`, `project`, `session`  | — built per stream |
+| Codex         | `engine`, `project`                     | one client per project, shared by its chat sessions |
+| Open Code     | `engine`                                | one pooled server per Profile, shared across projects |
+
+A caller that names only its project resolves the chat session to the most
+recent stream *in that project*; a caller that names only its engine resolves to
+the most recent stream *on that engine*. Both are guesses, but confined ones —
+and when a config gains a narrower lifetime, pass the richer context and the
+guess disappears.
 
 #### `resolveOpenCodeToolName(toolName)`
 Resolve a remote-MCP tool name to `mcp__server__tool` format (single source
@@ -660,13 +685,16 @@ engines. Each returns the **same** `/mcp` URL in the SDK-specific shape:
 
 ```typescript
 // Codex (config object flattened to --config flags)
-getCodexMcpConfig();
-// { 'clopen-mcp': { url: 'http://localhost:9151/mcp', tools: { ... } } }
+getCodexMcpConfig(profileFilter, mcpContext);
+// { 'clopen-mcp': { url: 'http://localhost:9151/mcp?engine=codex&project=…', tools: { ... } } }
 
 // Copilot (MCPHTTPServerConfig from @github/copilot-sdk)
-getCopilotMcpConfig();
-// { 'clopen-mcp': { type: 'http', url: 'http://localhost:9151/mcp', tools: [...] } }
+getCopilotMcpConfig(profileFilter, mcpContext);
+// { 'clopen-mcp': { type: 'http', url: 'http://localhost:9151/mcp?engine=copilot&project=…&session=…', tools: [...] } }
 ```
+
+Pass the stream's `mcpContext` — without it the bridge cannot tell whose tool
+call it is holding (see "Who is calling" above).
 
 When adding a new engine that consumes streamable-HTTP MCP, add a sibling
 `getXxxMcpConfig()` here — do **not** introduce a new HTTP listener or a

--- a/backend/mcp/index.ts
+++ b/backend/mcp/index.ts
@@ -121,33 +121,33 @@ export function getOpenCodeMcpConfig(profileFilter?: Set<string>) {
 }
 
 /** Codex MCP config. */
-export function getCodexMcpConfig(profileFilter?: Set<string>) {
+export function getCodexMcpConfig(profileFilter?: Set<string>, context?: McpExecutionContext) {
 	return {
-		...internal.getCodexMcpConfig(profileFilter),
+		...internal.getCodexMcpConfig(profileFilter, context),
 		...external.getCodexExternalMcpConfig(profileFilter)
 	};
 }
 
 /** Copilot MCP config. */
-export function getCopilotMcpConfig(profileFilter?: Set<string>) {
+export function getCopilotMcpConfig(profileFilter?: Set<string>, context?: McpExecutionContext) {
 	return {
-		...internal.getCopilotMcpConfig(profileFilter),
+		...internal.getCopilotMcpConfig(profileFilter, context),
 		...external.getCopilotExternalMcpConfig(profileFilter)
 	};
 }
 
 /** Cursor MCP config: internal `clopen-mcp` remote bridge + external servers. */
-export function getCursorMcpConfig(profileFilter?: Set<string>) {
+export function getCursorMcpConfig(profileFilter?: Set<string>, context?: McpExecutionContext) {
 	return {
-		...internal.getCursorMcpConfig(profileFilter),
+		...internal.getCursorMcpConfig(profileFilter, context),
 		...external.getCursorExternalMcpConfig(profileFilter)
 	};
 }
 
 /** Qwen Code MCP config. */
-export function getQwenMcpConfig(profileFilter?: Set<string>) {
+export function getQwenMcpConfig(profileFilter?: Set<string>, context?: McpExecutionContext) {
 	return {
-		...internal.getQwenMcpConfig(profileFilter),
+		...internal.getQwenMcpConfig(profileFilter, context),
 		...external.getQwenExternalMcpConfig(profileFilter)
 	};
 }

--- a/backend/mcp/internal/config.ts
+++ b/backend/mcp/internal/config.ts
@@ -12,6 +12,7 @@ import type { CLIMcpServerConfig as QwenMcpServerConfig } from '@qwen-code/sdk';
 import type { McpServerConfig as CursorMcpServerConfig } from '@cursor/sdk';
 import type { ServerConfig, ParsedMcpToolName, ServerName } from './types';
 import type { McpExecutionContext } from '../../engine/types';
+import type { EngineType } from '$shared/types/unified';
 import { serverMetadata } from './servers';
 import { loadEngineSdk } from '$backend/engine/sdk-loader';
 import { projectContextService } from './project-context';
@@ -435,6 +436,40 @@ export function resolveOpenCodeToolName(toolName: string): string | null {
 }
 
 // ============================================================================
+// Internal bridge URL
+// ============================================================================
+
+/**
+ * Loopback URL of the internal `clopen-mcp` bridge, addressed to the caller.
+ *
+ * The in-process engines (Claude, Pi, Cline) bind `McpExecutionContext` around
+ * every tool handler, so a tool call always knows which project asked. The
+ * engines that reach the bridge over HTTP had no such thing: the request
+ * carries no identity, so the handler fell back to "the most recently started
+ * stream" — which is the project the *user* last prompted in, not the one the
+ * agent is working in. An agent running in project A opened its tabs in project
+ * B the moment the user moved over there.
+ *
+ * The query string closes that. Each config says as much as its own lifetime
+ * allows, and the bridge binds whatever it is told:
+ *
+ * - `project` + `session` — the caller named outright. Copilot, Cursor and Qwen
+ *   build their config per stream, so both are true for the whole MCP session.
+ * - `project` alone — Codex, whose client (and therefore this URL) is built
+ *   once per project and reused by every chat session in it.
+ * - `engine` alone — Open Code, whose URL is baked into a server the pool shares
+ *   across projects. All it can honestly say is which engine is asking.
+ */
+function internalBridgeUrl(engine: EngineType, context?: McpExecutionContext): string {
+	const params = new URLSearchParams({ engine });
+
+	if (context?.projectId) params.set('project', context.projectId);
+	if (context?.chatSessionId) params.set('session', context.chatSessionId);
+
+	return `http://localhost:${SERVER_ENV.PORT}/mcp?${params.toString()}`;
+}
+
+// ============================================================================
 // Open Code MCP Configuration
 // ============================================================================
 
@@ -454,14 +489,17 @@ export function getOpenCodeMcpConfig(profileFilter?: Set<string>): Record<string
 		return {};
 	}
 
-	const port = SERVER_ENV.PORT;
+	// No caller binding: this URL is baked into a server the pool shares across
+	// projects and chat sessions (see `scopeKeyFor` in the Open Code adapter),
+	// so the engine marker is all it can honestly carry.
+	const url = internalBridgeUrl('opencode');
 
-	debug.log('mcp', `📦 Open Code MCP: remote server at http://localhost:${port}/mcp`);
+	debug.log('mcp', `📦 Open Code MCP: remote server at ${url}`);
 
 	return {
 		'clopen-mcp': {
 			type: 'remote',
-			url: `http://localhost:${port}/mcp`,
+			url,
 			enabled: true,
 			timeout: MCP_TOOL_CALL_TIMEOUT_MS,
 			headers: { Authorization: `Bearer ${getMcpServiceToken()}` },
@@ -507,13 +545,16 @@ type CodexMcpServerConfig = {
  * `--config mcp_servers.clopen-mcp.<dotted-key>=<value>` flags when the SDK
  * invokes the CLI subprocess for each turn.
  */
-export function getCodexMcpConfig(profileFilter?: Set<string>): Record<string, CodexMcpServerConfig> {
+export function getCodexMcpConfig(
+	profileFilter?: Set<string>,
+	context?: McpExecutionContext
+): Record<string, CodexMcpServerConfig> {
 	const enabledServers = activeInternalServerNames(profileFilter);
 	if (enabledServers.length === 0) {
 		return {};
 	}
 
-	const port = SERVER_ENV.PORT;
+	const url = internalBridgeUrl('codex', context);
 
 	const tools: Record<string, { approval_mode: 'approve' }> = {};
 	for (const serverName of enabledServers) {
@@ -523,11 +564,11 @@ export function getCodexMcpConfig(profileFilter?: Set<string>): Record<string, C
 		}
 	}
 
-	debug.log('mcp', `📦 Codex MCP: remote server at http://localhost:${port}/mcp (auto-approving ${Object.keys(tools).length} tools)`);
+	debug.log('mcp', `📦 Codex MCP: remote server at ${url} (auto-approving ${Object.keys(tools).length} tools)`);
 
 	return {
 		'clopen-mcp': {
-			url: `http://localhost:${port}/mcp`,
+			url,
 			http_headers: { Authorization: `Bearer ${getMcpServiceToken()}` },
 			tools,
 		},
@@ -557,13 +598,16 @@ export function getCodexMcpConfig(profileFilter?: Set<string>): Record<string, C
  * `resolveOpenCodeToolName()` to recover the canonical
  * `mcp__<server>__<tool>` form.
  */
-export function getCopilotMcpConfig(profileFilter?: Set<string>): Record<string, MCPHTTPServerConfig> {
+export function getCopilotMcpConfig(
+	profileFilter?: Set<string>,
+	context?: McpExecutionContext
+): Record<string, MCPHTTPServerConfig> {
 	const enabledServers = activeInternalServerNames(profileFilter);
 	if (enabledServers.length === 0) {
 		return {};
 	}
 
-	const port = SERVER_ENV.PORT;
+	const url = internalBridgeUrl('copilot', context);
 
 	const tools: string[] = [];
 	for (const serverName of enabledServers) {
@@ -573,12 +617,12 @@ export function getCopilotMcpConfig(profileFilter?: Set<string>): Record<string,
 		}
 	}
 
-	debug.log('mcp', `📦 Copilot MCP: remote server at http://localhost:${port}/mcp (${tools.length} tools)`);
+	debug.log('mcp', `📦 Copilot MCP: remote server at ${url} (${tools.length} tools)`);
 
 	return {
 		'clopen-mcp': {
 			type: 'http',
-			url: `http://localhost:${port}/mcp`,
+			url,
 			tools,
 			timeout: MCP_TOOL_CALL_TIMEOUT_MS,
 			headers: { Authorization: `Bearer ${getMcpServiceToken()}` },
@@ -598,20 +642,23 @@ export function getCopilotMcpConfig(profileFilter?: Set<string>): Record<string,
  * Open Code, Codex, Copilot and Qwen already consume — no new HTTP server, no
  * per-engine bridge (README §10.12). The service-token bearer authorises the hop.
  */
-export function getCursorMcpConfig(profileFilter?: Set<string>): Record<string, CursorMcpServerConfig> {
+export function getCursorMcpConfig(
+	profileFilter?: Set<string>,
+	context?: McpExecutionContext
+): Record<string, CursorMcpServerConfig> {
 	const enabledServers = activeInternalServerNames(profileFilter);
 	if (enabledServers.length === 0) {
 		return {};
 	}
 
-	const port = SERVER_ENV.PORT;
+	const url = internalBridgeUrl('cursor', context);
 
-	debug.log('mcp', `📦 Cursor MCP: remote server at http://localhost:${port}/mcp`);
+	debug.log('mcp', `📦 Cursor MCP: remote server at ${url}`);
 
 	return {
 		'clopen-mcp': {
 			type: 'http',
-			url: `http://localhost:${port}/mcp`,
+			url,
 			headers: { Authorization: `Bearer ${getMcpServiceToken()}` },
 		},
 	};
@@ -636,13 +683,16 @@ export function getCursorMcpConfig(profileFilter?: Set<string>): Record<string, 
  * so the model never sees it. The callback covers MCP tool calls too — no
  * per-tool enumeration needed.
  */
-export function getQwenMcpConfig(profileFilter?: Set<string>): Record<string, QwenMcpServerConfig> {
+export function getQwenMcpConfig(
+	profileFilter?: Set<string>,
+	context?: McpExecutionContext
+): Record<string, QwenMcpServerConfig> {
 	const enabledServers = activeInternalServerNames(profileFilter);
 	if (enabledServers.length === 0) {
 		return {};
 	}
 
-	const port = SERVER_ENV.PORT;
+	const url = internalBridgeUrl('qwen', context);
 
 	const includeTools: string[] = [];
 	for (const serverName of enabledServers) {
@@ -652,11 +702,11 @@ export function getQwenMcpConfig(profileFilter?: Set<string>): Record<string, Qw
 		}
 	}
 
-	debug.log('mcp', `📦 Qwen MCP: remote server at http://localhost:${port}/mcp (${includeTools.length} tools)`);
+	debug.log('mcp', `📦 Qwen MCP: remote server at ${url} (${includeTools.length} tools)`);
 
 	return {
 		'clopen-mcp': {
-			httpUrl: `http://localhost:${port}/mcp`,
+			httpUrl: url,
 			includeTools,
 			timeout: MCP_TOOL_CALL_TIMEOUT_MS,
 			trust: true,

--- a/backend/mcp/internal/project-context.test.ts
+++ b/backend/mcp/internal/project-context.test.ts
@@ -20,3 +20,43 @@ describe('projectContextService.clearByProjectId', () => {
 		expect(projectContextService.getLastUsedProjectId()).toBe('project-2');
 	});
 });
+
+describe('projectContextService bridge identity', () => {
+	beforeEach(() => {
+		projectContextService.clear();
+	});
+
+	test('a bound project wins over the most recently started stream', () => {
+		projectContextService.registerSession('session-a', 'project-a');
+		projectContextService.registerStream('stream-a', 'project-a', 'session-a', 'codex');
+		// The user moves to another project and prompts there — this is the stream
+		// the old ambient fallback would have attributed project-a's tool call to.
+		projectContextService.registerSession('session-b', 'project-b');
+		projectContextService.registerStream('stream-b', 'project-b', 'session-b', 'codex');
+
+		projectContextService.runWithContext({ projectId: 'project-a' }, () => {
+			expect(projectContextService.getCurrentProjectId()).toBe('project-a');
+			expect(projectContextService.getCurrentChatSessionId()).toBe('session-a');
+		});
+	});
+
+	test('engine scoping ignores streams belonging to another engine', () => {
+		projectContextService.registerSession('session-a', 'project-a');
+		projectContextService.registerStream('stream-a', 'project-a', 'session-a', 'opencode');
+		projectContextService.registerSession('session-b', 'project-b');
+		projectContextService.registerStream('stream-b', 'project-b', 'session-b', 'claude-code');
+
+		expect(projectContextService.getContextForEngine('opencode')).toMatchObject({
+			projectId: 'project-a',
+			chatSessionId: 'session-a'
+		});
+		expect(projectContextService.getContextForEngine('cursor')).toBeUndefined();
+	});
+
+	test('an unidentified caller still falls back to the most recent stream', () => {
+		projectContextService.registerSession('session-a', 'project-a');
+		projectContextService.registerStream('stream-a', 'project-a', 'session-a', 'codex');
+
+		expect(projectContextService.getCurrentProjectId()).toBe('project-a');
+	});
+});

--- a/backend/mcp/internal/project-context.ts
+++ b/backend/mcp/internal/project-context.ts
@@ -11,6 +11,7 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { debug } from '$shared/utils/logger';
+import type { EngineType } from '$shared/types/unified';
 
 // Execution context for MCP tool handlers
 interface ExecutionContext {
@@ -30,7 +31,10 @@ class ProjectContextService {
 	private streamProjectMap = new Map<string, string>();
 
 	// Track active streams (streamId -> context)
-	private activeStreams = new Map<string, { chatSessionId: string; projectId: string; startedAt: number }>();
+	private activeStreams = new Map<
+		string,
+		{ chatSessionId: string; projectId: string; startedAt: number; engine?: EngineType }
+	>();
 
 	// Track the most recently active stream (for MCP tool execution context)
 	private mostRecentActiveStream: { streamId: string; chatSessionId: string; projectId: string } | null = null;
@@ -42,9 +46,10 @@ class ProjectContextService {
 	 * Per-stream AbortSignal map. The stream-manager registers each stream's
 	 * AbortController.signal here when the stream starts so MCP tool handlers
 	 * can fast-fail on cancellation. The remote-MCP HTTP transport (used by
-	 * OpenCode/Codex/Copilot/Qwen) does not preserve the engine's
-	 * AsyncLocalStorage context across the HTTP boundary — `mostRecentActiveStream`
-	 * is the practical fallback for resolving "which stream is asking right now".
+	 * OpenCode/Codex/Copilot/Qwen/Cursor) does not preserve the engine's
+	 * AsyncLocalStorage context across the HTTP boundary; the bridge re-creates
+	 * it from the identity in its URL, and `mostRecentActiveStream` is the last
+	 * resort for a caller that could not be identified at all.
 	 */
 	private streamSignals = new Map<string, AbortSignal>();
 
@@ -69,7 +74,7 @@ class ProjectContextService {
 	 * Register a stream ID with its project ID
 	 * Should be called when a chat stream starts
 	 */
-	registerStream(streamId: string, projectId: string, chatSessionId?: string): void {
+	registerStream(streamId: string, projectId: string, chatSessionId?: string, engine?: EngineType): void {
 		if (!streamId || !projectId) {
 			debug.warn('mcp', `⚠️ Cannot register stream: streamId='${streamId}' projectId='${projectId}'`);
 			return;
@@ -82,7 +87,8 @@ class ProjectContextService {
 			this.activeStreams.set(streamId, {
 				chatSessionId,
 				projectId,
-				startedAt: Date.now()
+				startedAt: Date.now(),
+				engine
 			});
 
 			// Update most recent active stream
@@ -156,6 +162,13 @@ class ProjectContextService {
 				}
 			}
 		}
+		if (context?.projectId) {
+			const inProject = this.mostRecentStreamInProject(context.projectId);
+			if (inProject) {
+				const signal = this.streamSignals.get(inProject.streamId);
+				if (signal) return signal;
+			}
+		}
 		if (this.mostRecentActiveStream) {
 			return this.streamSignals.get(this.mostRecentActiveStream.streamId);
 		}
@@ -186,6 +199,60 @@ class ProjectContextService {
 				this.mostRecentActiveStream = null;
 			}
 		}
+	}
+
+	/**
+	 * The most recently started live stream in `projectId`.
+	 *
+	 * The bridge can bind a project without a chat session — Codex's client, and
+	 * therefore its bridge URL, is built once per project and shared by every
+	 * chat session in it. Resolving the session inside that project is still a
+	 * guess when several of them stream at once, but it is a guess confined to
+	 * the right project, which is what tab ownership and cancellation need.
+	 */
+	private mostRecentStreamInProject(projectId: string): { streamId: string; chatSessionId: string } | undefined {
+		let best: { streamId: string; chatSessionId: string; startedAt: number } | undefined;
+		for (const [streamId, info] of this.activeStreams) {
+			if (info.projectId !== projectId) continue;
+			if (!best || info.startedAt > best.startedAt) {
+				best = { streamId, chatSessionId: info.chatSessionId, startedAt: info.startedAt };
+			}
+		}
+		return best ? { streamId: best.streamId, chatSessionId: best.chatSessionId } : undefined;
+	}
+
+	/**
+	 * The execution context of the most recent stream running on `engine`.
+	 *
+	 * For the engines whose MCP bridge URL cannot carry the calling stream —
+	 * Open Code bakes its MCP config into a server that is pooled per Profile
+	 * and shared by every project — this is as precise as the bridge can be. It
+	 * is still strictly narrower than "the most recent stream anywhere", which
+	 * is what sent a tool call from the project the agent is working in to
+	 * whichever project the user had most recently prompted in.
+	 */
+	getContextForEngine(engine: EngineType): ExecutionContext | undefined {
+		let best: { streamId: string; chatSessionId: string; projectId: string; startedAt: number } | undefined;
+		let candidates = 0;
+
+		for (const [streamId, info] of this.activeStreams) {
+			if (info.engine !== engine) continue;
+			candidates++;
+			if (!best || info.startedAt > best.startedAt) {
+				best = { streamId, chatSessionId: info.chatSessionId, projectId: info.projectId, startedAt: info.startedAt };
+			}
+		}
+
+		if (!best) return undefined;
+		if (candidates > 1) {
+			debug.warn(
+				'mcp',
+				`⚠️ ${candidates} ${engine} streams are live and the bridge cannot tell them apart — ` +
+					`attributing this call to the most recent one (project ${best.projectId})`
+			);
+		}
+
+		return { chatSessionId: best.chatSessionId, projectId: best.projectId, streamId: best.streamId };
 	}
 
 	/**
@@ -286,7 +353,13 @@ class ProjectContextService {
 			return context.chatSessionId;
 		}
 
-		// 2. Fallback to most recent active stream
+		// 2. Within the bound project, when the caller could only name that much
+		if (context?.projectId) {
+			const inProject = this.mostRecentStreamInProject(context.projectId);
+			if (inProject) return inProject.chatSessionId;
+		}
+
+		// 3. Fallback to most recent active stream
 		if (this.mostRecentActiveStream) {
 			return this.mostRecentActiveStream.chatSessionId;
 		}

--- a/backend/mcp/internal/remote-server.test.ts
+++ b/backend/mcp/internal/remote-server.test.ts
@@ -37,10 +37,10 @@ function sessionCount(userId: string): number {
 	return row.count;
 }
 
-function mcpRequest(token?: string): Request {
+function mcpRequest(token?: string, query = ''): Request {
 	const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 	if (token) headers['Authorization'] = `Bearer ${token}`;
-	return new Request('http://localhost/mcp', {
+	return new Request(`http://localhost/mcp${query}`, {
 		method: 'POST',
 		headers,
 		body: JSON.stringify({
@@ -132,6 +132,21 @@ describe('MCP Remote Server Authentication', () => {
 		const response = await handleMcpRequest(mcpRequest(sessionToken));
 		// Past auth — the MCP transport handles the body from here.
 		expect(response.status).not.toBe(401);
+	});
+
+	test('accepts a caller-identified bridge URL', async () => {
+		// Each engine's config builder addresses the bridge with the project (and
+		// where its config lives that long, the chat session) driving the call, so
+		// tool handlers are bound to it instead of guessing from ambient state.
+		// Routing must not care that the query string is there.
+		const query = '?engine=codex&project=project-a&session=session-a';
+		const response = await handleMcpRequest(mcpRequest(getMcpServiceToken(), query));
+		expect(response.status).not.toBe(401);
+	});
+
+	test('rejects a caller-identified bridge URL without a token', async () => {
+		const response = await handleMcpRequest(mcpRequest(undefined, '?engine=opencode'));
+		expect(response.status).toBe(401);
 	});
 
 	test('accepts a valid PAT token', async () => {

--- a/backend/mcp/internal/remote-server.ts
+++ b/backend/mcp/internal/remote-server.ts
@@ -18,7 +18,7 @@
 
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { createRemoteMcpServer } from './servers/helper';
+import { createRemoteMcpServer, type RemoteMcpCaller } from './servers/helper';
 import { createExternalProxyServer } from '../external/proxy';
 import { debug } from '$shared/utils/logger';
 import { authQueries } from '$backend/database/queries';
@@ -214,13 +214,46 @@ async function handleStreamable(
 }
 
 /**
+ * Who is on the other end of an internal-bridge request.
+ *
+ * Read from the query string each engine's config builder writes (see
+ * `internalBridgeUrl` in `./config.ts`), which says as much as that config's
+ * lifetime allows: the calling stream, its project, or only the engine. A URL
+ * with none of it — an older config, or a client that stripped the query —
+ * yields `undefined` and the handlers fall back to their own resolution, which
+ * is what every engine did before this existed.
+ */
+function callerFromRequest(request: Request): RemoteMcpCaller | undefined {
+	const params = new URL(request.url).searchParams;
+	const projectId = params.get('project') ?? undefined;
+	const chatSessionId = params.get('session') ?? undefined;
+	const engine = (params.get('engine') as EngineType | null) ?? undefined;
+
+	if (projectId) return { context: { projectId, ...(chatSessionId && { chatSessionId }) }, engine };
+	if (engine) return { engine };
+	return undefined;
+}
+
+/**
  * Handle an incoming request to the INTERNAL `clopen-mcp` bridge (`/mcp`).
  * Serves the in-process custom tools defined via `defineServer()`.
+ *
+ * The caller is read from the initialize request only, and the resulting server
+ * stays bound to that session — the same way the external bridge binds its
+ * per-engine tool filter. That is correct because the identity in the URL is a
+ * property of the engine session, not of a single tool call: a Codex turn gets
+ * a fresh subprocess and therefore a fresh MCP session, while Copilot/Qwen/
+ * Cursor keep one per chat session, which is exactly the scope of `session`.
  */
 export async function handleMcpRequest(request: Request): Promise<Response> {
-	return handleStreamable(request, 'Remote MCP', async () => {
+	const caller = callerFromRequest(request);
+	const label = caller?.context
+		? `Remote MCP (${caller.engine ?? 'engine'}, project ${caller.context.projectId})`
+		: `Remote MCP${caller?.engine ? ` (${caller.engine})` : ''}`;
+
+	return handleStreamable(request, label, async () => {
 		const { allServers, enabledConfig } = await getServerDeps();
-		return { server: createRemoteMcpServer(allServers, enabledConfig) };
+		return { server: createRemoteMcpServer(allServers, enabledConfig, caller) };
 	});
 }
 

--- a/backend/mcp/internal/servers/helper.ts
+++ b/backend/mcp/internal/servers/helper.ts
@@ -13,6 +13,8 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { z } from "zod";
 import { projectContextService } from '../project-context';
 import { validateMcpOutput } from '../output-validator';
+import type { McpExecutionContext } from '$backend/engine/types';
+import type { EngineType } from '$shared/types/unified';
 
 /**
  * Infer argument types from Zod schema
@@ -144,6 +146,21 @@ export function buildServerRegistries<
 // ============================================================================
 
 /**
+ * Who the bridge is talking to.
+ *
+ * `context` is the calling stream, named by the query string its engine's
+ * config builder put on the bridge URL — the HTTP equivalent of the
+ * `McpExecutionContext` the in-process engines bind directly. `engine` alone is
+ * the fallback for a config that cannot name the caller (Open Code's pooled
+ * server), and is resolved per call rather than pinned, because the stream it
+ * refers to changes while the MCP session stays open.
+ */
+export interface RemoteMcpCaller {
+	context?: McpExecutionContext;
+	engine?: EngineType;
+}
+
+/**
  * Create a McpServer instance (from @modelcontextprotocol/sdk) with tools registered
  * from the same RawToolDef definitions used by Claude Code.
  *
@@ -152,10 +169,12 @@ export function buildServerRegistries<
  *
  * @param servers - Server definitions from defineServer()
  * @param enabledConfig - Which servers/tools are enabled (from mcpServersConfig)
+ * @param caller - Identity of the engine/stream on the other end of the bridge
  */
 export function createRemoteMcpServer(
 	servers: readonly ServerWithMeta<string, readonly string[]>[],
-	enabledConfig: Record<string, { enabled: boolean; tools: readonly string[] }>
+	enabledConfig: Record<string, { enabled: boolean; tools: readonly string[] }>,
+	caller?: RemoteMcpCaller
 ): McpServer {
 	const mcpServer = new McpServer({
 		name: 'clopen-mcp',
@@ -178,23 +197,34 @@ export function createRemoteMcpServer(
 				// at runtime. Cast to bridge the mismatch.
 				inputSchema: def.schema as Record<string, any>,
 			}, async (args: Record<string, unknown>) => {
-				// Fast-fail when the owning chat stream has already been
-				// cancelled — the handler never runs. Without this, the
-				// engine subprocess dies on cancel but in-flight HTTP-MCP
-				// tool calls continue to drive puppeteer ops, surfacing as
-				// "preview keeps moving by itself" after interrupt.
-				const signal = projectContextService.getCurrentSignal();
-				if (signal?.aborted) {
-					return {
-						content: [{ type: 'text' as const, text: `Tool ${String(toolName)} was cancelled because the chat stream was interrupted.` }],
-						isError: true,
-					} as any;
-				}
-				const result = await def.handler(args) as any;
-				if (result?.content) {
-					result.content = validateMcpOutput(result.content, toolName as string);
-				}
-				return result;
+				const run = async () => {
+					// Fast-fail when the owning chat stream has already been
+					// cancelled — the handler never runs. Without this, the
+					// engine subprocess dies on cancel but in-flight HTTP-MCP
+					// tool calls continue to drive puppeteer ops, surfacing as
+					// "preview keeps moving by itself" after interrupt.
+					const signal = projectContextService.getCurrentSignal();
+					if (signal?.aborted) {
+						return {
+							content: [{ type: 'text' as const, text: `Tool ${String(toolName)} was cancelled because the chat stream was interrupted.` }],
+							isError: true,
+						} as any;
+					}
+					const result = await def.handler(args) as any;
+					if (result?.content) {
+						result.content = validateMcpOutput(result.content, toolName as string);
+					}
+					return result;
+				};
+
+				// Bind the caller for the duration of the handler, exactly as the
+				// in-process path does. Without it every handler that asks "which
+				// project is this?" answers with the most recently started stream
+				// anywhere in the app.
+				const bound = caller?.context
+					?? (caller?.engine ? projectContextService.getContextForEngine(caller.engine) : undefined);
+
+				return bound ? projectContextService.runWithContextAsync(bound, run) : run();
 			});
 		}
 	}

--- a/backend/preview/browser/browser-video-capture.ts
+++ b/backend/preview/browser/browser-video-capture.ts
@@ -169,6 +169,13 @@ interface VideoStreamSession {
 	lastEncodedAt: number;
 	/** Guards the watchdog against re-entering while a repair is in flight. */
 	repairing: boolean;
+	/**
+	 * Repairs attempted since the stream last produced anything. A repair that
+	 * did not restore frames must escalate rather than be repeated: the cheap
+	 * one asks the page what it thinks, and a page whose own answer is the
+	 * wrong one will give the same answer every time.
+	 */
+	stallRounds: number;
 	/** Codecs every viewer can decode — one encoder serves them all. */
 	codecSupport: ClientCodecSupport;
 	/** Display metrics of the most demanding viewer. */
@@ -587,6 +594,12 @@ export class BrowserVideoCapture extends EventEmitter {
 	 */
 	private static readonly STREAM_STALL_MS = 6_000;
 
+	/**
+	 * Cheap stall repairs before the watchdog stops taking the page's word for
+	 * its own health and rebuilds the peer from scratch.
+	 */
+	private static readonly STALL_REPAIR_ROUNDS = 1;
+
 	private sessions = new Map<string, VideoStreamSession>();
 	private feeders = new Map<string, ScreencastFeeder>();
 	private preInjectPromises = new Map<string, Promise<boolean>>();
@@ -729,6 +742,7 @@ export class BrowserVideoCapture extends EventEmitter {
 			scriptsPreInjected: false,
 			lastEncodedAt: 0,
 			repairing: false,
+			stallRounds: 0,
 			codecSupport: { ...DEFAULT_CODEC_SUPPORT },
 			display: {},
 			profile,
@@ -978,6 +992,20 @@ export class BrowserVideoCapture extends EventEmitter {
 		const codecChanged = injection.codecSignature !== this.codecSignature(videoSession);
 		const needsInjection = epochMismatch || codecChanged;
 
+		// In push mode the page is only the encoder — the frames come from a CDP
+		// screencast this process owns. `capturing: true` then means "willing",
+		// not "being fed", so a feeder that has gone away leaves a session both
+		// halves call healthy and which produces nothing at all. That state is
+		// self-sustaining: the page keeps answering, so this check keeps taking
+		// the cheap branch, and the viewer keeps waiting for a first frame that
+		// no longer has a source.
+		const sourceMissing =
+			!needsInjection &&
+			!!health?.capturing &&
+			health.captureMode === 'push' &&
+			!videoSession.paused &&
+			!this.feeders.has(sessionId);
+
 		if (needsInjection) {
 			const reason = options.force
 				? 'forced'
@@ -993,7 +1021,10 @@ export class BrowserVideoCapture extends EventEmitter {
 			this.feeders.get(sessionId)?.invalidatePeerHandle();
 		}
 
-		if (needsInjection || !health?.capturing) {
+		if (needsInjection || !health?.capturing || sourceMissing) {
+			if (sourceMissing) {
+				debug.warn('webcodecs', `Page for ${sessionId} reports capturing with no frame source — rebuilding it`);
+			}
 			const started = await this.startPageCapture(page);
 			if (!started) {
 				debug.error('webcodecs', `Page refused to start capturing for ${sessionId}`);
@@ -1593,10 +1624,23 @@ export class BrowserVideoCapture extends EventEmitter {
 		if (videoSession.lastEncodedAt === 0 || silentFor < BrowserVideoCapture.STREAM_STALL_MS) return;
 
 		const { sessionId, tab } = videoSession;
-		debug.warn('webcodecs', `Stream for ${sessionId} produced nothing for ${silentFor}ms — repairing`);
+		videoSession.stallRounds++;
+
+		// The first round asks the page what state it is in and repairs from
+		// that answer, which is cheap and keeps every viewer's peer intact. Once
+		// that has been tried and the stream is still silent, the page's own
+		// account is the thing that cannot be trusted — so rebuild the peer
+		// outright. Viewers lose their connection and re-handshake, which is a
+		// visible hiccup, but they are looking at a frozen picture either way.
+		const force = videoSession.stallRounds > BrowserVideoCapture.STALL_REPAIR_ROUNDS;
+		debug.warn(
+			'webcodecs',
+			`Stream for ${sessionId} produced nothing for ${silentFor}ms — ` +
+				`${force ? 'rebuilding the page peer' : 'repairing'} (round ${videoSession.stallRounds})`
+		);
 
 		videoSession.repairing = true;
-		void this.ensureLive(sessionId, tab, () => !tab.isDestroyed)
+		void this.ensureLive(sessionId, tab, () => !tab.isDestroyed, { force })
 			.then((live) => {
 				if (live) return this.requestKeyframe(sessionId, tab);
 			})
@@ -1620,7 +1664,10 @@ export class BrowserVideoCapture extends EventEmitter {
 		// Frames reaching the encoder is the one signal that means the pipeline
 		// is genuinely alive end to end. The counter is per-window, so any
 		// non-zero report is proof of life for this window.
-		if (stats.framesAttempted > 0) videoSession.lastEncodedAt = Date.now();
+		if (stats.framesAttempted > 0) {
+			videoSession.lastEncodedAt = Date.now();
+			videoSession.stallRounds = 0;
+		}
 
 		// In-page capture can end on its own — the captured surface goes away
 		// on some navigations — and the page has no way to start a screencast.

--- a/frontend/components/preview/browser/BrowserPreview.svelte
+++ b/frontend/components/preview/browser/BrowserPreview.svelte
@@ -477,6 +477,37 @@
 		}
 	});
 
+	/**
+	 * Adopt an address that has no browser behind it.
+	 *
+	 * A tab whose `url` is set but whose `sessionId` is not renders no Canvas at
+	 * all — the device frame is empty and the solid overlay covers it — so no
+	 * stream, and therefore no stream watchdog, ever exists to notice. The panel
+	 * sits on "Loading preview…" for good while every other tab is fine, and the
+	 * backend tab the agent is driving is a different one.
+	 *
+	 * The URL watcher above cannot close this, because it only fires when the
+	 * address *changes*: a blank slot rebuilt from the workspace snapshot, or a
+	 * switch to a tab whose address happens to equal the one already seen, both
+	 * arrive with `url === previousUrl` and are skipped. This looks at the tab's
+	 * own state instead, so it is true whenever it is true.
+	 *
+	 * `errorMessage` is part of the guard on purpose — a launch that failed is
+	 * reported to the user and must not be retried in a loop by an effect that
+	 * re-runs on every field of the tab.
+	 */
+	$effect(() => {
+		const tab = activeTab;
+		if (!tab || !tab.url) return;
+		if (tab.sessionId || tab.isLaunchingBrowser || tab.errorMessage) return;
+		if (mcpLaunchInProgress) return;
+		if (tab.url.startsWith('chrome-error://') || tab.url.startsWith('chrome://')) return;
+
+		debug.log('preview', `🩹 Tab ${tab.id} has a URL but no session — launching for it`);
+		previousUrl = tab.url;
+		coordinator.launchBrowserForTab(tab.id, tab.url);
+	});
+
 	// Store previewDimensions in active tab. (canvasAPI is not stored: see the
 	// note where the tab state is adopted.)
 	$effect(() => {

--- a/frontend/components/preview/browser/components/Canvas.svelte
+++ b/frontend/components/preview/browser/components/Canvas.svelte
@@ -161,6 +161,20 @@
 	const WATCHDOG_ESCALATION_STEP_MS = 3000;
 	const WATCHDOG_MAX_WAIT_MS = 15000;
 
+	/**
+	 * How many rounds the watchdog spends asking the source to re-send before it
+	 * stops believing the connection is the healthy half.
+	 *
+	 * "Connected but blank" has two causes that look identical from here: a
+	 * source that simply has no new frame to send, which a refresh fixes, and a
+	 * source whose capture is broken, which it cannot. Only ever asking for a
+	 * refresh made the second case permanent — the request is cheap, it always
+	 * "succeeds", and nothing else in the ladder is reached while the peer is
+	 * connected. After this many fruitless rounds the connection is torn down
+	 * and rebuilt, which is what re-injects the page-side capture.
+	 */
+	const WATCHDOG_REFRESH_ROUNDS = 2;
+
 	// Sync isStreamReady with hasReceivedFirstFrame for parent component
 	$effect(() => {
 		isStreamReady = hasReceivedFirstFrame;
@@ -1297,8 +1311,13 @@
 
 		// Connected, decoding nothing: the source half is the broken one, and
 		// restarting its capture is both cheaper and likelier to work than
-		// re-negotiating a connection that is demonstrably fine.
-		if (isWebCodecsActive && stats?.isConnected) {
+		// re-negotiating a connection that is demonstrably fine — for the first
+		// couple of rounds. Past that the refresh has demonstrably not worked,
+		// and staying on this branch forever (which it did, because a connected
+		// peer never reaches the re-handshake below) is the whole reason a tab
+		// could sit on "Loading preview…" indefinitely while the page behind it
+		// was perfectly healthy.
+		if (isWebCodecsActive && stats?.isConnected && watchdogRound <= WATCHDOG_REFRESH_ROUNDS) {
 			debug.warn('webcodecs', `Watchdog: connected but blank for ${patience}ms, refreshing capture (round ${watchdogRound})`);
 			onRequestScreencastRefresh();
 			return;

--- a/frontend/components/preview/browser/components/Container.svelte
+++ b/frontend/components/preview/browser/components/Container.svelte
@@ -495,13 +495,21 @@
 		onRetry();
 	}
 
-	// Handle screencast refresh request from Canvas (when stream is stuck)
-	// This sends a scale-update which triggers CDP screencast restart on backend
+	/**
+	 * Ask the source to re-send — the Canvas watchdog's cheap repair.
+	 *
+	 * Carried as a scale update because that is the message the source treats as
+	 * "rebuild your capture".
+	 *
+	 * Falling back to 1 matters: the scale is only known once the container has
+	 * been measured, and skipping the send while it is not made the watchdog's
+	 * recovery a silent no-op in exactly the case it exists for — a preview that
+	 * has never painted anything.
+	 */
 	function handleScreencastRefresh() {
-		if (previewDimensions?.scale) {
-			debug.log('preview', `📐 Requesting screencast refresh with scale: ${previewDimensions.scale}`);
-			sendScaleUpdate(previewDimensions.scale);
-		}
+		const scale = previewDimensions?.scale && previewDimensions.scale > 0 ? previewDimensions.scale : 1;
+		debug.log('preview', `📐 Requesting screencast refresh with scale: ${scale}`);
+		sendScaleUpdate(scale);
 	}
 
 	// Initial dimensions calculation


### PR DESCRIPTION
## Summary
Fixes two intermittent Preview Browser bugs: a tab that sits on "Loading preview…" forever while the page behind it is healthy, and a `browser-automation` call from one project opening its tab in another.

## Why
Both were reported as "sometimes". Both turned out to be deterministic dead ends rather than races.

**Stuck preview** — three of them, each sufficient on its own, and each matching the report exactly (one tab affected, other tabs fine, MCP still able to click and screenshot the page):

- A tab with a `url` but no `sessionId` renders no `Canvas` (`Container.svelte` gates it on `sessionInfo`), so no stream and no stream watchdog exists to notice. The only launcher is BrowserPreview's URL watcher, which fires on *change* — a blank slot rebuilt from the workspace snapshot, or a switch to a tab whose address equals `previousUrl`, are skipped.
- `watchdogTick()`'s "connected but blank" branch only ever requested a screencast refresh and returned, so a connected peer never reached the re-handshake below it. A source whose capture is broken was retried forever with the one repair that cannot fix it. The refresh was also a silent no-op while `previewDimensions.scale` was unmeasured — exactly the state of a preview that never painted.
- In push mode the page is only the encoder; frames come from a CDP screencast the backend owns. `ensureLive()` took the cheap branch on `health.capturing === true`, which means "willing", not "being fed". A feeder that had gone away left a session both halves called healthy, and `checkForStall()` re-ran the same non-repair every 6s.

**Wrong project** — `getPreviewService()` resolves via `projectContextService.getCurrentProjectId()`. In-process engines (Claude, Pi, Cline) bind `McpExecutionContext` around every tool handler; engines reaching MCP over the HTTP bridge carried no context, so resolution fell through to `mostRecentActiveStream` — the project the *user* last prompted in. Switch to project B while project A's agent is working and A's tool call lands in B.

## Changes
- `frontend/components/preview/browser/BrowserPreview.svelte` — adopt an address with no browser behind it, guarded on `isLaunchingBrowser`/`errorMessage` so a failed launch is not retried in a loop.
- `frontend/components/preview/browser/components/Canvas.svelte` — `WATCHDOG_REFRESH_ROUNDS`; past it, the watchdog stops believing the connection is the healthy half and re-handshakes.
- `frontend/components/preview/browser/components/Container.svelte` — screencast refresh falls back to scale 1 instead of sending nothing.
- `backend/preview/browser/browser-video-capture.ts` — `ensureLive()` rebuilds when the page reports push-mode capture with no feeder; `checkForStall()` tracks `stallRounds` and forces a full peer rebuild on the second round.
- `backend/mcp/internal/config.ts` — `internalBridgeUrl()`; every engine config builder takes the stream's `McpExecutionContext`.
- `backend/mcp/internal/remote-server.ts` / `servers/helper.ts` — `callerFromRequest()` + `RemoteMcpCaller`; tool handlers run inside the caller's context, mirroring the in-process path.
- `backend/mcp/internal/project-context.ts` — per-stream engine, `getContextForEngine()`, and session/signal resolution scoped to a bound project.
- `backend/engine/adapters/{codex,copilot,cursor,qwen}/stream.ts` — forward `mcpContext`; Codex bakes its project into the client it caches per project.
- `backend/mcp/README.md`, `backend/engine/docs/adapter-contract.md` — document the caller-identified bridge URL and what skipping it costs.

## Test plan
- `bun run check` — 0 errors (2 pre-existing warnings in unrelated files).
- `bun run lint` — clean.
- `bun run test` — 511 pass / 17 skip / 0 fail.
- New: `project-context.test.ts` covers a bound project beating the most-recent stream, engine scoping ignoring another engine's streams, and the unidentified-caller fallback still working.
- New: `remote-server.test.ts` covers the bridge routing and authenticating a caller-identified URL.

## Notes
Open Code is the one engine that cannot name its caller: its bridge URL is baked into a server the pool keys per Profile and shares across projects, and moving the project into that key would relocate its session data dir and break `session.fork`. It sends `engine=opencode` and resolves to the most recent Open Code stream, which is strictly narrower than the old global fallback; the ambiguous case (two Open Code streams live at once) logs a warning rather than resolving silently.