### PR TITLE
feat(files): stream file downloads with a progress bar

### DIFF
--- a/backend/database/queries/file-audit-log-queries.ts
+++ b/backend/database/queries/file-audit-log-queries.ts
@@ -26,6 +26,7 @@ export interface FileAuditLogEntry {
 
 export type FileAuditAction = 
 	| 'upload'
+	| 'download'
 	| 'delete'
 	| 'move'
 	| 'rename'

--- a/backend/http/audio.ts
+++ b/backend/http/audio.ts
@@ -12,40 +12,13 @@ import { join } from 'node:path';
 import { mkdir, readdir, rename, stat, unlink } from 'node:fs/promises';
 
 import { debug } from '$shared/utils/logger';
-import { hashToken } from '../auth/tokens';
-import { authQueries } from '../database/queries';
 import { getClopenDir } from '../utils/paths';
+import { authenticateRequest, type AuthIdentity } from './bearer-auth';
 import {
 	NOTIFICATION_SOUND_ALLOWED_EXTS,
 	NOTIFICATION_SOUND_MAX_BYTES,
 	isValidNotificationSoundExt
 } from '$shared/constants/notification-sounds';
-
-type AuthIdentity = { userId: string; role: string };
-
-function authenticate(request: Request): AuthIdentity {
-	const header = request.headers.get('authorization') || request.headers.get('Authorization');
-	if (!header || !header.toLowerCase().startsWith('bearer ')) {
-		throw Object.assign(new Error('Authorization required'), { status: 401 });
-	}
-	const token = header.slice(7).trim();
-	if (!token) {
-		throw Object.assign(new Error('Authorization required'), { status: 401 });
-	}
-	const session = authQueries.getSessionByTokenHash(hashToken(token));
-	if (!session) {
-		throw Object.assign(new Error('Invalid session token'), { status: 401 });
-	}
-	if (new Date(session.expires_at) < new Date()) {
-		throw Object.assign(new Error('Session expired'), { status: 401 });
-	}
-	const user = authQueries.getUserById(session.user_id);
-	if (!user) {
-		throw Object.assign(new Error('User not found'), { status: 401 });
-	}
-	authQueries.updateLastActive(session.id);
-	return { userId: user.id, role: user.role };
-}
 
 function getUserAudioDir(userId: string): string {
 	return join(getClopenDir(), 'audio', userId);
@@ -78,7 +51,7 @@ export const audioRoute = new Elysia()
 	.post('/api/audio/upload', async ({ request, query }) => {
 		let identity: AuthIdentity;
 		try {
-			identity = authenticate(request);
+			identity = authenticateRequest(request);
 		} catch (error) {
 			const status = (error as { status?: number }).status ?? 401;
 			const message = error instanceof Error ? error.message : 'Unauthorized';
@@ -173,7 +146,7 @@ export const audioRoute = new Elysia()
 	.get('/api/audio/custom/meta', async ({ request }) => {
 		let identity: AuthIdentity;
 		try {
-			identity = authenticate(request);
+			identity = authenticateRequest(request);
 		} catch (error) {
 			const status = (error as { status?: number }).status ?? 401;
 			const message = error instanceof Error ? error.message : 'Unauthorized';
@@ -196,7 +169,7 @@ export const audioRoute = new Elysia()
 	.get('/api/audio/custom', async ({ request }) => {
 		let identity: AuthIdentity;
 		try {
-			identity = authenticate(request);
+			identity = authenticateRequest(request);
 		} catch (error) {
 			const status = (error as { status?: number }).status ?? 401;
 			const message = error instanceof Error ? error.message : 'Unauthorized';
@@ -220,7 +193,7 @@ export const audioRoute = new Elysia()
 	.delete('/api/audio/custom', async ({ request }) => {
 		let identity: AuthIdentity;
 		try {
-			identity = authenticate(request);
+			identity = authenticateRequest(request);
 		} catch (error) {
 			const status = (error as { status?: number }).status ?? 401;
 			const message = error instanceof Error ? error.message : 'Unauthorized';

--- a/backend/http/bearer-auth.ts
+++ b/backend/http/bearer-auth.ts
@@ -1,0 +1,47 @@
+/**
+ * Bearer-token authentication for the HTTP routes.
+ *
+ * The HTTP routes sit next to the WebSocket router rather than inside it, so
+ * they cannot lean on `WSConnection` for identity. They all accept the same
+ * `Authorization: Bearer <session-token>` the frontend already holds (issued
+ * by `auth:login`, stored in `localStorage`), which this module resolves to a
+ * user exactly once instead of once per route file.
+ */
+
+import { hashToken } from '../auth/tokens';
+import { authQueries } from '../database/queries';
+
+export interface AuthIdentity {
+	userId: string;
+	role: string;
+}
+
+/**
+ * Resolve the caller from the request's bearer token.
+ *
+ * Throws an `Error` carrying a `status` property so a route can answer with
+ * the right code without re-deriving it.
+ */
+export function authenticateRequest(request: Request): AuthIdentity {
+	const header = request.headers.get('authorization') || request.headers.get('Authorization');
+	if (!header || !header.toLowerCase().startsWith('bearer ')) {
+		throw Object.assign(new Error('Authorization required'), { status: 401 });
+	}
+	const token = header.slice(7).trim();
+	if (!token) {
+		throw Object.assign(new Error('Authorization required'), { status: 401 });
+	}
+	const session = authQueries.getSessionByTokenHash(hashToken(token));
+	if (!session) {
+		throw Object.assign(new Error('Invalid session token'), { status: 401 });
+	}
+	if (new Date(session.expires_at) < new Date()) {
+		throw Object.assign(new Error('Session expired'), { status: 401 });
+	}
+	const user = authQueries.getUserById(session.user_id);
+	if (!user) {
+		throw Object.assign(new Error('User not found'), { status: 401 });
+	}
+	authQueries.updateLastActive(session.id);
+	return { userId: user.id, role: user.role };
+}

--- a/backend/http/files-download.test.ts
+++ b/backend/http/files-download.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Integration tests for the file download route.
+ *
+ * The point of this route is a streamed body with a real `Content-Length` —
+ * that header is what makes the browser's progress event computable, so it is
+ * asserted here rather than left to be noticed missing in the UI. Access
+ * control is exercised too: a path outside the caller's projects must not be
+ * readable just because the token is valid.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { filesDownloadRoute } from './files-download';
+import { authQueries } from '../database/queries';
+import { hashToken } from '../auth/tokens';
+import { projectQueries } from '../database/queries/project-queries';
+import { initializeDatabase, closeDatabase } from '../database';
+
+const TEST_DIR = join(import.meta.dir, '.test-download-integration');
+const TEST_WORKSPACE = join(TEST_DIR, 'workspace');
+const OUTSIDE_DIR = join(TEST_DIR, 'outside');
+
+let testUserId: string;
+let testToken: string;
+let testProjectId: string;
+
+function createMockDownloadRequest(path: string, token: string | null): Request {
+	const url = new URL('http://localhost/api/files/download');
+	url.searchParams.set('path', path);
+
+	return new Request(url.toString(), {
+		method: 'GET',
+		headers: token ? { authorization: `Bearer ${token}` } : {}
+	});
+}
+
+beforeAll(async () => {
+	await initializeDatabase();
+
+	await mkdir(TEST_WORKSPACE, { recursive: true });
+	await mkdir(OUTSIDE_DIR, { recursive: true });
+
+	testUserId = randomUUID();
+	authQueries.createUser({
+		id: testUserId,
+		name: 'Test User',
+		color: '#000000',
+		avatar: 'test',
+		role: 'member',
+		personal_access_token_hash: null,
+		created_at: new Date().toISOString()
+	});
+
+	testToken = randomUUID();
+	authQueries.createSession({
+		id: randomUUID(),
+		user_id: testUserId,
+		token_hash: hashToken(testToken),
+		expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+		created_at: new Date().toISOString(),
+		last_active_at: new Date().toISOString(),
+		user_agent: null,
+		ip_address: null,
+		source: null
+	});
+
+	const project = projectQueries.create({
+		name: 'Test Project',
+		path: TEST_WORKSPACE,
+		created_at: new Date().toISOString(),
+		last_opened_at: new Date().toISOString()
+	});
+	testProjectId = project.id;
+	projectQueries.addUserProject(testUserId, testProjectId);
+});
+
+afterAll(async () => {
+	authQueries.deleteSessionsByUserId(testUserId);
+	authQueries.deleteUser(testUserId);
+	projectQueries.deleteProject(testProjectId);
+	closeDatabase();
+	await rm(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('File download route', () => {
+	it('streams the file with a computable length and an attachment name', async () => {
+		const content = 'x'.repeat(10000);
+		const filePath = join(TEST_WORKSPACE, 'report card.txt');
+		await writeFile(filePath, content);
+
+		const response = await filesDownloadRoute.handle(createMockDownloadRequest(filePath, testToken));
+
+		expect(response.status).toBe(200);
+		// The client's progress bar prefers this over the size it already knows,
+		// so a file that grew since the listing still reports an honest total.
+		expect(response.headers.get('content-length')).toBe(String(content.length));
+		expect(response.headers.get('content-disposition')).toBe(
+			"attachment; filename*=UTF-8''report%20card.txt"
+		);
+		expect(await response.text()).toBe(content);
+	});
+
+	it('preserves bytes exactly for binary content', async () => {
+		const bytes = new Uint8Array([0, 1, 2, 253, 254, 255]);
+		const filePath = join(TEST_WORKSPACE, 'blob.bin');
+		await writeFile(filePath, bytes);
+
+		const response = await filesDownloadRoute.handle(createMockDownloadRequest(filePath, testToken));
+
+		expect(response.status).toBe(200);
+		expect(new Uint8Array(await response.arrayBuffer())).toEqual(bytes);
+	});
+
+	it('rejects a path outside the caller projects', async () => {
+		const filePath = join(OUTSIDE_DIR, 'secret.txt');
+		await writeFile(filePath, 'secret');
+
+		const response = await filesDownloadRoute.handle(createMockDownloadRequest(filePath, testToken));
+
+		expect(response.status).toBe(403);
+	});
+
+	it('rejects an unauthenticated request', async () => {
+		const filePath = join(TEST_WORKSPACE, 'open.txt');
+		await writeFile(filePath, 'hello');
+
+		const response = await filesDownloadRoute.handle(createMockDownloadRequest(filePath, null));
+
+		expect(response.status).toBe(401);
+	});
+
+	it('reports a missing file as 404 and a directory as 400', async () => {
+		const missing = await filesDownloadRoute.handle(
+			createMockDownloadRequest(join(TEST_WORKSPACE, 'nope.txt'), testToken)
+		);
+		expect(missing.status).toBe(404);
+
+		const directory = await filesDownloadRoute.handle(
+			createMockDownloadRequest(TEST_WORKSPACE, testToken)
+		);
+		expect(directory.status).toBe(400);
+	});
+});

--- a/backend/http/files-download.ts
+++ b/backend/http/files-download.ts
@@ -1,0 +1,109 @@
+/**
+ * HTTP download route for files.
+ *
+ * The counterpart to `/api/files/upload`, and it exists for the same reason
+ * plus one more. Reading a file over the WebSocket (`files:read-content`)
+ * base64-encodes the whole thing into a single message: the transfer is
+ * invisible until it lands, it costs a third more bytes on the wire, and both
+ * ends hold the entire file in memory. Streaming over HTTP with a known
+ * `Content-Length` lets the browser report progress while the bytes arrive.
+ *
+ * Auth: `Authorization: Bearer <session-token>` (same token as the upload
+ * route), followed by the same project-scoped path check the WS handlers use.
+ *
+ * Query: `path` (absolute path of the file to download).
+ */
+
+import { Elysia } from 'elysia';
+import { stat } from 'node:fs/promises';
+import { basename } from 'node:path';
+
+import { debug } from '$shared/utils/logger';
+import { fileAuditLogQueries } from '../database/queries';
+import { findContainingProjectId, requireFilePathAccessFor } from '../ws/files/path-access';
+import { clientIpFromRequest } from '../utils/client-ip';
+import { authenticateRequest, type AuthIdentity } from './bearer-auth';
+
+export const filesDownloadRoute = new Elysia().get('/api/files/download', async ({ request, query, server }) => {
+	let identity: AuthIdentity;
+	try {
+		identity = authenticateRequest(request);
+	} catch (error) {
+		const status = (error as { status?: number }).status ?? 401;
+		const message = error instanceof Error ? error.message : 'Unauthorized';
+		return new Response(message, { status });
+	}
+
+	const pathParam = typeof query.path === 'string' ? query.path : '';
+	if (!pathParam) {
+		return new Response('Missing required query parameter: path', { status: 400 });
+	}
+
+	const ipAddress = clientIpFromRequest(request, server);
+	const userAgent = request.headers.get('user-agent') ?? undefined;
+	const projectId = await findContainingProjectId(pathParam);
+
+	const logFailure = (message: string, size: number | null = null) => {
+		fileAuditLogQueries.logOperation({
+			userId: identity.userId,
+			projectId,
+			action: 'download',
+			filePath: pathParam,
+			fileSize: size,
+			ipAddress,
+			userAgent,
+			success: false,
+			errorMessage: message
+		});
+	};
+
+	let resolvedPath: string;
+	try {
+		resolvedPath = await requireFilePathAccessFor(pathParam, identity.role, identity.userId);
+	} catch (error) {
+		logFailure('Path access denied');
+		return new Response(error instanceof Error ? error.message : 'Access denied', { status: 403 });
+	}
+
+	try {
+		const stats = await stat(resolvedPath).catch(() => null);
+		if (!stats) {
+			logFailure('File not found');
+			return new Response('File not found', { status: 404 });
+		}
+		if (stats.isDirectory()) {
+			logFailure('Not a file');
+			return new Response('Cannot download a directory — compress it first', { status: 400 });
+		}
+
+		const file = Bun.file(resolvedPath);
+
+		const name = basename(resolvedPath);
+
+		fileAuditLogQueries.logOperation({
+			userId: identity.userId,
+			projectId,
+			action: 'download',
+			filePath: resolvedPath,
+			fileSize: stats.size,
+			ipAddress,
+			userAgent
+		});
+
+		// Streamed straight from disk — a large file must never be buffered in
+		// this process just to be handed to the browser. `Content-Length` is what
+		// makes the client's progress event computable, so it is always set.
+		return new Response(file.stream(), {
+			headers: {
+				'Content-Type': file.type || 'application/octet-stream',
+				'Content-Length': String(stats.size),
+				'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(name)}`
+			}
+		});
+	} catch (error) {
+		debug.error('file', 'HTTP download error:', error);
+		const message = error instanceof Error ? error.message : 'Download failed';
+		logFailure(message);
+		return new Response(message, { status: 500 });
+	}
+});

--- a/backend/http/files-upload.ts
+++ b/backend/http/files-upload.ts
@@ -19,43 +19,17 @@ import { join } from 'node:path';
 import { link, mkdir, stat, unlink } from 'node:fs/promises';
 
 import { debug } from '$shared/utils/logger';
-import { hashToken } from '../auth/tokens';
-import { authQueries, fileAuditLogQueries } from '../database/queries';
+import { fileAuditLogQueries } from '../database/queries';
 import { findContainingProjectId, requireFilePathAccessFor } from '../ws/files/path-access';
 import { clientIpFromRequest } from '../utils/client-ip';
 import { validateFileSize } from '../files/file-size-limit';
 import { uploadTempCleanup } from './upload-temp-cleanup';
-
-type AuthIdentity = { userId: string; role: string };
-
-function authenticate(request: Request): AuthIdentity {
-	const header = request.headers.get('authorization') || request.headers.get('Authorization');
-	if (!header || !header.toLowerCase().startsWith('bearer ')) {
-		throw Object.assign(new Error('Authorization required'), { status: 401 });
-	}
-	const token = header.slice(7).trim();
-	if (!token) {
-		throw Object.assign(new Error('Authorization required'), { status: 401 });
-	}
-	const session = authQueries.getSessionByTokenHash(hashToken(token));
-	if (!session) {
-		throw Object.assign(new Error('Invalid session token'), { status: 401 });
-	}
-	if (new Date(session.expires_at) < new Date()) {
-		throw Object.assign(new Error('Session expired'), { status: 401 });
-	}
-	const user = authQueries.getUserById(session.user_id);
-	if (!user) {
-		throw Object.assign(new Error('User not found'), { status: 401 });
-	}
-	authQueries.updateLastActive(session.id);
-	return { userId: user.id, role: user.role };
-}
+import { authenticateRequest, type AuthIdentity } from './bearer-auth';
 
 export const filesUploadRoute = new Elysia().post('/api/files/upload', async ({ request, query, server }) => {
 	let identity: AuthIdentity;
 	try {
-		identity = authenticate(request);
+		identity = authenticateRequest(request);
 	} catch (error) {
 		const status = (error as { status?: number }).status ?? 401;
 		const message = error instanceof Error ? error.message : 'Unauthorized';

--- a/backend/http/ssh-sftp.ts
+++ b/backend/http/ssh-sftp.ts
@@ -14,42 +14,13 @@ import { Elysia } from 'elysia';
 import { Readable } from 'node:stream';
 
 import { debug } from '$shared/utils/logger';
-import { hashToken } from '../auth/tokens';
-import { authQueries, sshConnectionQueries } from '../database/queries';
+import { sshConnectionQueries } from '../database/queries';
 import { joinRemote, sftpService } from '../ssh/sftp';
-
-interface AuthIdentity {
-	userId: string;
-	role: string;
-}
-
-function authenticate(request: Request): AuthIdentity {
-	const header = request.headers.get('authorization') || request.headers.get('Authorization');
-	if (!header || !header.toLowerCase().startsWith('bearer ')) {
-		throw Object.assign(new Error('Authorization required'), { status: 401 });
-	}
-	const token = header.slice(7).trim();
-	if (!token) {
-		throw Object.assign(new Error('Authorization required'), { status: 401 });
-	}
-	const session = authQueries.getSessionByTokenHash(hashToken(token));
-	if (!session) {
-		throw Object.assign(new Error('Invalid session token'), { status: 401 });
-	}
-	if (new Date(session.expires_at) < new Date()) {
-		throw Object.assign(new Error('Session expired'), { status: 401 });
-	}
-	const user = authQueries.getUserById(session.user_id);
-	if (!user) {
-		throw Object.assign(new Error('User not found'), { status: 401 });
-	}
-	authQueries.updateLastActive(session.id);
-	return { userId: user.id, role: user.role };
-}
+import { authenticateRequest } from './bearer-auth';
 
 /** Resolve the caller and confirm they own the SSH connection they named. */
 function authorizeConnection(request: Request, connectionId: string): void {
-	const identity = authenticate(request);
+	const identity = authenticateRequest(request);
 	const connection = sshConnectionQueries.getForUser(
 		connectionId,
 		identity.userId,

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -43,6 +43,7 @@ import { wsRouter } from './ws';
 // HTTP upload route — bypasses the Vite WS proxy, which corrupts sustained
 // binary transfers with `write EPIPE`. See backend/http/files-upload.ts.
 import { filesUploadRoute } from './http/files-upload';
+import { filesDownloadRoute } from './http/files-download';
 
 // HTTP routes for per-user notification sounds (upload / serve / delete).
 import { audioRoute } from './http/audio';
@@ -181,9 +182,10 @@ const app = new Elysia()
 		}
 	})
 
-	// HTTP file upload — mounted before the WS plugin so /api/files/upload
-	// stays on the HTTP path through the Vite dev proxy.
+	// HTTP file transfer — mounted before the WS plugin so /api/files/* stays
+	// on the HTTP path through the Vite dev proxy.
 	.use(filesUploadRoute)
+	.use(filesDownloadRoute)
 
 	// Per-user notification sound upload/serve/delete.
 	.use(audioRoute)

--- a/frontend/components/files/FileViewer.svelte
+++ b/frontend/components/files/FileViewer.svelte
@@ -12,6 +12,7 @@
 	import { getFolderIcon } from '$frontend/utils/folder-icon-mappings';
 	import { isImageFile, isSvgFile, isPdfFile, isAudioFile, isVideoFile, isBinaryFile, isBinaryContent, isPreviewableFile, isEditableImageFile } from '$frontend/utils/file-type';
 	import { formatFileSize } from '$frontend/utils/format';
+	import { fetchFileBlob, isAbortError, saveBlob } from '$frontend/utils/file-download';
 	import { onMount } from 'svelte';
 	import { scale } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
@@ -1905,13 +1906,19 @@
 		}
 	}
 
-	function saveBlob(blob: Blob, name: string) {
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = name;
-		a.click();
-		URL.revokeObjectURL(url);
+	// Progress of the one download this viewer can have in flight, so a large
+	// binary reports movement instead of sitting on a dead button.
+	let downloadProgress = $state<{ transferredBytes: number; totalBytes: number | null } | null>(null);
+	let downloadAbort: AbortController | null = null;
+
+	const downloadPercent = $derived(
+		downloadProgress && downloadProgress.totalBytes
+			? Math.min(100, Math.round((downloadProgress.transferredBytes / downloadProgress.totalBytes) * 100))
+			: null
+	);
+
+	function cancelDownload() {
+		downloadAbort?.abort();
 	}
 
 	async function downloadFile() {
@@ -1925,19 +1932,26 @@
 			return;
 		}
 
-		// Binary / media files: fetch the original bytes from disk so the download
-		// is byte-for-byte intact. `preview` is omitted so transcodable formats
-		// (TIFF/HEIC) download in their original format, not a PNG copy.
+		// Binary / media files: stream the original bytes from disk so the download
+		// is byte-for-byte intact and reports progress on the way. `preview` is not
+		// involved, so transcodable formats (TIFF/HEIC) download in their original
+		// format, not a PNG copy.
+		if (downloadAbort) return;
+		const controller = new AbortController();
+		downloadAbort = controller;
+		downloadProgress = { transferredBytes: 0, totalBytes: file.size ?? null };
 		try {
-			const response = await ws.http('files:read-content', { path: file.path });
-			const binaryString = atob(response.content);
-			const bytes = new Uint8Array(binaryString.length);
-			for (let i = 0; i < binaryString.length; i++) {
-				bytes[i] = binaryString.charCodeAt(i);
-			}
-			saveBlob(new Blob([bytes], { type: response.contentType || 'application/octet-stream' }), file.name);
+			const blob = await fetchFileBlob(file.path, {
+				totalBytes: file.size ?? null,
+				signal: controller.signal,
+				onProgress: (progress) => { downloadProgress = progress; }
+			});
+			saveBlob(blob, file.name);
 		} catch (err) {
-			debug.error('file', 'Failed to download file:', err);
+			if (!isAbortError(err)) debug.error('file', 'Failed to download file:', err);
+		} finally {
+			downloadAbort = null;
+			downloadProgress = null;
 		}
 	}
 </script>
@@ -2298,12 +2312,38 @@
 					<p class="text-sm text-slate-500 dark:text-slate-400 text-center mb-4">
 						This file cannot be previewed in the browser.
 					</p>
-					<button
-						class="px-6 py-2.5 bg-violet-600 text-white rounded-xl hover:bg-violet-700 transition-all duration-200"
-						onclick={downloadFile}
-					>
-						Download File
-					</button>
+					{#if downloadProgress}
+						<div class="w-full max-w-xs flex flex-col items-center gap-2">
+							<div class="h-1.5 w-full rounded-full bg-slate-200 dark:bg-slate-700 overflow-hidden">
+								{#if downloadPercent !== null}
+									<div
+										class="h-full bg-violet-600 transition-all duration-150"
+										style="width: {downloadPercent}%"
+									></div>
+								{:else}
+									<div class="h-full w-1/3 bg-violet-600 animate-pulse"></div>
+								{/if}
+							</div>
+							<div class="text-xs text-slate-500 dark:text-slate-400">
+								{formatFileSize(downloadProgress.transferredBytes)}{downloadProgress.totalBytes
+									? ` / ${formatFileSize(downloadProgress.totalBytes)}`
+									: ''}
+							</div>
+							<button
+								class="text-xs text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 cursor-pointer"
+								onclick={cancelDownload}
+							>
+								Cancel
+							</button>
+						</div>
+					{:else}
+						<button
+							class="px-6 py-2.5 bg-violet-600 text-white rounded-xl hover:bg-violet-700 transition-all duration-200"
+							onclick={downloadFile}
+						>
+							Download File
+						</button>
+					{/if}
 				</div>
 			{:else}
 				<!-- Code content (always in edit mode) -->

--- a/frontend/components/workspace/panels/FilesPanel.svelte
+++ b/frontend/components/workspace/panels/FilesPanel.svelte
@@ -74,6 +74,7 @@
 	import { stripArchiveExtension, extensionFor, type ArchiveFormat, type ZipMethod } from '$frontend/utils/archive';
 	import { acquireFileWatch } from '$frontend/utils/file-watch';
 	import { authStore } from '$frontend/stores/features/auth.svelte';
+	import { fetchFileBlob, isAbortError, saveBlob } from '$frontend/utils/file-download';
 	import { showConfirm } from '$frontend/stores/ui/dialog.svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 	import { getFileIcon } from '$frontend/utils/file-icon-mappings';
@@ -1245,25 +1246,45 @@
 		}
 	}
 
-	// Download a file from the sidebar context menu. Fetches the on-disk bytes
-	// (base64) over WS and saves them client-side, preserving the original format.
+	// Download a file from the sidebar context menu. Streams the on-disk bytes
+	// over HTTP and saves them client-side, preserving the original format.
+	// It takes the same banner as an upload: a big file used to give no sign of
+	// movement at all, then simply appear on the device.
 	async function downloadFileNode(file: FileNode) {
+		const opId = crypto.randomUUID();
+		const controller = new AbortController();
+		// Deliberately not `markBusy` — that greys the row out and blocks it, which
+		// is right for a mutation but wrong for a read: the file is still openable
+		// while its bytes are being copied. The banner carries the feedback.
+		pushOp({
+			id: opId,
+			kind: 'download',
+			label: `Downloading ${file.name}`,
+			progress: 0,
+			onCancel: () => controller.abort()
+		});
+
 		try {
-			const response = await ws.http('files:read-content', { path: file.path });
-			const binaryString = atob(response.content);
-			const bytes = new Uint8Array(binaryString.length);
-			for (let i = 0; i < binaryString.length; i++) {
-				bytes[i] = binaryString.charCodeAt(i);
-			}
-			const blob = new Blob([bytes], { type: response.contentType || 'application/octet-stream' });
-			const url = URL.createObjectURL(blob);
-			const a = document.createElement('a');
-			a.href = url;
-			a.download = file.name;
-			a.click();
-			URL.revokeObjectURL(url);
+			const blob = await fetchFileBlob(file.path, {
+				totalBytes: file.size ?? null,
+				signal: controller.signal,
+				onProgress: ({ transferredBytes, totalBytes }) => {
+					updateOp(opId, {
+						label: totalBytes
+							? `Downloading ${file.name} (${formatBytes(transferredBytes)} / ${formatBytes(totalBytes)})`
+							: `Downloading ${file.name} (${formatBytes(transferredBytes)})`,
+						// Undefined leaves the banner on its indeterminate spinner,
+						// which is honest when the total is unknown.
+						progress: totalBytes ? transferredBytes / totalBytes : undefined
+					});
+				}
+			});
+			saveBlob(blob, file.name);
 		} catch (err) {
+			if (isAbortError(err)) return;
 			showErrorAlert(err instanceof Error ? err.message : 'Failed to download file');
+		} finally {
+			popOp(opId);
 		}
 	}
 
@@ -1359,9 +1380,12 @@
 
 	type ActiveOp = {
 		id: string;
-		kind: 'upload' | 'zip' | 'extract';
+		kind: 'upload' | 'download' | 'zip' | 'extract';
 		label: string;
-		progress?: number; // 0–1, only set for chunked uploads
+		progress?: number; // 0–1, only set for transfers that report bytes
+		// Present only for ops that can be stopped mid-flight (transfers);
+		// its presence is what puts a cancel button on the banner row.
+		onCancel?: () => void;
 	};
 	const activeOps = new SvelteMap<string, ActiveOp>();
 	const activeOpsList = $derived(Array.from(activeOps.values()));
@@ -2496,6 +2520,16 @@
 							</div>
 						{/if}
 					</div>
+					{#if op.onCancel}
+						<button
+							onclick={op.onCancel}
+							class="flex-shrink-0 p-1 rounded text-slate-400 hover:text-slate-100 hover:bg-slate-700/60 transition-colors cursor-pointer"
+							title="Cancel"
+							aria-label="Cancel {op.label}"
+						>
+							<Icon name="lucide:x" class="w-3.5 h-3.5" />
+						</button>
+					{/if}
 				</div>
 			{/each}
 		</div>

--- a/frontend/utils/file-download.ts
+++ b/frontend/utils/file-download.ts
@@ -1,0 +1,110 @@
+/**
+ * Downloading a project file to the user's device, with progress.
+ *
+ * The bytes come from `GET /api/files/download` rather than the WebSocket:
+ * the WS path base64-encodes the whole file into one message, so nothing is
+ * observable until it has all arrived — the user sees no movement and then a
+ * finished file. HTTP streams it with a `Content-Length`, which is what makes
+ * a real progress bar possible.
+ *
+ * XHR rather than `fetch`, for the same reason the SSH file browser uses it:
+ * it is the only way to get both download progress events and a cancel.
+ */
+
+import { authStore } from '$frontend/stores/features/auth.svelte';
+
+export interface FileDownloadProgress {
+	transferredBytes: number;
+	/** Null while the total is unknown (no computable length and no known size). */
+	totalBytes: number | null;
+}
+
+export interface FileDownloadOptions {
+	/**
+	 * Size the caller already knows (e.g. from the file tree), used as the
+	 * denominator if the response turns out not to carry a computable length.
+	 */
+	totalBytes?: number | null;
+	onProgress?: (progress: FileDownloadProgress) => void;
+	signal?: AbortSignal;
+}
+
+/** True for the rejection `fetchFileBlob` throws when the caller cancels. */
+export function isAbortError(error: unknown): boolean {
+	return error instanceof DOMException && error.name === 'AbortError';
+}
+
+/**
+ * Read a file off the server into a blob, reporting progress as it arrives.
+ *
+ * Rejects with an `AbortError` if `signal` fires, so a cancelled download is
+ * distinguishable from a failed one.
+ */
+export function fetchFileBlob(filePath: string, options: FileDownloadOptions = {}): Promise<Blob> {
+	const { totalBytes = null, onProgress, signal } = options;
+
+	const token = authStore.sessionToken;
+	if (!token) return Promise.reject(new Error('Not authenticated'));
+	if (signal?.aborted) return Promise.reject(new DOMException('Download cancelled', 'AbortError'));
+
+	const params = new URLSearchParams({ path: filePath });
+
+	return new Promise<Blob>((resolve, reject) => {
+		const request = new XMLHttpRequest();
+		request.open('GET', `/api/files/download?${params.toString()}`);
+		request.responseType = 'blob';
+		request.setRequestHeader('Authorization', `Bearer ${token}`);
+
+		const abort = () => request.abort();
+		signal?.addEventListener('abort', abort);
+		const detach = () => signal?.removeEventListener('abort', abort);
+
+		request.onprogress = (event) => {
+			onProgress?.({
+				transferredBytes: event.loaded,
+				totalBytes: event.lengthComputable && event.total > 0 ? event.total : totalBytes
+			});
+		};
+
+		request.onload = () => {
+			detach();
+			if (request.status >= 200 && request.status < 300) {
+				const blob = request.response as Blob;
+				onProgress?.({ transferredBytes: blob.size, totalBytes: blob.size });
+				resolve(blob);
+				return;
+			}
+			// The route reports why in the body, which is a blob here like any
+			// other response — read it rather than losing the reason.
+			const body: unknown = request.response;
+			if (body instanceof Blob) {
+				body
+					.text()
+					.then((text) => reject(new Error(text.trim() || `HTTP ${request.status}`)))
+					.catch(() => reject(new Error(`HTTP ${request.status}`)));
+				return;
+			}
+			reject(new Error(`HTTP ${request.status}`));
+		};
+		request.onerror = () => {
+			detach();
+			reject(new Error('Network error during download'));
+		};
+		request.onabort = () => {
+			detach();
+			reject(new DOMException('Download cancelled', 'AbortError'));
+		};
+
+		request.send();
+	});
+}
+
+/** Hand a blob to the browser as a file save. */
+export function saveBlob(blob: Blob, fileName: string): void {
+	const url = URL.createObjectURL(blob);
+	const anchor = document.createElement('a');
+	anchor.href = url;
+	anchor.download = fileName;
+	anchor.click();
+	URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
Downloads from the Files dock now stream over HTTP and report progress, matching what uploads have shown since they moved off the WebSocket path.

## Why
Download went through the WS handler `files:read-content`, which base64-encodes the whole file into one message. Nothing is observable until the last byte lands, so a large file gave no sign of movement at all and then simply appeared on the device. The encoding also costs a third more bytes on the wire and holds the entire file in memory on both ends.

## Changes
- Add `GET /api/files/download` (`backend/http/files-download.ts`) — streams from disk with `Content-Length` and `Content-Disposition`, reusing `requireFilePathAccessFor` for authorization and logging the transfer to the file audit log. Directories are rejected, missing files 404, paths outside the caller's projects 403.
- Add `download` to `FileAuditAction`.
- Add `frontend/utils/file-download.ts` — shared `fetchFileBlob` (XHR, progress + `AbortSignal`) and `saveBlob`.
- `FilesPanel.svelte` — the download op joins the existing operations banner with a byte counter and progress bar; `ActiveOp` gains an optional `onCancel` that renders a cancel button. Downloads deliberately don't take `markBusy`, which disables the row.
- `FileViewer.svelte` — the binary-file "Download File" button becomes a progress bar with a cancel while the transfer runs.
- Extract the bearer-token check the HTTP routes each duplicated into `backend/http/bearer-auth.ts`; `audio.ts`, `files-upload.ts` and `ssh-sftp.ts` now share it.

## Test plan
- `bun run check` — 0 errors.
- `bun run lint` — clean.
- `bun run test` — 616 pass, 0 fail, including the new `backend/http/files-download.test.ts` (transfer headers, byte-exact binary content, out-of-project path rejected, unauthenticated request rejected, missing file and directory).

## Security impact
The route exposes file bytes over HTTP, so it repeats the WS path's full check rather than trusting the token alone: a valid session resolves to a user, and `requireFilePathAccessFor` then confirms the resolved real path lies inside a project that user belongs to — symlinks are resolved on both sides, so a link inside a project cannot reach outside it. An authenticated member could not read another member's project files before and cannot now; every attempt, successful or not, is recorded in the file audit log with IP and user agent.

## Notes
Where an intermediary drops `Content-Length` and re-chunks the response, `event.total` is zero and progress falls back to the size from the file listing; with neither available the banner stays on its indeterminate spinner instead of showing a fabricated bar. The WS `files:read-content` handler is untouched — the image editor and media preview still use it.