### PR TITLE
feat(ports): manage listening ports on local and SSH hosts

### DIFF
--- a/backend/auth/permissions.ts
+++ b/backend/auth/permissions.ts
@@ -43,6 +43,9 @@ export const ADMIN_ONLY_ROUTES = new Set([
 	'settings:update-batch',
 	'system:run-update',
 	'system:clear-data',
+	// Port manager — anyone signed in may see what is listening, but ending a
+	// process can take down another member's work, so stopping is admin-only.
+	'ports:kill',
 	// Stack — binary installation is an admin-only operation.
 	'stack:status',
 	'stack:status-all',

--- a/backend/db-client/connection-manager.ts
+++ b/backend/db-client/connection-manager.ts
@@ -40,6 +40,19 @@ class ConnectionManager {
 	private entries = new Map<string, ConnectionEntry>();
 	private sweeperHandle: ReturnType<typeof setInterval> | null = null;
 
+	/**
+	 * Local ports currently held open by SSH tunnels, for the port manager.
+	 * These are ephemeral ports nobody asked for by number, so without this the
+	 * panel would show them as an unexplained listener owned by Clopen itself.
+	 */
+	activeTunnelPorts(): Array<{ connectionId: string; localPort: number }> {
+		const ports: Array<{ connectionId: string; localPort: number }> = [];
+		for (const [connectionId, entry] of this.entries) {
+			if (entry.tunnel) ports.push({ connectionId, localPort: entry.tunnel.localPort });
+		}
+		return ports;
+	}
+
 	private startSweeper(): void {
 		if (this.sweeperHandle) return;
 		this.sweeperHandle = setInterval(() => {

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -64,6 +64,7 @@ import { getAuthMode } from './settings/system-settings';
 import { authQueries } from './database/queries';
 import { authRateLimiter } from './auth';
 import { sessionCleanupScheduler } from './auth/session-cleanup';
+import { portMonitor } from './ports/monitor';
 import { uploadTempCleanup } from './http/upload-temp-cleanup';
 import { ws as wsServer } from './utils/ws';
 import { messageRateLimiter } from './ws/message-rate-limiter';
@@ -269,6 +270,10 @@ async function startServer() {
 		// which also runs on the live process during "Clear All Data".
 		startEngineHotReload();
 		startEngineConfigWatcher();
+		// Sidebar count for the port manager. Idle-cheap by construction: with no
+		// terminal sessions running there are no session-born ports to count, so
+		// the tick skips the scan entirely.
+		portMonitor.start();
 	} catch (error) {
 		console.error('❌ Database initialization failed — refusing to start:', error);
 		console.error(`   Data directory: ${SERVER_ENV.DATA_DIR}`);
@@ -332,6 +337,8 @@ async function gracefulShutdown() {
 		sessionCleanupScheduler.dispose();
 		// Dispose upload temp cleanup timer
 		uploadTempCleanup.dispose();
+		// Stop port polling and release any SSH leases it holds
+		portMonitor.stop();
 		// Close MCP remote server (before engines, as they may still reference it)
 		await closeMcpServer();
 		// Cleanup browser preview sessions

--- a/backend/ports/attribute.test.ts
+++ b/backend/ports/attribute.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from 'bun:test';
+import type { PortProcess, PortSocket } from '$shared/types/ports';
+import { findClopenPids, groupListenerPids, traceAncestry, type SessionPid } from './attribute';
+import { findConnectionSshd, parseEnvironProbe, sameConnection } from './ssh-lineage';
+
+function proc(pid: number, parentPid: number | null, command: string): PortProcess {
+	return { pid, parentPid, user: 'deploy', command, startedAt: null, cwd: null };
+}
+
+function table(...processes: PortProcess[]): Map<number, PortProcess> {
+	return new Map(processes.map((process) => [process.pid, process]));
+}
+
+describe('groupListenerPids', () => {
+	test('collapses workers onto a master that listens alongside them', () => {
+		const processes = table(
+			proc(100, 1, 'node server.js'),
+			proc(101, 100, 'node server.js'),
+			proc(102, 100, 'node server.js')
+		);
+
+		const groups = groupListenerPids([100, 101, 102], processes);
+
+		expect(groups).toHaveLength(1);
+		expect(groups[0]).toEqual({ owner: 100, members: [100, 101, 102] });
+	});
+
+	test('collapses workers onto a shared parent that holds no socket itself', () => {
+		// nginx on macOS: the master binds nothing, every worker inherits it.
+		const processes = table(
+			proc(500, 1, 'nginx: master process /usr/sbin/nginx'),
+			proc(501, 500, 'nginx: worker process'),
+			proc(502, 500, 'nginx: worker process'),
+			proc(503, 500, 'nginx: worker process')
+		);
+
+		const groups = groupListenerPids([501, 502, 503], processes);
+
+		expect(groups).toHaveLength(1);
+		expect(groups[0]).toEqual({ owner: 500, members: [501, 502, 503] });
+	});
+
+	test('keeps unrelated programs apart even when they share a parent shell', () => {
+		// Two different servers started from one shell, both bound to the same
+		// port number on different addresses. Merging them would invent a
+		// relationship that does not exist.
+		const processes = table(
+			proc(700, 1, '-bash'),
+			proc(701, 700, 'node vite.js'),
+			proc(702, 700, 'python -m http.server')
+		);
+
+		const groups = groupListenerPids([701, 702], processes);
+
+		expect(groups).toHaveLength(2);
+		expect(groups.map((group) => group.owner).sort()).toEqual([701, 702]);
+	});
+
+	test('keeps a lone listener as its own group', () => {
+		const processes = table(proc(900, 1, 'redis-server'));
+		expect(groupListenerPids([900], processes)).toEqual([{ owner: 900, members: [900] }]);
+	});
+
+	test('does not fold onto init when the parent chain is unknown', () => {
+		// Both parents point at pid 1, which is every daemon's parent — folding
+		// there would merge the whole machine into one row.
+		const processes = table(proc(310, 1, 'postgres'), proc(320, 1, 'mysqld'));
+		expect(groupListenerPids([310, 320], processes)).toHaveLength(2);
+	});
+
+	test('survives a parent chain that loops', () => {
+		const processes = table(proc(10, 11, 'a'), proc(11, 10, 'b'));
+		expect(() => groupListenerPids([10, 11], processes)).not.toThrow();
+	});
+});
+
+describe('traceAncestry', () => {
+	const sessions = new Map<number, SessionPid>([
+		[400, { pid: 400, sessionId: 'sess-1', projectId: 'proj-1', projectName: 'shop', cwd: '/srv/shop' }]
+	]);
+
+	test('finds the terminal session a process descends from', () => {
+		const processes = table(
+			proc(400, 1, '/bin/zsh'),
+			proc(401, 400, 'bun run dev'),
+			proc(402, 401, 'node vite.js')
+		);
+
+		const ancestry = traceAncestry(402, processes, sessions);
+
+		expect(ancestry.session?.sessionId).toBe('sess-1');
+		expect(ancestry.chain.map((process) => process.pid)).toEqual([402, 401, 400]);
+	});
+
+	test('recognises the sshd session Clopen itself is using', () => {
+		// The remote counterpart of a PtyKit session pid: same tier, same
+		// certainty, resolved from the host's end instead of ours.
+		const processes = table(
+			proc(600, 1, 'sshd: deploy@pts/0'),
+			proc(601, 600, '-bash'),
+			proc(602, 601, 'node vite.js')
+		);
+
+		const ancestry = traceAncestry(602, processes, new Map(), new Set([600]));
+
+		expect(ancestry.fromClopen).toBe(true);
+	});
+
+	test('does not claim someone else’s SSH session as Clopen’s', () => {
+		const processes = table(
+			proc(650, 1, 'sshd: other@pts/3'),
+			proc(651, 650, 'node server.js')
+		);
+
+		const ancestry = traceAncestry(651, processes, new Map(), new Set([600]));
+
+		expect(ancestry.fromClopen).toBe(false);
+		expect(ancestry.sshdUser).toBe('other');
+	});
+
+	test('reports the sshd session user when the lineage ends at sshd', () => {
+		const processes = table(
+			proc(600, 1, 'sshd: deploy@pts/0'),
+			proc(601, 600, '-bash'),
+			proc(602, 601, 'node server.js')
+		);
+
+		const ancestry = traceAncestry(602, processes, new Map());
+
+		expect(ancestry.sshdUser).toBe('deploy');
+		expect(ancestry.session).toBeNull();
+	});
+
+	test('stops cleanly when an ancestor is missing from the table', () => {
+		const processes = table(proc(800, 799, 'node server.js'));
+		const ancestry = traceAncestry(800, processes, new Map());
+		expect(ancestry.chain.map((process) => process.pid)).toEqual([800]);
+		expect(ancestry.session).toBeNull();
+	});
+
+	test('survives a parent chain that loops', () => {
+		const processes = table(proc(20, 21, 'a'), proc(21, 20, 'b'));
+		expect(() => traceAncestry(20, processes, new Map())).not.toThrow();
+	});
+});
+
+describe('remote connection identity', () => {
+	const ours = '103.0.113.7 51234 10.0.0.5 64000';
+
+	test('matches a process started on the same SSH connection', () => {
+		expect(sameConnection('103.0.113.7 51234 10.0.0.5 64000', ours)).toBe(true);
+	});
+
+	test('rejects another session from the same client machine', () => {
+		// Same address, different source port — a separate connection, and the
+		// port is what makes a connection unique while it is open.
+		expect(sameConnection('103.0.113.7 51999 10.0.0.5 64000', ours)).toBe(false);
+	});
+
+	test('rejects a session from somewhere else entirely', () => {
+		expect(sameConnection('198.51.100.4 51234 10.0.0.5 64000', ours)).toBe(false);
+	});
+
+	test('rejects an empty or unset value rather than matching loosely', () => {
+		expect(sameConnection('', ours)).toBe(false);
+		expect(sameConnection('$SSH_CONNECTION', ours)).toBe(false);
+	});
+
+	test('a process with our connection is claimed through the tier-2 path', () => {
+		// The environment is inherited, so the listening process carries it
+		// directly — no walk to a session leader is needed, which is what makes
+		// this survive a disowned or reparented server.
+		const processes = table(proc(42802, 42800, 'node app.js'));
+		const ancestry = traceAncestry(42802, processes, new Map(), new Set([42802]));
+		expect(ancestry.fromClopen).toBe(true);
+	});
+});
+
+describe('parseEnvironProbe', () => {
+	// One line per pid: the marker, then the matching environment entry if the
+	// process had one and we were allowed to read it.
+	const output = [
+		'@42802 SSH_CONNECTION=103.0.113.7 51234 10.0.0.5 64000',
+		'@1201 ',
+		'@1310 SSH_CONNECTION=198.51.100.4 40001 10.0.0.5 64000',
+		''
+	].join('\n');
+
+	const values = parseEnvironProbe(output);
+
+	test('reads the value for each process that had one', () => {
+		expect(values.get(42802)).toBe('103.0.113.7 51234 10.0.0.5 64000');
+		expect(values.get(1310)).toBe('198.51.100.4 40001 10.0.0.5 64000');
+	});
+
+	test('records nothing for a process whose environment was unreadable', () => {
+		// Unreadable is not the same as "not ours" — it simply has no answer.
+		expect(values.has(1201)).toBe(false);
+	});
+});
+
+describe('findConnectionSshd', () => {
+	// The macOS path: that host reports no process environment at all, so the
+	// connection has to be identified through the tree instead.
+	const processes = table(
+		proc(700, 1, '/usr/sbin/sshd -D'),
+		proc(800, 700, 'sshd: deploy [priv]'),
+		proc(815, 800, 'sshd: deploy@ttys000'),
+		proc(820, 800, 'sshd: deploy@notty')
+	);
+
+	test('climbs to the sshd every channel of the connection shares', () => {
+		// Resolved from the probe's own channel; the shell channel hangs off the
+		// same session leader, which is what makes the whole tree ours.
+		expect(findConnectionSshd(820, processes)).toBe(800);
+	});
+
+	test('stops before the listening daemon, which parents everyone’s sessions', () => {
+		expect(findConnectionSshd(815, processes)).not.toBe(700);
+	});
+
+	test('returns null when the chain never looked like an SSH session', () => {
+		const unlabelled = table(proc(900, 1, '/usr/sbin/sshd'), proc(910, 900, 'bash'));
+		expect(findConnectionSshd(910, unlabelled)).toBeNull();
+	});
+
+	test('survives a parent chain that loops', () => {
+		const looped = table(proc(30, 31, 'sshd: a@ttys000'), proc(31, 30, 'sshd: a [priv]'));
+		expect(() => findConnectionSshd(30, looped)).not.toThrow();
+	});
+});

--- a/backend/ports/attribute.ts
+++ b/backend/ports/attribute.ts
@@ -1,0 +1,444 @@
+/**
+ * Port manager — answering "where did this come from, and what is it for".
+ *
+ * Three tiers, ordered by how much Clopen actually knows, and the tier itself
+ * travels with the answer so the UI never dresses a guess up as a fact:
+ *
+ * 1. `clopen`   Clopen opened the listener. The label comes from the feature
+ *               that owns it, so it is exact.
+ * 2. `session`  The process descends from a Clopen terminal session. Walking
+ *               the parent chain proves the lineage; the purpose is still read
+ *               off the command line, but "you started this in tab X" is fact.
+ * 3. `external` Everything else. Only the command line, the user and the
+ *               working directory are known, so the label is a guess and is
+ *               marked as one.
+ *
+ * On an SSH host tier 2 is not available. Clopen's remote shells are addressed
+ * through a synthetic id rather than the host's real pid (see
+ * `backend/ssh/pty-backend.ts`), so a lineage ending at *our* shell cannot be
+ * told apart from one ending at any other. The walk still reports that the
+ * process descends from an sshd session and for which user, which is true, and
+ * stops there rather than claiming a tab.
+ */
+
+import type { PortOrigin, PortProcess, PortSocket } from '$shared/types/ports';
+import type { ProbePlatform } from './runner';
+import { ptyKitManager } from '../terminal/ptykit';
+import { projectQueries } from '../database/queries';
+import { collectOwnedPorts, ownedPortKey, type OwnedPort } from './registry';
+import { debug } from '$shared/utils/logger';
+
+/** A live Clopen terminal session, keyed by the pid of its shell. */
+export interface SessionPid {
+	pid: number;
+	sessionId: string;
+	projectId: string;
+	projectName: string | null;
+	cwd: string;
+}
+
+/**
+ * Shell pids of every active PTY session. The manager lists per namespace and
+ * a namespace is a project, so every project is asked in turn.
+ */
+export function collectSessionPids(): Map<number, SessionPid> {
+	const sessions = new Map<number, SessionPid>();
+
+	try {
+		for (const project of projectQueries.getAll()) {
+			for (const session of ptyKitManager.list(project.id)) {
+				const info = session.info();
+				if (info.status !== 'active' || !info.pid) continue;
+				sessions.set(info.pid, {
+					pid: info.pid,
+					sessionId: info.sessionId,
+					projectId: project.id,
+					projectName: project.name ?? null,
+					cwd: info.cwd
+				});
+			}
+		}
+	} catch (error) {
+		debug.log('ports', 'could not read terminal sessions:', error);
+	}
+
+	return sessions;
+}
+
+/** Guard against a malformed parent chain looping forever. */
+const MAX_ANCESTRY_DEPTH = 40;
+
+/**
+ * A Clopen server process, by the shape of its command line.
+ *
+ * Deliberately anchored on files that only exist inside a Clopen install —
+ * the published package path, or the repo's own entry points — rather than on
+ * the word "clopen" appearing anywhere. A user with a directory of that name
+ * should not have their processes claimed.
+ */
+const CLOPEN_PROCESS = new RegExp(
+	[
+		'@myrialabs[/\\\\]clopen[/\\\\]',
+		'clopen[/\\\\]scripts[/\\\\]start\\.ts',
+		'clopen[/\\\\]backend[/\\\\]index\\.ts',
+		'clopen[/\\\\]bin[/\\\\]clopen',
+		'clopen[/\\\\]dist[/\\\\]'
+	].join('|')
+);
+
+export function isClopenProcess(process: PortProcess | null): boolean {
+	return process ? CLOPEN_PROCESS.test(process.command) : false;
+}
+
+/**
+ * Every Clopen process on this machine, this one included.
+ *
+ * These are the roots tier-2 attribution walks up to. Anything descended from
+ * one was started by Clopen — a terminal shell, an engine, a command an agent
+ * ran, an MCP server, a dev server launched from any of them. Keying on the
+ * process tree rather than on terminal sessions is what makes that hold for
+ * all of them instead of only the shells.
+ *
+ * Other Clopen instances count too: a port opened from a second install's
+ * terminal is still a port Clopen opened, and the user reads it that way.
+ */
+export function findClopenPids(
+	processes: Map<number, PortProcess>,
+	selfPid: number | null
+): Set<number> {
+	const pids = new Set<number>();
+	if (selfPid !== null) pids.add(selfPid);
+	for (const [pid, process] of processes) {
+		if (isClopenProcess(process)) pids.add(pid);
+	}
+	return pids;
+}
+
+export interface Ancestry {
+	/** The chain from the process itself up to init, self first. */
+	chain: PortProcess[];
+	/** The Clopen terminal session it descends from, if any. */
+	session: SessionPid | null;
+	/**
+	 * True when the chain reaches a process Clopen is: one of its own instances
+	 * locally, or the sshd session it is using on a remote host.
+	 */
+	fromClopen: boolean;
+	/** The user of the sshd session it descends from, on a remote host. */
+	sshdUser: string | null;
+}
+
+/** `sshd: arga@pts/0` and `sshd: arga [priv]` both name the session's user. */
+function sshdUserOf(command: string): string | null {
+	const match = command.match(/^sshd:\s+([^\s@[]+)/);
+	return match ? match[1] : null;
+}
+
+export function traceAncestry(
+	pid: number,
+	processes: Map<number, PortProcess>,
+	sessions: Map<number, SessionPid>,
+	clopenRootPids: ReadonlySet<number> = new Set()
+): Ancestry {
+	const chain: PortProcess[] = [];
+	const seen = new Set<number>();
+
+	let session: SessionPid | null = null;
+	let sshdUser: string | null = null;
+	let fromClopen = false;
+	let current: number | null = pid;
+
+	for (let depth = 0; depth < MAX_ANCESTRY_DEPTH && current !== null && current > 0; depth++) {
+		if (seen.has(current)) break;
+		seen.add(current);
+
+		const found = sessions.get(current);
+		if (found && !session) session = found;
+		if (clopenRootPids.has(current)) fromClopen = true;
+
+		const process = processes.get(current);
+		if (!process) break;
+		chain.push(process);
+
+		if (!sshdUser) sshdUser = sshdUserOf(process.command);
+
+		current = process.parentPid;
+	}
+
+	return { chain, session, fromClopen, sshdUser };
+}
+
+/**
+ * What an unattributed process most likely is. Matched against the full
+ * command line so `node .../vite/bin/vite.js` reads as Vite rather than Node.
+ * Deliberately shallow: the raw command is always shown next to this, and a
+ * confident wrong answer is worse than "Listening process".
+ */
+const COMMAND_HINTS: Array<{ pattern: RegExp; label: string }> = [
+	{ pattern: /\bvite\b/, label: 'Vite dev server' },
+	{ pattern: /\bnext(-server)?\b|\bnext\/dist\b/, label: 'Next.js' },
+	{ pattern: /\bnuxt\b/, label: 'Nuxt' },
+	{ pattern: /\bastro\b/, label: 'Astro' },
+	{ pattern: /webpack-dev-server|react-scripts/, label: 'Webpack dev server' },
+	{ pattern: /\bng\s+serve\b|@angular\/cli/, label: 'Angular dev server' },
+	{ pattern: /\bstorybook\b/, label: 'Storybook' },
+	{ pattern: /\bpostgres\b|\bpostmaster\b/, label: 'PostgreSQL' },
+	{ pattern: /\bmysqld\b|\bmariadbd\b/, label: 'MySQL / MariaDB' },
+	{ pattern: /\bredis-server\b/, label: 'Redis' },
+	{ pattern: /\bmongod\b/, label: 'MongoDB' },
+	{ pattern: /\bdocker-proxy\b|com\.docker/, label: 'Docker published port' },
+	{ pattern: /\bnginx\b/, label: 'nginx' },
+	{ pattern: /\bcaddy\b/, label: 'Caddy' },
+	{ pattern: /\bhttpd\b|\bapache2\b/, label: 'Apache' },
+	{ pattern: /\bsshd\b/, label: 'SSH server' },
+	{ pattern: /\bcloudflared\b/, label: 'Cloudflare tunnel' },
+	{ pattern: /\bollama\b/, label: 'Ollama' },
+	{ pattern: /python[0-9.]*\s+-m\s+http\.server/, label: 'Python http.server' },
+	{ pattern: /\bphp\b.*\s-S\s/, label: 'PHP built-in server' },
+	{ pattern: /\brails\b|\bpuma\b/, label: 'Rails / Puma' }
+];
+
+function guessLabel(process: PortProcess | null, fallbackName: string | null): string {
+	const command = process?.command ?? '';
+	for (const hint of COMMAND_HINTS) {
+		if (hint.pattern.test(command)) return hint.label;
+	}
+	if (fallbackName) return fallbackName;
+	if (command) return command.split(/\s+/)[0].split('/').pop() || 'Listening process';
+	return 'Listening process';
+}
+
+/** Trim a command line to something a table cell can hold. */
+function shorten(command: string, max = 140): string {
+	return command.length <= max ? command : `${command.slice(0, max - 1)}…`;
+}
+
+export interface AttributionContext {
+	platform: ProbePlatform;
+	/** Ports Clopen opened on this host, whichever host it is. */
+	owned: Map<string, OwnedPort>;
+	/** Shell pids of local terminal sessions; empty on an SSH host. */
+	sessions: Map<number, SessionPid>;
+	/**
+	 * The processes that count as "Clopen" on this host: its own instances
+	 * locally, and remotely everything found to belong to Clopen's own SSH
+	 * connection. One field for both, because it answers the same question
+	 * either way — is this Clopen's doing.
+	 */
+	clopenRootPids: ReadonlySet<number>;
+	/** Host label, so remote attributions can name where they were found. */
+	hostName: string;
+	processes: Map<number, PortProcess>;
+	isLocal: boolean;
+}
+
+export function buildContext(input: {
+	platform: ProbePlatform;
+	processes: Map<number, PortProcess>;
+	hostId: string;
+	hostName: string;
+	isLocal: boolean;
+	clopenPids: ReadonlySet<number>;
+}): AttributionContext {
+	// A Clopen install is recognised the same way wherever it runs, and on a
+	// remote host every process on Clopen's own SSH connection counts too. One
+	// set, built from whichever of those apply to this host.
+	const clopenRootPids = findClopenPids(input.processes, input.isLocal ? process.pid : null);
+	for (const pid of input.clopenPids) clopenRootPids.add(pid);
+
+	return {
+		platform: input.platform,
+		owned: collectOwnedPorts(input.hostId),
+		sessions: input.isLocal ? collectSessionPids() : new Map(),
+		clopenRootPids,
+		hostName: input.hostName,
+		processes: input.processes,
+		isLocal: input.isLocal
+	};
+}
+
+/** Decide where a listening socket came from. */
+export function attribute(socket: PortSocket, context: AttributionContext): PortOrigin {
+	const owned = context.owned.get(ownedPortKey(socket.protocol, socket.port));
+	if (owned) {
+		return {
+			kind: 'clopen',
+			confidence: 'certain',
+			label: owned.label,
+			detail: owned.detail,
+			ownerFeature: owned.feature,
+			ownerId: owned.ownerId ?? undefined
+		};
+	}
+
+	const process = socket.pid !== null ? (context.processes.get(socket.pid) ?? null) : null;
+
+	// Another Clopen install listening on its own port. The registry only knows
+	// the ports of *this* process, so without this the other instance would be
+	// filed under "outside Clopen" — which is not how anyone reads it. A Clopen
+	// on an SSH host is recognised by the same signature, on purpose.
+	if (isClopenProcess(process)) {
+		return {
+			kind: 'clopen',
+			confidence: 'certain',
+			label: 'Clopen server',
+			detail: context.isLocal
+				? 'Another Clopen instance running on this machine'
+				: `A Clopen instance running on ${context.hostName}`,
+			ownerFeature: 'server'
+		};
+	}
+
+	const ancestry =
+		socket.pid !== null
+			? traceAncestry(socket.pid, context.processes, context.sessions, context.clopenRootPids)
+			: null;
+
+	if (ancestry?.session) {
+		const { session } = ancestry;
+		const where = session.projectName ? `project ${session.projectName}` : session.cwd;
+		return {
+			kind: 'session',
+			confidence: 'certain',
+			label: guessLabel(process, socket.processName),
+			detail: `Started from a terminal session in ${where}`,
+			sessionId: session.sessionId,
+			projectId: session.projectId
+		};
+	}
+
+	if (ancestry?.fromClopen) {
+		return {
+			kind: 'session',
+			confidence: 'certain',
+			label: guessLabel(process, socket.processName),
+			// Which tab is not knowable here — every channel Clopen opens shares
+			// one sshd connection — but that Clopen started it is not in doubt.
+			detail: `Started through Clopen on ${context.hostName}`
+		};
+	}
+
+	if (ancestry?.sshdUser) {
+		return {
+			kind: 'session',
+			confidence: 'certain',
+			label: guessLabel(process, socket.processName),
+			// Someone else's SSH session: real lineage, but not Clopen's doing.
+			detail: `Started from an SSH session as ${ancestry.sshdUser}`,
+			remoteSessionUser: ancestry.sshdUser
+		};
+	}
+
+	const detail = process?.command ? shorten(process.command) : null;
+	return {
+		kind: 'external',
+		confidence: 'guess',
+		label: guessLabel(process, socket.processName),
+		detail: detail ?? (socket.pid === null ? 'Owner not visible without elevated privileges' : null)
+	};
+}
+
+/**
+ * The program a command line belongs to, used to tell a worker pool apart from
+ * unrelated processes that merely share a parent. `nginx: worker process` and
+ * `nginx: master process` both reduce to `nginx`.
+ */
+function programKey(command: string): string {
+	const first = command.trim().split(/\s+/)[0] ?? '';
+	return (first.replace(/:$/, '').split('/').pop() ?? '').toLowerCase();
+}
+
+export interface PidGroup {
+	/** The process that represents the port. */
+	owner: number;
+	/** Every listening pid in the group, the owner included when it listens. */
+	members: number[];
+}
+
+/**
+ * Group the pids holding one port by the process that actually owns it.
+ *
+ * A server that pre-forks workers has every worker inherit the listening
+ * socket, so a plain listing shows eight identical rows for one port. Two
+ * shapes of that are collapsed here:
+ *
+ * 1. One candidate is an ancestor of the others — a master that also listens.
+ * 2. The candidates are siblings of one parent and all run the same program as
+ *    that parent, which is what a worker pool looks like when the master holds
+ *    no socket of its own (nginx on macOS). The parent becomes the owner even
+ *    though it is not listening, because it is the process a user means when
+ *    they say "nginx".
+ *
+ * Everything else stays separate. Unrelated programs can hold the same port
+ * number on different addresses, and merging those would invent a relationship.
+ */
+export function groupListenerPids(pids: number[], processes: Map<number, PortProcess>): PidGroup[] {
+	const candidates = new Set(pids);
+
+	/** Highest ancestor that also holds this port, else the pid itself. */
+	const ancestorRoot = (pid: number): number => {
+		let root = pid;
+		let current: number | null = processes.get(pid)?.parentPid ?? null;
+		const seen = new Set<number>([pid]);
+
+		for (let depth = 0; depth < MAX_ANCESTRY_DEPTH && current !== null && current > 0; depth++) {
+			if (seen.has(current)) break;
+			seen.add(current);
+			if (candidates.has(current)) root = current;
+			current = processes.get(current)?.parentPid ?? null;
+		}
+
+		return root;
+	};
+
+	const byRoot = new Map<number, number[]>();
+	for (const pid of pids) {
+		const root = ancestorRoot(pid);
+		const members = byRoot.get(root);
+		if (members) members.push(pid);
+		else byRoot.set(root, [pid]);
+	}
+
+	// Second pass: fold sibling roots onto a shared parent running the same
+	// program. Roots with no such parent are emitted untouched.
+	const bySharedParent = new Map<number, number[]>();
+	const groups: PidGroup[] = [];
+
+	for (const root of byRoot.keys()) {
+		const parentPid = processes.get(root)?.parentPid ?? null;
+		if (parentPid === null || parentPid <= 1) continue;
+		const siblings = bySharedParent.get(parentPid);
+		if (siblings) siblings.push(root);
+		else bySharedParent.set(parentPid, [root]);
+	}
+
+	const folded = new Set<number>();
+	for (const [parentPid, roots] of bySharedParent) {
+		if (roots.length < 2) continue;
+
+		const parent = processes.get(parentPid);
+		if (!parent) continue;
+		const parentProgram = programKey(parent.command);
+		if (!parentProgram) continue;
+
+		const sameProgram = roots.every((root) => {
+			const process = processes.get(root);
+			return process ? programKey(process.command) === parentProgram : false;
+		});
+		if (!sameProgram) continue;
+
+		const members: number[] = [];
+		for (const root of roots) {
+			members.push(...(byRoot.get(root) ?? [root]));
+			folded.add(root);
+		}
+		groups.push({ owner: parentPid, members: [...new Set(members)].sort((a, b) => a - b) });
+	}
+
+	for (const [root, members] of byRoot) {
+		if (folded.has(root)) continue;
+		groups.push({ owner: root, members: [...new Set(members)].sort((a, b) => a - b) });
+	}
+
+	return groups;
+}

--- a/backend/ports/kill.ts
+++ b/backend/ports/kill.ts
@@ -1,0 +1,203 @@
+/**
+ * Port manager — stopping what is holding a port.
+ *
+ * Three paths, because "kill it" means three different things:
+ *
+ * - A port a Clopen feature owns is released through that feature, never by
+ *   signalling a pid. Killing the process behind an SSH forward would leave the
+ *   forward's own record claiming it is still running.
+ * - Anything else is stopped by signalling the process tree, children first so
+ *   a supervisor cannot restart them on the way down, SIGTERM before SIGKILL so
+ *   a dev server gets its chance to shut down cleanly.
+ * - Clopen's own socket is never a target.
+ *
+ * A refusal by the OS is reported as what it is. Nothing here escalates to
+ * `sudo`: a port owned by another user is the administrator's business, and
+ * quietly acquiring privilege to end someone else's process is not a thing this
+ * panel should do behind the user's back.
+ */
+
+import type { PortKillResult, PortOwnerFeature } from '$shared/types/ports';
+import { parsePsOutput, unixPsArgv } from './processes';
+import type { CommandRunner, ProbePlatform } from './runner';
+import { sshForwardManager } from '../ssh/forwards';
+import { connectionManager } from '../db-client/connection-manager';
+import { debug } from '$shared/utils/logger';
+
+/** Grace between the polite signal and the final one. */
+const SIGKILL_DELAY_MS = 2_000;
+
+/** Ceiling on tree depth, so a malformed parent chain cannot loop. */
+const MAX_TREE_DEPTH = 20;
+
+export interface KillTarget {
+	pid: number;
+	/** Set when a Clopen feature owns the port. */
+	ownerFeature?: PortOwnerFeature;
+	ownerId?: string;
+}
+
+/** Release a port through the feature that opened it. */
+async function stopFeature(feature: PortOwnerFeature, ownerId: string | undefined): Promise<PortKillResult> {
+	if (!ownerId) {
+		return { ok: false, killedPids: [], stoppedFeature: null, error: 'That port has no owning record to stop.' };
+	}
+
+	try {
+		switch (feature) {
+			case 'ssh-forward':
+				await sshForwardManager.stop(ownerId);
+				return { ok: true, killedPids: [], stoppedFeature: feature, error: null };
+			case 'db-client-tunnel':
+				await connectionManager.release(ownerId);
+				return { ok: true, killedPids: [], stoppedFeature: feature, error: null };
+			default:
+				return {
+					ok: false,
+					killedPids: [],
+					stoppedFeature: null,
+					error: 'That port belongs to Clopen and cannot be released from here.'
+				};
+		}
+	} catch (error) {
+		return {
+			ok: false,
+			killedPids: [],
+			stoppedFeature: null,
+			error: error instanceof Error ? error.message : String(error)
+		};
+	}
+}
+
+/**
+ * Every descendant of `pid`, deepest first. Read fresh rather than from the
+ * scan cache: a tick-old tree could name a pid the OS has already recycled.
+ */
+async function descendantsOf(pid: number, runner: CommandRunner, platform: ProbePlatform): Promise<number[]> {
+	if (platform === 'win32') return [];
+
+	const result = await runner.run(unixPsArgv(platform));
+
+	const children = new Map<number, number[]>();
+	for (const process of parsePsOutput(result.stdout)) {
+		if (process.parentPid === null) continue;
+		const siblings = children.get(process.parentPid);
+		if (siblings) siblings.push(process.pid);
+		else children.set(process.parentPid, [process.pid]);
+	}
+
+	const ordered: number[] = [];
+	const visit = (current: number, depth: number): void => {
+		if (depth >= MAX_TREE_DEPTH) return;
+		for (const child of children.get(current) ?? []) {
+			visit(child, depth + 1);
+			ordered.push(child);
+		}
+	};
+	visit(pid, 0);
+
+	return ordered;
+}
+
+/** Is the process still there? `kill -0` asks without sending anything. */
+async function isAlive(pid: number, runner: CommandRunner, platform: ProbePlatform): Promise<boolean> {
+	try {
+		if (platform === 'win32') {
+			const result = await runner.run(['tasklist', '/FI', `PID eq ${pid}`, '/FO', 'CSV', '/NH']);
+			return result.stdout.includes(`"${pid}"`);
+		}
+		const result = await runner.run(['kill', '-0', String(pid)]);
+		return result.code === 0;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Turn a failed signal into something worth reading. `kill` says "Operation not
+ * permitted" and nothing about why, which is the most common outcome here.
+ */
+function explain(stderr: string, pid: number): string {
+	const text = stderr.trim();
+	if (/not permitted|access is denied/i.test(text)) {
+		return `Not allowed to stop process ${pid}. It belongs to another user — stop it from an account that owns it.`;
+	}
+	if (/no such process/i.test(text)) return `Process ${pid} had already exited.`;
+	return text || `Could not stop process ${pid}.`;
+}
+
+/** Signal a process tree, children first, escalating only if it survives. */
+export async function killProcessTree(
+	pid: number,
+	runner: CommandRunner,
+	platform: ProbePlatform
+): Promise<PortKillResult> {
+	const killed: number[] = [];
+
+	if (platform === 'win32') {
+		// taskkill walks the tree itself, which is the only reliable way to do it
+		// on Windows — there is no signal to escalate through.
+		try {
+			const result = await runner.run(['taskkill', '/T', '/F', '/PID', String(pid)]);
+			if (result.code === 0) return { ok: true, killedPids: [pid], stoppedFeature: null, error: null };
+			return { ok: false, killedPids: [], stoppedFeature: null, error: explain(result.stderr || result.stdout, pid) };
+		} catch (error) {
+			return {
+				ok: false,
+				killedPids: [],
+				stoppedFeature: null,
+				error: error instanceof Error ? error.message : String(error)
+			};
+		}
+	}
+
+	const targets = [...(await descendantsOf(pid, runner, platform)), pid];
+	let lastError: string | null = null;
+
+	for (const target of targets) {
+		try {
+			const result = await runner.run(['kill', '-TERM', String(target)]);
+			if (result.code === 0) killed.push(target);
+			else if (target === pid) lastError = explain(result.stderr, target);
+		} catch (error) {
+			if (target === pid) lastError = error instanceof Error ? error.message : String(error);
+		}
+	}
+
+	if (killed.length === 0) {
+		return { ok: false, killedPids: [], stoppedFeature: null, error: lastError ?? `Could not stop process ${pid}.` };
+	}
+
+	await new Promise((resolve) => setTimeout(resolve, SIGKILL_DELAY_MS));
+
+	for (const target of killed) {
+		if (!(await isAlive(target, runner, platform))) continue;
+		try {
+			await runner.run(['kill', '-KILL', String(target)]);
+		} catch (error) {
+			debug.log('ports', `SIGKILL failed for ${target}:`, error);
+		}
+	}
+
+	// The port is only actually free if the process that held it is gone.
+	if (await isAlive(pid, runner, platform)) {
+		return {
+			ok: false,
+			killedPids: killed,
+			stoppedFeature: null,
+			error: `Process ${pid} ignored both signals and is still running.`
+		};
+	}
+
+	return { ok: true, killedPids: killed, stoppedFeature: null, error: null };
+}
+
+/** Stop whatever holds a port, by the route that suits its owner. */
+export async function stopPortHolder(
+	target: KillTarget,
+	runner: CommandRunner,
+	platform: ProbePlatform
+): Promise<PortKillResult> {
+	if (target.ownerFeature) return stopFeature(target.ownerFeature, target.ownerId);
+	return killProcessTree(target.pid, runner, platform);
+}

--- a/backend/ports/monitor.ts
+++ b/backend/ports/monitor.ts
@@ -1,0 +1,365 @@
+/**
+ * Port manager — keeping the table live.
+ *
+ * No operating system offers a portable way to be *told* that a port opened.
+ * macOS exposes no socket-table event API at all, Windows' change
+ * notifications do not cover the TCP listener table, and Linux's `sock_diag`
+ * netlink is a query interface — `ss --events` only reports destroyed sockets
+ * and needs privileges besides. An event-driven implementation would therefore
+ * exist on one platform and be partial even there.
+ *
+ * So this polls, and earns the right to by being cheap and quiet:
+ *
+ * - A warm local scan is one `lsof` plus a cached process table — tens of
+ *   milliseconds — so a watched panel ticks every second and reads as live. An
+ *   SSH host ticks every three: each scan is a round trip on the connection the
+ *   terminal and file browser are also using.
+ * - Results are diffed server-side and only pushed when something actually
+ *   changed, so a static machine costs no traffic at all.
+ * - With no panel open, the only work is the sidebar count, refreshed every
+ *   fifteen seconds at roughly fifteen milliseconds a time.
+ * - A remote host is scanned only while its tab is open, on a lease borrowed
+ *   from the pool the terminal and file browser already keep warm.
+ */
+
+import type { PortScanResult } from '$shared/types/ports';
+import { LOCAL_PORT_HOST } from '$shared/types/ports';
+import { HostPortScanner, localPrincipal, type ScanPrincipal } from './scan-host';
+import {
+	LocalCommandRunner,
+	SshCommandRunner,
+	detectRemotePlatform,
+	forgetRemotePlatform,
+	localPlatform,
+	type CommandRunner,
+	type ProbePlatform
+} from './runner';
+import { sshClientPool, type SshLease } from '../ssh/client-pool';
+import { forgetClopenRootPid } from './ssh-lineage';
+import { sshConnectionQueries } from '../database/queries';
+import { ws } from '../utils/ws';
+import { debug } from '$shared/utils/logger';
+
+/** Panel open on this machine: a scan is milliseconds, so it can be brisk. */
+const WATCH_INTERVAL_MS = 1_000;
+/**
+ * Panel open on an SSH host. Every scan there is a round trip over the same
+ * connection the terminal and file browser are using, so it is paced to stay
+ * out of their way while still reading as live.
+ */
+const REMOTE_WATCH_INTERVAL_MS = 3_000;
+/** Panel closed: only the sidebar count, and only when a terminal is running. */
+const BADGE_INTERVAL_MS = 15_000;
+
+interface HostState {
+	scanner: HostPortScanner;
+	runner: CommandRunner;
+	platform: ProbePlatform;
+	lease: SshLease | null;
+	/** User ids currently looking at this host. */
+	watchers: Set<string>;
+	timer: ReturnType<typeof setInterval> | null;
+	last: PortScanResult | null;
+	signature: string;
+	scanning: boolean;
+}
+
+/**
+ * What a client would notice changing. Deliberately excludes the timestamp and
+ * live counters like cpu, so an idle machine produces an identical signature
+ * tick after tick and nothing is sent.
+ */
+function signatureOf(result: PortScanResult): string {
+	if (result.error) return `error:${result.error}`;
+	return result.entries
+		.map((entry) => `${entry.key}|${entry.origin.label}|${entry.peerCount}|${entry.publicUrl ?? ''}|${entry.workerPids.length}`)
+		.join('\n');
+}
+
+class PortMonitor {
+	private hosts = new Map<string, HostState>();
+	/**
+	 * Hosts being set up right now. Creating a host acquires an SSH lease, so two
+	 * concurrent callers would each take one and only the last would be kept —
+	 * the other lease then leaks for the life of the process, holding a
+	 * connection open that nothing will ever release.
+	 */
+	private opening = new Map<string, Promise<HostState>>();
+	private badgeTimer: ReturnType<typeof setInterval> | null = null;
+	private badgeCount = 0;
+
+	// -- host lifecycle ------------------------------------------------------
+
+	/** The host's state, created once however many callers ask at the same time. */
+	private async ensureHost(hostId: string): Promise<HostState> {
+		const existing = this.hosts.get(hostId);
+		if (existing) return existing;
+
+		const opening = this.opening.get(hostId);
+		if (opening) return opening;
+
+		const created = this.createHost(hostId)
+			.then((state) => {
+				// Another caller may have finished first; keep theirs and let this
+				// one's lease go rather than overwriting it.
+				const settled = this.hosts.get(hostId);
+				if (settled) {
+					state.lease?.release();
+					return settled;
+				}
+				this.hosts.set(hostId, state);
+				return state;
+			})
+			.finally(() => {
+				this.opening.delete(hostId);
+			});
+
+		this.opening.set(hostId, created);
+		return created;
+	}
+
+	private async createHost(hostId: string): Promise<HostState> {
+		if (hostId === LOCAL_PORT_HOST) {
+			const runner = new LocalCommandRunner();
+			const platform = localPlatform();
+			return {
+				scanner: new HostPortScanner(hostId, 'this machine', runner, platform, localPrincipal()),
+				runner,
+				platform,
+				lease: null,
+				watchers: new Set(),
+				timer: null,
+				last: null,
+				signature: '',
+				scanning: false
+			};
+		}
+
+		const connection = sshConnectionQueries.get(hostId);
+		if (!connection) throw new Error('That SSH host no longer exists.');
+
+		const lease = await sshClientPool.acquire(hostId);
+		try {
+			const runner = new SshCommandRunner(connection.name, lease.client);
+			const platform = await detectRemotePlatform(hostId, runner);
+			const principal: ScanPrincipal = {
+				user: connection.username,
+				isRoot: connection.username === 'root'
+			};
+			return {
+				scanner: new HostPortScanner(hostId, connection.name, runner, platform, principal),
+				runner,
+				platform,
+				lease,
+				watchers: new Set(),
+				timer: null,
+				last: null,
+				signature: '',
+				scanning: false
+			};
+		} catch (error) {
+			lease.release();
+			throw error;
+		}
+	}
+
+	private disposeHost(hostId: string): void {
+		const state = this.hosts.get(hostId);
+		if (!state) return;
+		if (state.timer) clearInterval(state.timer);
+		state.lease?.release();
+		this.hosts.delete(hostId);
+		if (hostId !== LOCAL_PORT_HOST) {
+			forgetRemotePlatform(hostId);
+			forgetClopenRootPid(hostId);
+		}
+	}
+
+	// -- scanning ------------------------------------------------------------
+
+	/**
+	 * Run one scan and push it to watchers if anything changed. Overlapping
+	 * ticks are dropped rather than queued: a slow host would otherwise build a
+	 * backlog of scans that are all stale by the time they run.
+	 */
+	private async tick(hostId: string): Promise<void> {
+		const state = this.hosts.get(hostId);
+		if (!state || state.scanning) return;
+
+		state.scanning = true;
+		try {
+			const result = await state.scanner.scan();
+			state.last = result;
+
+			if (hostId === LOCAL_PORT_HOST) this.publishBadge(countSessionPorts(result));
+
+			const signature = signatureOf(result);
+			if (signature === state.signature) return;
+			state.signature = signature;
+
+			for (const userId of state.watchers) {
+				ws.emit.user(userId, 'ports:changed', { result });
+			}
+		} catch (error) {
+			debug.warn('ports', `scan failed for ${hostId}:`, error);
+		} finally {
+			state.scanning = false;
+		}
+	}
+
+	private ensureTimer(hostId: string): void {
+		const state = this.hosts.get(hostId);
+		if (!state || state.timer) return;
+		state.timer = setInterval(
+			() => {
+				void this.tick(hostId);
+			},
+			hostId === LOCAL_PORT_HOST ? WATCH_INTERVAL_MS : REMOTE_WATCH_INTERVAL_MS
+		);
+		// A poll for a panel nobody is looking at must not hold the process open.
+		state.timer.unref?.();
+	}
+
+	// -- public API ----------------------------------------------------------
+
+	/** Start watching a host for a user, and return the first scan immediately. */
+	async watch(hostId: string, userId: string): Promise<PortScanResult> {
+		const state = await this.ensureHost(hostId);
+
+		state.watchers.add(userId);
+
+		// Scan before starting the timer, and through the scanner's own guard, so
+		// this first read cannot run alongside a tick on the same connection.
+		const result = state.last ?? (await state.scanner.scan());
+		state.last = result;
+		state.signature = signatureOf(result);
+		if (hostId === LOCAL_PORT_HOST) this.publishBadge(countSessionPorts(result));
+
+		this.ensureTimer(hostId);
+		return result;
+	}
+
+	/** Stop watching. The host is torn down once nobody is left looking. */
+	unwatch(hostId: string, userId: string): void {
+		const state = this.hosts.get(hostId);
+		if (!state) return;
+
+		state.watchers.delete(userId);
+		if (state.watchers.size > 0) return;
+
+		// The local host keeps its scanner: the badge ticker reuses the process
+		// cache, and rebuilding it costs a full sweep.
+		if (hostId === LOCAL_PORT_HOST) {
+			if (state.timer) clearInterval(state.timer);
+			state.timer = null;
+			return;
+		}
+		this.disposeHost(hostId);
+	}
+
+	/** A one-shot scan, for a host the caller is not watching. */
+	async scanOnce(hostId: string): Promise<PortScanResult> {
+		const existing = this.hosts.get(hostId);
+		if (existing) return existing.scanner.scan();
+
+		const state = await this.createHost(hostId);
+		try {
+			return await state.scanner.scan();
+		} finally {
+			state.lease?.release();
+			if (hostId !== LOCAL_PORT_HOST) {
+				forgetRemotePlatform(hostId);
+				forgetClopenRootPid(hostId);
+			}
+		}
+	}
+
+	/** The runner and platform for a host, so an action can reuse the transport. */
+	async withHost<T>(hostId: string, fn: (runner: CommandRunner, platform: ProbePlatform) => Promise<T>): Promise<T> {
+		const existing = this.hosts.get(hostId);
+		if (existing) return fn(existing.runner, existing.platform);
+
+		const state = await this.createHost(hostId);
+		try {
+			return await fn(state.runner, state.platform);
+		} finally {
+			state.lease?.release();
+		}
+	}
+
+	/** Force the next tick to push, after an action that changed the table. */
+	invalidate(hostId: string): void {
+		const state = this.hosts.get(hostId);
+		if (state) state.signature = '';
+		void this.tick(hostId);
+	}
+
+	// -- sidebar count -------------------------------------------------------
+
+	private publishBadge(count: number): void {
+		if (count === this.badgeCount) return;
+		this.badgeCount = count;
+		ws.emit.global('ports:badge', { count });
+	}
+
+	/**
+	 * The count behind the sidebar dot: ports Clopen started on this machine.
+	 *
+	 * Returned as well as published, because a client that has just loaded needs
+	 * the current number and pushes only carry changes — a page refresh would
+	 * otherwise sit at zero until something happened to move it.
+	 */
+	async refreshBadge(): Promise<number> {
+		const local = this.hosts.get(LOCAL_PORT_HOST);
+		// A watched panel is already scanning; reuse what it last saw.
+		if (local?.timer && local.last) return countSessionPorts(local.last);
+
+		try {
+			const state = await this.ensureHost(LOCAL_PORT_HOST);
+			const result = await state.scanner.scan();
+			state.last = result;
+			const count = countSessionPorts(result);
+			this.publishBadge(count);
+			return count;
+		} catch (error) {
+			debug.warn('ports', 'badge scan failed:', error);
+			return this.badgeCount;
+		}
+	}
+
+	/**
+	 * The periodic count.
+	 *
+	 * This used to skip the scan when no terminal session existed, on the
+	 * grounds that nothing could then have been started from Clopen. That stops
+	 * being true once the count includes everything Clopen spawns — an engine,
+	 * an MCP server, the preview browser — none of which need a terminal. The
+	 * guard would have reported a confident zero over a running engine, so it
+	 * is gone: a scan every fifteen seconds costs about fifteen milliseconds.
+	 */
+	private async badgeTick(): Promise<void> {
+		const local = this.hosts.get(LOCAL_PORT_HOST);
+		if (local?.timer) return; // A watched panel already refreshes the count.
+		await this.refreshBadge();
+	}
+
+	start(): void {
+		if (this.badgeTimer) return;
+		this.badgeTimer = setInterval(() => {
+			void this.badgeTick();
+		}, BADGE_INTERVAL_MS);
+		this.badgeTimer.unref?.();
+	}
+
+	stop(): void {
+		if (this.badgeTimer) clearInterval(this.badgeTimer);
+		this.badgeTimer = null;
+		for (const hostId of [...this.hosts.keys()]) this.disposeHost(hostId);
+	}
+}
+
+function countSessionPorts(result: PortScanResult): number {
+	return result.entries.filter((entry) => entry.origin.kind === 'session').length;
+}
+
+export const portMonitor = new PortMonitor();

--- a/backend/ports/processes.test.ts
+++ b/backend/ports/processes.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'bun:test';
+import { parseLsofCwd, parseProcCwd, parsePsOutput, parseWindowsProcesses } from './processes';
+
+describe('parsePsOutput', () => {
+	// `ps -o pid=,ppid=,user=,lstart=,args=` — lstart is always five tokens, so
+	// the row is read positionally and the argv keeps its own spaces.
+	const output = [
+		'    1     0 root             Tue Aug 25 08:24:48 2026     /sbin/launchd',
+		' 1310  1200 deploy           Tue Aug 25 09:02:11 2026     node /srv/app/node_modules/.bin/vite --port 5173',
+		'  640     1 root             Tue Aug 25 08:24:52 2026     nginx: master process /usr/sbin/nginx -g daemon off;',
+		''
+	].join('\n');
+
+	const processes = parsePsOutput(output);
+
+	test('reads every row', () => {
+		expect(processes).toHaveLength(3);
+	});
+
+	test('keeps the full command line including its arguments', () => {
+		expect(processes[1].command).toBe('node /srv/app/node_modules/.bin/vite --port 5173');
+		expect(processes[2].command).toBe('nginx: master process /usr/sbin/nginx -g daemon off;');
+	});
+
+	test('reads pid, parent and user', () => {
+		expect(processes[1]).toMatchObject({ pid: 1310, parentPid: 1200, user: 'deploy' });
+	});
+
+	test('turns the five lstart tokens into a timestamp', () => {
+		expect(processes[0].startedAt).toBe(new Date('Tue Aug 25 08:24:48 2026').toISOString());
+	});
+
+	test('reports no start time rather than a wrong one when the date is unreadable', () => {
+		// A non-English locale prints month names `Date` cannot parse.
+		const localised = '  900     1 root             mar. ao\u00fbt 25 08:24:48 2026     /usr/sbin/cron';
+		expect(parsePsOutput(localised)[0]).toMatchObject({ pid: 900, startedAt: null });
+	});
+
+	test('skips rows too short to be a process', () => {
+		expect(parsePsOutput('garbage\n\n  1 0 root\n')).toHaveLength(0);
+	});
+});
+
+describe('parseWindowsProcesses', () => {
+	const output = [
+		'ProcessId        : 1044',
+		'ParentProcessId  : 640',
+		'Name             : node.exe',
+		'CommandLine      : "C:\\Program Files\\nodejs\\node.exe" server.js',
+		'CreationDate     : 2026-08-25T09:02:11',
+		'',
+		'ProcessId        : 4',
+		'ParentProcessId  : 0',
+		'Name             : System',
+		'CommandLine      :',
+		'CreationDate     :',
+		''
+	].join('\n');
+
+	const processes = parseWindowsProcesses(output);
+
+	test('reads one process per blank-line-separated block', () => {
+		expect(processes).toHaveLength(2);
+	});
+
+	test('prefers the command line over the bare name', () => {
+		expect(processes[0].command).toBe('"C:\\Program Files\\nodejs\\node.exe" server.js');
+	});
+
+	test('falls back to the name when there is no command line', () => {
+		expect(processes[1].command).toBe('System');
+		expect(processes[1].startedAt).toBeNull();
+	});
+});
+
+describe('cwd probes', () => {
+	test('parses lsof cwd blocks', () => {
+		const output = ['p1310', 'fcwd', 'n/srv/app', 'p1400', 'fcwd', 'n/srv/api', ''].join('\n');
+		expect([...parseLsofCwd(output).entries()]).toEqual([
+			[1310, '/srv/app'],
+			[1400, '/srv/api']
+		]);
+	});
+
+	test('parses /proc symlink listings and ignores rows it could not read', () => {
+		const output = [
+			'lrwxrwxrwx 1 deploy deploy 0 Aug 25 09:02 /proc/1310/cwd -> /srv/app',
+			"ls: cannot read symbolic link '/proc/800/cwd': Permission denied",
+			'lrwxrwxrwx 1 deploy deploy 0 Aug 25 09:02 /proc/1400/cwd -> /srv/api',
+			''
+		].join('\n');
+
+		const cwds = parseProcCwd(output);
+		expect(cwds.get(1310)).toBe('/srv/app');
+		expect(cwds.get(1400)).toBe('/srv/api');
+		expect(cwds.has(800)).toBe(false);
+	});
+});

--- a/backend/ports/processes.ts
+++ b/backend/ports/processes.ts
@@ -1,0 +1,374 @@
+/**
+ * Port manager — who the pid behind a socket actually is.
+ *
+ * A socket row carries a pid and, on some platforms, a truncated process name.
+ * Neither answers "what is this and where did it come from" — that needs the
+ * parent pid (to trace lineage back to a Clopen terminal), the full argv, and
+ * the working directory (the strongest hint at which project a dev server
+ * belongs to).
+ *
+ * The table is cached per host and refreshed incrementally: a full sweep on the
+ * first tick and every `FULL_SWEEP_MS` after, and in between only pids never
+ * seen before are looked up. That keeps a one-second poll to a single cheap
+ * probe on Unix, and makes it affordable on Windows where the only source of
+ * argv and parent pid is a PowerShell query that costs hundreds of milliseconds
+ * to start.
+ *
+ * Cache entries are keyed by pid *and* start time, so a recycled pid is treated
+ * as the new process it is rather than inheriting the dead one's identity.
+ */
+
+import type { PortLimitation, PortProcess } from '$shared/types/ports';
+import type { CommandRunner, ProbePlatform } from './runner';
+import { debug } from '$shared/utils/logger';
+
+/** How often the whole table is re-read, so exited pids stop being reported. */
+const FULL_SWEEP_MS = 30_000;
+
+/** Ceiling on pids named in one targeted lookup, to stay under argv limits. */
+const LOOKUP_BATCH = 200;
+
+const UNIX_PS_FORMAT = 'pid=,ppid=,user=,lstart=,args=';
+
+/**
+ * `ps` is run through `env LC_ALL=C` so lstart comes back in the English form
+ * the parser below expects. `env` is on every POSIX host, and going through it
+ * works identically for a local spawn and a remote exec — the alternative,
+ * setting an environment variable, has no equivalent over an SSH command.
+ */
+export function unixPsArgv(platform: ProbePlatform, selector: string[] = []): string[] {
+	const flag = platform === 'darwin' && selector.length === 0 ? '-axo' : '-eo';
+	return selector.length > 0
+		? ['env', 'LC_ALL=C', 'ps', '-o', UNIX_PS_FORMAT, ...selector]
+		: ['env', 'LC_ALL=C', 'ps', flag, UNIX_PS_FORMAT];
+}
+
+const C_LOCALE_MONTHS: Record<string, number> = {
+	Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5,
+	Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11
+};
+
+/**
+ * Turn the five lstart tokens into a timestamp, strictly.
+ *
+ * `Date` must not be handed this text directly: given a French `mar. août 25`
+ * it does not fail, it reads `mar.` as March and returns a date four months
+ * off. So the shape is checked and the month looked up in a table, and
+ * anything that does not match yields null — no start time is honest, a
+ * confidently wrong one is not.
+ */
+export function parseCLocaleStart(tokens: string[]): string | null {
+	if (tokens.length !== 5) return null;
+	const [, month, day, time, year] = tokens;
+
+	const monthIndex = C_LOCALE_MONTHS[month];
+	if (monthIndex === undefined) return null;
+
+	const dayNumber = Number.parseInt(day, 10);
+	const yearNumber = Number.parseInt(year, 10);
+	const clock = time.match(/^(\d{2}):(\d{2}):(\d{2})$/);
+	if (!Number.isFinite(dayNumber) || !Number.isFinite(yearNumber) || !clock) return null;
+
+	const started = new Date(
+		yearNumber,
+		monthIndex,
+		dayNumber,
+		Number.parseInt(clock[1], 10),
+		Number.parseInt(clock[2], 10),
+		Number.parseInt(clock[3], 10)
+	);
+	return Number.isNaN(started.getTime()) ? null : started.toISOString();
+}
+
+/**
+ * `ps` prints lstart as exactly five tokens ("Tue Aug 25 08:24:48 2026"), so
+ * the row is parsed positionally — that holds whatever the locale does to the
+ * words themselves.
+ */
+function parsePsLine(line: string): PortProcess | null {
+	const trimmed = line.trim();
+	if (!trimmed) return null;
+
+	const tokens = trimmed.split(/\s+/);
+	if (tokens.length < 9) return null;
+
+	const pid = Number.parseInt(tokens[0], 10);
+	if (!Number.isFinite(pid)) return null;
+	const parentPid = Number.parseInt(tokens[1], 10);
+
+	return {
+		pid,
+		parentPid: Number.isFinite(parentPid) ? parentPid : null,
+		user: tokens[2] || null,
+		command: tokens.slice(8).join(' '),
+		startedAt: parseCLocaleStart(tokens.slice(3, 8)),
+		cwd: null
+	};
+}
+
+export function parsePsOutput(stdout: string): PortProcess[] {
+	const processes: PortProcess[] = [];
+	for (const line of stdout.split('\n')) {
+		const parsed = parsePsLine(line);
+		if (parsed) processes.push(parsed);
+	}
+	return processes;
+}
+
+/**
+ * PowerShell CIM output, one record per blank-line-separated block of
+ * `Name: value` pairs. Windows has no `ps`, and `tasklist` reports neither the
+ * parent pid nor the command line.
+ */
+export function parseWindowsProcesses(stdout: string): PortProcess[] {
+	const processes: PortProcess[] = [];
+
+	for (const block of stdout.split(/\r?\n\r?\n/)) {
+		if (!block.trim()) continue;
+		const fields = new Map<string, string>();
+		for (const line of block.split(/\r?\n/)) {
+			const separator = line.indexOf(':');
+			if (separator <= 0) continue;
+			fields.set(line.slice(0, separator).trim(), line.slice(separator + 1).trim());
+		}
+
+		const pid = Number.parseInt(fields.get('ProcessId') ?? '', 10);
+		if (!Number.isFinite(pid)) continue;
+		const parentPid = Number.parseInt(fields.get('ParentProcessId') ?? '', 10);
+		const started = new Date(fields.get('CreationDate') ?? '');
+
+		processes.push({
+			pid,
+			parentPid: Number.isFinite(parentPid) ? parentPid : null,
+			user: fields.get('UserName') || null,
+			command: fields.get('CommandLine') || fields.get('Name') || '',
+			startedAt: Number.isNaN(started.getTime()) ? null : started.toISOString(),
+			cwd: null
+		});
+	}
+
+	return processes;
+}
+
+/** `lsof -Fn` cwd output: a `p<pid>` line followed by that process's `n<path>`. */
+export function parseLsofCwd(stdout: string): Map<number, string> {
+	const cwds = new Map<number, string>();
+	let pid: number | null = null;
+
+	for (const line of stdout.split('\n')) {
+		if (!line) continue;
+		if (line[0] === 'p') {
+			pid = Number.parseInt(line.slice(1), 10) || null;
+		} else if (line[0] === 'n' && pid !== null) {
+			cwds.set(pid, line.slice(1));
+			pid = null;
+		}
+	}
+
+	return cwds;
+}
+
+/** `ls -l /proc/<pid>/cwd` output: `… /proc/800/cwd -> /srv/app`. */
+export function parseProcCwd(stdout: string): Map<number, string> {
+	const cwds = new Map<number, string>();
+
+	for (const line of stdout.split('\n')) {
+		const match = line.match(/\/proc\/(\d+)\/cwd -> (.+)$/);
+		if (!match) continue;
+		const pid = Number.parseInt(match[1], 10);
+		if (Number.isFinite(pid)) cwds.set(pid, match[2].trim());
+	}
+
+	return cwds;
+}
+
+const NO_CWD_ON_WINDOWS: PortLimitation = {
+	code: 'no-cwd-support',
+	message: 'Windows does not expose a process working directory, so the project a port belongs to cannot be inferred.'
+};
+
+const NO_ARGS_ON_WINDOWS: PortLimitation = {
+	code: 'no-process-args',
+	message: 'PowerShell was unavailable, so only process names could be read — no command line or parent process.'
+};
+
+/**
+ * A host's process table. One instance per host, held for as long as that host
+ * is being watched.
+ */
+export class ProcessTable {
+	private readonly entries = new Map<number, PortProcess>();
+	/** Pids whose cwd has been resolved, including those that resolved to none. */
+	private readonly cwdResolved = new Set<number>();
+	private lastFullSweep = 0;
+	private readonly limitations: PortLimitation[] = [];
+
+	constructor(
+		private readonly runner: CommandRunner,
+		private readonly platform: ProbePlatform
+	) {}
+
+	/** Limitations discovered while reading this host, deduplicated by code. */
+	getLimitations(): PortLimitation[] {
+		return [...this.limitations];
+	}
+
+	private noteLimitation(limitation: PortLimitation): void {
+		if (this.limitations.some((existing) => existing.code === limitation.code)) return;
+		this.limitations.push(limitation);
+	}
+
+	private absorb(processes: PortProcess[]): void {
+		for (const process of processes) {
+			const existing = this.entries.get(process.pid);
+			// A pid whose start time moved is a different process wearing the same
+			// number; drop everything remembered about the old one.
+			if (existing && existing.startedAt !== process.startedAt) {
+				this.cwdResolved.delete(process.pid);
+			} else if (existing) {
+				process.cwd = existing.cwd;
+			}
+			this.entries.set(process.pid, process);
+		}
+	}
+
+	private async readAll(): Promise<PortProcess[]> {
+		if (this.platform === 'win32') return this.readWindows(null);
+		const result = await this.runner.run(unixPsArgv(this.platform));
+		return parsePsOutput(result.stdout);
+	}
+
+	private async readSome(pids: number[]): Promise<PortProcess[]> {
+		if (this.platform === 'win32') return this.readWindows(pids);
+		const result = await this.runner.run(unixPsArgv(this.platform, ['-p', pids.join(',')]));
+		return parsePsOutput(result.stdout);
+	}
+
+	/**
+	 * Windows has no `ps`. `Get-CimInstance Win32_Process` is the one source
+	 * that carries the parent pid and command line together, so it is asked for
+	 * the pids in question and its cost amortised by the cache.
+	 */
+	private async readWindows(pids: number[] | null): Promise<PortProcess[]> {
+		const filter = pids && pids.length > 0 ? `-Filter "${pids.map((pid) => `ProcessId=${pid}`).join(' or ')}"` : '';
+		const script =
+			`Get-CimInstance Win32_Process ${filter} | ` +
+			'Select-Object ProcessId,ParentProcessId,Name,CommandLine,CreationDate | Format-List';
+
+		try {
+			const result = await this.runner.run(['powershell', '-NoProfile', '-NonInteractive', '-Command', script]);
+			if (result.code === 0) return parseWindowsProcesses(result.stdout);
+		} catch (error) {
+			debug.log('ports', 'PowerShell process lookup failed:', error);
+		}
+
+		// Fall back to names only, and say so — an unnamed parent means lineage
+		// attribution silently stops working, which the user should know about.
+		this.noteLimitation(NO_ARGS_ON_WINDOWS);
+		try {
+			const result = await this.runner.run(['tasklist', '/FO', 'CSV', '/NH']);
+			return result.stdout
+				.split(/\r?\n/)
+				.map((line) => line.match(/^"([^"]*)","(\d+)"/))
+				.filter((match): match is RegExpMatchArray => Boolean(match))
+				.map((match) => ({
+					pid: Number.parseInt(match[2], 10),
+					parentPid: null,
+					user: null,
+					command: match[1],
+					startedAt: null,
+					cwd: null
+				}));
+		} catch (error) {
+			debug.log('ports', 'tasklist fallback failed:', error);
+			return [];
+		}
+	}
+
+	/**
+	 * Resolve working directories for pids that still lack one. Best-effort by
+	 * design: on Unix the kernel only reveals it for our own processes, and on
+	 * Windows there is no way to ask at all.
+	 */
+	private async resolveCwds(pids: number[]): Promise<void> {
+		const pending = pids.filter((pid) => !this.cwdResolved.has(pid));
+		if (pending.length === 0) return;
+
+		if (this.platform === 'win32') {
+			this.noteLimitation(NO_CWD_ON_WINDOWS);
+			for (const pid of pending) this.cwdResolved.add(pid);
+			return;
+		}
+
+		const batch = pending.slice(0, LOOKUP_BATCH);
+		try {
+			const cwds =
+				this.platform === 'darwin'
+					? parseLsofCwd((await this.runner.run(['lsof', '-a', '-d', 'cwd', '-Fn', '-p', batch.join(',')])).stdout)
+					: parseProcCwd(
+							(await this.runner.run(['ls', '-l', ...batch.map((pid) => `/proc/${pid}/cwd`)])).stdout
+						);
+
+			for (const pid of batch) {
+				const cwd = cwds.get(pid);
+				const entry = this.entries.get(pid);
+				if (entry) entry.cwd = cwd ?? null;
+				// Mark resolved either way: a process we may not inspect will not
+				// become inspectable on the next tick, and retrying costs a probe.
+				this.cwdResolved.add(pid);
+			}
+		} catch (error) {
+			debug.log('ports', `cwd lookup failed on ${this.runner.label}:`, error);
+			for (const pid of batch) this.cwdResolved.add(pid);
+		}
+	}
+
+	/**
+	 * Bring the table up to date for the pids a scan just produced. Returns the
+	 * table itself so callers can walk parent chains beyond the pids they asked
+	 * about — lineage needs ancestors that own no socket at all.
+	 */
+	async refresh(pids: number[], now: number): Promise<Map<number, PortProcess>> {
+		const dueForSweep = now - this.lastFullSweep >= FULL_SWEEP_MS;
+
+		if (dueForSweep || this.entries.size === 0) {
+			try {
+				const all = await this.readAll();
+				this.absorb(all);
+				this.lastFullSweep = now;
+				// A full sweep is the only moment the table knows which pids are
+				// gone, so prune here rather than letting dead entries accumulate.
+				// A sweep that returned nothing failed; keep what we had.
+				if (all.length > 0) this.prune(new Set(all.map((process) => process.pid)));
+			} catch (error) {
+				debug.log('ports', `process sweep failed on ${this.runner.label}:`, error);
+			}
+		} else {
+			const unknown = pids.filter((pid) => !this.entries.has(pid)).slice(0, LOOKUP_BATCH);
+			if (unknown.length > 0) {
+				try {
+					this.absorb(await this.readSome(unknown));
+				} catch (error) {
+					debug.log('ports', `process lookup failed on ${this.runner.label}:`, error);
+				}
+			}
+		}
+
+		await this.resolveCwds(pids.filter((pid) => this.entries.has(pid)));
+
+		return this.entries;
+	}
+
+	private prune(live: Set<number>): void {
+		for (const pid of this.entries.keys()) {
+			if (!live.has(pid)) {
+				this.entries.delete(pid);
+				this.cwdResolved.delete(pid);
+			}
+		}
+	}
+
+	get(pid: number): PortProcess | null {
+		return this.entries.get(pid) ?? null;
+	}
+}

--- a/backend/ports/registry.ts
+++ b/backend/ports/registry.ts
@@ -1,0 +1,165 @@
+/**
+ * Port manager — the listeners Clopen itself is responsible for.
+ *
+ * This is the tier where a label is a fact rather than a guess, so it is built
+ * by asking each feature what it currently holds open instead of keeping a
+ * second list that features must remember to update. A registration that
+ * drifts is worse than none: it would confidently mislabel someone else's port.
+ *
+ * A Cloudflare tunnel is deliberately not an owner. `cloudflared` dials the
+ * local service rather than binding it, so the port still belongs to whatever
+ * is listening — the tunnel only means that port is also reachable from the
+ * public internet, which is recorded separately as an exposure.
+ */
+
+import type { PortOwnerFeature, PortProtocol } from '$shared/types/ports';
+import { LOCAL_PORT_HOST } from '$shared/types/ports';
+import { SERVER_ENV } from '../utils/env';
+import { sshForwardManager } from '../ssh/forwards';
+import { connectionManager } from '../db-client/connection-manager';
+import { sshConnectionQueries } from '../database/queries';
+import { tunnelKit, portFromService } from '../tunnel/tunnel-config';
+import { debug } from '$shared/utils/logger';
+
+export interface OwnedPort {
+	protocol: PortProtocol;
+	port: number;
+	feature: PortOwnerFeature;
+	/** The record this port belongs to, so the UI can offer the right stop path. */
+	ownerId: string | null;
+	label: string;
+	detail: string | null;
+	/** Clopen's own socket must never be offered as something to kill. */
+	isClopenItself: boolean;
+}
+
+/** A port that is reachable publicly, keyed the same way as owned ports. */
+export interface ExposedPort {
+	port: number;
+	publicUrl: string;
+}
+
+function key(protocol: PortProtocol, port: number): string {
+	return `${protocol}:${port}`;
+}
+
+/**
+ * Ports Clopen opened on a given host, keyed `protocol:port`.
+ *
+ * Both kinds of host are answered here so neither is a special case: on the
+ * machine Clopen runs on that means its own socket, its local forwards and its
+ * database tunnels; on an SSH host it means the ports Clopen asked that host's
+ * sshd to bind. A remote forward is Clopen's doing just as much as a local one,
+ * and the panel says so in the same words.
+ */
+export function collectOwnedPorts(hostId: string): Map<string, OwnedPort> {
+	return hostId === LOCAL_PORT_HOST ? collectLocalOwnedPorts() : collectRemoteOwnedPorts(hostId);
+}
+
+function collectRemoteOwnedPorts(connectionId: string): Map<string, OwnedPort> {
+	const owned = new Map<string, OwnedPort>();
+
+	try {
+		for (const { forward, boundPort } of sshForwardManager.remoteListeners(connectionId)) {
+			owned.set(key('tcp', boundPort), {
+				protocol: 'tcp',
+				port: boundPort,
+				feature: 'ssh-forward',
+				ownerId: forward.id,
+				label: `SSH forward — ${forward.name}`,
+				detail: `Clopen asked this host to listen, and forwards to ${forward.destHost}:${forward.destPort}`,
+				isClopenItself: false
+			});
+		}
+	} catch (error) {
+		debug.log('ports', 'could not read remote SSH forwards:', error);
+	}
+
+	return owned;
+}
+
+function collectLocalOwnedPorts(): Map<string, OwnedPort> {
+	const owned = new Map<string, OwnedPort>();
+
+	owned.set(key('tcp', SERVER_ENV.PORT), {
+		protocol: 'tcp',
+		port: SERVER_ENV.PORT,
+		feature: 'server',
+		ownerId: null,
+		label: 'Clopen server',
+		detail: 'The app you are looking at right now',
+		isClopenItself: true
+	});
+
+	// In development the UI is served by Vite on its own port, in a process
+	// Clopen does not parent. It is still Clopen as far as anyone using it is
+	// concerned — and stopping it would take away the page they are reading.
+	if (SERVER_ENV.isDevelopment) {
+		owned.set(key('tcp', SERVER_ENV.PORT_FRONTEND), {
+			protocol: 'tcp',
+			port: SERVER_ENV.PORT_FRONTEND,
+			feature: 'server',
+			ownerId: null,
+			label: 'Clopen frontend',
+			detail: 'Vite dev server for the interface you are looking at',
+			isClopenItself: true
+		});
+	}
+
+	try {
+		for (const { forward, boundPort } of sshForwardManager.localListeners()) {
+			const host = sshConnectionQueries.get(forward.connectionId);
+			const via = host ? ` via ${host.name}` : '';
+			owned.set(key('tcp', boundPort), {
+				protocol: 'tcp',
+				port: boundPort,
+				feature: 'ssh-forward',
+				ownerId: forward.id,
+				label: `SSH forward — ${forward.name}`,
+				detail:
+					forward.type === 'dynamic'
+						? `SOCKS5 proxy${via}`
+						: `Forwards to ${forward.destHost}:${forward.destPort}${via}`,
+				isClopenItself: false
+			});
+		}
+	} catch (error) {
+		debug.log('ports', 'could not read SSH forwards:', error);
+	}
+
+	try {
+		for (const { connectionId, localPort } of connectionManager.activeTunnelPorts()) {
+			owned.set(key('tcp', localPort), {
+				protocol: 'tcp',
+				port: localPort,
+				feature: 'db-client-tunnel',
+				ownerId: connectionId,
+				label: 'DB Client SSH tunnel',
+				detail: 'Carries one database connection over SSH',
+				isClopenItself: false
+			});
+		}
+	} catch (error) {
+		debug.log('ports', 'could not read DB Client tunnels:', error);
+	}
+
+	return owned;
+}
+
+/** Local ports currently published through a Cloudflare tunnel. */
+export function collectExposedPorts(): Map<number, string> {
+	const exposed = new Map<number, string>();
+
+	try {
+		for (const tunnel of tunnelKit.list()) {
+			const port = portFromService(tunnel.service);
+			if (port > 0 && tunnel.publicUrl) exposed.set(port, tunnel.publicUrl);
+		}
+	} catch (error) {
+		debug.log('ports', 'could not read tunnels:', error);
+	}
+
+	return exposed;
+}
+
+export const ownedPortKey = key;

--- a/backend/ports/runner.ts
+++ b/backend/ports/runner.ts
@@ -1,0 +1,195 @@
+/**
+ * Port manager — one command interface, two transports.
+ *
+ * Every probe in this feature is a small POSIX/Windows command, and the same
+ * probe has to run on the machine hosting Clopen and on a saved SSH host. So
+ * the probes are written once against `CommandRunner` and the transport is
+ * swapped underneath: `Bun.spawn` locally, an exec channel remotely.
+ *
+ * Commands are argv arrays rather than shell strings. Locally that removes
+ * quoting from the picture entirely; remotely each argument is quoted by
+ * `shellQuote` on the way out, so a hostile process name in an argument can
+ * never turn into a second command.
+ */
+
+import type { Client as SshClient } from 'ssh2';
+import { runCommandDetailed, shellQuote } from '../ssh/connect';
+import { sshClientPool } from '../ssh/client-pool';
+import { debug } from '$shared/utils/logger';
+
+/**
+ * The directories a probe might live in, prepended for every POSIX command.
+ *
+ * A non-interactive SSH exec channel gets whatever PATH the account's shell
+ * sets up, and on shared hosting that routinely omits `/usr/sbin` and `/sbin`
+ * — which is exactly where `ss`, `netstat` and `lsof` are installed. Without
+ * this, a host with every tool present still reports having none.
+ */
+const PROBE_PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/homebrew/bin';
+
+/**
+ * Wrap a POSIX command so it runs with a predictable PATH and locale.
+ *
+ * Going through `env` rather than a shell keeps the no-shell rule intact —
+ * arguments stay arguments — while fixing both problems a bare command has on
+ * a remote host: a PATH too narrow to find the tool, and a locale that renders
+ * dates in words nothing can parse.
+ */
+export function posixArgv(argv: string[]): string[] {
+	return ['env', 'LC_ALL=C', `PATH=${PROBE_PATH}`, ...argv];
+}
+
+export interface RunResult {
+	stdout: string;
+	stderr: string;
+	code: number;
+}
+
+/** Platforms the probes know how to interrogate. */
+export type ProbePlatform = 'darwin' | 'linux' | 'win32' | 'unknown';
+
+export interface CommandRunner {
+	/** Human label for logs and errors ("this machine", the host name). */
+	readonly label: string;
+	run(argv: string[], timeoutMs?: number): Promise<RunResult>;
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+/** Runs probes on the machine Clopen itself is running on. */
+export class LocalCommandRunner implements CommandRunner {
+	readonly label = 'this machine';
+
+	async run(argv: string[], timeoutMs = DEFAULT_TIMEOUT_MS): Promise<RunResult> {
+		const child = Bun.spawn(argv, { stdout: 'pipe', stderr: 'pipe', stdin: 'ignore' });
+		// A probe that hangs must not wedge the poll loop; kill it and report
+		// the timeout as a failed command so the caller can fall back.
+		const timer = setTimeout(() => {
+			try {
+				child.kill();
+			} catch {
+				// Already gone — nothing to do.
+			}
+		}, timeoutMs);
+		try {
+			const [stdout, stderr, code] = await Promise.all([
+				new Response(child.stdout).text(),
+				new Response(child.stderr).text(),
+				child.exited
+			]);
+			return { stdout, stderr, code };
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+}
+
+/**
+ * Runs probes on a saved SSH host over the shared pooled transport, so the
+ * scan reuses whatever connection the terminal and file browser already hold
+ * open instead of dialing its own.
+ */
+export class SshCommandRunner implements CommandRunner {
+	/**
+	 * Commands run one at a time on a connection.
+	 *
+	 * Every `exec` opens an SSH channel, and sshd caps how many a connection may
+	 * hold at once — `MaxSessions`, ten by default. A scan issues several
+	 * commands, and the terminal, SFTP browser and forwards share the same
+	 * transport, so letting them overlap exhausts that budget and the server
+	 * answers `Unable to exec` before dropping the connection outright. Queueing
+	 * costs a little latency and removes the ceiling entirely.
+	 */
+	private queue: Promise<unknown> = Promise.resolve();
+
+	constructor(
+		readonly label: string,
+		private readonly client: SshClient
+	) {}
+
+	async run(argv: string[], timeoutMs = DEFAULT_TIMEOUT_MS): Promise<RunResult> {
+		const command = argv.map(shellQuote).join(' ');
+		// Chained on the tail whether or not the previous command succeeded, so
+		// one failure cannot wedge every command behind it.
+		const result = this.queue.then(
+			() => runCommandDetailed(this.client, command, timeoutMs),
+			() => runCommandDetailed(this.client, command, timeoutMs)
+		);
+		this.queue = result.catch(() => undefined);
+
+		const { stdout, stderr, code } = await result;
+		return { stdout, stderr, code };
+	}
+}
+
+/** Borrow a pooled SSH transport for the duration of `fn`. */
+export async function withSshRunner<T>(
+	connectionId: string,
+	label: string,
+	fn: (runner: CommandRunner) => Promise<T>
+): Promise<T> {
+	const lease = await sshClientPool.acquire(connectionId);
+	try {
+		return await fn(new SshCommandRunner(label, lease.client));
+	} finally {
+		lease.release();
+	}
+}
+
+/**
+ * Which OS a runner is talking to. Local is known outright; a remote host is
+ * asked once and remembered, because `uname` per scan tick is a round-trip
+ * spent on an answer that cannot change while the connection lives.
+ */
+const remotePlatforms = new Map<string, ProbePlatform>();
+
+export function localPlatform(): ProbePlatform {
+	switch (process.platform) {
+		case 'darwin':
+			return 'darwin';
+		case 'linux':
+			return 'linux';
+		case 'win32':
+			return 'win32';
+		default:
+			// The BSDs answer the Linux probes closely enough to be worth trying.
+			return process.platform === 'freebsd' || process.platform === 'openbsd' ? 'linux' : 'unknown';
+	}
+}
+
+export async function detectRemotePlatform(cacheKey: string, runner: CommandRunner): Promise<ProbePlatform> {
+	const cached = remotePlatforms.get(cacheKey);
+	if (cached) return cached;
+
+	let platform: ProbePlatform = 'unknown';
+	try {
+		const result = await runner.run(['uname', '-s'], 5_000);
+		const name = result.stdout.trim().toLowerCase();
+		if (result.code === 0 && name) {
+			if (name.includes('darwin')) platform = 'darwin';
+			else if (name.includes('linux')) platform = 'linux';
+			else if (name.includes('bsd')) platform = 'linux';
+		}
+	} catch (error) {
+		debug.log('ports', `uname failed on ${runner.label}:`, error);
+	}
+
+	// No `uname` usually means a Windows host answering over OpenSSH, where the
+	// shell is cmd and `ver` is the equivalent question.
+	if (platform === 'unknown') {
+		try {
+			const result = await runner.run(['cmd', '/c', 'ver'], 5_000);
+			if (result.code === 0 && /windows/i.test(result.stdout)) platform = 'win32';
+		} catch {
+			// Leave it unknown — the caller reports that honestly.
+		}
+	}
+
+	remotePlatforms.set(cacheKey, platform);
+	return platform;
+}
+
+/** Drop a host's cached platform when its connection goes away. */
+export function forgetRemotePlatform(cacheKey: string): void {
+	remotePlatforms.delete(cacheKey);
+}

--- a/backend/ports/scan-host.ts
+++ b/backend/ports/scan-host.ts
@@ -1,0 +1,260 @@
+/**
+ * Port manager — one host, one scan, one table.
+ *
+ * Ties the probe, the process table and the attribution together into the rows
+ * the panel renders. Held per host so the process cache survives between ticks,
+ * which is what makes a one-second poll cost a single cheap probe.
+ */
+
+import os from 'node:os';
+import type {
+	PortEntry,
+	PortKillBlockedReason,
+	PortLimitation,
+	PortPeer,
+	PortProtocol,
+	PortScanResult,
+	PortSocket
+} from '$shared/types/ports';
+import { LOCAL_PORT_HOST } from '$shared/types/ports';
+import { scanSockets, type ProbeMemo } from './scan';
+import { ProcessTable } from './processes';
+import { attribute, buildContext, groupListenerPids } from './attribute';
+import { collectExposedPorts } from './registry';
+import { resolveClopenPids } from './ssh-lineage';
+import type { CommandRunner, ProbePlatform } from './runner';
+
+/** Who the scan is running as, which decides what it may signal. */
+export interface ScanPrincipal {
+	user: string | null;
+	isRoot: boolean;
+}
+
+export function localPrincipal(): ScanPrincipal {
+	let user: string | null = null;
+	try {
+		user = os.userInfo().username;
+	} catch {
+		// Some container images have no passwd entry for the running uid.
+		user = null;
+	}
+	const uid = typeof process.getuid === 'function' ? process.getuid() : null;
+	// Windows has no uid; an Administrator there still fails to signal some
+	// processes, so the kill attempt reports the truth rather than predicting it.
+	return { user, isRoot: uid === 0 };
+}
+
+const NO_CLOPEN_LINEAGE: PortLimitation = {
+	code: 'no-session-attribution',
+	message:
+		'Nothing listening here belongs to Clopen’s own SSH connection. If you started a server from a Clopen terminal on this host and it is not listed under “Started from Clopen”, this host does not let Clopen read a process’s environment.'
+};
+
+function protocolPortKey(protocol: PortProtocol, port: number): string {
+	return `${protocol}:${port}`;
+}
+
+/** Peers connected to each listening port, keyed `protocol:port`. */
+function collectPeers(sockets: PortSocket[]): Map<string, PortPeer[]> {
+	const peers = new Map<string, PortPeer[]>();
+
+	for (const socket of sockets) {
+		if (socket.state !== 'established' || socket.peerAddress === null || socket.peerPort === null) continue;
+		const key = protocolPortKey(socket.protocol, socket.port);
+		const list = peers.get(key);
+		const peer: PortPeer = {
+			address: socket.peerAddress,
+			port: socket.peerPort,
+			processName: socket.processName
+		};
+		if (list) list.push(peer);
+		else peers.set(key, [peer]);
+	}
+
+	return peers;
+}
+
+function unique<T>(values: T[]): T[] {
+	return [...new Set(values)];
+}
+
+/**
+ * One host's scanner. Construct once per watched host so the process table and
+ * its cwd cache persist; drop it when the host stops being watched.
+ */
+export class HostPortScanner {
+	private readonly processes: ProcessTable;
+	/** Which probe answered for this host; the chain is walked once. */
+	private readonly probeMemo: ProbeMemo = {};
+	/**
+	 * A scan already running. Callers join it instead of starting a second one:
+	 * a remote scan can outlast the poll interval, and two in flight would double
+	 * the SSH channels while writing to the same process cache.
+	 */
+	private inFlight: Promise<PortScanResult> | null = null;
+
+	constructor(
+		private readonly hostId: string,
+		private readonly hostName: string,
+		private readonly runner: CommandRunner,
+		private readonly platform: ProbePlatform,
+		private readonly principal: ScanPrincipal
+	) {
+		this.processes = new ProcessTable(runner, platform);
+	}
+
+	private get isLocal(): boolean {
+		return this.hostId === LOCAL_PORT_HOST;
+	}
+
+	/**
+	 * Whether this scan could plausibly signal a process. Ownership is the only
+	 * thing knowable in advance; anything subtler is left to the kill attempt,
+	 * which reports what the OS actually said.
+	 */
+	private killability(
+		pid: number | null,
+		ownerUser: string | null,
+		isClopenItself: boolean
+	): { canKill: boolean; reason: PortKillBlockedReason | null } {
+		if (isClopenItself) return { canKill: false, reason: 'is-clopen-itself' };
+		if (pid === null) return { canKill: false, reason: 'unknown-pid' };
+		if (pid <= 1) return { canKill: false, reason: 'system-process' };
+		if (this.principal.isRoot) return { canKill: true, reason: null };
+		if (ownerUser && this.principal.user && ownerUser !== this.principal.user) {
+			return { canKill: false, reason: 'not-permitted' };
+		}
+		return { canKill: true, reason: null };
+	}
+
+	/** Read this host, joining a scan already in progress rather than racing it. */
+	async scan(now = Date.now()): Promise<PortScanResult> {
+		if (this.inFlight) return this.inFlight;
+		this.inFlight = this.runScan(now).finally(() => {
+			this.inFlight = null;
+		});
+		return this.inFlight;
+	}
+
+	private async runScan(now: number): Promise<PortScanResult> {
+		const scannedAt = new Date(now).toISOString();
+
+		let sockets: PortSocket[];
+		let limitations: PortLimitation[];
+		let probe: string;
+		try {
+			const result = await scanSockets(this.runner, this.platform, this.probeMemo);
+			sockets = result.sockets;
+			limitations = result.limitations;
+			probe = result.probe;
+		} catch (error) {
+			return {
+				hostId: this.hostId,
+				scannedAt,
+				platform: this.platform,
+				probe: 'none',
+				entries: [],
+				limitations: [],
+				error: error instanceof Error ? error.message : String(error)
+			};
+		}
+
+		const listening = sockets.filter((socket) => socket.state === 'listen');
+		const pids = unique(listening.map((socket) => socket.pid).filter((pid): pid is number => pid !== null));
+
+		const processes = await this.processes.refresh(pids, now);
+		limitations = [...limitations, ...this.processes.getLimitations()];
+
+		// On an SSH host, a process is Clopen's if it belongs to Clopen's own SSH
+		// connection — the same tier as locally, established from the far end.
+		const clopenPids = this.isLocal
+			? new Set<number>()
+			: await resolveClopenPids(this.hostId, this.runner, this.platform, pids, processes);
+		if (!this.isLocal && clopenPids.size === 0 && pids.length > 0) {
+			limitations.push(NO_CLOPEN_LINEAGE);
+		}
+
+		const context = buildContext({
+			platform: this.platform,
+			processes,
+			hostId: this.hostId,
+			hostName: this.hostName,
+			isLocal: this.isLocal,
+			clopenPids
+		});
+		const peers = collectPeers(sockets);
+		const exposed = this.isLocal ? collectExposedPorts() : new Map<number, string>();
+
+		// Bucket the listening sockets per protocol+port first; a port is the
+		// unit the user thinks in, and the addresses under it are detail.
+		const buckets = new Map<string, PortSocket[]>();
+		for (const socket of listening) {
+			const key = protocolPortKey(socket.protocol, socket.port);
+			const bucket = buckets.get(key);
+			if (bucket) bucket.push(socket);
+			else buckets.set(key, [socket]);
+		}
+
+		const entries: PortEntry[] = [];
+
+		for (const [key, bucket] of buckets) {
+			const { protocol, port } = bucket[0];
+			const bucketPids = unique(bucket.map((socket) => socket.pid).filter((pid): pid is number => pid !== null));
+			const groups = groupListenerPids(bucketPids, processes);
+
+			// Sockets whose owner the probe could not name still deserve a row —
+			// an unexplained open port is exactly what someone opens this for.
+			const orphans = bucket.filter((socket) => socket.pid === null);
+			if (orphans.length > 0) groups.push({ owner: -1, members: [] });
+
+			for (const { owner, members } of groups) {
+				const memberPids = new Set(members);
+				const groupSockets =
+					owner === -1
+						? orphans
+						: bucket.filter((socket) => socket.pid !== null && memberPids.has(socket.pid));
+				if (groupSockets.length === 0) continue;
+
+				const representative = groupSockets[0];
+				const pid = owner === -1 ? null : owner;
+				const process = pid !== null ? (processes.get(pid) ?? null) : null;
+				const origin = attribute({ ...representative, pid }, context);
+				const ownerUser = process?.user ?? representative.user;
+				const { canKill, reason } = this.killability(
+					pid,
+					ownerUser,
+					origin.ownerFeature === 'server'
+				);
+
+				entries.push({
+					key: `${this.hostId}:${key}:${pid ?? 'unknown'}`,
+					protocol,
+					port,
+					addresses: unique(groupSockets.map((socket) => socket.address)).sort(),
+					ipVersions: unique(groupSockets.map((socket) => socket.ipVersion)).sort(),
+					pid,
+					process,
+					workerPids: members,
+					origin,
+					peers: peers.get(key) ?? [],
+					peerCount: (peers.get(key) ?? []).length,
+					publicUrl: exposed.get(port) ?? null,
+					canKill,
+					killBlockedReason: reason
+				});
+			}
+		}
+
+		entries.sort((a, b) => a.port - b.port || a.protocol.localeCompare(b.protocol));
+
+		return {
+			hostId: this.hostId,
+			scannedAt,
+			platform: this.platform,
+			probe,
+			entries,
+			limitations,
+			error: null
+		};
+	}
+}

--- a/backend/ports/scan.test.ts
+++ b/backend/ports/scan.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, test } from 'bun:test';
+import type { CommandRunner } from './runner';
+import {
+	parseLsof,
+	parseNetstatUnix,
+	parseNetstatWindows,
+	parseProcFdInodes,
+	parseProcNet,
+	parseSs,
+	scanSockets
+} from './scan';
+
+/**
+ * Fixtures are shaped like real probe output but describe an invented machine,
+ * so nothing about a contributor's own box ends up in the repository.
+ */
+
+describe('parseLsof', () => {
+	// Field blocks as `lsof -FpcLfPntT` emits them: a process block, then one
+	// block per socket, with process fields carrying forward.
+	const output = [
+		'p1200',
+		'cnginx',
+		'Lwww',
+		'f6',
+		'tIPv4',
+		'PTCP',
+		'n*:8080',
+		'TST=LISTEN',
+		'TQR=0',
+		'f7',
+		'tIPv6',
+		'PTCP',
+		'n[::1]:8080',
+		'TST=LISTEN',
+		'p1310',
+		'cnode',
+		'Ldeploy',
+		'f22',
+		'tIPv4',
+		'PTCP',
+		'n127.0.0.1:5173',
+		'TST=LISTEN',
+		'f23',
+		'tIPv4',
+		'PTCP',
+		'n127.0.0.1:5173->127.0.0.1:54120',
+		'TST=ESTABLISHED',
+		'f24',
+		'tIPv4',
+		'PUDP',
+		'n*:5353',
+		''
+	].join('\n');
+
+	const sockets = parseLsof(output);
+
+	test('reads every socket across process blocks', () => {
+		expect(sockets).toHaveLength(5);
+	});
+
+	test('carries process identity forward across a process’s sockets', () => {
+		expect(sockets[0]).toMatchObject({ pid: 1200, processName: 'nginx', user: 'www' });
+		expect(sockets[1]).toMatchObject({ pid: 1200, port: 8080, ipVersion: 'v6', address: '::1' });
+		expect(sockets[2]).toMatchObject({ pid: 1310, processName: 'node', user: 'deploy' });
+	});
+
+	test('splits an established socket into local and peer', () => {
+		expect(sockets[3]).toMatchObject({
+			state: 'established',
+			port: 5173,
+			peerAddress: '127.0.0.1',
+			peerPort: 54120
+		});
+	});
+
+	test('treats a bound UDP socket with no peer as listening', () => {
+		expect(sockets[4]).toMatchObject({ protocol: 'udp', port: 5353, state: 'listen', address: '*' });
+	});
+});
+
+describe('parseSs', () => {
+	const output = [
+		'Netid State  Recv-Q Send-Q Local Address:Port Peer Address:Port Process',
+		'tcp   LISTEN 0      128    0.0.0.0:22         0.0.0.0:*         users:(("sshd",pid=800,fd=3))',
+		'tcp   LISTEN 0      511    [::]:443           [::]:*            users:(("caddy",pid=910,fd=8),("caddy",pid=911,fd=8))',
+		'tcp   ESTAB  0      0      10.0.0.5:22        10.0.0.9:51234    users:(("sshd",pid=1422,fd=4))',
+		'udp   UNCONN 0      0      0.0.0.0:68         0.0.0.0:*',
+		''
+	].join('\n');
+
+	const sockets = parseSs(output);
+
+	test('skips the header and keeps every socket row', () => {
+		expect(sockets).toHaveLength(4);
+	});
+
+	test('pulls the owning pid out of the users:(…) field', () => {
+		expect(sockets[0]).toMatchObject({ port: 22, state: 'listen', pid: 800, processName: 'sshd' });
+		expect(sockets[1]).toMatchObject({ port: 443, pid: 910, processName: 'caddy' });
+	});
+
+	test('normalises a wildcard bind and reads the IP family from the address', () => {
+		expect(sockets[0].address).toBe('*');
+		expect(sockets[1]).toMatchObject({ address: '*', ipVersion: 'v4' });
+	});
+
+	test('records the peer of an established socket', () => {
+		expect(sockets[2]).toMatchObject({ state: 'established', peerAddress: '10.0.0.9', peerPort: 51234 });
+	});
+
+	test('leaves the owner null when the kernel withheld it', () => {
+		expect(sockets[3]).toMatchObject({ protocol: 'udp', port: 68, pid: null, state: 'listen' });
+	});
+});
+
+describe('parseNetstatUnix', () => {
+	const output = [
+		'Active Internet connections (servers and established)',
+		'Proto Recv-Q Send-Q Local Address Foreign Address State PID/Program name',
+		'tcp        0      0 0.0.0.0:22      0.0.0.0:*     LISTEN      800/sshd',
+		'tcp6       0      0 :::443          :::*          LISTEN      -',
+		'tcp        0      0 10.0.0.5:22     10.0.0.9:5123 ESTABLISHED 1422/sshd: deploy',
+		'udp        0      0 0.0.0.0:68      0.0.0.0:*                 640/dhclient',
+		''
+	].join('\n');
+
+	const sockets = parseNetstatUnix(output);
+
+	test('keeps only socket rows', () => {
+		expect(sockets).toHaveLength(4);
+	});
+
+	test('reads the family from the proto column rather than guessing', () => {
+		// A wildcard IPv6 bind prints as `:::443`, which looks like no address at
+		// all once normalised — only `tcp6` says which family it is.
+		expect(sockets[1]).toMatchObject({ port: 443, ipVersion: 'v6', address: '*' });
+	});
+
+	test('treats a withheld owner as unknown rather than pid 0', () => {
+		expect(sockets[1].pid).toBeNull();
+	});
+
+	test('takes the owner from the right column for UDP, which has no state', () => {
+		expect(sockets[3]).toMatchObject({ protocol: 'udp', port: 68, pid: 640, processName: 'dhclient' });
+	});
+
+	test('splits pid from program name', () => {
+		expect(sockets[0]).toMatchObject({ pid: 800, processName: 'sshd' });
+	});
+});
+
+describe('parseNetstatWindows', () => {
+	const output = [
+		'Active Connections',
+		'',
+		'  Proto  Local Address          Foreign Address        State           PID',
+		'  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       1044',
+		'  TCP    [::]:445               [::]:0                 LISTENING       4',
+		'  TCP    10.0.0.5:52200         93.184.216.34:443      ESTABLISHED     7320',
+		'  UDP    0.0.0.0:5353           *:*                                    3180',
+		''
+	].join('\n');
+
+	const sockets = parseNetstatWindows(output);
+
+	test('keeps only socket rows', () => {
+		expect(sockets).toHaveLength(4);
+	});
+
+	test('reads the pid from the state-shifted column per protocol', () => {
+		expect(sockets[0]).toMatchObject({ port: 135, state: 'listen', pid: 1044 });
+		// UDP rows have no state column, so the pid sits one place to the left.
+		expect(sockets[3]).toMatchObject({ protocol: 'udp', port: 5353, pid: 3180, state: 'listen' });
+	});
+
+	test('unwraps a bracketed IPv6 address', () => {
+		expect(sockets[1]).toMatchObject({ address: '*', port: 445, ipVersion: 'v4' });
+	});
+
+	test('records the peer of an established socket', () => {
+		expect(sockets[2]).toMatchObject({
+			state: 'established',
+			peerAddress: '93.184.216.34',
+			peerPort: 443
+		});
+	});
+
+	test('never names a process, leaving that to the process table', () => {
+		expect(sockets.every((socket) => socket.processName === null)).toBe(true);
+	});
+});
+
+describe('parseProcNet', () => {
+	// What `grep '' /proc/net/tcp /proc/net/tcp6 …` prints: each line prefixed
+	// with the file it came from, which is what names the protocol and family.
+	const output = [
+		'/proc/net/tcp:  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode',
+		'/proc/net/tcp:   0: 00000000:0016 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 14200 1 0000 100 0 0 10 0',
+		'/proc/net/tcp:   1: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 25100 1 0000 100 0 0 10 0',
+		'/proc/net/tcp:   2: 0500000A:0016 0900000A:C822 01 00000000:00000000 00:00000000 00000000     0        0 25999 1 0000 20 0 0 10 -1',
+		'/proc/net/tcp6:  0: 00000000000000000000000000000000:01BB 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000 0 0 14555 1 0000 100 0 0 10 0',
+		'/proc/net/tcp6:  1: 0000000000000000FFFF00000100007F:2383 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000 0 0 30100 1 0000 100 0 0 10 0',
+		'/proc/net/udp:  2680: 00000000:0044 00000000:0000 07 00000000:00000000 00:00000000 00000000 0 0 15001 2 0000 0',
+		''
+	].join('\n');
+
+	const rows = parseProcNet(output);
+
+	test('skips the header and reads every socket', () => {
+		expect(rows).toHaveLength(6);
+	});
+
+	test('decodes little-endian hex addresses and ports', () => {
+		expect(rows[1].socket).toMatchObject({ address: '127.0.0.1', port: 8080, state: 'listen' });
+	});
+
+	test('renders an all-zero IPv6 bind as a wildcard, not a stray colon', () => {
+		expect(rows[3].socket).toMatchObject({ address: '*', port: 443, ipVersion: 'v6' });
+	});
+
+	test('renders a v4-mapped IPv6 address as the address people recognise', () => {
+		expect(rows[4].socket).toMatchObject({ address: '127.0.0.1', port: 9091, ipVersion: 'v6' });
+	});
+
+	test('reads the peer of an established socket', () => {
+		expect(rows[2].socket).toMatchObject({
+			state: 'established',
+			address: '10.0.0.5',
+			peerAddress: '10.0.0.9',
+			peerPort: 51234
+		});
+	});
+
+	test('treats a bound UDP socket as listening whatever its state column says', () => {
+		expect(rows[5].socket).toMatchObject({ protocol: 'udp', port: 68, state: 'listen' });
+	});
+
+	test('carries the inode, which is the only link back to a process', () => {
+		expect(rows.map((row) => row.inode)).toEqual([14200, 25100, 25999, 14555, 30100, 15001]);
+	});
+});
+
+describe('parseProcFdInodes', () => {
+	const output = [
+		'/proc/1234/fd/:',
+		'lrwx------ 1 deploy deploy 64 Aug 25 09:00 3 -> socket:[25100]',
+		'lrwx------ 1 deploy deploy 64 Aug 25 09:00 4 -> /dev/null',
+		'',
+		'/proc/1300/fd/:',
+		'lrwx------ 1 deploy deploy 64 Aug 25 09:00 7 -> socket:[30100]',
+		'lrwx------ 1 deploy deploy 64 Aug 25 09:00 8 -> socket:[25100]',
+		''
+	].join('\n');
+
+	const owners = parseProcFdInodes(output);
+
+	test('maps each socket inode to the process holding it', () => {
+		expect(owners.get(25100)).toBe(1234);
+		expect(owners.get(30100)).toBe(1300);
+	});
+
+	test('credits an inherited socket to the parent, not the forked child', () => {
+		// 1300 also holds inode 25100, but 1234 saw it first and is the ancestor.
+		expect(owners.get(25100)).toBe(1234);
+	});
+
+	test('ignores descriptors that are not sockets', () => {
+		expect(owners.size).toBe(2);
+	});
+});
+
+describe('probe selection on a host with no port tools', () => {
+	/** A host where `ss`, `netstat` and `lsof` are all absent. */
+	function bareHost(): { runner: CommandRunner; calls: string[] } {
+		const calls: string[] = [];
+		const runner: CommandRunner = {
+			label: 'bare host',
+			async run(argv: string[]) {
+				const name = argv.find((part) => !part.includes('=') && part !== 'env') ?? argv[0];
+				calls.push(name);
+				if (name === 'grep') {
+					return {
+						stdout:
+							'/proc/net/tcp:   0: 0100007F:1F90 00000000:0000 0A 0:0 00:0 0 1000 0 25100 1\n',
+						stderr: '',
+						code: 0
+					};
+				}
+				if (name === 'sh') return { stdout: '', stderr: '', code: 0 };
+				return { stdout: '', stderr: 'command not found', code: 127 };
+			}
+		};
+		return { runner, calls };
+	}
+
+	test('falls through to the kernel’s own tables and still reports the port', async () => {
+		const { runner } = bareHost();
+		const scan = await scanSockets(runner, 'linux');
+
+		expect(scan.probe).toBe('/proc/net');
+		expect(scan.sockets).toHaveLength(1);
+		expect(scan.sockets[0]).toMatchObject({ port: 8080, state: 'listen' });
+	});
+
+	test('remembers what worked instead of re-walking the chain every scan', async () => {
+		// This is what exhausted an SSH connection: four failing commands per
+		// tick, each one a channel, on a host that will never have those tools.
+		const { runner, calls } = bareHost();
+		const memo = {};
+
+		await scanSockets(runner, 'linux', memo);
+		const firstPass = calls.length;
+		calls.length = 0;
+
+		await scanSockets(runner, 'linux', memo);
+
+		expect(firstPass).toBeGreaterThan(3);
+		expect(calls).not.toContain('ss');
+		expect(calls).not.toContain('netstat');
+		expect(calls).not.toContain('lsof');
+	});
+
+	test('re-derives the probe if the remembered one stops answering', async () => {
+		const { runner } = bareHost();
+		const memo = {};
+		await scanSockets(runner, 'linux', memo);
+
+		// The host changes under us — every probe now fails.
+		const dead: CommandRunner = {
+			label: 'bare host',
+			async run() {
+				return { stdout: '', stderr: 'command not found', code: 127 };
+			}
+		};
+
+		// Re-derivation finds nothing either, and says so rather than reporting
+		// an empty table as though the host had no open ports.
+		await expect(scanSockets(dead, 'linux', memo)).rejects.toThrow(/Could not read the port table/);
+	});
+});

--- a/backend/ports/scan.ts
+++ b/backend/ports/scan.ts
@@ -1,0 +1,687 @@
+/**
+ * Port manager — reading the socket table on any supported platform.
+ *
+ * Each platform gets the probe that actually answers the question there, and
+ * every probe is normalised into the same `PortSocket` row so nothing
+ * downstream has to care which one ran:
+ *
+ * - macOS   `lsof -F`      — pid, login name and full bind address in one pass
+ * - Linux   `ss -tuna -p`  — falls back to `netstat`, then to `lsof`
+ * - Windows `netstat -ano` — pid only; the process name comes from the table
+ *                            built in processes.ts
+ *
+ * Two honest limits are reported rather than papered over. On Linux the kernel
+ * only names the owning process for sockets belonging to the calling user, so
+ * an unprivileged scan legitimately returns rows with no pid. And when a
+ * primary probe is missing and a fallback ran, the caller is told, because the
+ * fallbacks carry less detail.
+ */
+
+import type {
+	PortIpVersion,
+	PortLimitation,
+	PortProtocol,
+	PortSocket,
+	PortSocketState
+} from '$shared/types/ports';
+import { posixArgv, type CommandRunner, type ProbePlatform } from './runner';
+import { debug } from '$shared/utils/logger';
+
+/** Per-host memory of which probe answered, held by the host's scanner. */
+export interface ProbeMemo {
+	probe?: string;
+	argv?: string[];
+	parse?: (stdout: string) => PortSocket[];
+	limitations?: PortLimitation[];
+}
+
+export interface SocketScan {
+	sockets: PortSocket[];
+	limitations: PortLimitation[];
+	/** The probe that produced these rows, for the panel to report. */
+	probe: string;
+}
+
+/** Split `addr:port` where addr may be IPv6, bracketed, wildcard, or scoped. */
+function splitAddressPort(value: string): { address: string; port: number } | null {
+	const trimmed = value.trim();
+	if (!trimmed || trimmed === '*') return null;
+
+	const lastColon = trimmed.lastIndexOf(':');
+	if (lastColon <= 0) return null;
+
+	let address = trimmed.slice(0, lastColon);
+	const portText = trimmed.slice(lastColon + 1);
+
+	// A wildcard port belongs to the peer column of a listening socket, which
+	// carries no information — the caller drops these.
+	if (portText === '*' || portText === '') return null;
+	const port = Number.parseInt(portText, 10);
+	if (!Number.isFinite(port) || port < 0 || port > 65535) return null;
+
+	if (address.startsWith('[') && address.endsWith(']')) address = address.slice(1, -1);
+	if (address === '' || address === '*') address = '*';
+
+	return { address, port };
+}
+
+/** `0.0.0.0` and `::` mean the same thing as `*` and read worse in a table. */
+function normaliseAddress(address: string): string {
+	if (address === '0.0.0.0' || address === '::' || address === '[::]') return '*';
+	return address;
+}
+
+function ipVersionOf(address: string, hint?: PortIpVersion): PortIpVersion {
+	if (hint) return hint;
+	return address.includes(':') ? 'v6' : 'v4';
+}
+
+/**
+ * Collapse the TCP state machine to the three states the UI acts on. A UDP
+ * socket has no state; a bound one with no peer is what "port in use" means,
+ * so it is reported as listening.
+ */
+function normaliseState(raw: string | null, protocol: PortProtocol, hasPeer: boolean): PortSocketState {
+	// UDP is connectionless, so whatever the probe puts in the state column is
+	// not a TCP state: `ss` says UNCONN, netstat leaves it blank. A bound socket
+	// with no peer is precisely what "this port is in use" means, so the peer
+	// decides and the reported state is ignored.
+	if (protocol === 'udp') return hasPeer ? 'established' : 'listen';
+
+	const state = (raw ?? '').toUpperCase();
+	if (state === 'LISTEN' || state === 'LISTENING') return 'listen';
+	if (state === 'ESTABLISHED' || state === 'ESTAB') return 'established';
+	return 'other';
+}
+
+function makeSocket(input: {
+	protocol: PortProtocol;
+	local: { address: string; port: number };
+	peer: { address: string; port: number } | null;
+	state: string | null;
+	pid: number | null;
+	processName: string | null;
+	user: string | null;
+	ipVersion?: PortIpVersion;
+}): PortSocket {
+	const address = normaliseAddress(input.local.address);
+	return {
+		protocol: input.protocol,
+		ipVersion: ipVersionOf(address, input.ipVersion),
+		address,
+		port: input.local.port,
+		state: normaliseState(input.state, input.protocol, Boolean(input.peer)),
+		pid: input.pid,
+		processName: input.processName,
+		user: input.user,
+		peerAddress: input.peer ? normaliseAddress(input.peer.address) : null,
+		peerPort: input.peer ? input.peer.port : null
+	};
+}
+
+// ---------------------------------------------------------------------------
+// lsof — macOS primary, Unix last resort
+// ---------------------------------------------------------------------------
+
+const LSOF_ARGV = posixArgv(['lsof', '-nP', '-iTCP', '-iUDP', '-FpcLfPntT']);
+
+/**
+ * `lsof -F` emits one field per line, tagged by its first character: a process
+ * block (`p`id, `c`ommand, `L`ogin) followed by that process's file blocks
+ * (`f`d, `t`ype, `P`rotocol, `n`ame, `T`CP state). Fields carry forward until
+ * replaced, so the parser tracks the current process and flushes a socket each
+ * time a new `f` block or process block begins.
+ */
+export function parseLsof(stdout: string): PortSocket[] {
+	const sockets: PortSocket[] = [];
+
+	let pid: number | null = null;
+	let processName: string | null = null;
+	let user: string | null = null;
+
+	let protocol: PortProtocol | null = null;
+	let name: string | null = null;
+	let state: string | null = null;
+	let ipVersion: PortIpVersion | undefined;
+
+	const flush = (): void => {
+		if (!protocol || !name) return;
+		const [localText, peerText] = name.split('->');
+		const local = splitAddressPort(localText);
+		if (local) {
+			sockets.push(
+				makeSocket({
+					protocol,
+					local,
+					peer: peerText ? splitAddressPort(peerText) : null,
+					state,
+					pid,
+					processName,
+					user,
+					ipVersion
+				})
+			);
+		}
+		protocol = null;
+		name = null;
+		state = null;
+		ipVersion = undefined;
+	};
+
+	for (const line of stdout.split('\n')) {
+		if (!line) continue;
+		const tag = line[0];
+		const value = line.slice(1);
+
+		switch (tag) {
+			case 'p':
+				flush();
+				pid = Number.parseInt(value, 10) || null;
+				break;
+			case 'c':
+				processName = value || null;
+				break;
+			case 'L':
+				user = value || null;
+				break;
+			case 'f':
+				flush();
+				break;
+			case 't':
+				ipVersion = value === 'IPv6' ? 'v6' : value === 'IPv4' ? 'v4' : undefined;
+				break;
+			case 'P':
+				protocol = value.toLowerCase() === 'udp' ? 'udp' : 'tcp';
+				break;
+			case 'n':
+				name = value;
+				break;
+			case 'T':
+				// Only the state matters; queue depths share this tag.
+				if (value.startsWith('ST=')) state = value.slice(3);
+				break;
+			default:
+				break;
+		}
+	}
+	flush();
+
+	return sockets;
+}
+
+// ---------------------------------------------------------------------------
+// ss — Linux primary
+// ---------------------------------------------------------------------------
+
+const SS_ARGV = posixArgv(['ss', '-tuna', '-p']);
+
+/** `users:(("nginx",pid=800,fd=6),("nginx",pid=801,fd=6))` → first pid + name. */
+function parseSsProcess(field: string | undefined): { pid: number | null; name: string | null } {
+	if (!field) return { pid: null, name: null };
+	const match = field.match(/\("([^"]+)",pid=(\d+)/);
+	if (!match) return { pid: null, name: null };
+	return { name: match[1], pid: Number.parseInt(match[2], 10) || null };
+}
+
+export function parseSs(stdout: string): PortSocket[] {
+	const sockets: PortSocket[] = [];
+
+	for (const rawLine of stdout.split('\n')) {
+		const line = rawLine.trim();
+		if (!line) continue;
+		// Older iproute2 has no -H, so the header is skipped by content.
+		if (line.startsWith('Netid') || line.startsWith('State')) continue;
+
+		const columns = line.split(/\s+/);
+		if (columns.length < 5) continue;
+
+		const netid = columns[0].toLowerCase();
+		if (netid !== 'tcp' && netid !== 'udp') continue;
+		const protocol: PortProtocol = netid === 'udp' ? 'udp' : 'tcp';
+
+		const local = splitAddressPort(columns[4]);
+		if (!local) continue;
+		const peer = columns.length > 5 ? splitAddressPort(columns[5]) : null;
+		const owner = parseSsProcess(columns.find((column) => column.startsWith('users:(')));
+
+		sockets.push(
+			makeSocket({
+				protocol,
+				local,
+				peer,
+				state: columns[1],
+				pid: owner.pid,
+				processName: owner.name,
+				user: null
+			})
+		);
+	}
+
+	return sockets;
+}
+
+// ---------------------------------------------------------------------------
+// netstat — Linux fallback and Windows primary
+// ---------------------------------------------------------------------------
+
+const NETSTAT_UNIX_ARGV = posixArgv(['netstat', '-tunap']);
+const NETSTAT_WINDOWS_ARGV = ['netstat', '-ano'];
+
+/** `800/sshd` → pid and name; a bare `-` means the kernel withheld the owner. */
+function parseNetstatProcess(field: string | undefined): { pid: number | null; name: string | null } {
+	if (!field || field === '-') return { pid: null, name: null };
+	const [pidText, ...rest] = field.split('/');
+	const pid = Number.parseInt(pidText, 10);
+	return {
+		pid: Number.isFinite(pid) ? pid : null,
+		name: rest.length ? rest.join('/').split(' ')[0] || null : null
+	};
+}
+
+export function parseNetstatUnix(stdout: string): PortSocket[] {
+	const sockets: PortSocket[] = [];
+
+	for (const rawLine of stdout.split('\n')) {
+		const line = rawLine.trim();
+		if (!line) continue;
+
+		const columns = line.split(/\s+/);
+		const proto = columns[0]?.toLowerCase() ?? '';
+		if (!proto.startsWith('tcp') && !proto.startsWith('udp')) continue;
+		const protocol: PortProtocol = proto.startsWith('udp') ? 'udp' : 'tcp';
+		// `tcp6`/`udp6` name the family directly, which beats guessing from the
+		// address — a wildcard bind looks identical in both families.
+		const ipVersion: PortIpVersion = proto.endsWith('6') ? 'v6' : 'v4';
+
+		const local = splitAddressPort(columns[3]);
+		if (!local) continue;
+		const peer = splitAddressPort(columns[4] ?? '');
+		// UDP rows have no state column, so the owner shifts one place left.
+		const state = protocol === 'tcp' ? (columns[5] ?? null) : null;
+		const owner = parseNetstatProcess(protocol === 'tcp' ? columns[6] : columns[5]);
+
+		sockets.push({
+			...makeSocket({
+				protocol,
+				local,
+				peer,
+				state,
+				pid: owner.pid,
+				processName: owner.name,
+				user: null,
+				ipVersion
+			})
+		});
+	}
+
+	return sockets;
+}
+
+export function parseNetstatWindows(stdout: string): PortSocket[] {
+	const sockets: PortSocket[] = [];
+
+	for (const rawLine of stdout.split('\n')) {
+		const line = rawLine.trim();
+		if (!line) continue;
+
+		const columns = line.split(/\s+/);
+		const proto = columns[0]?.toUpperCase() ?? '';
+		if (proto !== 'TCP' && proto !== 'UDP') continue;
+		const protocol: PortProtocol = proto === 'UDP' ? 'udp' : 'tcp';
+
+		const local = splitAddressPort(columns[1]);
+		if (!local) continue;
+		const peer = splitAddressPort(columns[2] ?? '');
+		// TCP: proto local peer state pid. UDP: proto local peer pid.
+		const state = protocol === 'tcp' ? (columns[3] ?? null) : null;
+		const pidText = protocol === 'tcp' ? columns[4] : columns[3];
+		const pid = Number.parseInt(pidText ?? '', 10);
+
+		sockets.push(
+			makeSocket({
+				protocol,
+				local,
+				peer,
+				state,
+				pid: Number.isFinite(pid) && pid > 0 ? pid : null,
+				// netstat never names the process; processes.ts fills this in.
+				processName: null,
+				user: null
+			})
+		);
+	}
+
+	return sockets;
+}
+
+// ---------------------------------------------------------------------------
+// /proc/net — the Linux probe that needs nothing installed
+// ---------------------------------------------------------------------------
+
+/**
+ * Every file the kernel publishes its socket tables in. `grep ''` over all four
+ * prints each line prefixed with the file it came from, so one command returns
+ * every family and protocol already labelled — and files that do not exist are
+ * simply absent from the output.
+ */
+const PROC_NET_ARGV = posixArgv([
+	'grep',
+	'',
+	'/proc/net/tcp',
+	'/proc/net/tcp6',
+	'/proc/net/udp',
+	'/proc/net/udp6'
+]);
+
+/**
+ * Sockets held open by processes we can see, as `inode → pid`.
+ *
+ * This is the one place a shell is used, because matching `/proc/<pid>/fd`
+ * across every process needs a glob and there is no way to expand one without
+ * it. The command is a fixed string with nothing interpolated into it.
+ */
+const PROC_FD_ARGV = ['sh', '-c', 'ls -l /proc/[0-9]*/fd/ 2>/dev/null'];
+
+/** `0100007F` → `127.0.0.1`: four little-endian bytes in hex. */
+function hexToIpv4(hex: string): string {
+	const octets: number[] = [];
+	for (let index = 6; index >= 0; index -= 2) octets.push(Number.parseInt(hex.slice(index, index + 2), 16));
+	return octets.join('.');
+}
+
+/** 32 hex chars as four little-endian 32-bit words, rendered as IPv6. */
+function hexToIpv6(hex: string): string {
+	const groups: string[] = [];
+	for (let word = 0; word < 4; word++) {
+		const chunk = hex.slice(word * 8, word * 8 + 8);
+		// Each 32-bit word is byte-swapped, giving two IPv6 groups once undone.
+		const swapped = chunk.slice(6, 8) + chunk.slice(4, 6) + chunk.slice(2, 4) + chunk.slice(0, 2);
+		groups.push(swapped.slice(0, 4), swapped.slice(4, 8));
+	}
+
+	// The v4-mapped form reads as the address people actually recognise.
+	if (groups.slice(0, 5).every((group) => group === '0000') && groups[5].toLowerCase() === 'ffff') {
+		const high = Number.parseInt(groups[6], 16);
+		const low = Number.parseInt(groups[7], 16);
+		return `${high >> 8}.${high & 255}.${low >> 8}.${low & 255}`;
+	}
+
+	return compressIpv6(groups.map((group) => group.replace(/^0+/, '') || '0'));
+}
+
+/**
+ * Collapse the longest run of zero groups into `::`, as IPv6 is written.
+ * Done by finding the run rather than by rewriting the string: a regex that
+ * chews through colons turns the all-zero address into a single `:`.
+ */
+function compressIpv6(groups: string[]): string {
+	let bestStart = -1;
+	let bestLength = 0;
+	let runStart = -1;
+
+	for (let index = 0; index <= groups.length; index++) {
+		if (index < groups.length && groups[index] === '0') {
+			if (runStart === -1) runStart = index;
+			continue;
+		}
+		if (runStart !== -1) {
+			const length = index - runStart;
+			// A single zero group is written out; `::` is only for a run.
+			if (length > bestLength && length > 1) {
+				bestStart = runStart;
+				bestLength = length;
+			}
+			runStart = -1;
+		}
+	}
+
+	if (bestStart === -1) return groups.join(':');
+
+	const head = groups.slice(0, bestStart).join(':');
+	const tail = groups.slice(bestStart + bestLength).join(':');
+	return `${head}::${tail}`;
+}
+
+/** TCP states as `/proc/net/tcp` numbers them. */
+const PROC_STATE_LISTEN = '0A';
+const PROC_STATE_ESTABLISHED = '01';
+
+interface ProcNetSocket {
+	socket: PortSocket;
+	inode: number;
+}
+
+export function parseProcNet(stdout: string): ProcNetSocket[] {
+	const results: ProcNetSocket[] = [];
+
+	for (const rawLine of stdout.split('\n')) {
+		const line = rawLine.trim();
+		if (!line) continue;
+
+		const labelled = line.match(/^\/proc\/net\/(tcp6?|udp6?):(.*)$/);
+		if (!labelled) continue;
+
+		const source = labelled[1];
+		const protocol: PortProtocol = source.startsWith('udp') ? 'udp' : 'tcp';
+		const ipVersion: PortIpVersion = source.endsWith('6') ? 'v6' : 'v4';
+
+		const columns = labelled[2].trim().split(/\s+/);
+		// sl, local, remote, state, queues, timers, retrans, uid, timeout, inode
+		if (columns.length < 10 || !columns[0].endsWith(':')) continue;
+
+		const [localHex, localPortHex] = (columns[1] ?? '').split(':');
+		const [peerHex, peerPortHex] = (columns[2] ?? '').split(':');
+		if (!localHex || !localPortHex) continue;
+
+		const port = Number.parseInt(localPortHex, 16);
+		if (!Number.isFinite(port)) continue;
+
+		const state = (columns[3] ?? '').toUpperCase();
+		const peerPort = Number.parseInt(peerPortHex ?? '', 16);
+		const hasPeer = Number.isFinite(peerPort) && peerPort > 0;
+
+		const toAddress = (hex: string): string =>
+			ipVersion === 'v6' ? hexToIpv6(hex) : hexToIpv4(hex);
+
+		results.push({
+			inode: Number.parseInt(columns[9], 10) || 0,
+			socket: makeSocket({
+				protocol,
+				local: { address: toAddress(localHex), port },
+				peer: hasPeer ? { address: toAddress(peerHex), port: peerPort } : null,
+				state:
+					state === PROC_STATE_LISTEN
+						? 'LISTEN'
+						: state === PROC_STATE_ESTABLISHED
+							? 'ESTABLISHED'
+							: state,
+				pid: null,
+				processName: null,
+				user: null,
+				ipVersion
+			})
+		});
+	}
+
+	return results;
+}
+
+/** `ls -l /proc/<pid>/fd/` output → which process holds which socket inode. */
+export function parseProcFdInodes(stdout: string): Map<number, number> {
+	const owners = new Map<number, number>();
+	let pid: number | null = null;
+
+	for (const line of stdout.split('\n')) {
+		const header = line.match(/^\/proc\/(\d+)\/fd\/?:$/);
+		if (header) {
+			pid = Number.parseInt(header[1], 10);
+			continue;
+		}
+		if (pid === null) continue;
+
+		const socket = line.match(/socket:\[(\d+)\]/);
+		if (!socket) continue;
+		const inode = Number.parseInt(socket[1], 10);
+		// First writer wins: a forked child inherits the same inode, and the
+		// listing walks pids in ascending order, so that is the parent.
+		if (Number.isFinite(inode) && !owners.has(inode)) owners.set(inode, pid);
+	}
+
+	return owners;
+}
+
+// ---------------------------------------------------------------------------
+// Probe selection
+// ---------------------------------------------------------------------------
+
+const PIDS_NEED_ROOT: PortLimitation = {
+	code: 'pids-need-root',
+	message:
+		'Some sockets are owned by other users. The kernel only names the owning process for your own, so those rows have no owner.'
+};
+
+function ranWithoutOwners(sockets: PortSocket[]): boolean {
+	if (sockets.length === 0) return false;
+	return sockets.some((socket) => socket.pid === null);
+}
+
+/**
+ * Read the socket table with whichever probe this host can actually run.
+ *
+ * The chain matters on locked-down hosts. Shared hosting and container images
+ * routinely ship without `ss`, without `netstat`, or with both present but
+ * outside the PATH a non-interactive SSH session is given — and some strip
+ * `lsof` too. The kernel's own `/proc/net` tables need nothing installed at
+ * all, so a Linux host can always be read even when every tool is missing;
+ * only the owning process needs a second lookup there.
+ */
+export async function scanSockets(
+	runner: CommandRunner,
+	platform: ProbePlatform,
+	/** Remembers which probe worked, so the chain is walked once per host. */
+	memo: ProbeMemo = {}
+): Promise<SocketScan> {
+	const limitations: PortLimitation[] = [];
+	const tried: string[] = [];
+	let probe = 'none';
+	let lastArgv: string[] = [];
+	let lastParse: (stdout: string) => PortSocket[] = parseLsof;
+
+	const attempt = async (
+		argv: string[],
+		parse: (stdout: string) => PortSocket[]
+	): Promise<PortSocket[] | null> => {
+		const name = argv.find((part) => !part.includes('=') && part !== 'env') ?? argv[0];
+		tried.push(name);
+		probe = name;
+		lastArgv = argv;
+		lastParse = parse;
+		try {
+			const result = await runner.run(argv);
+			// `ss` and `netstat` exit non-zero on a missing binary but also when
+			// they merely could not resolve some rows, so output wins over status.
+			const sockets = parse(result.stdout);
+			if (sockets.length > 0) return sockets;
+			if (result.code === 0) return sockets;
+			return null;
+		} catch (error) {
+			debug.log('ports', `probe ${argv[0]} failed on ${runner.label}:`, error);
+			return null;
+		}
+	};
+
+	/** The kernel's own tables, plus a best-effort owner for each socket. */
+	const attemptProcNet = async (): Promise<PortSocket[] | null> => {
+		tried.push('/proc/net');
+		probe = '/proc/net';
+		try {
+			const result = await runner.run(PROC_NET_ARGV);
+			const rows = parseProcNet(result.stdout);
+			if (rows.length === 0) return null;
+
+			let owners = new Map<number, number>();
+			try {
+				const fds = await runner.run(PROC_FD_ARGV);
+				owners = parseProcFdInodes(fds.stdout);
+			} catch (error) {
+				// Ports without an owner still answer "what is in use", which is
+				// the question that brought the user here.
+				debug.log('ports', `/proc fd scan failed on ${runner.label}:`, error);
+			}
+
+			return rows.map(({ socket, inode }) => ({ ...socket, pid: owners.get(inode) ?? null }));
+		} catch (error) {
+			debug.log('ports', `/proc/net read failed on ${runner.label}:`, error);
+			return null;
+		}
+	};
+
+	const noteFallback = (message: string): void => {
+		limitations.push({ code: 'probe-fallback', message });
+	};
+
+	let sockets: PortSocket[] | null = null;
+
+	// A host that has already answered is asked the same way again. Walking the
+	// whole chain every tick means four failed commands a second on a host that
+	// has none of the tools — which on an SSH connection is four channels spent
+	// re-learning something that cannot change.
+	if (memo.probe) {
+		sockets = memo.probe === '/proc/net' ? await attemptProcNet() : await attempt(memo.argv ?? [], memo.parse ?? parseLsof);
+		if (sockets) {
+			for (const limitation of memo.limitations ?? []) limitations.push(limitation);
+			if (platform !== 'win32' && ranWithoutOwners(sockets)) limitations.push(PIDS_NEED_ROOT);
+			return { sockets, limitations, probe: memo.probe };
+		}
+		// The tool went away, or the host changed under us. Fall through and
+		// re-derive rather than reporting an empty table.
+		memo.probe = undefined;
+	}
+
+	if (platform === 'win32') {
+		sockets = await attempt(NETSTAT_WINDOWS_ARGV, parseNetstatWindows);
+	} else if (platform === 'darwin') {
+		sockets = await attempt(LSOF_ARGV, parseLsof);
+		if (!sockets) {
+			sockets = await attempt(NETSTAT_UNIX_ARGV, parseNetstatUnix);
+			if (sockets) noteFallback('`lsof` is unavailable here, so `netstat` was used instead.');
+		}
+	} else {
+		sockets = await attempt(SS_ARGV, parseSs);
+
+		if (!sockets) {
+			sockets = await attempt(NETSTAT_UNIX_ARGV, parseNetstatUnix);
+			if (sockets) noteFallback('`ss` is unavailable here, so `netstat` was used instead.');
+		}
+		if (!sockets) {
+			sockets = await attempt(LSOF_ARGV, parseLsof);
+			if (sockets) noteFallback('Neither `ss` nor `netstat` is available here, so `lsof` was used instead.');
+		}
+		if (!sockets) {
+			sockets = await attemptProcNet();
+			if (sockets) {
+				noteFallback(
+					'No port tool is installed here, so the kernel’s own /proc/net tables were read directly. Process names are unavailable that way.'
+				);
+			}
+		}
+	}
+
+	if (!sockets) {
+		throw new Error(
+			platform === 'unknown'
+				? `Could not tell what operating system ${runner.label} runs, so no port probe could be chosen.`
+				: `Could not read the port table on ${runner.label}. Tried: ${tried.join(', ')}.`
+		);
+	}
+
+	memo.probe = probe;
+	memo.argv = lastArgv;
+	memo.parse = lastParse;
+	// Kept so a remembered probe still reports the same caveats it earned.
+	memo.limitations = [...limitations];
+
+	if (platform !== 'win32' && ranWithoutOwners(sockets)) limitations.push(PIDS_NEED_ROOT);
+
+	return { sockets, limitations, probe };
+}

--- a/backend/ports/ssh-lineage.ts
+++ b/backend/ports/ssh-lineage.ts
@@ -1,0 +1,318 @@
+/**
+ * Port manager — recognising Clopen's own work on an SSH host.
+ *
+ * On the machine Clopen runs on, a port is traced to Clopen by walking parent
+ * pids up to a Clopen process. A remote host needs the same fact established
+ * from the other end: PtyKit addresses remote shells through an internal id,
+ * and ssh2 never learns what the far side numbered anything.
+ *
+ * The answer is in the environment, not the process tree. sshd sets
+ * `SSH_CONNECTION` for every session it opens, holding the client address and
+ * source port of the TCP connection behind it. Every channel Clopen opens —
+ * shells, SFTP, forwards, the probes in this file — rides one connection, so
+ * they all carry the same value, and every process started from any of them
+ * inherits it. Reading it back off a listening process therefore says whether
+ * Clopen started it, with no privileges and no guesswork.
+ *
+ * Two earlier attempts are worth not repeating:
+ *
+ * - Matching `SSH_CONNECTION` against the host's *socket table* to find the
+ *   sshd holding the connection. That socket belongs to root's sshd, so an
+ *   unprivileged account never sees its pid.
+ * - Walking up from a probe's `$PPID` to the outermost process calling itself
+ *   `sshd:`. That depends on how a host labels its sshd processes and on where
+ *   the daemon sits in the tree, and it found nothing on a real cPanel host.
+ *
+ * Both tried to identify a process Clopen has no right to see. Asking what
+ * connection a process belongs to sidesteps that entirely.
+ *
+ * macOS is the exception, and only because it cannot answer the question:
+ * `ps -E` returns no environment there at all under SIP, verified rather than
+ * assumed. A macOS host therefore falls back to the process-tree walk, which
+ * is sound there — its sshd labels sessions the same way. This mirrors how the
+ * port probes already differ per platform: one question, asked the way each
+ * operating system will answer it.
+ */
+
+import type { PortProcess } from '$shared/types/ports';
+import { posixArgv, type CommandRunner, type ProbePlatform } from './runner';
+import { parsePsOutput } from './processes';
+import { debug } from '$shared/utils/logger';
+
+/** `SSH_CONNECTION` is `<client ip> <client port> <server ip> <server port>`. */
+export function parseSshConnection(value: string): { address: string; port: number } | null {
+	const parts = value.trim().split(/\s+/);
+	if (parts.length < 2) return null;
+	const port = Number.parseInt(parts[1], 10);
+	if (!Number.isFinite(port) || port <= 0) return null;
+	return { address: parts[0], port };
+}
+
+/**
+ * Two `SSH_CONNECTION` values describing the same connection.
+ *
+ * The source port carries the match: it is unique per connection for as long
+ * as that connection is open. The address is compared only as a guard against
+ * a port number colliding across interfaces.
+ */
+export function sameConnection(a: string, b: string): boolean {
+	const left = parseSshConnection(a);
+	const right = parseSshConnection(b);
+	if (!left || !right) return false;
+	return left.port === right.port && left.address === right.address;
+}
+
+/** Pids are interpolated into a shell script, so they must be exactly numbers. */
+function safePids(pids: number[]): number[] {
+	return pids.filter((pid) => Number.isInteger(pid) && pid > 0 && pid < 4_294_967_296);
+}
+
+/**
+ * Read `SSH_CONNECTION` out of each process's environment.
+ *
+ * On Linux that is `/proc/<pid>/environ`, a NUL-separated blob readable for
+ * one's own processes — which is exactly the set that could have come from
+ * Clopen. macOS exposes the same thing through `ps -E`. Neither needs any
+ * privilege beyond owning the process.
+ */
+function environProbeArgv(pids: number[]): string[] | null {
+	if (pids.length === 0) return null;
+	const list = pids.join(' ');
+
+	// A fixed script; only vetted integers are interpolated into it.
+	return posixArgv([
+		'sh',
+		'-c',
+		// `cat` rather than a `<` redirect: a redirect that fails is reported by
+		// the shell itself, before `2>/dev/null` on that command can apply.
+		`for p in ${list}; do printf '@%s ' "$p"; cat /proc/$p/environ 2>/dev/null | ` +
+			`tr '\\0' '\\n' | grep '^SSH_CONNECTION=' || printf '\\n'; done`
+	]);
+}
+
+/** `@42802 SSH_CONNECTION=1.2.3.4 55 5.6.7.8 22` → pid and value. */
+export function parseEnvironProbe(stdout: string): Map<number, string> {
+	const found = new Map<number, string>();
+
+	for (const line of stdout.split('\n')) {
+		const marked = line.match(/^@(\d+)\s*(.*)$/);
+		if (!marked) continue;
+		const pid = Number.parseInt(marked[1], 10);
+		const value = marked[2].replace(/^.*?SSH_CONNECTION=/, '');
+		if (Number.isFinite(pid) && value && marked[2].includes('SSH_CONNECTION=')) {
+			found.set(pid, value.trim());
+		}
+	}
+
+	return found;
+}
+
+/**
+ * A per-connection sshd, which announces itself as `sshd: user@ttys000`,
+ * `sshd: user@pts/0` or `sshd: user [priv]`. The listening daemon
+ * (`/usr/sbin/sshd -D`) deliberately does not match: it parents every session
+ * on the host, so treating it as the root would hand Clopen credit for every
+ * other user's processes.
+ */
+function isSessionSshd(process: PortProcess | null): boolean {
+	return process ? /(^|\s)sshd:\s/.test(process.command) : false;
+}
+
+/**
+ * From the sshd serving one channel, the sshd serving the whole connection.
+ *
+ * sshd forks a child per channel, so the chain from a command runs shell →
+ * channel sshd → connection sshd → listening daemon. The outermost link still
+ * calling itself `sshd:` is the one every channel shares, which makes it the
+ * root of everything Clopen does on that host.
+ */
+export function findConnectionSshd(
+	execParentPid: number,
+	processes: Map<number, PortProcess>
+): number | null {
+	let best: number | null = null;
+	let current: number | null = execParentPid;
+	const seen = new Set<number>();
+
+	for (let depth = 0; depth < 20 && current !== null && current > 1; depth++) {
+		if (seen.has(current)) break;
+		seen.add(current);
+
+		const process = processes.get(current);
+		if (!process || !isSessionSshd(process)) break;
+
+		best = current;
+		current = process.parentPid;
+	}
+
+	return best;
+}
+
+/**
+ * The pid and the process list must come from the *same* command: sshd reaps
+ * the exec channel's child the moment the command exits, so a pid read by one
+ * exec is already gone before a second could run `ps` against it.
+ */
+async function probeTreeRoot(runner: CommandRunner): Promise<number | null> {
+	try {
+		const result = await runner.run(
+			posixArgv(['sh', '-c', 'echo "$PPID"; ps -eo pid=,ppid=,user=,lstart=,args=']),
+			10_000
+		);
+
+		const newline = result.stdout.indexOf('\n');
+		if (newline === -1) return null;
+
+		const execParentPid = Number.parseInt(result.stdout.slice(0, newline).trim(), 10);
+		if (!Number.isFinite(execParentPid) || execParentPid <= 1) return null;
+
+		const processes = new Map<number, PortProcess>();
+		for (const entry of parsePsOutput(result.stdout.slice(newline + 1))) processes.set(entry.pid, entry);
+
+		return findConnectionSshd(execParentPid, processes);
+	} catch (error) {
+		debug.log('ports', `SSH tree probe failed on ${runner.label}:`, error);
+		return null;
+	}
+}
+
+/**
+ * What connection Clopen's own commands run on. Cached per host: it cannot
+ * change while the pooled transport lives, and re-asking would spend a round
+ * trip per tick on a constant.
+ */
+const ownConnections = new Map<string, string>();
+
+async function readOwnConnection(
+	hostId: string,
+	runner: CommandRunner,
+	platform: ProbePlatform
+): Promise<string | null> {
+	const cached = ownConnections.get(hostId);
+	if (cached) return cached;
+	if (platform === 'win32') return null;
+
+	try {
+		const result = await runner.run(posixArgv(['sh', '-c', 'printf %s "$SSH_CONNECTION"']), 5_000);
+		const value = result.stdout.trim();
+		// Judged on output, not exit status: a restricted shell can report a
+		// non-zero status and still have answered the question.
+		if (!parseSshConnection(value)) return null;
+		ownConnections.set(hostId, value);
+		return value;
+	} catch (error) {
+		debug.log('ports', `could not read SSH_CONNECTION on ${runner.label}:`, error);
+		return null;
+	}
+}
+
+/**
+ * Which of these listening processes belong to Clopen's own SSH connection.
+ *
+ * Answers per pid rather than by finding one root process, so a server that
+ * was disowned or reparented is still recognised — the environment survives
+ * what the process tree does not.
+ */
+/**
+ * What has already been decided about a process, keyed by pid *and* start time
+ * so a recycled pid is judged afresh. A live process's environment does not
+ * change, so re-reading it every tick would be a round trip spent confirming a
+ * constant.
+ */
+const verdicts = new Map<string, Map<string, boolean>>();
+
+function verdictKey(pid: number, processes: Map<number, PortProcess>): string {
+	return `${pid}:${processes.get(pid)?.startedAt ?? ''}`;
+}
+
+export async function resolveClopenPids(
+	hostId: string,
+	runner: CommandRunner,
+	platform: ProbePlatform,
+	pids: number[],
+	processes: Map<number, PortProcess>
+): Promise<Set<number>> {
+	const ours = new Set<number>();
+	if (platform === 'win32') return ours;
+
+	// macOS will not report a process's environment, so its connection has to
+	// be identified through the process tree instead. Adding the session sshd
+	// is enough: the ancestry walk downstream reaches it from every descendant.
+	if (platform === 'darwin') {
+		const root = await resolveTreeRoot(hostId, runner);
+		if (root !== null) ours.add(root);
+		return ours;
+	}
+
+	const own = await readOwnConnection(hostId, runner, platform);
+	if (!own) return ours;
+
+	// Ancestors count too: a process that cleared its own environment is still
+	// ours if the shell that spawned it is.
+	const candidates = new Set<number>();
+	for (const pid of pids) {
+		let current: number | null = pid;
+		const seen = new Set<number>();
+		for (let depth = 0; depth < 20 && current !== null && current > 1; depth++) {
+			if (seen.has(current)) break;
+			seen.add(current);
+			candidates.add(current);
+			current = processes.get(current)?.parentPid ?? null;
+		}
+	}
+
+	let known = verdicts.get(hostId);
+	if (!known) {
+		known = new Map();
+		verdicts.set(hostId, known);
+	}
+
+	// Only ask about processes never judged before; the rest are already settled.
+	const unknown: number[] = [];
+	for (const pid of candidates) {
+		const decided = known.get(verdictKey(pid, processes));
+		if (decided === undefined) unknown.push(pid);
+		else if (decided) ours.add(pid);
+	}
+
+	const argv = environProbeArgv(safePids(unknown));
+	if (!argv) return ours;
+
+	try {
+		const result = await runner.run(argv, 10_000);
+		const values = parseEnvironProbe(result.stdout);
+
+		for (const pid of unknown) {
+			const value = values.get(pid);
+			// A process whose environment could not be read is recorded as not
+			// ours, so it is not asked about again — unreadable will not become
+			// readable while it lives.
+			const mine = value !== undefined && sameConnection(value, own);
+			known.set(verdictKey(pid, processes), mine);
+			if (mine) ours.add(pid);
+		}
+	} catch (error) {
+		debug.log('ports', `environment probe failed on ${runner.label}:`, error);
+	}
+
+	return ours;
+}
+
+/** Resolved once per host; a failure is not cached, so a later tick retries. */
+const treeRoots = new Map<string, number>();
+
+async function resolveTreeRoot(hostId: string, runner: CommandRunner): Promise<number | null> {
+	const cached = treeRoots.get(hostId);
+	if (cached !== undefined) return cached;
+
+	const root = await probeTreeRoot(runner);
+	if (root !== null) treeRoots.set(hostId, root);
+	return root;
+}
+
+/** Drop a host's cached connection identity when its transport goes away. */
+export function forgetClopenRootPid(hostId: string): void {
+	ownConnections.delete(hostId);
+	treeRoots.delete(hostId);
+	verdicts.delete(hostId);
+}

--- a/backend/ssh/forwards.ts
+++ b/backend/ssh/forwards.ts
@@ -74,6 +74,37 @@ class SshForwardManager {
 		};
 	}
 
+	/**
+	 * Forwards holding a listener on the machine Clopen runs on, for the port
+	 * manager. `server` is the local `net.Server`, so its presence is what makes
+	 * a forward local — remote forwards bind on the far host and are reported by
+	 * `remoteListeners` instead.
+	 */
+	localListeners(): Array<{ forward: SshForward; boundPort: number }> {
+		const listeners: Array<{ forward: SshForward; boundPort: number }> = [];
+		for (const active of this.running.values()) {
+			if (!active.server) continue;
+			listeners.push({ forward: active.forward, boundPort: active.boundPort });
+		}
+		return listeners;
+	}
+
+	/**
+	 * Forwards holding a listener on a given SSH host. A remote forward asks the
+	 * host's sshd to bind a port on Clopen's behalf, so that port is every bit as
+	 * much Clopen's doing as a local one — the port manager names it the same way
+	 * when looking at that host.
+	 */
+	remoteListeners(connectionId: string): Array<{ forward: SshForward; boundPort: number }> {
+		const listeners: Array<{ forward: SshForward; boundPort: number }> = [];
+		for (const active of this.running.values()) {
+			if (active.server) continue;
+			if (active.forward.connectionId !== connectionId) continue;
+			listeners.push({ forward: active.forward, boundPort: active.boundPort });
+		}
+		return listeners;
+	}
+
 	statusesForConnection(connectionId: string): SshForwardStatus[] {
 		return sshPortForwardQueries.listForConnection(connectionId).map((forward) => this.status(forward));
 	}

--- a/backend/ws/index.ts
+++ b/backend/ws/index.ts
@@ -32,6 +32,7 @@ import { engineRouter } from './engine';
 import { stackRouter } from './stack';
 import { dbClientRouter } from './db-client';
 import { sshRouter } from './ssh';
+import { portsRouter } from './ports';
 import { mcpRouter } from './mcp';
 import { skillsRouter } from './skills';
 import { commandsRouter } from './commands';
@@ -87,6 +88,7 @@ export const wsRouter = createRouter()
 
 	// SSH client (terminal, SFTP, port forwarding)
 	.merge(sshRouter)
+	.merge(portsRouter)
 
 	// External MCP server management (install from the official registry)
 	.merge(mcpRouter)

--- a/backend/ws/ports/index.ts
+++ b/backend/ws/ports/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Port manager WebSocket router.
+ *
+ * Reading the table is open to any signed-in user; `ports:kill` is registered
+ * in ADMIN_ONLY_ROUTES and gated there.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { portsListHandler } from './list';
+import { portsKillHandler } from './kill';
+
+export const portsRouter = createRouter()
+	.merge(portsListHandler)
+	.merge(portsKillHandler)
+	// Pushed only when a watched host's table actually changed.
+	.emit('ports:changed', t.Object({ result: t.Any() }))
+	// The sidebar count: ports born in a Clopen terminal session.
+	.emit('ports:badge', t.Object({ count: t.Number() }));

--- a/backend/ws/ports/kill.ts
+++ b/backend/ws/ports/kill.ts
@@ -1,0 +1,80 @@
+/**
+ * Port manager — stopping a process, admin only.
+ *
+ * The route is listed in ADMIN_ONLY_ROUTES; this handler re-scans before
+ * acting rather than trusting the pid the client sent. A table is up to a
+ * second old, and a second is long enough for a pid to be recycled onto an
+ * unrelated process — signalling that would be indefensible.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { LOCAL_PORT_HOST } from '$shared/types/ports';
+import { portMonitor } from '../../ports/monitor';
+import { stopPortHolder } from '../../ports/kill';
+import { sshConnectionQueries } from '../../database/queries';
+import { ws } from '../../utils/ws';
+import { debug } from '$shared/utils/logger';
+
+export const portsKillHandler = createRouter().http(
+	'ports:kill',
+	{
+		data: t.Object({
+			hostId: t.String({ minLength: 1 }),
+			/** Identifies the row the user clicked, so the re-scan can match it. */
+			entryKey: t.String({ minLength: 1 })
+		}),
+		response: t.Any()
+	},
+	async ({ data, conn }) => {
+		const userId = ws.getUserId(conn);
+		if (data.hostId !== LOCAL_PORT_HOST) {
+			// The route is admin-only, but the host check still runs on the real
+			// role rather than a hardcoded one — a gate that trusts its caller is
+			// no gate at all.
+			sshConnectionQueries.ensureAccess(data.hostId, userId, ws.getRole(conn) === 'admin');
+		}
+
+		const fresh = await portMonitor.scanOnce(data.hostId);
+		const entry = fresh.entries.find((candidate) => candidate.key === data.entryKey);
+		if (!entry) {
+			return {
+				result: {
+					ok: true,
+					killedPids: [],
+					stoppedFeature: null,
+					error: null
+				},
+				gone: true
+			};
+		}
+
+		if (!entry.canKill || entry.pid === null) {
+			return {
+				result: {
+					ok: false,
+					killedPids: [],
+					stoppedFeature: null,
+					error: 'That port cannot be stopped from here.'
+				},
+				gone: false
+			};
+		}
+
+		debug.log('ports', `stopping ${entry.protocol}/${entry.port} (pid ${entry.pid}) on ${data.hostId}`);
+
+		const result = await portMonitor.withHost(data.hostId, (runner, platform) =>
+			stopPortHolder(
+				{ pid: entry.pid as number, ownerFeature: entry.origin.ownerFeature, ownerId: entry.origin.ownerId },
+				runner,
+				platform
+			)
+		);
+
+		// Whatever happened, the table moved — push it now rather than at the
+		// next tick, so the row disappears as the button is released.
+		portMonitor.invalidate(data.hostId);
+
+		return { result, gone: false };
+	}
+);

--- a/backend/ws/ports/list.ts
+++ b/backend/ws/ports/list.ts
@@ -1,0 +1,60 @@
+/**
+ * Port manager — reading the table.
+ *
+ * Watching is per connection: a client asks for a host when it opens that tab
+ * and is pushed a fresh table whenever the host's ports actually change. The
+ * watch is torn down when the socket closes, so a browser tab that vanishes
+ * cannot leave a host being polled forever.
+ *
+ * Reading is open to any signed-in user; stopping a process is not, and lives
+ * in kill.ts.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { LOCAL_PORT_HOST } from '$shared/types/ports';
+import { portMonitor } from '../../ports/monitor';
+import { sshConnectionQueries } from '../../database/queries';
+import { ws } from '../../utils/ws';
+
+/**
+ * A member may only watch an SSH host they can already reach. The local
+ * machine is watchable by anyone signed in — it is the machine they are
+ * already using Clopen on.
+ */
+function requireHostAccess(conn: Parameters<typeof ws.getUserId>[0], hostId: string): void {
+	if (hostId === LOCAL_PORT_HOST) return;
+	const userId = ws.getUserId(conn);
+	const isAdmin = ws.getRole(conn) === 'admin';
+	sshConnectionQueries.ensureAccess(hostId, userId, isAdmin);
+}
+
+const hostSchema = t.Object({ hostId: t.String({ minLength: 1 }) });
+
+export const portsListHandler = createRouter()
+	.http('ports:watch', { data: hostSchema, response: t.Any() }, async ({ data, conn }) => {
+		requireHostAccess(conn, data.hostId);
+		const userId = ws.getUserId(conn);
+
+		const result = await portMonitor.watch(data.hostId, userId);
+		// The watch belongs to this socket; a reload must not leave it running.
+		ws.addCleanup(conn, () => portMonitor.unwatch(data.hostId, userId));
+		return { result };
+	})
+
+	.http('ports:unwatch', { data: hostSchema, response: t.Any() }, async ({ data, conn }) => {
+		portMonitor.unwatch(data.hostId, ws.getUserId(conn));
+		return { ok: true };
+	})
+
+	/**
+	 * The sidebar count, on demand.
+	 *
+	 * Pushes only carry changes, so a client that has just loaded — or just
+	 * reconnected — has no way to learn a count that has been steady. Asking for
+	 * it is how the badge survives a page refresh instead of reading zero until
+	 * something happens to move it.
+	 */
+	.http('ports:summary', { data: t.Object({}), response: t.Any() }, async () => ({
+		count: await portMonitor.refreshBadge()
+	}));

--- a/frontend/App.svelte
+++ b/frontend/App.svelte
@@ -18,6 +18,7 @@
 	import { globalStreamMonitor } from '$frontend/services/notification/global-stream-monitor';
 	import { tunnelStore } from '$frontend/stores/features/tunnel.svelte';
 	import { remoteAccessStore } from '$frontend/stores/features/remote-access.svelte';
+	import { portsStore } from '$frontend/stores/features/ports.svelte';
 	import { startUpdateChecker, stopUpdateChecker } from '$frontend/stores/ui/update.svelte';
 	import ws from '$frontend/utils/ws';
 	import { showNotificationWithActions } from '$frontend/stores/ui/notification.svelte';
@@ -55,6 +56,10 @@
 
 			// Keep the Remote Access share count in sync for the sidebar indicator
 			remoteAccessStore.initRealtimeListener();
+
+			// Keep the Ports count in sync. The server only scans when a terminal
+			// session is actually running, so an idle workspace costs nothing.
+			portsStore.initRealtimeListener();
 
 			// Nudge admins to set project access when a new member joins via an invite,
 			// so the "invite → join → grant access" flow doesn't dead-end.

--- a/frontend/components/ports/PortDetailLayer.svelte
+++ b/frontend/components/ports/PortDetailLayer.svelte
@@ -1,0 +1,67 @@
+<!--
+	Ports — how the details for a row appear.
+
+	Alongside the table on a wide screen, over it from below on a narrow one.
+	Both entry points render this rather than deciding for themselves, so a row
+	behaves the same wherever it was tapped.
+
+	`|global` on the transitions is what makes them run: a transition is local by
+	default and only plays when its own block is created, and these sit inside a
+	block an ancestor creates.
+-->
+<script lang="ts">
+	import { fade, fly } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
+	import PortDetail from './main/PortDetail.svelte';
+	import type { PortEntry } from '$shared/types/ports';
+
+	interface Props {
+		entry: PortEntry;
+		onClose: () => void;
+	}
+
+	const { entry, onClose }: Props = $props();
+
+	/** Space left above the sheet so the table behind it stays visible. */
+	const SHEET_TOP_GAP = 56;
+	/** The side panel's own width, so it slides exactly its own length. */
+	const PANEL_TRAVEL = 320;
+
+	let windowWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 1024);
+	let windowHeight = $state(typeof window !== 'undefined' ? window.innerHeight : 768);
+
+	const isMobile = $derived(windowWidth < 768);
+	/**
+	 * How far the sheet travels. Derived from the viewport rather than measured
+	 * after mount, so the first open slides the same distance as every one after.
+	 */
+	const sheetTravel = $derived(Math.max(240, Math.round(windowHeight * 0.85) - SHEET_TOP_GAP));
+</script>
+
+<svelte:window bind:innerWidth={windowWidth} bind:innerHeight={windowHeight} />
+
+{#if isMobile}
+	<button
+		type="button"
+		class="absolute inset-0 z-20 bg-black/40 border-none p-0 cursor-default"
+		transition:fade|global={{ duration: 200 }}
+		onclick={onClose}
+		aria-label="Close details"
+	></button>
+	<!-- Stops short of the top on purpose: the strip of table left showing is
+	     what says this is a layer over the list, not a page you navigated to. -->
+	<div
+		class="absolute inset-x-0 bottom-0 z-30 flex shadow-[0_-8px_30px_rgba(0,0,0,0.25)]"
+		style="top: {SHEET_TOP_GAP}px"
+		transition:fly|global={{ y: sheetTravel, duration: 280, easing: cubicOut, opacity: 1 }}
+	>
+		<PortDetail sheet {entry} {onClose} />
+	</div>
+{:else}
+	<div
+		class="shrink-0 flex w-80"
+		transition:fly|global={{ x: PANEL_TRAVEL, duration: 240, easing: cubicOut, opacity: 1 }}
+	>
+		<PortDetail {entry} {onClose} />
+	</div>
+{/if}

--- a/frontend/components/ports/PortKillDialog.svelte
+++ b/frontend/components/ports/PortKillDialog.svelte
@@ -1,0 +1,57 @@
+<!--
+	Ports — the confirmation before stopping a port, and what it reports back.
+
+	Lives in one place because both entry points need it to say exactly the same
+	things: what will actually happen, and the honest difference between
+	releasing a port through the feature that opened it and signalling a process
+	Clopen never started.
+-->
+<script lang="ts">
+	import Dialog from '$frontend/components/common/overlay/Dialog.svelte';
+	import { portsStore } from '$frontend/stores/features/ports.svelte';
+	import { showError, showSuccess } from '$frontend/stores/ui/notification.svelte';
+	import type { PortEntry } from '$shared/types/ports';
+	import { debug } from '$shared/utils/logger';
+
+	interface Props {
+		/** The row awaiting confirmation, cleared once the user decides. */
+		entry: PortEntry | null;
+	}
+
+	let { entry = $bindable() }: Props = $props();
+
+	const message = $derived(
+		entry
+			? entry.origin.ownerFeature
+				? `${entry.origin.label} will be shut down properly through the feature that opened it.`
+				: `Process ${entry.pid} (${entry.origin.label}) and anything it started will be asked to stop, then forced if it refuses.` +
+					(entry.origin.confidence === 'guess'
+						? ' Clopen did not start this process, so check the command before continuing.'
+						: '')
+			: ''
+	);
+
+	async function run(): Promise<void> {
+		const target = entry;
+		entry = null;
+		if (!target) return;
+
+		const outcome = await portsStore.kill(target);
+		if (outcome.ok) {
+			showSuccess('Port released', `Nothing is holding ${target.protocol}/${target.port} now.`);
+			return;
+		}
+		debug.warn('ports', `could not stop ${target.key}:`, outcome.error);
+		showError('Could not stop it', outcome.error ?? 'The host refused.');
+	}
+</script>
+
+<Dialog
+	isOpen={entry !== null}
+	onClose={() => (entry = null)}
+	type="warning"
+	title="Stop this port?"
+	{message}
+	confirmText="Stop it"
+	onConfirm={run}
+/>

--- a/frontend/components/ports/PortsModal.svelte
+++ b/frontend/components/ports/PortsModal.svelte
@@ -1,0 +1,115 @@
+<!--
+	Ports — what is listening on this machine, where it came from, how to stop it.
+
+	Scoped to the machine Clopen runs on. A saved SSH host's ports live in the
+	SSH Client, on the host they belong to, rather than behind a second host
+	picker here — one place per machine, no ambiguity about which is canonical.
+	The implementation underneath is shared: the same store, the same scan and
+	the same table serve both.
+-->
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import Modal from '$frontend/components/common/overlay/Modal.svelte';
+	import PortTable from './main/PortTable.svelte';
+	import PortDetailLayer from './PortDetailLayer.svelte';
+	import PortKillDialog from './PortKillDialog.svelte';
+	import { portsStore } from '$frontend/stores/features/ports.svelte';
+	import { authStore } from '$frontend/stores/features/auth.svelte';
+	import { LOCAL_PORT_HOST, type PortEntry } from '$shared/types/ports';
+
+	interface Props {
+		isOpen: boolean;
+		onClose: () => void;
+	}
+
+	let { isOpen = $bindable(), onClose }: Props = $props();
+
+	let pendingKill = $state<PortEntry | null>(null);
+
+	const result = $derived(portsStore.result);
+	const selected = $derived(portsStore.selected);
+	/** Reading is open to every member; stopping a process is not. */
+	const canKill = $derived(authStore.isAdmin);
+
+	$effect(() => {
+		if (!isOpen) return;
+		// `untrack` because starting a watch writes the store state it also reads
+		// — tracked, that is an effect that invalidates itself.
+		untrack(() => void portsStore.watch(LOCAL_PORT_HOST));
+		// Closing the panel must stop the polling behind it, not just hide it.
+		return () => {
+			void portsStore.unwatch(LOCAL_PORT_HOST);
+		};
+	});
+</script>
+
+<Modal
+	bind:isOpen
+	{onClose}
+	bare
+	mobileFullscreen
+	ariaLabelledBy="ports-title"
+	className="flex flex-col w-full max-w-4xl h-[85dvh] max-h-[900px] bg-slate-50 dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-2xl overflow-hidden shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)] dark:shadow-[0_25px_50px_-12px_rgba(0,0,0,0.5)]"
+>
+	{#snippet children()}
+		<header
+			class="flex items-center justify-between gap-3 px-4 py-2.5 shrink-0 border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900"
+		>
+			<div class="flex items-center gap-2.5 min-w-0">
+				<Icon name="lucide:cable" class="w-4 h-4 shrink-0 text-amber-600 dark:text-amber-400" />
+				<span id="ports-title" class="text-md font-bold text-slate-900 dark:text-slate-100">Ports</span>
+				<span class="hidden sm:block text-xs text-slate-500 dark:text-slate-500 truncate">
+					on this machine
+				</span>
+			</div>
+			<button
+				type="button"
+				class="flex items-center justify-center w-9 h-9 shrink-0 bg-transparent border-none rounded-lg text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10"
+				onclick={onClose}
+				aria-label="Close"
+			>
+				<Icon name="lucide:x" class="w-5 h-5" />
+			</button>
+		</header>
+
+		<div class="flex items-center gap-2 px-3 py-2 shrink-0 border-b border-slate-200 dark:border-slate-800">
+			<div
+				class="flex items-center gap-2 flex-1 min-w-0 px-2.5 h-8 rounded-lg bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800"
+			>
+				<Icon name="lucide:search" class="w-3.5 h-3.5 shrink-0 text-slate-400" />
+				<input
+					type="text"
+					class="flex-1 min-w-0 bg-transparent border-none outline-none text-xs text-slate-800 dark:text-slate-200 placeholder:text-slate-400"
+					placeholder="Search port, process, command, directory…"
+					bind:value={portsStore.search}
+				/>
+			</div>
+
+			{#if result}
+				<span
+					class="hidden sm:flex items-center gap-1.5 shrink-0 text-[11px] text-slate-400 dark:text-slate-600"
+					title="This table refreshes about once a second while the panel is open"
+				>
+					<span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
+					live
+				</span>
+			{/if}
+		</div>
+
+		{#if portsStore.isLoading && !result}
+			<div class="flex-1 flex items-center justify-center">
+				<Icon name="lucide:loader-circle" class="w-5 h-5 animate-spin text-slate-400" />
+			</div>
+		{:else}
+			<div class="flex flex-1 min-h-0 relative bg-slate-50 dark:bg-slate-950">
+				<PortTable {canKill} onKill={(entry) => (pendingKill = entry)} />
+				{#if selected}
+					<PortDetailLayer entry={selected} onClose={() => portsStore.select(null)} />
+				{/if}
+			</div>
+		{/if}
+	{/snippet}
+</Modal>
+
+<PortKillDialog bind:entry={pendingKill} />

--- a/frontend/components/ports/main/PortDetail.svelte
+++ b/frontend/components/ports/main/PortDetail.svelte
@@ -1,0 +1,167 @@
+<!--
+	Port manager — everything known about one port.
+
+	The table answers "what is this"; this answers "and how do you know". The
+	full command, the working directory, the process lineage and the peers that
+	are actually connected all live here, including the fields the host could
+	not supply — shown as unknown rather than quietly omitted.
+-->
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import type { PortEntry } from '$shared/types/ports';
+
+	interface Props {
+		entry: PortEntry;
+		onClose: () => void;
+		/** Rendered as a bottom sheet on small screens rather than a side panel. */
+		sheet?: boolean;
+	}
+
+	const { entry, onClose, sheet = false }: Props = $props();
+
+	const started = $derived(
+		entry.process?.startedAt ? new Date(entry.process.startedAt).toLocaleString() : null
+	);
+
+	const tier = $derived(
+		entry.origin.kind === 'clopen'
+			? 'Clopen opened this listener, so this is exact.'
+			: entry.origin.kind === 'session'
+				? 'Traced through the process tree — the lineage is certain.'
+				: 'Inferred from the command line. Clopen did not start this, so treat the label as a guess.'
+	);
+</script>
+
+<aside
+	class="flex flex-col w-full min-h-0 bg-white dark:bg-slate-900
+		{sheet
+		? 'rounded-t-2xl border-t border-slate-200 dark:border-slate-800'
+		: 'border-l border-slate-200 dark:border-slate-800'}"
+>
+	{#if sheet}
+		<div class="flex justify-center pt-2 pb-1 shrink-0">
+			<span class="w-9 h-1 rounded-full bg-slate-300 dark:bg-slate-700"></span>
+		</div>
+	{/if}
+
+	<header
+		class="flex items-center justify-between gap-2 px-4 py-3 border-b border-slate-200 dark:border-slate-800 shrink-0"
+	>
+		<div class="min-w-0">
+			<p class="m-0 font-mono text-sm font-semibold text-slate-900 dark:text-slate-100">
+				{entry.protocol}/{entry.port}
+			</p>
+			<p class="m-0 text-xs text-slate-500 dark:text-slate-500 truncate">{entry.origin.label}</p>
+		</div>
+		<button
+			type="button"
+			class="shrink-0 flex items-center justify-center w-7 h-7 rounded-md border-none bg-transparent text-slate-400 cursor-pointer hover:bg-violet-500/10"
+			onclick={onClose}
+			aria-label="Close details"
+		>
+			<Icon name="lucide:x" class="w-4 h-4" />
+		</button>
+	</header>
+
+	<div class="flex-1 min-h-0 overflow-y-auto p-4 flex flex-col gap-4">
+		<section class="flex flex-col gap-1">
+			<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+				How this was identified
+			</h4>
+			<p class="m-0 text-xs text-slate-600 dark:text-slate-400">{tier}</p>
+			{#if entry.origin.detail}
+				<p class="m-0 text-xs text-slate-500 dark:text-slate-500">{entry.origin.detail}</p>
+			{/if}
+		</section>
+
+		{#if entry.publicUrl}
+			<section class="flex flex-col gap-1 p-2.5 rounded-lg bg-amber-500/10">
+				<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-amber-700 dark:text-amber-400">
+					Reachable from the internet
+				</h4>
+				<!-- A tunnel dials this port, it does not own it — so this is stated
+				     as exposure, separate from whoever is listening. -->
+				<p class="m-0 text-xs text-amber-800 dark:text-amber-300 break-all">{entry.publicUrl}</p>
+			</section>
+		{/if}
+
+		<section class="flex flex-col gap-1.5">
+			<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-slate-500">Binding</h4>
+			<dl class="m-0 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+				<dt class="text-slate-500 dark:text-slate-500">Addresses</dt>
+				<dd class="m-0 font-mono text-slate-700 dark:text-slate-300 break-all">
+					{entry.addresses.join(', ')}
+				</dd>
+				<dt class="text-slate-500 dark:text-slate-500">IP</dt>
+				<dd class="m-0 text-slate-700 dark:text-slate-300">
+					{entry.ipVersions.map((version) => (version === 'v4' ? 'IPv4' : 'IPv6')).join(' + ')}
+				</dd>
+			</dl>
+		</section>
+
+		<section class="flex flex-col gap-1.5">
+			<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-slate-500">Process</h4>
+			{#if entry.pid === null}
+				<p class="m-0 text-xs text-slate-500 dark:text-slate-500">
+					This host did not name the owning process. On Linux the kernel only
+					reveals it for your own processes.
+				</p>
+			{:else}
+				<dl class="m-0 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+					<dt class="text-slate-500 dark:text-slate-500">PID</dt>
+					<dd class="m-0 font-mono text-slate-700 dark:text-slate-300">{entry.pid}</dd>
+
+					{#if entry.workerPids.length > 1}
+						<dt class="text-slate-500 dark:text-slate-500">Workers</dt>
+						<dd class="m-0 font-mono text-slate-700 dark:text-slate-300">
+							{entry.workerPids.length} sharing this port
+						</dd>
+					{/if}
+
+					<dt class="text-slate-500 dark:text-slate-500">User</dt>
+					<dd class="m-0 text-slate-700 dark:text-slate-300">
+						{entry.process?.user ?? 'unknown'}
+					</dd>
+
+					<dt class="text-slate-500 dark:text-slate-500">Started</dt>
+					<dd class="m-0 text-slate-700 dark:text-slate-300">{started ?? 'unknown'}</dd>
+
+					<dt class="text-slate-500 dark:text-slate-500">Directory</dt>
+					<dd class="m-0 font-mono text-slate-700 dark:text-slate-300 break-all">
+						{entry.process?.cwd ?? 'not available on this host'}
+					</dd>
+				</dl>
+
+				{#if entry.process?.command}
+					<p
+						class="m-0 mt-1 p-2 rounded-md bg-slate-100 dark:bg-slate-950 font-mono text-[11px] text-slate-600 dark:text-slate-400 break-all"
+					>
+						{entry.process.command}
+					</p>
+				{/if}
+			{/if}
+		</section>
+
+		<section class="flex flex-col gap-1.5">
+			<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+				Connected now ({entry.peerCount})
+			</h4>
+			{#if entry.peers.length === 0}
+				<p class="m-0 text-xs text-slate-500 dark:text-slate-500">Nothing is connected to this port.</p>
+			{:else}
+				<ul class="m-0 p-0 list-none flex flex-col gap-1">
+					{#each entry.peers.slice(0, 20) as peer, index (`${peer.address}:${peer.port}:${index}`)}
+						<li class="font-mono text-[11px] text-slate-600 dark:text-slate-400 break-all">
+							{peer.address}:{peer.port}
+						</li>
+					{/each}
+				</ul>
+				{#if entry.peers.length > 20}
+					<p class="m-0 text-[11px] text-slate-400 dark:text-slate-600">
+						and {entry.peers.length - 20} more
+					</p>
+				{/if}
+			{/if}
+		</section>
+	</div>
+</aside>

--- a/frontend/components/ports/main/PortRow.svelte
+++ b/frontend/components/ports/main/PortRow.svelte
@@ -1,0 +1,148 @@
+<!--
+	Port manager — one port.
+
+	The origin tier decides how much the row asserts. A port Clopen opened is
+	named outright; a guessed one shows its label beside the command it was
+	guessed from, so the user can overrule it at a glance.
+-->
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import type { PortEntry } from '$shared/types/ports';
+	import type { IconName } from '$shared/types/ui/icons';
+
+	interface Props {
+		entry: PortEntry;
+		selected: boolean;
+		killing: boolean;
+		canKill: boolean;
+		onSelect: () => void;
+		onKill: () => void;
+	}
+
+	const { entry, selected, killing, canKill, onSelect, onKill }: Props = $props();
+
+	const icon = $derived<IconName>(
+		entry.origin.kind === 'clopen'
+			? 'lucide:shield-check'
+			: entry.origin.kind === 'session'
+				? 'lucide:terminal'
+				: 'lucide:circle-question-mark'
+	);
+
+	const accent = $derived(
+		entry.origin.kind === 'clopen'
+			? 'text-violet-600 dark:text-violet-400'
+			: entry.origin.kind === 'session'
+				? 'text-sky-600 dark:text-sky-400'
+				: 'text-slate-400 dark:text-slate-500'
+	);
+
+	/** Why the stop button is absent, in the user's terms rather than a code. */
+	const blockedReason = $derived(
+		entry.killBlockedReason === 'is-clopen-itself'
+			? 'This is Clopen itself'
+			: entry.killBlockedReason === 'unknown-pid'
+				? 'Owner not visible without elevated privileges'
+				: entry.killBlockedReason === 'not-permitted'
+					? `Owned by ${entry.process?.user ?? 'another user'}`
+					: entry.killBlockedReason === 'system-process'
+						? 'System process'
+						: null
+	);
+</script>
+
+<div
+	class="group flex items-center gap-3 px-3 py-2 rounded-lg border transition-colors
+		{selected
+		? 'bg-violet-500/10 border-violet-500/30'
+		: 'bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800 hover:border-violet-500/30'}"
+>
+	<button
+		type="button"
+		class="flex items-center gap-3 flex-1 min-w-0 bg-transparent border-none p-0 text-left cursor-pointer"
+		onclick={onSelect}
+	>
+		<Icon name={icon} class="w-4 h-4 shrink-0 {accent}" />
+
+		<span class="w-24 shrink-0 font-mono text-sm font-semibold text-slate-900 dark:text-slate-100">
+			{entry.port}
+			<span class="text-[10px] font-normal text-slate-400 dark:text-slate-500 uppercase">
+				{entry.protocol}
+			</span>
+		</span>
+
+		<span class="flex flex-col min-w-0 flex-1">
+			<span class="flex items-center gap-1.5 min-w-0">
+				<span class="truncate text-sm font-medium text-slate-800 dark:text-slate-200">
+					{entry.origin.label}
+				</span>
+				{#if entry.origin.confidence === 'guess'}
+					<!-- Never dress a guess as a fact: the badge is the whole point. -->
+					<span
+						class="shrink-0 px-1 py-px rounded text-[9px] font-semibold uppercase tracking-wide bg-slate-200 dark:bg-slate-800 text-slate-500 dark:text-slate-400"
+						title="Inferred from the command line — it may be wrong"
+					>
+						guess
+					</span>
+				{/if}
+				{#if entry.publicUrl}
+					<span
+						class="shrink-0 px-1 py-px rounded text-[9px] font-semibold uppercase tracking-wide bg-amber-500/15 text-amber-700 dark:text-amber-400"
+						title="Reachable from the public internet via {entry.publicUrl}"
+					>
+						public
+					</span>
+				{/if}
+			</span>
+			{#if entry.origin.detail}
+				<span class="truncate text-xs text-slate-500 dark:text-slate-500">
+					{entry.origin.detail}
+				</span>
+			{/if}
+		</span>
+
+		<span class="hidden sm:flex flex-col items-end shrink-0 w-28">
+			<span class="text-[11px] text-slate-500 dark:text-slate-500 truncate max-w-full">
+				{entry.addresses.join(', ')}
+			</span>
+			<span class="text-[11px] text-slate-400 dark:text-slate-600">
+				{#if entry.pid === null}
+					owner unknown
+				{:else}
+					pid {entry.pid}{#if entry.workerPids.length > 1}
+						· {entry.workerPids.length} workers{/if}
+				{/if}
+			</span>
+		</span>
+
+		{#if entry.peerCount > 0}
+			<span
+				class="shrink-0 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 text-[11px] font-semibold"
+				title="{entry.peerCount} connection{entry.peerCount === 1 ? '' : 's'} open to this port"
+			>
+				<Icon name="lucide:arrow-right-left" class="w-3 h-3" />
+				{entry.peerCount}
+			</span>
+		{/if}
+	</button>
+
+	{#if entry.canKill && canKill}
+		<button
+			type="button"
+			class="shrink-0 flex items-center justify-center w-7 h-7 rounded-md border-none bg-transparent text-slate-400 cursor-pointer transition-colors hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50 disabled:cursor-wait"
+			onclick={onKill}
+			disabled={killing}
+			title="Stop whatever is holding this port"
+			aria-label="Stop port {entry.port}"
+		>
+			<Icon name={killing ? 'lucide:loader-circle' : 'lucide:square'} class="w-3.5 h-3.5 {killing ? 'animate-spin' : ''}" />
+		</button>
+	{:else if blockedReason}
+		<span
+			class="shrink-0 flex items-center justify-center w-7 h-7 text-slate-300 dark:text-slate-700"
+			title={blockedReason}
+		>
+			<Icon name="lucide:lock" class="w-3.5 h-3.5" />
+		</span>
+	{/if}
+</div>

--- a/frontend/components/ports/main/PortTable.svelte
+++ b/frontend/components/ports/main/PortTable.svelte
@@ -1,0 +1,104 @@
+<!--
+	Port manager — the table, grouped by where each port came from.
+
+	Grouping is the whole argument of this panel: the ports Clopen is
+	responsible for, the ones it started, and the ones it merely found. The
+	groups are always all present, so a machine with nothing running still shows
+	that the third group is where unexplained ports would appear.
+-->
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import PortRow from './PortRow.svelte';
+	import { portsStore } from '$frontend/stores/features/ports.svelte';
+	import type { PortEntry } from '$shared/types/ports';
+
+	interface Props {
+		canKill: boolean;
+		onKill: (entry: PortEntry) => void;
+	}
+
+	const { canKill, onKill }: Props = $props();
+
+	const groups = $derived(portsStore.groups);
+	const result = $derived(portsStore.result);
+	const total = $derived(result?.entries.length ?? 0);
+	const shown = $derived(portsStore.entries.length);
+</script>
+
+<div class="flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 p-3">
+	{#if result?.error}
+		<div
+			class="flex items-start gap-2.5 p-3 rounded-lg bg-red-500/10 text-red-700 dark:text-red-400"
+		>
+			<Icon name="lucide:circle-alert" class="w-4 h-4 shrink-0 mt-0.5" />
+			<p class="m-0 text-xs">{result.error}</p>
+		</div>
+	{/if}
+
+	{#each groups as group (group.kind)}
+		{@const collapsed = portsStore.isCollapsed(group.kind)}
+		<section class="flex flex-col gap-1.5">
+			<button
+				type="button"
+				class="flex items-center gap-2 w-full px-1 py-1 bg-transparent border-none cursor-pointer text-left"
+				onclick={() => portsStore.toggleGroup(group.kind)}
+			>
+				<Icon
+					name={collapsed ? 'lucide:chevron-right' : 'lucide:chevron-down'}
+					class="w-3.5 h-3.5 shrink-0 text-slate-400"
+				/>
+				<span class="text-[11px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-400">
+					{group.title}
+				</span>
+				<span class="text-[11px] text-slate-400 dark:text-slate-600">{group.entries.length}</span>
+				<span class="hidden sm:block flex-1 text-[11px] text-slate-400 dark:text-slate-600 truncate">
+					{group.blurb}
+				</span>
+			</button>
+
+			{#if !collapsed}
+				{#if group.entries.length === 0}
+					<p class="m-0 px-3 py-2 text-xs text-slate-400 dark:text-slate-600">
+						Nothing here right now.
+					</p>
+				{:else}
+					<div class="flex flex-col gap-1">
+						{#each group.entries as entry (entry.key)}
+							<PortRow
+								{entry}
+								{canKill}
+								selected={portsStore.selectedKey === entry.key}
+								killing={portsStore.killingKey === entry.key}
+								onSelect={() => portsStore.select(entry.key)}
+								onKill={() => onKill(entry)}
+							/>
+						{/each}
+					</div>
+				{/if}
+			{/if}
+		</section>
+	{/each}
+
+	{#if total > 0 && shown === 0}
+		<p class="m-0 px-3 py-6 text-center text-xs text-slate-500 dark:text-slate-500">
+			No port matches that search.
+		</p>
+	{/if}
+
+	{#if result && !result.error}
+		<!-- Stated plainly rather than hidden: a row with no owner is this host
+		     refusing to say, not Clopen failing to look. The probe is named
+		     because how much a row can carry depends entirely on which one ran. -->
+		<section class="flex flex-col gap-1.5 mt-2 p-3 rounded-lg bg-slate-100 dark:bg-slate-900/60">
+			<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+				How this host was read
+			</h4>
+			<p class="m-0 text-xs text-slate-500 dark:text-slate-500">
+				{result.platform} · read with <code class="font-mono">{result.probe}</code>
+			</p>
+			{#each result.limitations as limitation (limitation.code)}
+				<p class="m-0 text-xs text-slate-500 dark:text-slate-500">{limitation.message}</p>
+			{/each}
+		</section>
+	{/if}
+</div>

--- a/frontend/components/ssh-client/SshClientModal.svelte
+++ b/frontend/components/ssh-client/SshClientModal.svelte
@@ -13,6 +13,7 @@
 	import TerminalPane from './main/TerminalPane.svelte';
 	import FileBrowser from './main/FileBrowser.svelte';
 	import ForwardsPanel from './main/ForwardsPanel.svelte';
+	import PortsPanel from './main/PortsPanel.svelte';
 	import HostOverview from './main/HostOverview.svelte';
 	import { sshClientStore, type SshView } from '$frontend/stores/features/ssh-client.svelte';
 	import { debug } from '$shared/utils/logger';
@@ -40,9 +41,12 @@
 	const activeView = $derived(view?.activeView ?? 'terminal');
 	const connected = $derived(sshClientStore.isConnected(activeConnection?.id));
 	const health = $derived(activeConnection ? sshClientStore.health[activeConnection.id] : null);
-	// Terminal and Files need a live transport; Forwards and Host are settings
-	// pages and stay readable while the host is disconnected.
-	const viewNeedsConnection = $derived(activeView === 'terminal' || activeView === 'files');
+	// Terminal, Files and Ports all run against the host itself, so they need a
+	// live transport; Forwards and Host are settings pages and stay readable
+	// while the host is disconnected.
+	const viewNeedsConnection = $derived(
+		activeView === 'terminal' || activeView === 'files' || activeView === 'ports'
+	);
 
 	let connecting = $state(false);
 
@@ -61,6 +65,7 @@
 	const VIEWS: Array<{ id: SshView; label: string; icon: IconName }> = [
 		{ id: 'terminal', label: 'Terminal', icon: 'lucide:terminal' },
 		{ id: 'files', label: 'Files', icon: 'lucide:folder' },
+		{ id: 'ports', label: 'Ports', icon: 'lucide:cable' },
 		{ id: 'forwards', label: 'Forwards', icon: 'lucide:arrow-left-right' },
 		{ id: 'overview', label: 'Host', icon: 'lucide:info' }
 	];
@@ -267,6 +272,8 @@
 										<TerminalPane connectionId={activeConnection.id} />
 									{:else if activeView === 'files'}
 										<FileBrowser connectionId={activeConnection.id} />
+									{:else if activeView === 'ports'}
+										<PortsPanel connectionId={activeConnection.id} />
 									{:else if activeView === 'forwards'}
 										<ForwardsPanel connectionId={activeConnection.id} />
 									{:else}

--- a/frontend/components/ssh-client/main/PortsPanel.svelte
+++ b/frontend/components/ssh-client/main/PortsPanel.svelte
@@ -1,0 +1,78 @@
+<!--
+	ssh-client — what is listening on this host.
+
+	The same table the Ports tool shows for the local machine, scoped to the host
+	the SSH Client is already on. Nothing is reimplemented here: the store, the
+	scan and the rows are shared, and this only decides which host is watched and
+	when to stop watching it.
+-->
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import PortTable from '$frontend/components/ports/main/PortTable.svelte';
+	import PortDetailLayer from '$frontend/components/ports/PortDetailLayer.svelte';
+	import PortKillDialog from '$frontend/components/ports/PortKillDialog.svelte';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { portsStore } from '$frontend/stores/features/ports.svelte';
+	import { authStore } from '$frontend/stores/features/auth.svelte';
+	import type { PortEntry } from '$shared/types/ports';
+
+	interface Props {
+		connectionId: string;
+	}
+
+	const { connectionId }: Props = $props();
+
+	let pendingKill = $state<PortEntry | null>(null);
+
+	const selected = $derived(portsStore.selected);
+	const result = $derived(portsStore.result);
+	/** Reading is open to every member; stopping a process is not. */
+	const canKill = $derived(authStore.isAdmin);
+
+	$effect(() => {
+		const hostId = connectionId;
+		// `untrack` because starting a watch writes the store state it also reads
+		// — tracked, that is an effect that invalidates itself, and each re-run
+		// costs another round of watch/unwatch on the host.
+		untrack(() => void portsStore.watch(hostId));
+		// Leaving this tab — or the modal — must stop the polling behind it.
+		return () => {
+			void portsStore.unwatch(hostId);
+		};
+	});
+</script>
+
+<div class="flex flex-col flex-1 min-h-0 bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden">
+	<div class="flex items-center gap-2 px-3 py-2 shrink-0 border-b border-slate-200 dark:border-slate-800">
+		<div
+			class="flex items-center gap-2 flex-1 min-w-0 px-2.5 h-8 rounded-lg bg-slate-50 dark:bg-slate-950 border border-slate-200 dark:border-slate-800"
+		>
+			<Icon name="lucide:search" class="w-3.5 h-3.5 shrink-0 text-slate-400" />
+			<input
+				type="text"
+				class="flex-1 min-w-0 bg-transparent border-none outline-none text-xs text-slate-800 dark:text-slate-200 placeholder:text-slate-400"
+				placeholder="Search port, process, command, directory…"
+				bind:value={portsStore.search}
+			/>
+		</div>
+
+		{#if result}
+			<span
+				class="hidden sm:flex items-center gap-1.5 shrink-0 text-[11px] text-slate-400 dark:text-slate-600"
+				title="This table refreshes about once a second while the tab is open"
+			>
+				<span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
+				live
+			</span>
+		{/if}
+	</div>
+
+	<div class="flex flex-1 min-h-0 relative">
+		<PortTable {canKill} onKill={(entry) => (pendingKill = entry)} />
+		{#if selected}
+			<PortDetailLayer entry={selected} onClose={() => portsStore.select(null)} />
+		{/if}
+	</div>
+</div>
+
+<PortKillDialog bind:entry={pendingKill} />

--- a/frontend/components/workspace/DesktopNavigator.svelte
+++ b/frontend/components/workspace/DesktopNavigator.svelte
@@ -26,6 +26,7 @@
 	import RemoteAccessPanel from '$frontend/components/remote-access/RemoteAccessPanel.svelte';
 	import DbClientModal from '$frontend/components/db-client/DbClientModal.svelte';
 	import SshClientModal from '$frontend/components/ssh-client/SshClientModal.svelte';
+	import PortsModal from '$frontend/components/ports/PortsModal.svelte';
 	import MemoryModal from '$frontend/components/memory/MemoryModal.svelte';
 	import SettingButton from '$frontend/components/settings/SettingButton.svelte';
 	import ProjectUserAvatars from '$frontend/components/common/display/ProjectUserAvatars.svelte';
@@ -42,6 +43,8 @@
 		closeDbClientDialog,
 		openSshClientDialog,
 		closeSshClientDialog,
+		openPortsDialog,
+		closePortsDialog,
 		openMemoryDialog,
 		closeMemoryDialog
 	} from '$frontend/stores/ui/quick-panels.svelte';
@@ -392,6 +395,7 @@
 					onPublicTunnel={openTunnelDialog}
 					onDbClient={openDbClientDialog}
 					onSshClient={openSshClientDialog}
+					onPorts={openPortsDialog}
 					onMemory={openMemoryDialog}
 				/>
 				<QuickSearchButton />
@@ -460,6 +464,7 @@
 					onPublicTunnel={openTunnelDialog}
 					onDbClient={openDbClientDialog}
 					onSshClient={openSshClientDialog}
+					onPorts={openPortsDialog}
 					onMemory={openMemoryDialog}
 				/>
 				<QuickSearchButton collapsed={true} />
@@ -551,4 +556,5 @@
 <!-- DB Client Modal -->
 <DbClientModal bind:isOpen={quickPanelsState.dbClientOpen} onClose={closeDbClientDialog} />
 <SshClientModal bind:isOpen={quickPanelsState.sshClientOpen} onClose={closeSshClientDialog} />
+<PortsModal bind:isOpen={quickPanelsState.portsOpen} onClose={closePortsDialog} />
 <MemoryModal bind:isOpen={quickPanelsState.memoryOpen} onClose={closeMemoryDialog} />

--- a/frontend/components/workspace/MobileNavigator.svelte
+++ b/frontend/components/workspace/MobileNavigator.svelte
@@ -11,6 +11,7 @@
 	import RemoteAccessPanel from '$frontend/components/remote-access/RemoteAccessPanel.svelte';
 	import DbClientModal from '$frontend/components/db-client/DbClientModal.svelte';
 	import SshClientModal from '$frontend/components/ssh-client/SshClientModal.svelte';
+	import PortsModal from '$frontend/components/ports/PortsModal.svelte';
 	import MemoryModal from '$frontend/components/memory/MemoryModal.svelte';
 	import SettingButton from '$frontend/components/settings/SettingButton.svelte';
 	import type { Project } from '$shared/types/database/schema';
@@ -31,6 +32,8 @@
 		closeDbClientDialog,
 		openSshClientDialog,
 		closeSshClientDialog,
+		openPortsDialog,
+		closePortsDialog,
 		openMemoryDialog,
 		closeMemoryDialog
 	} from '$frontend/stores/ui/quick-panels.svelte';
@@ -178,6 +181,7 @@
 			onPublicTunnel={openTunnelDialog}
 			onDbClient={openDbClientDialog}
 					onSshClient={openSshClientDialog}
+					onPorts={openPortsDialog}
 					onMemory={openMemoryDialog}
 		/>
 
@@ -423,4 +427,5 @@
 <!-- DB Client Modal -->
 <DbClientModal bind:isOpen={quickPanelsState.dbClientOpen} onClose={closeDbClientDialog} />
 <SshClientModal bind:isOpen={quickPanelsState.sshClientOpen} onClose={closeSshClientDialog} />
+<PortsModal bind:isOpen={quickPanelsState.portsOpen} onClose={closePortsDialog} />
 <MemoryModal bind:isOpen={quickPanelsState.memoryOpen} onClose={closeMemoryDialog} />

--- a/frontend/components/workspace/ToolsMenu.svelte
+++ b/frontend/components/workspace/ToolsMenu.svelte
@@ -7,6 +7,7 @@
 	import { remoteAccessStore } from '$frontend/stores/features/remote-access.svelte';
 	import { dbClientStore } from '$frontend/stores/features/db-client.svelte';
 	import { sshClientStore } from '$frontend/stores/features/ssh-client.svelte';
+	import { portsStore } from '$frontend/stores/features/ports.svelte';
 	import type { IconName } from '$shared/types/ui/icons';
 
 	interface Props {
@@ -16,6 +17,7 @@
 		onPublicTunnel: () => void;
 		onDbClient: () => void;
 		onSshClient: () => void;
+		onPorts: () => void;
 		onMemory: () => void;
 	}
 
@@ -26,6 +28,7 @@
 		onPublicTunnel,
 		onDbClient,
 		onSshClient,
+		onPorts,
 		onMemory
 	}: Props = $props();
 
@@ -35,8 +38,11 @@
 	const tunnelCount = $derived(tunnelStore.activeDomainCount);
 	const dbCount = $derived(dbClientStore.liveCount);
 	const sshCount = $derived(sshClientStore.liveCount);
+	const portsCount = $derived(portsStore.liveCount);
 	// A single dot on the trigger signals "something under here is active".
-	const hasActivity = $derived(remoteCount > 0 || tunnelCount > 0 || dbCount > 0 || sshCount > 0);
+	const hasActivity = $derived(
+		remoteCount > 0 || tunnelCount > 0 || dbCount > 0 || sshCount > 0 || portsCount > 0
+	);
 
 	interface ToolItem {
 		label: string;
@@ -79,6 +85,16 @@
 			onClick: onSshClient,
 			count: sshCount,
 			accent: 'text-sky-600 dark:text-sky-400'
+		},
+		{
+			label: 'Ports',
+			description: 'What is listening on this machine',
+			icon: 'lucide:cable',
+			onClick: onPorts,
+			// Counts ports born in a Clopen terminal, not every port on the box —
+			// a machine's own listeners are a constant, not a sign of activity.
+			count: portsCount,
+			accent: 'text-amber-600 dark:text-amber-400'
 		},
 		{
 			label: 'Memory',

--- a/frontend/config/command-registry.ts
+++ b/frontend/config/command-registry.ts
@@ -16,7 +16,8 @@ import {
 	openRemoteAccessDialog,
 	openTunnelDialog,
 	openDbClientDialog,
-	openSshClientDialog
+	openSshClientDialog,
+	openPortsDialog
 } from '$frontend/stores/ui/quick-panels.svelte';
 import { addNotification } from '$frontend/stores/ui/notification.svelte';
 
@@ -192,6 +193,15 @@ export function getCommandActions(): CommandAction[] {
 		icon: 'lucide:server',
 		keywords: ['ssh', 'shell', 'sftp', 'remote', 'server', 'tunnel', 'port forward'],
 		run: openSshClientDialog
+	});
+
+	actions.push({
+		id: 'ports',
+		label: 'Ports',
+		description: 'What is listening on this machine, and how to stop it',
+		icon: 'lucide:cable',
+		keywords: ['port', 'listening', 'process', 'kill', 'netstat', 'lsof', 'in use', 'occupied'],
+		run: openPortsDialog
 	});
 
 	actions.push({

--- a/frontend/stores/features/ports.svelte.ts
+++ b/frontend/stores/features/ports.svelte.ts
@@ -1,0 +1,249 @@
+/**
+ * Port manager store — what is listening, on whichever host is selected.
+ *
+ * The server owns the tables and pushes them; this owns which host is being
+ * looked at, how the rows are filtered, and the sidebar count. Watching is
+ * explicit on both ends: opening a host asks the server to watch it, and
+ * leaving stops it, so no host is polled for a view nobody has open.
+ *
+ * One store serves both places ports are shown — the Ports panel for this
+ * machine, and the SSH Client's Ports tab for a host. `local` is not a special
+ * case here; it is just the host whose id happens to be `local`.
+ */
+
+import { debug } from '$shared/utils/logger';
+import ws, { onWsReconnect } from '$frontend/utils/ws';
+import { SvelteSet } from 'svelte/reactivity';
+import type { PortEntry, PortOriginKind, PortScanResult } from '$shared/types/ports';
+import { LOCAL_PORT_HOST } from '$shared/types/ports';
+
+/** Rows are grouped by where they came from, most explicable first. */
+export const ORIGIN_GROUPS: Array<{ kind: PortOriginKind; title: string; blurb: string }> = [
+	{ kind: 'clopen', title: 'Opened by Clopen', blurb: 'Listeners Clopen is responsible for' },
+	{ kind: 'session', title: 'Started from Clopen', blurb: 'Terminals, engines, and anything they launched' },
+	{ kind: 'external', title: 'Outside Clopen', blurb: 'Everything else on this host' }
+];
+
+interface PortsState {
+	/** The host being watched: `local`, or an SSH connection id. */
+	activeHostId: string;
+	/** Latest table per host, so switching back is instant. */
+	results: Record<string, PortScanResult>;
+	/** Hosts this client has asked the server to watch. */
+	watching: SvelteSet<string>;
+	search: string;
+	/** Groups the user has collapsed, remembered while the panel is open. */
+	collapsed: SvelteSet<PortOriginKind>;
+	selectedKey: string | null;
+	badge: number;
+	isLoading: boolean;
+	error: string | null;
+	/** Entry key currently being stopped, so its row can show progress. */
+	killingKey: string | null;
+}
+
+const state = $state<PortsState>({
+	activeHostId: LOCAL_PORT_HOST,
+	results: {},
+	watching: new SvelteSet(),
+	search: '',
+	collapsed: new SvelteSet(),
+	selectedKey: null,
+	badge: 0,
+	isLoading: false,
+	error: null,
+	killingKey: null
+});
+
+function matches(entry: PortEntry, needle: string): boolean {
+	if (!needle) return true;
+	const haystack = [
+		String(entry.port),
+		entry.protocol,
+		entry.origin.label,
+		entry.origin.detail ?? '',
+		entry.process?.command ?? '',
+		entry.process?.user ?? '',
+		entry.process?.cwd ?? '',
+		entry.pid === null ? '' : String(entry.pid),
+		...entry.addresses
+	]
+		.join(' ')
+		.toLowerCase();
+	return haystack.includes(needle);
+}
+
+export const portsStore = {
+	get activeHostId(): string {
+		return state.activeHostId;
+	},
+	get result(): PortScanResult | null {
+		return state.results[state.activeHostId] ?? null;
+	},
+	get search(): string {
+		return state.search;
+	},
+	set search(value: string) {
+		state.search = value;
+	},
+	get isLoading(): boolean {
+		return state.isLoading;
+	},
+	get error(): string | null {
+		return state.error;
+	},
+	get killingKey(): string | null {
+		return state.killingKey;
+	},
+	get selectedKey(): string | null {
+		return state.selectedKey;
+	},
+
+	/** The sidebar count: ports born in a Clopen terminal on this machine. */
+	get liveCount(): number {
+		return state.badge;
+	},
+
+	get entries(): PortEntry[] {
+		const needle = state.search.trim().toLowerCase();
+		return (this.result?.entries ?? []).filter((entry) => matches(entry, needle));
+	},
+
+	/** Rows in display order, split into the three origin groups. */
+	get groups(): Array<{ kind: PortOriginKind; title: string; blurb: string; entries: PortEntry[] }> {
+		const entries = this.entries;
+		return ORIGIN_GROUPS.map((group) => ({
+			...group,
+			entries: entries.filter((entry) => entry.origin.kind === group.kind)
+		}));
+	},
+
+	get selected(): PortEntry | null {
+		if (!state.selectedKey) return null;
+		return (this.result?.entries ?? []).find((entry) => entry.key === state.selectedKey) ?? null;
+	},
+
+	isCollapsed(kind: PortOriginKind): boolean {
+		return state.collapsed.has(kind);
+	},
+
+	toggleGroup(kind: PortOriginKind): void {
+		if (state.collapsed.has(kind)) state.collapsed.delete(kind);
+		else state.collapsed.add(kind);
+	},
+
+	select(key: string | null): void {
+		state.selectedKey = state.selectedKey === key ? null : key;
+	},
+
+	/**
+	 * Open a host: start the server watching it and show its first table.
+	 *
+	 * Only one host is watched at a time. Leaving a host stops its polling —
+	 * an SSH host in particular should not keep costing a scan per second for a
+	 * tab that is no longer on screen — while its last table stays cached, so
+	 * coming back renders immediately and then refreshes.
+	 */
+	async watch(hostId: string): Promise<void> {
+		const previous = state.activeHostId;
+		state.activeHostId = hostId;
+		state.selectedKey = null;
+		state.error = null;
+		if (previous !== hostId) await this.unwatch(previous);
+		if (state.watching.has(hostId)) return;
+
+		state.isLoading = !state.results[hostId];
+		try {
+			const response = (await ws.http('ports:watch', { hostId })) as { result: PortScanResult };
+			state.watching.add(hostId);
+			state.results[hostId] = response.result;
+			if (response.result.error) state.error = response.result.error;
+		} catch (error) {
+			debug.warn('ports', `Could not watch ${hostId}:`, error);
+			state.error = error instanceof Error ? error.message : String(error);
+		} finally {
+			state.isLoading = false;
+		}
+	},
+
+	/** Stop watching one host, leaving its last table cached for a quick return. */
+	async unwatch(hostId: string): Promise<void> {
+		if (!state.watching.has(hostId)) return;
+		state.watching.delete(hostId);
+		try {
+			await ws.http('ports:unwatch', { hostId });
+		} catch (error) {
+			debug.warn('ports', `Could not unwatch ${hostId}:`, error);
+		}
+	},
+
+	/**
+	 * Stop whatever holds a port. The server re-scans before acting, so the row
+	 * only has to name itself — a stale pid from this table is never signalled.
+	 */
+	async kill(entry: PortEntry): Promise<{ ok: boolean; error: string | null }> {
+		state.killingKey = entry.key;
+		try {
+			const response = (await ws.http('ports:kill', {
+				hostId: state.activeHostId,
+				entryKey: entry.key
+			})) as { result: { ok: boolean; error: string | null }; gone: boolean };
+
+			if (response.gone) return { ok: true, error: null };
+			return { ok: response.result.ok, error: response.result.error };
+		} catch (error) {
+			return { ok: false, error: error instanceof Error ? error.message : String(error) };
+		} finally {
+			state.killingKey = null;
+		}
+	},
+
+	/** Ask for the current count, which pushes alone cannot deliver on load. */
+	async loadBadge(): Promise<void> {
+		try {
+			const response = (await ws.http('ports:summary', {})) as { count: number };
+			state.badge = typeof response?.count === 'number' ? response.count : 0;
+		} catch (error) {
+			debug.warn('ports', 'Could not read the port count:', error);
+		}
+	},
+
+	/**
+	 * Subscribe to pushed tables and the sidebar count. Call once on app mount:
+	 * the badge arrives whether or not the panel has ever been opened.
+	 */
+	initRealtimeListener(): () => void {
+		const cleanupChanged = ws.on('ports:changed', (data: { result: PortScanResult }) => {
+			if (!data?.result) return;
+			state.results[data.result.hostId] = data.result;
+			if (data.result.hostId === state.activeHostId) {
+				state.error = data.result.error;
+			}
+		});
+
+		const cleanupBadge = ws.on('ports:badge', (data: { count: number }) => {
+			state.badge = typeof data?.count === 'number' ? data.count : 0;
+		});
+
+		// A watch lives on the socket that asked for it, so a reconnect leaves the
+		// server watching nothing while this side still believes it is. Without
+		// re-asking, the table would sit there looking live and never change again.
+		const cleanupReconnect = onWsReconnect(() => {
+			const wasWatching = state.watching.size > 0;
+			state.watching.clear();
+			void portsStore.loadBadge();
+			if (!wasWatching) return;
+			void portsStore.watch(state.activeHostId);
+		});
+
+		// The count is state, not an event, so it is read on load rather than
+		// waited for — a refreshed page must not sit at zero until it changes.
+		void portsStore.loadBadge();
+
+		return () => {
+			cleanupChanged();
+			cleanupBadge();
+			cleanupReconnect();
+		};
+	}
+};

--- a/frontend/stores/features/ssh-client.svelte.ts
+++ b/frontend/stores/features/ssh-client.svelte.ts
@@ -32,7 +32,7 @@ import type {
 	SshKnownHost
 } from '$shared/types/ssh';
 
-export type SshView = 'terminal' | 'files' | 'forwards' | 'overview';
+export type SshView = 'terminal' | 'files' | 'ports' | 'forwards' | 'overview';
 
 /** One terminal tab. `sessionId` is the PtyKit session it renders. */
 export interface SshTerminalTab {

--- a/frontend/stores/ui/quick-panels.svelte.ts
+++ b/frontend/stores/ui/quick-panels.svelte.ts
@@ -12,6 +12,7 @@ interface QuickPanelsState {
 	tunnelOpen: boolean;
 	dbClientOpen: boolean;
 	sshClientOpen: boolean;
+	portsOpen: boolean;
 	memoryOpen: boolean;
 }
 
@@ -21,6 +22,7 @@ export const quickPanelsState = $state<QuickPanelsState>({
 	tunnelOpen: false,
 	dbClientOpen: false,
 	sshClientOpen: false,
+	portsOpen: false,
 	memoryOpen: false
 });
 
@@ -62,6 +64,14 @@ export function openSshClientDialog() {
 
 export function closeSshClientDialog() {
 	quickPanelsState.sshClientOpen = false;
+}
+
+export function openPortsDialog() {
+	quickPanelsState.portsOpen = true;
+}
+
+export function closePortsDialog() {
+	quickPanelsState.portsOpen = false;
 }
 
 export function openMemoryDialog() {

--- a/shared/types/ports/index.ts
+++ b/shared/types/ports/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Port manager types barrel export.
+ */
+
+export * from './port';

--- a/shared/types/ports/port.ts
+++ b/shared/types/ports/port.ts
@@ -1,0 +1,192 @@
+/**
+ * Port manager — the shape of "what is listening, and who opened it".
+ *
+ * One model serves both the machine running Clopen and any saved SSH host, so
+ * the same table, the same attribution and the same detail pane render either.
+ * Where a platform cannot answer a question the field is `null` and the reason
+ * is reported in `limitations` — a port with an unknown owner says so rather
+ * than guessing.
+ */
+
+export type PortProtocol = 'tcp' | 'udp';
+
+export type PortIpVersion = 'v4' | 'v6';
+
+/**
+ * Only the three states worth acting on. Everything transient (TIME_WAIT,
+ * SYN_SENT, the rest of the TCP state machine) collapses into `other` — it
+ * describes a socket that is closing, not a port anyone owns.
+ */
+export type PortSocketState = 'listen' | 'established' | 'other';
+
+/** A socket row exactly as the OS probe reported it, before any attribution. */
+export interface PortSocket {
+	protocol: PortProtocol;
+	ipVersion: PortIpVersion;
+	/** Local bind address. `*` means every interface. */
+	address: string;
+	port: number;
+	state: PortSocketState;
+	/** Null when the probe could not see the owner — see `PortLimitationCode`. */
+	pid: number | null;
+	/** Short on Linux `ss`, full path on macOS `lsof`, absent on Windows netstat. */
+	processName: string | null;
+	user: string | null;
+	peerAddress: string | null;
+	peerPort: number | null;
+}
+
+/** Process facts behind a socket, resolved once per pid and cached. */
+export interface PortProcess {
+	pid: number;
+	parentPid: number | null;
+	user: string | null;
+	/** Full argv when the platform exposes it, else the executable name. */
+	command: string;
+	/** ISO timestamp. Also disambiguates a reused pid from the cached one. */
+	startedAt: string | null;
+	/**
+	 * Working directory — the strongest hint at *which project* a dev server
+	 * belongs to. Unavailable on Windows, and on Unix only for our own user.
+	 */
+	cwd: string | null;
+}
+
+/**
+ * How confident the attribution is. `certain` means Clopen either opened the
+ * listener itself or watched the process being born; `guess` means the label
+ * was inferred from the command line and may be wrong.
+ */
+export type PortOriginConfidence = 'certain' | 'guess';
+
+/**
+ * The three tiers the UI groups by:
+ * - `clopen`   — a listener Clopen opened, registered by the feature that owns it
+ * - `session`  — a process descended from a Clopen terminal session
+ * - `external` — everything else on the machine
+ */
+export type PortOriginKind = 'clopen' | 'session' | 'external';
+
+/** Which Clopen feature owns a `clopen` port, so it can be stopped properly. */
+export type PortOwnerFeature =
+	| 'server'
+	| 'tunnel'
+	| 'ssh-forward'
+	| 'db-client-tunnel'
+	| 'preview-browser'
+	| 'mcp'
+	| 'engine';
+
+export interface PortOrigin {
+	kind: PortOriginKind;
+	confidence: PortOriginConfidence;
+	/** Short human label, e.g. "Clopen server" or "Vite dev server". */
+	label: string;
+	/** Second line: the host being forwarded to, the project, the raw command. */
+	detail: string | null;
+	/** Set when `kind` is `clopen`. */
+	ownerFeature?: PortOwnerFeature;
+	/** Identifies the owning record (forward id, tunnel id, …) for the stop path. */
+	ownerId?: string;
+	/** Set when `kind` is `session` — the PTY session the process descends from. */
+	sessionId?: string;
+	/** Project the session belongs to, so the UI can name it. */
+	projectId?: string;
+	/** Set when the lineage ends at an sshd session rather than a Clopen one. */
+	remoteSessionUser?: string;
+}
+
+/** A peer currently connected to a listening port. */
+export interface PortPeer {
+	address: string;
+	port: number;
+	/** Present when the probe could attribute the peer socket to a process. */
+	processName: string | null;
+}
+
+/** Why a port cannot be stopped from here. */
+export type PortKillBlockedReason =
+	| 'is-clopen-itself'
+	| 'unknown-pid'
+	| 'not-permitted'
+	| 'system-process';
+
+/** One row in the table: a port, its owner, and what is connected to it. */
+export interface PortEntry {
+	/** Stable across scans, so the UI can diff without rebuilding the table. */
+	key: string;
+	protocol: PortProtocol;
+	port: number;
+	/** Every address this pid binds the port on, e.g. `127.0.0.1` and `::1`. */
+	addresses: string[];
+	ipVersions: PortIpVersion[];
+	pid: number | null;
+	process: PortProcess | null;
+	/**
+	 * Every process holding this port, when a server pre-forks workers that
+	 * inherit the listening socket. One row is reported for the group, and this
+	 * says how wide the group is.
+	 */
+	workerPids: number[];
+	origin: PortOrigin;
+	peers: PortPeer[];
+	peerCount: number;
+	/**
+	 * Set when a Cloudflare tunnel points at this port. A tunnel dials the port
+	 * rather than binding it, so this is exposure, not ownership — the port
+	 * still belongs to whatever process is listening, and this says it is also
+	 * reachable from the public internet.
+	 */
+	publicUrl: string | null;
+	canKill: boolean;
+	killBlockedReason: PortKillBlockedReason | null;
+}
+
+/**
+ * A capability the scan could not deliver on this host. Surfaced in the UI so
+ * a missing owner reads as "this platform cannot tell us" rather than a bug.
+ */
+export type PortLimitationCode =
+	| 'pids-need-root'
+	| 'no-cwd-support'
+	| 'no-process-args'
+	| 'no-session-attribution'
+	| 'probe-fallback';
+
+export interface PortLimitation {
+	code: PortLimitationCode;
+	message: string;
+}
+
+/** `local` is the machine running Clopen; any other id is an SSH connection. */
+export type PortHostId = string;
+
+export const LOCAL_PORT_HOST: PortHostId = 'local';
+
+export interface PortScanResult {
+	hostId: PortHostId;
+	/** ISO timestamp of the scan that produced these entries. */
+	scannedAt: string;
+	platform: string;
+	/**
+	 * Which probe actually read the socket table. Reported because how much a
+	 * row can say depends entirely on this — `netstat` on Windows names no
+	 * process, `/proc/net` needs a second lookup for one — and because a host
+	 * that answers with less than expected is otherwise impossible to explain.
+	 */
+	probe: string;
+	entries: PortEntry[];
+	limitations: PortLimitation[];
+	/** Set when the scan failed outright; `entries` is then empty. */
+	error: string | null;
+}
+
+/** What a kill attempt did, reported honestly including refusals. */
+export interface PortKillResult {
+	ok: boolean;
+	/** Pids actually signalled, children first. */
+	killedPids: number[];
+	/** Set when the port belonged to a feature and was stopped, not signalled. */
+	stoppedFeature: PortOwnerFeature | null;
+	error: string | null;
+}

--- a/shared/utils/logger.ts
+++ b/shared/utils/logger.ts
@@ -47,6 +47,7 @@ export type LogLabel =
 	| 'remote-access'
 	| 'db-client'
 	| 'ssh'
+	| 'ports'
 	
 	// User
 	| 'user'


### PR DESCRIPTION
## Summary
Adds a **Ports** view showing what is listening on a machine, where each port
came from, and how to stop it. Ports on this machine live under More Tools;
a saved host's ports live in **SSH Client → Ports**, on the host they belong to.
Both render the same components over the same store and the same scan.

## Why
An occupied port was a dead end. Nothing in Clopen could say which process held
it, whether Clopen itself had opened it, or how to release it — and ports opened
outside Clopen were invisible entirely. Answering it meant leaving for a
terminal and reading `lsof`/`ss` by hand.

## Changes
**Reading a host**
- `backend/ports/runner.ts` — one `CommandRunner` over two transports
  (`Bun.spawn` locally, an ssh2 exec channel remotely); argv arrays, never shell
  strings. `posixArgv()` wraps POSIX probes in `env LC_ALL=C PATH=…`, since a
  non-interactive SSH channel's PATH routinely omits `/usr/sbin`. Remote
  commands are serialised, because every `exec` is an SSH channel and sshd caps
  how many a connection may hold
- `backend/ports/scan.ts` — per-platform probes normalised to one row shape:
  `lsof -F` (macOS), `ss` → `netstat` → `lsof` → `/proc/net` (Linux),
  `netstat -ano` (Windows). The `/proc/net` path needs nothing installed.
  `ProbeMemo` remembers which one answered so the chain is walked once per host
- `backend/ports/processes.ts` — incremental process table; full sweep every 30s,
  only unseen pids in between, keyed by pid *and* start time so a recycled pid
  cannot inherit a dead process's identity

**Deciding where a port came from**
- `backend/ports/attribute.ts` — three tiers over a set of "Clopen pids", plus
  worker-pool folding so a pre-forking server is one row rather than eight
- `backend/ports/ssh-lineage.ts` — on an SSH host, matches each process's
  inherited `SSH_CONNECTION` against Clopen's own, per-pid and cached
- `backend/ports/registry.ts` — owned ports pulled from live feature state for
  both host kinds; tunnels recorded as exposure rather than ownership

**Serving it**
- `backend/ports/monitor.ts`, `kill.ts`, `backend/ws/ports/` — the poll/diff
  loop, the stop paths, and the WS surface. `ports:kill` added to
  `ADMIN_ONLY_ROUTES`. Host setup is deduplicated so concurrent watchers cannot
  each take an SSH lease, and a scan already in flight is joined rather than
  raced
- `sshForwardManager.localListeners`/`remoteListeners` and
  `connectionManager.activeTunnelPorts` accessors, so the registry reads live
  state instead of keeping a second list that could drift

**UI**
- `frontend/components/ports/` — the table, the row, the detail view, the kill
  confirmation, and `PortDetailLayer`, which owns whether details appear beside
  the table or as a bottom sheet
- `frontend/components/ssh-client/main/PortsPanel.svelte` — the same components
  scoped to the open host; gated with Terminal and Files on a live connection
- More Tools entry, command-palette action, badge listener in `App.svelte`,
  `portsOpen` in the quick-panels SSOT

## Test plan
- [x] `bun run check` — 0 errors
- [x] `bun run lint` — clean
- [x] `bun run test` — 715 pass, 0 fail (66 in the ports module)
- [x] Local scan on macOS: 71 listening sockets → 26 rows; an engine and the
      preview browser resolve to "Started from Clopen", a second Clopen install
      to "Opened by Clopen"
- [x] Commands per scan measured: cold 3, warm 1, three concurrent scans 1
- [x] Real cPanel host over SSH: read via `/proc/net` after every tool was
      absent, and a server started in a Clopen terminal resolves to "Started
      from Clopen"
- [ ] A Windows host

## Security impact
The view exposes the full process list of the host being read — command lines
included — and can end processes. Reading is open to any signed-in user;
`ports:kill` is admin-only, and SSH hosts still go through
`sshConnectionQueries.ensureAccess` on the caller's real role. Kill re-scans
before acting rather than trusting the pid the client sent, since a table a
second old can name a recycled pid. Nothing escalates to `sudo`: a port owned by
another user reports `EPERM` and stops there. The one shell command in the
feature is a fixed string with only vetted integers interpolated; everything
else is passed as argv.

## Notes
Realtime is polling by necessity, not preference. No OS offers a portable
socket-table event: macOS exposes none, Windows' change notifications do not
cover the TCP listener table, and Linux's `ss --events` reports only destroyed
sockets and needs privileges. The poll earns it — server-side diffing so a
static host pushes nothing, one host watched at a time, and a slower interval on
SSH where each scan is a round trip on the connection the terminal is also
using.

Limits are surfaced in the UI rather than hidden, next to the name of the probe
that ran: Windows exposes no process working directory, and on Linux the kernel
names the owning process only for the caller's own sockets. A specific terminal
*tab* is not identifiable on an SSH host — every channel Clopen opens shares one
connection — so those rows say "Started through Clopen on <host>" rather than
claiming a tab. macOS SSH hosts fall back to a process-tree walk for that tier,
because `ps -E` returns no environment there under SIP.