### PR TITLE
fix(workspace): add scale transition to panel actions menu

### DIFF
--- a/frontend/components/workspace/PanelHeader.svelte
+++ b/frontend/components/workspace/PanelHeader.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { browser } from '$frontend/app-environment';
 	import { onMount, onDestroy } from 'svelte';
+	import { scale } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
 	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import AvatarBubble from '$frontend/components/common/display/AvatarBubble.svelte';
 	import { sessionState } from '$frontend/stores/core/sessions.svelte';
@@ -201,7 +203,11 @@
 
 		{#if showActionsMenu}
 			<div class="fixed inset-0 z-40" onclick={closeActionsMenu}></div>
-			<div class="fixed z-50 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg overflow-hidden min-w-44 py-1" style="top: {menuPosition.top}px; left: {menuPosition.left}px;">
+			<div
+				class="fixed z-50 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg overflow-hidden min-w-44 py-1"
+				style="top: {menuPosition.top}px; left: {menuPosition.left}px;"
+				transition:scale={{ duration: 150, easing: cubicOut, start: 0.95, opacity: 0 }}
+			>
 				<!-- Split actions -->
 				<button
 					type="button"


### PR DESCRIPTION
## Summary
Add missing `scale` transition to the panel header actions menu (three dots: Split Right / Split Down / Close Panel) to match other workspace menus.

## Why
The ellipsis menu in `PanelHeader` was rendered with a plain `{#if showActionsMenu}` without any transition, while `ToolsMenu` (More Tools) and `ViewMenu` (Layout Presets) both use `transition:scale` with `cubicOut`. This made the panel actions menu appear abruptly and feel inconsistent with the rest of the workspace (e.g., clicking Open Code / More Tools).

## Changes
- `frontend/components/workspace/PanelHeader.svelte:4` - import `scale` from `svelte/transition` and `cubicOut` from `svelte/easing`
- `frontend/components/workspace/PanelHeader.svelte:209` - add `transition:scale={{ duration: 150, easing: cubicOut, start: 0.95, opacity: 0 }}` to the fixed menu container, same params as `ToolsMenu.svelte:171` and `ViewMenu.svelte:100`

## Test plan
- `bun run check` - no type errors
- `bun run lint` - passes