### PR TITLE
fix(git): report only sub-repos that have something to show

### DIFF
--- a/backend/git/nested-repos.test.ts
+++ b/backend/git/nested-repos.test.ts
@@ -7,10 +7,14 @@ import { findNestedRepoPaths, findRepoForFile } from './nested-repos';
 
 /**
  * Sub-repo detection used to walk the whole tree and report every directory
- * with a `.git` inside it. On an iOS project that meant Swift Package
- * Manager's `build/…/SourcePackages/checkouts/*` — thousands of foreign
- * changes in the Changes tab. These cover both sides of the policy: package
- * caches stay out, repos the user actually embedded stay in.
+ * with a `.git` inside it — on an iOS project, Swift Package Manager's
+ * `build/…/SourcePackages/checkouts/*` put thousands of foreign changes in the
+ * Changes tab. Pruning by directory name fixed that case and nothing more:
+ * `plugins/` is where tmux clones its packages *and* where a WordPress
+ * developer keeps their own plugin repos, so no denylist can be right on both
+ * sides. The policy these tests pin down is structural instead — inside a tree
+ * the project ignores, a sub-repo is reported only if it holds local work or
+ * is a declared submodule.
  */
 
 let root: string;
@@ -29,6 +33,15 @@ async function initRepo(dir: string) {
 	await git(dir, 'config', 'user.email', 'test@example.com');
 	await git(dir, 'config', 'user.name', 'Test');
 	await git(dir, 'config', 'commit.gpgsign', 'false');
+}
+
+/**
+ * Give a repo something the Git panel could show. An untracked file is what an
+ * agent writing into a sub-repo produces, and it is what tells a repo the user
+ * works in apart from a package manager's pristine checkout.
+ */
+async function addLocalWork(dir: string) {
+	await writeFile(path.join(dir, 'index.php'), '<?php // edited\n');
 }
 
 /** Paths relative to the project root, for readable assertions. */
@@ -78,17 +91,107 @@ describe('findNestedRepoPaths', () => {
 		expect(await detected()).toEqual(['wp-content/themes/mytheme']);
 	});
 
