### PR TITLE
fix(update): tighten release note entries and show the same versions everywhere

### DIFF
--- a/frontend/components/common/feedback/ReleaseNotesList.svelte
+++ b/frontend/components/common/feedback/ReleaseNotesList.svelte
@@ -13,16 +13,21 @@
 		releases: ReleaseNote[];
 		/** How many releases (from the top) start expanded. The rest collapse into an accordion. Default 1. */
 		defaultExpandedCount?: number;
+		/** Expand this specific release instead of the top `defaultExpandedCount` ones. */
+		expandedTagName?: string;
 	}
 
-	const { releases, defaultExpandedCount = 1 }: Props = $props();
+	const { releases, defaultExpandedCount = 1, expandedTagName }: Props = $props();
 
 	let expanded = $state(new Set<string>());
 
 	// Seed which entries start expanded whenever the release list itself changes
 	// (new fetch, different version list) — not on every unrelated re-render.
 	$effect(() => {
-		expanded = new Set(releases.slice(0, defaultExpandedCount).map(r => r.tag_name));
+		const initiallyExpanded = expandedTagName
+			? releases.filter(release => release.tag_name === expandedTagName)
+			: releases.slice(0, defaultExpandedCount);
+		expanded = new Set(initiallyExpanded.map(release => release.tag_name));
 	});
 
 	function toggle(tag_name: string) {
@@ -32,6 +37,21 @@
 			expanded.add(tag_name);
 		}
 		expanded = new Set(expanded);
+	}
+
+	// GitHub's auto-generated notes end every entry with " in <pull-request-url>". In a
+	// narrow dialog that link wraps onto its own line and doubles the height of the list
+	// without saying anything the entry doesn't already say, so drop it. Only bullet
+	// lines are touched — the trailing "Full Changelog" link stays clickable.
+	const TRAILING_PULL_REQUEST_LINK = /\s+in\s+<?https:\/\/github\.com\/\S+?>?\s*$/;
+
+	function stripPullRequestLinks(body: string): string {
+		return body
+			.split('\n')
+			.map(line =>
+				/^\s*([-*+]|\d+\.)\s/.test(line) ? line.replace(TRAILING_PULL_REQUEST_LINK, '') : line
+			)
+			.join('\n');
 	}
 
 	function formatDate(published_at: string): string {
@@ -64,7 +84,7 @@
 
 			{#if expanded.has(release.tag_name)}
 				<div class="mt-2 release-notes-body">
-					<Markdown variant="compact" content={release.body} />
+					<Markdown variant="compact" content={stripPullRequestLinks(release.body)} />
 					<div class="mt-2">
 						<a
 							href={release.html_url}

--- a/frontend/components/common/feedback/RestartRequiredDialog.svelte
+++ b/frontend/components/common/feedback/RestartRequiredDialog.svelte
@@ -8,16 +8,14 @@
 		hideRestartModal();
 	}
 
-	// Show the changelog entry matching the version that was just installed, if we have it.
-	// Wrapped in a single-item array here (rather than inline in the template) so the
-	// reference stays stable across unrelated re-renders — ReleaseNotesList reseeds its
-	// expand/collapse state whenever the `releases` array reference changes.
-	const installedReleaseNote = $derived(
-		updateState.releaseNotes?.find(
-			release => release.tag_name.replace(/^v/, '') === updateState.latestVersion
-		) ?? null
+	// Show the same last-few-versions changelog the other update surfaces show, with the
+	// version that was just installed expanded — a user who skipped a release still gets
+	// to read what landed in it.
+	const releaseNotes = $derived(updateState.releaseNotes ?? []);
+	const installedTagName = $derived(
+		releaseNotes.find(release => release.tag_name.replace(/^v/, '') === updateState.latestVersion)
+			?.tag_name
 	);
-	const installedReleaseNoteList = $derived(installedReleaseNote ? [installedReleaseNote] : []);
 </script>
 
 <Dialog
@@ -62,11 +60,11 @@
 				</li>
 			</ol>
 
-			{#if installedReleaseNote}
+			{#if releaseNotes.length}
 				<div class="pt-3 mt-1 border-t border-slate-200 dark:border-slate-700">
 					<div class="text-sm font-semibold text-slate-500 dark:text-slate-400 mb-2">What's new</div>
 					<div class="px-3 py-3 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-700 rounded-lg max-h-64 overflow-y-auto">
-						<ReleaseNotesList releases={installedReleaseNoteList} defaultExpandedCount={0} />
+						<ReleaseNotesList releases={releaseNotes} defaultExpandedCount={0} expandedTagName={installedTagName} />
 					</div>
 				</div>
 			{/if}


### PR DESCRIPTION
## Summary
Drop the trailing pull request link from each release note entry and make the post-update restart dialog show the same three versions the other update surfaces show.

## Why
GitHub's auto-generated notes end every bullet with `in <pull-request-url>`. Inside the update dialogs that link wraps onto a second line and roughly doubles the height of the changelog without adding information the entry doesn't already carry.

Separately, the "Updated to vX" restart dialog rendered only the version that was just installed, while Settings → Update ("Last 3 versions") and the "What's new" preview both render the last three. A user who skipped a release never got to read what landed in it.

## Changes
- `ReleaseNotesList.svelte`: strip a trailing `in https://github.com/...` from list lines before rendering; non-list lines (notably `**Full Changelog**`) are untouched, and the per-release *View on GitHub* link still points at the source
- `ReleaseNotesList.svelte`: new optional `expandedTagName` prop to expand one specific release instead of the top `defaultExpandedCount`
- `RestartRequiredDialog.svelte`: render the full release list with the just-installed version expanded, instead of a single-entry list

## Test plan
- `bun run check` — 0 errors
- `bun run lint` — clean
- Stripping verified against the real v0.4.32 release body, including the "New Contributors" section and the `Full Changelog` line