-	test('detects a repo sitting directly under an ignored parent', async () => {
+	test('detects a worked-in repo sitting directly under an ignored parent', async () => {
 		await writeFile(path.join(root, '.gitignore'), 'themes/\n');
+		await initRepo(path.join(root, 'themes/mytheme'));
+		await addLocalWork(path.join(root, 'themes/mytheme'));
+
+		expect(await detected()).toEqual(['themes/mytheme']);
+	});
+
+	test('leaves a pristine repo under an ignored parent out until it changes', async () => {
+		// The deliberate trade-off: with nothing to show, a repo inside an
+		// ignored tree is indistinguishable from a package checkout. It comes
+		// back the moment there is a change — which is when the panel needs it.
+		await writeFile(path.join(root, '.gitignore'), 'themes/\n');
+		await initRepo(path.join(root, 'themes/mytheme'));
+
+		expect(await detected()).toEqual([]);
+
+		await addLocalWork(path.join(root, 'themes/mytheme'));
+		expect(await detected()).toEqual(['themes/mytheme']);
+	});
+
+	test.each([
+		['elixir mix', '/deps/\n', ['deps/daisyui', 'deps/heroicons']],
+		['openwrt feeds', 'feeds/\n', ['feeds/packages', 'feeds/luci']],
+		['vim pathogen', 'bundle/\n', ['bundle/vim-fugitive']],
+		['tmux tpm', 'plugins/\n', ['plugins/tpm']],
+		['ansible galaxy', 'roles/\n', ['roles/geerlingguy.nginx']],
+		['puppet librarian', 'modules/\n', ['modules/stdlib']],
+		['chef berkshelf', 'berks-cookbooks/\n', ['berks-cookbooks/nginx']],
+		['zephyr west', 'west-modules/\n', ['west-modules/hal_stm32']],
+		['composer source install', 'vendor/\n', ['vendor/acme/lib']],
+		['cmake fetchcontent', 'build/\n', ['build/_deps/googletest-src']]
+	])(
+		'ignores %s checkouts inside an ignored tree',
+		async (_name, gitignore, repos) => {
+			// Every one of these clones into an ignored directory, several of
+			// them exactly one level down where the peek looks. They are all
+			// pristine, which is the only thing the policy needs to know —
+			// `plugins/` and `modules/` appear on the user's side of the fence
+			// too, so their names cannot be the signal.
+			await writeFile(path.join(root, '.gitignore'), gitignore);
+			for (const repo of repos) await initRepo(path.join(root, repo));
+
+			expect(await detected()).toEqual([]);
+		}
+	);
+
+	test('reports the user plugin repo under an ignored dir that tmux also uses', async () => {
+		// Same directory name as the tmux case above, opposite verdict.
+		await writeFile(path.join(root, '.gitignore'), 'wp-content/plugins/\n');
+		await initRepo(path.join(root, 'wp-content/plugins/my-plugin'));
+		await addLocalWork(path.join(root, 'wp-content/plugins/my-plugin'));
+
+		expect(await detected()).toEqual(['wp-content/plugins/my-plugin']);
+	});
+
+	test('reports a declared submodule inside an ignored tree even when pristine', async () => {
+		// `.gitmodules` is the user naming the sub-repo themselves, which
+		// outranks anything its working tree could tell us.
+		await writeFile(path.join(root, '.gitignore'), 'themes/\n');
+		await writeFile(
+			path.join(root, '.gitmodules'),
+			'[submodule "themes/mytheme"]\n\tpath = themes/mytheme\n\turl = https://example.com/t.git\n'
+		);
 		await initRepo(path.join(root, 'themes/mytheme'));
 
 		expect(await detected()).toEqual(['themes/mytheme']);
 	});
 
+	test('a repo inside a rejected checkout cannot launder itself', async () => {
+		// Entering a repo resets the ignore budget, so without inheriting the
+		// "inside an ignored tree" flag the vendored repo would be treated as
+		// part of `pkg`'s own tracked structure and reported unconditionally.
+		await writeFile(path.join(root, '.gitignore'), '/deps/\n');
+		const pkg = path.join(root, 'deps/pkg');
+		await initRepo(pkg);
+		// Committed, so `pkg` itself stays pristine — otherwise the vendored
+		// directory would show up as untracked work and this would test nothing.
+		await writeFile(path.join(pkg, '.gitignore'), 'vendored/\n');
+		await git(pkg, 'add', '-A');
+		await git(pkg, 'commit', '-m', 'init');
+		await initRepo(path.join(pkg, 'vendored'));
+
+		expect(await detected()).toEqual([]);
+	});
+
+	test('still reports an ignored build dir that is itself a repo', async () => {
+		// A `dist/` deploy worktree is a repo the user works in; only the
+		// contents of a dependency-named dir are off limits, not the dir itself.
+		await writeFile(path.join(root, '.gitignore'), 'dist/\n');
+		await initRepo(path.join(root, 'dist'));
+
+		expect(await detected()).toEqual(['dist']);
+	});
+
 	test('does not report repos generated deep inside an ignored tree', async () => {
 		await writeFile(path.join(root, '.gitignore'), 'themes/\n');
 		await initRepo(path.join(root, 'themes/mytheme'));
+		await addLocalWork(path.join(root, 'themes/mytheme'));
 		await initRepo(path.join(root, 'themes/cache/vendor/dep/checkout'));
+		await addLocalWork(path.join(root, 'themes/cache/vendor/dep/checkout'));
 
 		expect(await detected()).toEqual(['themes/mytheme']);
 	});

--- a/backend/git/nested-repos.ts
+++ b/backend/git/nested-repos.ts
@@ -18,15 +18,31 @@
  * are machine-generated, the user never commits them, and listing them floods
  * the Changes tab with thousands of foreign files.
  *
- * Two signals separate the two, both applied while walking:
+ * Names alone cannot separate the two. `plugins/` holds tmux's cloned packages
+ * and a WordPress developer's own plugin repos; `modules/` holds Puppet's
+ * librarian checkouts and hand-written modules. Any denylist of directory
+ * names is wrong on one side of those, and every new package manager adds
+ * another name to chase. So the policy leans on structure instead:
  *
- * 1. **Name** — directories in `HARD_SKIP_DIRS` are dependency/build caches by
- *    definition; never descend into them.
+ * 1. **Name, for cost only** — `HARD_SKIP_DIRS` are caches so large that
+ *    walking them is wasteful. Pruning them is an optimisation, not the policy.
  * 2. **Ignore state** — a directory the enclosing repo ignores is not part of
  *    the project's own structure. We still peek `IGNORED_DESCENT_LEVELS` level
  *    into it, because an embedded repo is commonly placed directly under an
- *    ignored parent (`wp-content/themes/` ignored, the theme repo inside it),
- *    but generated checkouts always sit much deeper.
+ *    ignored parent (`wp-content/plugins/` ignored, the plugin repo inside it).
+ * 3. **Local work** — a repo found inside an ignored tree is reported only if
+ *    it has something to show: uncommitted changes, or a `.gitmodules` entry
+ *    declaring it. A package manager's checkout is pristine by construction —
+ *    it is a clone at a pinned ref that nobody edits — so this drops Mix's
+ *    `deps/*`, OpenWrt's `feeds/*`, Vim's `bundle/*` and every future
+ *    equivalent without naming any of them. A repo the user actually works in
+ *    appears the moment there is a change to see, which is exactly when the
+ *    Changes tab needs it.
+ *
+ * Repos in the project's own tracked structure are never subject to (3): they
+ * are listed whether or not they are clean. That includes a repo whose own
+ * path is ignored while its parents are tracked — a directory that is itself a
+ * repo is recognised before its ignore state is ever consulted.
  *
  * A repo found this way resets the ignore budget: its own contents are then
  * judged by its own `.gitignore`, not the outer repo's.
@@ -38,10 +54,11 @@ import { debug } from '$shared/utils/logger';
 import { execGit } from './git-executor';
 
 /**
- * Directories that never hold a user's own repo — VCS internals, dependency
- * caches, and package-manager checkout dirs. Pruned by name at any depth,
- * whether or not the enclosing repo ignores them (a project may well commit
- * its `Pods/`, and it still isn't where sub-repos live).
+ * Directories large enough that walking them is pure waste — VCS internals and
+ * the big dependency caches. Pruned by name at any depth, whether or not the
+ * enclosing repo ignores them. This list is a cost guard, not the policy: what
+ * keeps package checkouts out of the panel is rule (3) above, so a name
+ * missing from here costs a little walking, not a wrong answer.
  */
 const HARD_SKIP_DIRS = new Set([
 	'.git', '.svn', '.hg',
@@ -77,6 +94,13 @@ interface WalkEntry {
 	 * when this directory is part of the enclosing repo's own structure.
 	 */
 	ignoredBudget: number | null;
+	/**
+	 * True once the walk has crossed into a tree the project ignores. Repos
+	 * found from here on must prove they hold local work before being
+	 * reported, and the flag is inherited so a repo nested inside a rejected
+	 * package checkout does not slip through on its own clean ignore state.
+	 */
+	insideIgnored: boolean;
 }
 
 /**
@@ -108,6 +132,25 @@ async function filterIgnored(repoRoot: string, relPaths: string[]): Promise<Set<
 	return ignored;
 }
 
+/**
+ * Whether `repoPath` has anything the Git panel could show — staged, unstaged,
+ * untracked or conflicted entries. This is what separates a repo the user
+ * works in from a package manager's checkout, which is a clone at a pinned ref
+ * that nobody edits and so reports nothing.
+ *
+ * A repo we cannot read is reported as having work: hiding a sub-repo the user
+ * edits is a far worse failure than showing one they do not care about.
+ */
+async function hasLocalWork(repoPath: string): Promise<boolean> {
+	try {
+		const result = await execGit(['status', '--porcelain', '-z'], repoPath, { timeout: 15000 });
+		if (result.exitCode !== 0) return true;
+		return result.stdout.length > 0;
+	} catch {
+		return true;
+	}
+}
+
 /** Whether `dirPath` is a git repo (`.git` is a dir for clones, a file for worktrees/submodules). */
 async function isRepoDir(dirPath: string): Promise<boolean> {
 	try {
@@ -125,7 +168,11 @@ async function isRepoDir(dirPath: string): Promise<boolean> {
  */
 export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
 	const found: string[] = [];
-	let level: WalkEntry[] = [{ dirPath: rootPath, repoRoot: rootPath, ignoredBudget: null }];
+	/** Repos found inside an ignored tree — reported only if they prove local work. */
+	const provisional: string[] = [];
+	let level: WalkEntry[] = [
+		{ dirPath: rootPath, repoRoot: rootPath, ignoredBudget: null, insideIgnored: false }
+	];
 	let truncated = false;
 
 	for (let depth = 0; depth < MAX_DEPTH && level.length > 0 && !truncated; depth++) {
@@ -172,13 +219,27 @@ export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
 		const next: WalkEntry[] = [];
 		candidates.forEach((c, i) => {
 			if (repoFlags[i]) {
-				if (found.length >= MAX_REPOS) {
-					truncated = true;
-					return;
+				if (c.parent.insideIgnored) {
+					// Candidates from an ignored tree get their own budget, so a
+					// directory full of package checkouts bounds the `git status`
+					// work without blinding the rest of the walk to real sub-repos.
+					if (provisional.length >= MAX_REPOS) return;
+					provisional.push(c.fullPath);
+				} else {
+					if (found.length >= MAX_REPOS) {
+						truncated = true;
+						return;
+					}
+					found.push(c.fullPath);
 				}
-				found.push(c.fullPath);
-				// Inside a repo, its own ignore rules apply from scratch.
-				next.push({ dirPath: c.fullPath, repoRoot: c.fullPath, ignoredBudget: null });
+				// Inside a repo, its own ignore rules apply from scratch — but a
+				// repo buried in an ignored tree cannot launder its children.
+				next.push({
+					dirPath: c.fullPath,
+					repoRoot: c.fullPath,
+					ignoredBudget: null,
+					insideIgnored: c.parent.insideIgnored
+				});
 				return;
 			}
 
@@ -187,7 +248,12 @@ export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
 				const ignored = ignoredByRepo.get(c.parent.repoRoot);
 				if (!ignored?.has(c.relPath)) {
 					// Part of the project's own structure — descend freely.
-					next.push({ dirPath: c.fullPath, repoRoot: c.parent.repoRoot, ignoredBudget: null });
+					next.push({
+						dirPath: c.fullPath,
+						repoRoot: c.parent.repoRoot,
+						ignoredBudget: null,
+						insideIgnored: c.parent.insideIgnored
+					});
 					return;
 				}
 				budget = IGNORED_DESCENT_LEVELS;
@@ -196,7 +262,12 @@ export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
 			}
 			// Inside an ignored tree: keep looking only while the budget lasts.
 			if (budget > 0) {
-				next.push({ dirPath: c.fullPath, repoRoot: c.parent.repoRoot, ignoredBudget: budget });
+				next.push({
+					dirPath: c.fullPath,
+					repoRoot: c.parent.repoRoot,
+					ignoredBudget: budget,
+					insideIgnored: true
+				});
 			}
 		});
 
@@ -205,6 +276,20 @@ export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
 
 	if (truncated) {
 		debug.warn('git', `Nested repo scan of ${rootPath} stopped at ${MAX_REPOS} repos`);
+	}
+
+	if (provisional.length > 0) {
+		// A submodule is the user declaring the sub-repo themselves, which
+		// outranks anything we could infer from its working tree.
+		const submodulePaths = await findSubmodulePaths(rootPath);
+		const isDeclared = (repoPath: string) =>
+			submodulePaths.has(path.relative(rootPath, repoPath).replace(/\\/g, '/'));
+		const verdicts = await Promise.all(
+			provisional.map(async (repoPath) => isDeclared(repoPath) || (await hasLocalWork(repoPath)))
+		);
+		provisional.forEach((repoPath, i) => {
+			if (verdicts[i]) found.push(repoPath);
+		});
 	}
 
 	found.sort();


### PR DESCRIPTION
## Summary
Sub-repos inside a gitignored tree are now reported only when they hold local work or are
declared submodules, which keeps every package manager's checkouts out of the Git panel
without maintaining a list of directory names.

## Why
#491 stopped Swift Package Manager checkouts from flooding the Changes tab, but the
ignored-directory peek it kept — there so a repo under an ignored parent is still found —
is exactly where other package managers put their clones. Elixir's Mix ignores `/deps/`
and clones into `deps/<name>`, so a Phoenix project listed `deps/daisyui` and
`deps/heroicons` as sub-repos.

Extending the name-based prune was tried first and abandoned: an audit across 18 ecosystem
layouts left 7 still leaking, and two of them are unfixable by name. `plugins/` is tmux's
package directory *and* a WordPress developer's own plugin repos; `modules/` is Puppet's
checkout directory *and* a hand-written source tree. A denylist is wrong on one side of
each, so the signal has to be structural.

## Changes
- `backend/git/nested-repos.ts`: track whether the walk has crossed into an ignored tree
  and carry that flag down, including through a nested repo — entering a repo resets the
  ignore budget, and without inheritance a repo vendored inside a rejected checkout would
  be treated as tracked structure.
- Repos found inside an ignored tree are held as provisional and reported only if
  `git status --porcelain` is non-empty or `.gitmodules` declares them. A repo whose status
  cannot be read is reported: hiding work the user edits is the worse failure.
- Repos in tracked structure keep their existing behaviour and are listed when clean. That
  includes a repo whose own path is ignored while its parents are tracked, since a
  directory that is itself a repo is recognised before its ignore state is consulted.
- Give the provisional set its own `MAX_REPOS` budget, so a directory full of package
  checkouts bounds the `git status` work instead of truncating the walk and hiding real
  sub-repos found later.
- Reframe `HARD_SKIP_DIRS` in the module comment as a walk-cost guard rather than policy.
- `backend/git/nested-repos.test.ts`: table-driven coverage for ten package managers
  (Mix, OpenWrt feeds, Vim pathogen, tmux tpm, Ansible Galaxy, Puppet librarian, Chef
  berkshelf, Zephyr west, Composer source installs, CMake FetchContent), the `plugins/`
  name collision resolved in both directions, submodule rescue, the inheritance guard, and
  the clean-repo trade-off documented as an explicit test.

## Test plan
- `bun run check` — 0 errors; `bun run lint` — clean
- `bun run test --isolate` — 526 pass, 17 skip, 0 fail
- Scratch matrix of 18 ecosystem layouts: 11/18 correct before, 18/18 after
- Ran discovery against the Phoenix project that reproduced the bug: 2 false sub-repos
  before, none after
- Mutation check: inverting the inherited flag fails the vendored-repo test, so the guard
  is actually covered
- Cost on that project: 58ms → 65ms per discovery (two status probes), so no caching added

## Notes
The trade-off, taken deliberately: a **clean** repo of the user's own sitting under a
wholesale-ignored parent (`.gitignore` containing `wp-content/plugins/`) is not listed
until it has a change. With nothing to show it is indistinguishable from a package
checkout, it contributes nothing to the Changes tab while clean, and it returns the instant
the agent or user touches it. Repos whose own path is ignored, submodules, and everything
in tracked structure are unaffected.

A per-project always-show / always-hide override would remove the last of the guesswork,
but it needs settings storage and UI — worth a separate PR if the default ever misjudges.