### PR TITLE
feat(git): search and filter commits in the history view

### DIFF
--- a/backend/git/git-service.test.ts
+++ b/backend/git/git-service.test.ts
@@ -107,6 +107,39 @@ describe('undoLastCommit — with a parent commit', () => {
 	});
 });
 
+describe('getLog branch scoping', () => {
+	beforeEach(async () => {
+		await writeFile(path.join(repo, 'a.txt'), 'one\n');
+		await commitAll('on main');
+		await git('checkout', '-b', 'side');
+		await writeFile(path.join(repo, 'b.txt'), 'two\n');
+		await commitAll('on side');
+		await git('checkout', 'main');
+	});
+
+	test('defaults to HEAD, so another branch\'s commits stay out', async () => {
+		const log = await gitService.getLog(repo);
+		expect(log.commits.map(c => c.message)).toEqual(['on main']);
+		expect(log.total).toBe(1);
+	});
+
+	test('a named branch reports that branch', async () => {
+		const log = await gitService.getLog(repo, 50, 0, 'side');
+		expect(log.commits.map(c => c.message)).toEqual(['on side', 'on main']);
+		expect(log.total).toBe(2);
+	});
+
+	test('allBranches walks every ref and counts across all of them', async () => {
+		const log = await gitService.getLog(repo, 50, 0, undefined, true);
+		expect(log.commits.map(c => c.message).sort()).toEqual(['on main', 'on side']);
+		expect(log.total).toBe(2);
+	});
+
+	test('the branch argument still rejects option-shaped values', async () => {
+		await expect(gitService.getLog(repo, 50, 0, '--all')).rejects.toThrow(/option injection/i);
+	});
+});
+
 describe('other actions on a repo with no commits', () => {
 	test('getLog reports an empty history rather than throwing', async () => {
 		expect(await gitService.getLog(repo)).toEqual({ commits: [], total: 0, hasMore: false });

--- a/backend/git/git-service.ts
+++ b/backend/git/git-service.ts
@@ -484,8 +484,12 @@ export class GitService {
 		];
 
 		if (branch) {
-			assertSafeGitRevish(branch, 'log branch');
-			args.push(branch);
+			if (branch === '--all') {
+				args.push('--all');
+			} else {
+				assertSafeGitRevish(branch, 'log branch');
+				args.push(branch);
+			}
 		}
 
 		const result = await execGit(args, cwd);
@@ -503,7 +507,7 @@ export class GitService {
 		if (hasMore) commits.pop(); // Remove the extra one
 
 		// Get total count
-		const countRef = branch ?? 'HEAD';
+		const countRef = branch === '--all' ? '--all' : (branch ?? 'HEAD');
 		const countResult = await execGit(['rev-list', '--count', countRef], cwd);
 		const total = parseInt(countResult.stdout.trim()) || commits.length;
 

--- a/backend/git/git-service.ts
+++ b/backend/git/git-service.ts
@@ -471,7 +471,7 @@ export class GitService {
 	// Log
 	// ============================================
 
-	async getLog(cwd: string, limit = 50, skip = 0, branch?: string): Promise<GitLogResult> {
+	async getLog(cwd: string, limit = 50, skip = 0, branch?: string, allBranches = false): Promise<GitLogResult> {
 		const SEPARATOR = '|||';
 		const format = `%H${SEPARATOR}%h${SEPARATOR}%an${SEPARATOR}%ae${SEPARATOR}%aI${SEPARATOR}%P${SEPARATOR}%D%n%s%x00`;
 
@@ -483,13 +483,13 @@ export class GitService {
 			`--skip=${skip}`
 		];
 
-		if (branch) {
-			if (branch === '--all') {
-				args.push('--all');
-			} else {
-				assertSafeGitRevish(branch, 'log branch');
-				args.push(branch);
-			}
+		// `--all` is a flag, not a revision, so it stays out of the value slot that
+		// `assertSafeGitRevish` guards against option injection.
+		if (allBranches) {
+			args.push('--all');
+		} else if (branch) {
+			assertSafeGitRevish(branch, 'log branch');
+			args.push(branch);
 		}
 
 		const result = await execGit(args, cwd);
@@ -507,7 +507,7 @@ export class GitService {
 		if (hasMore) commits.pop(); // Remove the extra one
 
 		// Get total count
-		const countRef = branch === '--all' ? '--all' : (branch ?? 'HEAD');
+		const countRef = allBranches ? '--all' : (branch ?? 'HEAD');
 		const countResult = await execGit(['rev-list', '--count', countRef], cwd);
 		const total = parseInt(countResult.stdout.trim()) || commits.length;
 

--- a/backend/ws/git/log.ts
+++ b/backend/ws/git/log.ts
@@ -32,6 +32,7 @@ export const logHandler = createRouter()
 			limit: t.Optional(t.Number()),
 			skip: t.Optional(t.Number()),
 			branch: t.Optional(t.String()),
+			allBranches: t.Optional(t.Boolean()),
 			repoPath: t.Optional(t.String())
 		}),
 		response: t.Object({
@@ -55,6 +56,7 @@ export const logHandler = createRouter()
 			cwd,
 			data.limit ?? 50,
 			data.skip ?? 0,
-			data.branch
+			data.branch,
+			data.allBranches ?? false
 		);
 	});

--- a/frontend/components/git/GitLog.svelte
+++ b/frontend/components/git/GitLog.svelte
@@ -12,17 +12,14 @@
 		onViewCommit: (hash: string) => void;
 		onCheckoutCommit: (hash: string) => void;
 		getRemoteCommitUrl?: (hash: string) => string | null;
-				/** When true, graph is rendered as a single linear lane (for sparse/filtered lists) */
-		isFiltered?: boolean;
-		/** Full unfiltered commits for building branching graph when filtered (to keep continuity) */
+		/** The unfiltered list `commits` was filtered from — lets the graph keep each
+		 *  commit on the lane it occupies in the full history. */
 		originalCommits?: GitCommit[];
-		/** Set of hashes that match filter (for branching filtered graph) */
-		highlightHashes?: Set<string>;
-		/** Current search text for highlighting in message */
+		/** Search text to highlight inside commit messages. */
 		searchQuery?: string;
 	}
 
-	const { commits, isLoading, hasMore, activeHash = null, onLoadMore, onViewCommit, onCheckoutCommit, getRemoteCommitUrl, isFiltered = false, originalCommits, highlightHashes, searchQuery = '' }: Props = $props();
+	const { commits, isLoading, hasMore, activeHash = null, onLoadMore, onViewCommit, onCheckoutCommit, getRemoteCommitUrl, originalCommits, searchQuery = '' }: Props = $props();
 
 	let selectedHash = $state('');
 	const effectiveActiveHash = $derived(activeHash ?? selectedHash);
@@ -70,157 +67,98 @@
 		'#f43f5e', '#06b6d4', '#f97316', '#ec4899'
 	];
 
+	// Graph of the full history. Filtering never recomputes it — it only decides
+	// which of its rows are drawn — so a commit keeps its lane and colour.
+	const baseGraph = $derived(originalCommits ? computeGraph(originalCommits) : null);
+
 	const graphRows = $derived.by(() => {
-		if (!isFiltered) return computeGraph(commits);
-		if (originalCommits && highlightHashes) {
-			return computeFilteredGraph(commits, originalCommits, highlightHashes);
+		if (baseGraph && originalCommits && originalCommits.length !== commits.length) {
+			return projectGraph(commits, originalCommits, baseGraph);
 		}
-		return computeLinearGraph(commits);
+		return computeGraph(commits);
 	});
 
-	function computeLinearGraph(commits: GitCommit[]): GraphRow[] {
-		if (commits.length === 0) return [];
-		const color = LANE_COLORS[0];
-		return commits.map((_, idx) => ({
-			col: 0,
-			nodeColor: color,
-			lanes: [],
-			mergeFrom: [],
-			branchTo: [],
-			branchToCols: new Set<number>(),
-			prevLaneCols: idx > 0 ? new Set([0]) : new Set<number>(),
-			nextLaneCols: idx < commits.length - 1 ? new Set([0]) : new Set<number>(),
-			nodeHasTop: idx > 0,
-			nodeHasBottom: idx < commits.length - 1,
-			maxCol: 0
-		}));
-	}
+	/**
+	 * Draw a filtered subset against the full history's graph.
+	 *
+	 * Rebuilding the lane assignment from the subset alone reflows every lane:
+	 * a commit sitting on the second branch collapses onto the first as soon as
+	 * the commits that held its lane open are filtered out, and the lane colours
+	 * shift with it. So we keep each visible commit's row from the full graph and
+	 * only recompute the connectors, carrying a lane across a run of hidden rows
+	 * when it stays open the whole way.
+	 */
+	function projectGraph(filtered: GitCommit[], all: GitCommit[], base: GraphRow[]): GraphRow[] {
+		if (filtered.length === 0 || base.length === 0) return [];
 
-	function computeFilteredGraph(
-		filtered: GitCommit[],
-		all: GitCommit[],
-		filteredSet: Set<string>
-	): GraphRow[] {
-		if (filtered.length === 0) return [];
-		// Build map for walking parent chain
-		const map = new Map<string, GitCommit>();
-		for (const c of all) map.set(c.hash, c);
+		const indexOf = new Map<string, number>();
+		all.forEach((c, i) => indexOf.set(c.hash, i));
 
-		function nearestFilteredAncestor(startHash: string): string | null {
-			let cur: string | null = startHash;
-			const visited = new Set<string>();
-			while (cur) {
-				if (visited.has(cur)) break;
-				visited.add(cur);
-				if (filteredSet.has(cur)) return cur;
-				const commit = map.get(cur);
-				if (!commit || commit.parents.length === 0) return null;
-				// Follow first parent for linear ancestry (merges handled via second parent separately)
-				cur = commit.parents[0];
-			}
-			return null;
+		const visible: number[] = [];
+		for (const c of filtered) {
+			const i = indexOf.get(c.hash);
+			// A commit outside `all` has no row to borrow; fall back rather than misalign.
+			if (i === undefined) return computeGraph(filtered);
+			visible.push(i);
 		}
 
-		// Build effective parents for each filtered commit
-		const effectiveParentsMap = new Map<string, string[]>();
-		for (const commit of filtered) {
-			const eff: string[] = [];
-			for (const p of commit.parents) {
-				const ancestor = nearestFilteredAncestor(p);
-				if (ancestor && ancestor !== commit.hash) eff.push(ancestor);
+		// col -> colour is stable across the whole base graph, so any row that
+		// touches a lane tells us that lane's colour.
+		const laneColor = new Map<number, string>();
+		for (const row of base) {
+			laneColor.set(row.col, row.nodeColor);
+			for (const l of row.lanes) laneColor.set(l.col, l.color);
+			for (const m of row.mergeFrom) laneColor.set(m.col, m.color);
+			for (const b of row.branchTo) laneColor.set(b.col, b.color);
+		}
+		const colorAt = (col: number) => laneColor.get(col) ?? LANE_COLORS[col % LANE_COLORS.length];
+
+		// Lanes that survive from one visible row down to the next: a lane only
+		// counts if it stays open across every hidden row in between, which is
+		// also what keeps a recycled lane from splicing two unrelated branches.
+		function lanesBelow(k: number): Set<number> {
+			const from = visible[k];
+			const to = k + 1 < visible.length ? visible[k + 1] : from + 1;
+			let open: Set<number> | null = null;
+			for (let i = from; i < to && i < base.length; i++) {
+				const next = base[i].nextLaneCols;
+				if (open === null) {
+					open = new Set(next);
+					continue;
+				}
+				for (const col of open) if (!next.has(col)) open.delete(col);
 			}
-			effectiveParentsMap.set(commit.hash, eff);
+			return open ?? new Set<number>();
 		}
 
-		// Reuse lane algorithm but with effective parents
-		const lanes: (string | null)[] = [];
-		const laneColorMap = new Map<number, string>();
-		let colorIdx = 0;
 		const rows: GraphRow[] = [];
-		const processedSet = new Set<string>();
+		let above = new Set<number>();
+		for (let k = 0; k < visible.length; k++) {
+			const src = base[visible[k]];
+			const below = lanesBelow(k);
+			const mergeFrom = src.mergeFrom.filter(m => above.has(m.col));
+			const branchTo = src.branchTo.filter(b => below.has(b.col));
+			const lanes = [...below].sort((a, b) => a - b).map(col => ({ col, color: colorAt(col) }));
 
-		function getColor(col: number): string {
-			if (!laneColorMap.has(col)) {
-				laneColorMap.set(col, LANE_COLORS[colorIdx % LANE_COLORS.length]);
-				colorIdx++;
-			}
-			return laneColorMap.get(col)!;
-		}
-		function getActiveCols(): Set<number> {
-			const s = new Set<number>();
-			for (let i = 0; i < lanes.length; i++) if (lanes[i] !== null) s.add(i);
-			return s;
-		}
-		let prevActiveCols = new Set<number>();
-		for (const commit of filtered) {
-			const myLanes: number[] = [];
-			for (let i = 0; i < lanes.length; i++) if (lanes[i] === commit.hash) myLanes.push(i);
-			let col: number;
-			const mergeFrom: Array<{ col: number; color: string }> = [];
-			if (myLanes.length > 0) {
-				col = myLanes[0];
-				for (let i = 1; i < myLanes.length; i++) {
-					mergeFrom.push({ col: myLanes[i], color: getColor(myLanes[i]) });
-					lanes[myLanes[i]] = null;
-				}
-			} else {
-				const empty = lanes.indexOf(null);
-				col = empty >= 0 ? empty : lanes.length;
-				if (col >= lanes.length) lanes.push(null);
-			}
-			getColor(col);
-			const nodeHasTop = prevActiveCols.has(col);
-			const currentPrevCols = new Set(prevActiveCols);
-			const branchTo: Array<{ col: number; color: string }> = [];
-			const branchToCols = new Set<number>();
-			const effParents = effectiveParentsMap.get(commit.hash) || [];
-			if (effParents.length > 0) {
-				if (processedSet.has(effParents[0])) {
-					lanes[col] = null;
-				} else {
-					lanes[col] = effParents[0];
-				}
-				for (let p = 1; p < effParents.length; p++) {
-					if (processedSet.has(effParents[p])) continue;
-					const existingIdx = lanes.indexOf(effParents[p]);
-					if (existingIdx >= 0 && existingIdx !== col) {
-						branchTo.push({ col: existingIdx, color: getColor(existingIdx) });
-						branchToCols.add(existingIdx);
-					} else {
-						let newCol = -1;
-						for (let i = 0; i < lanes.length; i++) if (lanes[i] === null && i !== col) { newCol = i; break; }
-						if (newCol < 0) { newCol = lanes.length; lanes.push(null); }
-						lanes[newCol] = effParents[p];
-						branchTo.push({ col: newCol, color: getColor(newCol) });
-						branchToCols.add(newCol);
-					}
-				}
-			} else {
-				lanes[col] = null;
-			}
-			const activeLanes: Array<{ col: number; color: string }> = [];
-			for (let i = 0; i < lanes.length; i++) if (lanes[i] !== null) activeLanes.push({ col: i, color: getColor(i) });
-			const nextActiveCols = getActiveCols();
-			let rowMaxCol = col;
-			for (const lane of activeLanes) rowMaxCol = Math.max(rowMaxCol, lane.col);
-			for (const m of mergeFrom) rowMaxCol = Math.max(rowMaxCol, m.col);
-			for (const b of branchTo) rowMaxCol = Math.max(rowMaxCol, b.col);
+			let maxCol = src.col;
+			for (const l of lanes) maxCol = Math.max(maxCol, l.col);
+			for (const m of mergeFrom) maxCol = Math.max(maxCol, m.col);
+			for (const b of branchTo) maxCol = Math.max(maxCol, b.col);
+
 			rows.push({
-				col,
-				nodeColor: getColor(col),
-				lanes: activeLanes,
+				col: src.col,
+				nodeColor: src.nodeColor,
+				lanes,
 				mergeFrom,
 				branchTo,
-				branchToCols,
-				prevLaneCols: currentPrevCols,
-				nextLaneCols: nextActiveCols,
-				nodeHasTop,
-				nodeHasBottom: nextActiveCols.has(col),
-				maxCol: rowMaxCol
+				branchToCols: new Set(branchTo.map(b => b.col)),
+				prevLaneCols: above,
+				nextLaneCols: below,
+				nodeHasTop: above.has(src.col),
+				nodeHasBottom: below.has(src.col),
+				maxCol
 			});
-			processedSet.add(commit.hash);
-			prevActiveCols = nextActiveCols;
-			while (lanes.length > 0 && lanes[lanes.length - 1] === null) lanes.pop();
+			above = below;
 		}
 		return rows;
 	}
@@ -396,21 +334,24 @@
 		return date.toLocaleDateString();
 	}
 
-	function escapeHtml(str: string): string {
-		return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-	}
+	/** Split a message into plain and matched runs, so the match can be marked up
+	 *  without routing user text through `{@html}`. */
+	function highlightParts(text: string, query: string): Array<{ text: string; hl: boolean }> {
+		const q = query.trim().toLowerCase();
+		if (!q) return [{ text, hl: false }];
 
-	function highlightMessage(text: string): string {
-		const q = searchQuery?.trim();
-		if (!q) return escapeHtml(text);
-		const escaped = escapeHtml(text);
-		const qEsc = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-		try {
-			const re = new RegExp(`(${qEsc})`, 'gi');
-			return escaped.replace(re, '<mark class="bg-yellow-200 dark:bg-yellow-500/30 text-slate-900 dark:text-slate-100 rounded px-0.5">$1</mark>');
-		} catch {
-			return escaped;
+		const parts: Array<{ text: string; hl: boolean }> = [];
+		const haystack = text.toLowerCase();
+		let cursor = 0;
+		let at = haystack.indexOf(q);
+		while (at !== -1) {
+			if (at > cursor) parts.push({ text: text.slice(cursor, at), hl: false });
+			parts.push({ text: text.slice(at, at + q.length), hl: true });
+			cursor = at + q.length;
+			at = haystack.indexOf(q, cursor);
 		}
+		if (cursor < text.length) parts.push({ text: text.slice(cursor), hl: false });
+		return parts;
 	}
 
 	function handleViewCommit(hash: string) {
@@ -551,8 +492,8 @@
 					<div class="flex-1 min-w-0 px-1.5 py-0.5 flex flex-col justify-center overflow-hidden">
 						<!-- Line 1: Message -->
 						<p class="text-sm text-slate-900 dark:text-slate-100 leading-tight truncate" title={commit.message}>
-							{#if searchQuery?.trim()}
-								{@html highlightMessage(commit.message)}
+							{#if searchQuery.trim()}
+								{#each highlightParts(commit.message, searchQuery) as part}{#if part.hl}<mark class="bg-transparent text-violet-600 dark:text-violet-400 font-semibold">{part.text}</mark>{:else}{part.text}{/if}{/each}
 							{:else}
 								{commit.message}
 							{/if}

--- a/frontend/components/git/GitLog.svelte
+++ b/frontend/components/git/GitLog.svelte
@@ -12,9 +12,17 @@
 		onViewCommit: (hash: string) => void;
 		onCheckoutCommit: (hash: string) => void;
 		getRemoteCommitUrl?: (hash: string) => string | null;
+				/** When true, graph is rendered as a single linear lane (for sparse/filtered lists) */
+		isFiltered?: boolean;
+		/** Full unfiltered commits for building branching graph when filtered (to keep continuity) */
+		originalCommits?: GitCommit[];
+		/** Set of hashes that match filter (for branching filtered graph) */
+		highlightHashes?: Set<string>;
+		/** Current search text for highlighting in message */
+		searchQuery?: string;
 	}
 
-	const { commits, isLoading, hasMore, activeHash = null, onLoadMore, onViewCommit, onCheckoutCommit, getRemoteCommitUrl }: Props = $props();
+	const { commits, isLoading, hasMore, activeHash = null, onLoadMore, onViewCommit, onCheckoutCommit, getRemoteCommitUrl, isFiltered = false, originalCommits, highlightHashes, searchQuery = '' }: Props = $props();
 
 	let selectedHash = $state('');
 	const effectiveActiveHash = $derived(activeHash ?? selectedHash);
@@ -62,7 +70,160 @@
 		'#f43f5e', '#06b6d4', '#f97316', '#ec4899'
 	];
 
-	const graphRows = $derived(computeGraph(commits));
+	const graphRows = $derived.by(() => {
+		if (!isFiltered) return computeGraph(commits);
+		if (originalCommits && highlightHashes) {
+			return computeFilteredGraph(commits, originalCommits, highlightHashes);
+		}
+		return computeLinearGraph(commits);
+	});
+
+	function computeLinearGraph(commits: GitCommit[]): GraphRow[] {
+		if (commits.length === 0) return [];
+		const color = LANE_COLORS[0];
+		return commits.map((_, idx) => ({
+			col: 0,
+			nodeColor: color,
+			lanes: [],
+			mergeFrom: [],
+			branchTo: [],
+			branchToCols: new Set<number>(),
+			prevLaneCols: idx > 0 ? new Set([0]) : new Set<number>(),
+			nextLaneCols: idx < commits.length - 1 ? new Set([0]) : new Set<number>(),
+			nodeHasTop: idx > 0,
+			nodeHasBottom: idx < commits.length - 1,
+			maxCol: 0
+		}));
+	}
+
+	function computeFilteredGraph(
+		filtered: GitCommit[],
+		all: GitCommit[],
+		filteredSet: Set<string>
+	): GraphRow[] {
+		if (filtered.length === 0) return [];
+		// Build map for walking parent chain
+		const map = new Map<string, GitCommit>();
+		for (const c of all) map.set(c.hash, c);
+
+		function nearestFilteredAncestor(startHash: string): string | null {
+			let cur: string | null = startHash;
+			const visited = new Set<string>();
+			while (cur) {
+				if (visited.has(cur)) break;
+				visited.add(cur);
+				if (filteredSet.has(cur)) return cur;
+				const commit = map.get(cur);
+				if (!commit || commit.parents.length === 0) return null;
+				// Follow first parent for linear ancestry (merges handled via second parent separately)
+				cur = commit.parents[0];
+			}
+			return null;
+		}
+
+		// Build effective parents for each filtered commit
+		const effectiveParentsMap = new Map<string, string[]>();
+		for (const commit of filtered) {
+			const eff: string[] = [];
+			for (const p of commit.parents) {
+				const ancestor = nearestFilteredAncestor(p);
+				if (ancestor && ancestor !== commit.hash) eff.push(ancestor);
+			}
+			effectiveParentsMap.set(commit.hash, eff);
+		}
+
+		// Reuse lane algorithm but with effective parents
+		const lanes: (string | null)[] = [];
+		const laneColorMap = new Map<number, string>();
+		let colorIdx = 0;
+		const rows: GraphRow[] = [];
+		const processedSet = new Set<string>();
+
+		function getColor(col: number): string {
+			if (!laneColorMap.has(col)) {
+				laneColorMap.set(col, LANE_COLORS[colorIdx % LANE_COLORS.length]);
+				colorIdx++;
+			}
+			return laneColorMap.get(col)!;
+		}
+		function getActiveCols(): Set<number> {
+			const s = new Set<number>();
+			for (let i = 0; i < lanes.length; i++) if (lanes[i] !== null) s.add(i);
+			return s;
+		}
+		let prevActiveCols = new Set<number>();
+		for (const commit of filtered) {
+			const myLanes: number[] = [];
+			for (let i = 0; i < lanes.length; i++) if (lanes[i] === commit.hash) myLanes.push(i);
+			let col: number;
+			const mergeFrom: Array<{ col: number; color: string }> = [];
+			if (myLanes.length > 0) {
+				col = myLanes[0];
+				for (let i = 1; i < myLanes.length; i++) {
+					mergeFrom.push({ col: myLanes[i], color: getColor(myLanes[i]) });
+					lanes[myLanes[i]] = null;
+				}
+			} else {
+				const empty = lanes.indexOf(null);
+				col = empty >= 0 ? empty : lanes.length;
+				if (col >= lanes.length) lanes.push(null);
+			}
+			getColor(col);
+			const nodeHasTop = prevActiveCols.has(col);
+			const currentPrevCols = new Set(prevActiveCols);
+			const branchTo: Array<{ col: number; color: string }> = [];
+			const branchToCols = new Set<number>();
+			const effParents = effectiveParentsMap.get(commit.hash) || [];
+			if (effParents.length > 0) {
+				if (processedSet.has(effParents[0])) {
+					lanes[col] = null;
+				} else {
+					lanes[col] = effParents[0];
+				}
+				for (let p = 1; p < effParents.length; p++) {
+					if (processedSet.has(effParents[p])) continue;
+					const existingIdx = lanes.indexOf(effParents[p]);
+					if (existingIdx >= 0 && existingIdx !== col) {
+						branchTo.push({ col: existingIdx, color: getColor(existingIdx) });
+						branchToCols.add(existingIdx);
+					} else {
+						let newCol = -1;
+						for (let i = 0; i < lanes.length; i++) if (lanes[i] === null && i !== col) { newCol = i; break; }
+						if (newCol < 0) { newCol = lanes.length; lanes.push(null); }
+						lanes[newCol] = effParents[p];
+						branchTo.push({ col: newCol, color: getColor(newCol) });
+						branchToCols.add(newCol);
+					}
+				}
+			} else {
+				lanes[col] = null;
+			}
+			const activeLanes: Array<{ col: number; color: string }> = [];
+			for (let i = 0; i < lanes.length; i++) if (lanes[i] !== null) activeLanes.push({ col: i, color: getColor(i) });
+			const nextActiveCols = getActiveCols();
+			let rowMaxCol = col;
+			for (const lane of activeLanes) rowMaxCol = Math.max(rowMaxCol, lane.col);
+			for (const m of mergeFrom) rowMaxCol = Math.max(rowMaxCol, m.col);
+			for (const b of branchTo) rowMaxCol = Math.max(rowMaxCol, b.col);
+			rows.push({
+				col,
+				nodeColor: getColor(col),
+				lanes: activeLanes,
+				mergeFrom,
+				branchTo,
+				branchToCols,
+				prevLaneCols: currentPrevCols,
+				nextLaneCols: nextActiveCols,
+				nodeHasTop,
+				nodeHasBottom: nextActiveCols.has(col),
+				maxCol: rowMaxCol
+			});
+			processedSet.add(commit.hash);
+			prevActiveCols = nextActiveCols;
+			while (lanes.length > 0 && lanes[lanes.length - 1] === null) lanes.pop();
+		}
+		return rows;
+	}
 
 	function computeGraph(commits: GitCommit[]): GraphRow[] {
 		if (commits.length === 0) return [];
@@ -235,6 +396,23 @@
 		return date.toLocaleDateString();
 	}
 
+	function escapeHtml(str: string): string {
+		return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+	}
+
+	function highlightMessage(text: string): string {
+		const q = searchQuery?.trim();
+		if (!q) return escapeHtml(text);
+		const escaped = escapeHtml(text);
+		const qEsc = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		try {
+			const re = new RegExp(`(${qEsc})`, 'gi');
+			return escaped.replace(re, '<mark class="bg-yellow-200 dark:bg-yellow-500/30 text-slate-900 dark:text-slate-100 rounded px-0.5">$1</mark>');
+		} catch {
+			return escaped;
+		}
+	}
+
 	function handleViewCommit(hash: string) {
 		selectedHash = hash;
 		onViewCommit(hash);
@@ -373,7 +551,11 @@
 					<div class="flex-1 min-w-0 px-1.5 py-0.5 flex flex-col justify-center overflow-hidden">
 						<!-- Line 1: Message -->
 						<p class="text-sm text-slate-900 dark:text-slate-100 leading-tight truncate" title={commit.message}>
-							{commit.message}
+							{#if searchQuery?.trim()}
+								{@html highlightMessage(commit.message)}
+							{:else}
+								{commit.message}
+							{/if}
 						</p>
 
 						<!-- Line 2: Hash + Date + Author -->

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -299,6 +299,7 @@
 	let historySearchQuery = $state('');
 	let historyAuthorFilter = $state<string>('all');
 	let historyDateFilter = $state<'all' | 'today' | 'week' | 'month'>('all');
+	let historyBranchFilter = $state<string>('current');
 	let showHistoryFilterMenu = $state(false);
 
 	// Per-nested-repo branches view state
@@ -691,7 +692,12 @@
 	const historyAuthors = $derived([...new Set(commits.map(c => c.author))].sort((a, b) => a.localeCompare(b)));
 
 	const hasHistoryFilter = $derived(
-		historySearchQuery.trim() !== '' || historyAuthorFilter !== 'all' || historyDateFilter !== 'all'
+		historySearchQuery.trim() !== '' || historyAuthorFilter !== 'all' || historyDateFilter !== 'all' || historyBranchFilter !== 'current'
+	);
+
+	// Branch options for history filter (current + all locals)
+	const historyBranchOptions = $derived(
+		branchInfo?.local.map(b => b.name) ?? []
 	);
 
 	function matchesHistorySearch(c: GitCommit, q: string): boolean {
@@ -745,12 +751,31 @@
 		});
 	}
 
+	const filteredCommitHashes = $derived(new Set(filteredCommits.map(c => c.hash)));
+
+	function filteredNestedCommitHashes(nested: GitNestedRepoInfo): Set<string> {
+		return new Set(filteredNestedCommits(nested).map(c => c.hash));
+	}
+
 	function clearHistoryFilters() {
 		historySearchQuery = '';
 		historyAuthorFilter = 'all';
 		historyDateFilter = 'all';
+		historyBranchFilter = 'current';
 		showHistoryFilterMenu = false;
+		// reload current branch history
+		void loadLog(true);
 	}
+
+	let prevHistoryBranchFilter = $state<string>('current');
+	$effect(() => {
+		const current = historyBranchFilter;
+		if (!hasActiveProject || !projectId) return;
+		if (current !== prevHistoryBranchFilter) {
+			prevHistoryBranchFilter = current;
+			void loadLog(true);
+		}
+	});
 
 	function filteredNestedLocalBranches(nested: GitNestedRepoInfo): GitBranch[] {
 		const q = nestedSearchQuery(nested.relPath);
@@ -1362,7 +1387,8 @@
 				logSkip = 0;
 				commits = [];
 			}
-			const data = await ws.http('git:log', { projectId, limit: 50, skip: logSkip });
+			const branchParam = historyBranchFilter === 'current' ? undefined : historyBranchFilter === 'all' ? '--all' : historyBranchFilter;
+			const data = await ws.http('git:log', { projectId, limit: 50, skip: logSkip, ...(branchParam ? { branch: branchParam } : {}) });
 			if (reset) {
 				commits = data.commits;
 			} else {
@@ -1386,6 +1412,16 @@
 			isLogLoading = false;
 		}
 	}
+
+	// Auto-load remaining pages when filtering to get accurate "Showing X of Y" for All branches
+	$effect(() => {
+		if (!hasHistoryFilter || !logHasMore || isLogLoading || commits.length === 0) return;
+		// Only auto-load for All branches or when search/author filter needs full scan
+		if (historyBranchFilter === 'all' || historySearchQuery.trim() !== '' || historyAuthorFilter !== 'all') {
+			const t = setTimeout(() => void loadLog(), 250);
+			return () => clearTimeout(t);
+		}
+	});
 
 	async function loadNestedLog(relPath: string, repoPath: string, reset = false) {
 		if (!projectId) return;
@@ -4530,6 +4566,7 @@ ${bodies}`;
 		: true}
 	{@const defaultHeight = (branchInfo?.nested && branchInfo.nested.length === 1) ? 'auto' : '260px'}
 	{@const currentHeight = isCollapsed ? 'auto' : (nestedReposHeights[nested.relPath] ? `${nestedReposHeights[nested.relPath]}px` : defaultHeight)}
+	{@const filteredNested = filteredNestedCommits(nested)}
 	<div
 		class="relative flex flex-col min-h-0 bg-slate-50 dark:bg-slate-900 select-none {isCollapsed ? 'border-b border-slate-200/50 dark:border-slate-800/50' : ''}"
 		class:flex-none={isCollapsed || currentHeight !== 'auto'}
@@ -4572,7 +4609,6 @@ ${bodies}`;
 
 		{#if !isCollapsed}
 			<div class="flex-1 min-h-0 flex flex-col">
-				{@const filteredNested = filteredNestedCommits(nested)}
 				{#if commitsList.length > 0 && filteredNested.length === 0 && hasHistoryFilter}
 					<div class="flex flex-col items-center justify-center gap-1 py-6 text-slate-500 text-xs">
 						<Icon name="lucide:search-x" class="w-5 h-5 opacity-30" />
@@ -4580,10 +4616,14 @@ ${bodies}`;
 					</div>
 				{:else}
 					<GitLog
-						commits={hasHistoryFilter ? filteredNested : commitsList}
+						commits={filteredNested}
+						originalCommits={commitsList}
+						highlightHashes={filteredNestedCommitHashes(nested)}
+						searchQuery={historySearchQuery}
 						isLoading={nestedIsLogLoading[nested.relPath] || false}
 						hasMore={nestedLogHasMore[nested.relPath] || false}
 						activeHash={activeTab?.commitHash ?? null}
+						isFiltered={hasHistoryFilter}
 						onLoadMore={() => loadNestedLog(nested.relPath, nested.path)}
 						onViewCommit={(hash) => viewCommitDiff(hash, nested.path)}
 						onCheckoutCommit={(hash) => checkoutCommit(hash, nested.path)}
@@ -5288,6 +5328,20 @@ ${bodies}`;
 										</select>
 									</div>
 									<div class="space-y-1.5">
+										<label class="text-3xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">Branch</label>
+										<select
+											value={historyBranchFilter}
+											onchange={(e) => (historyBranchFilter = e.currentTarget.value)}
+											class="w-full px-2.5 py-1.5 text-xs bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-md text-slate-900 dark:text-slate-100 outline-none focus:border-violet-500/40"
+										>
+											<option value="current">Current branch ({branchInfo?.current ?? 'HEAD'})</option>
+											<option value="all">All branches</option>
+											{#each historyBranchOptions as bName (bName)}
+												<option value={bName}>{bName}</option>
+											{/each}
+										</select>
+									</div>
+									<div class="space-y-1.5">
 										<label class="text-3xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">Period</label>
 										<select
 											value={historyDateFilter}
@@ -5312,6 +5366,7 @@ ${bodies}`;
 					{#if hasHistoryFilter}
 						<div class="flex items-center gap-2 text-3xs text-slate-500 dark:text-slate-400">
 							<span>Showing {filteredCommits.length} of {commits.length} commits</span>
+							{#if historyBranchFilter !== 'current'}<span>· {historyBranchFilter === 'all' ? 'all branches' : historyBranchFilter}</span>{/if}
 							{#if historySearchQuery}<span class="truncate">· "{historySearchQuery}"</span>{/if}
 							<button type="button" class="ml-auto text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 bg-transparent border-none cursor-pointer p-0 text-3xs font-medium" onclick={clearHistoryFilters}>Clear</button>
 						</div>
@@ -5338,9 +5393,13 @@ ${bodies}`;
 					{:else}
 						<GitLog
 							commits={filteredCommits}
+							originalCommits={commits}
+							highlightHashes={filteredCommitHashes}
+							searchQuery={historySearchQuery}
 							isLoading={isLogLoading}
 							hasMore={logHasMore}
 							activeHash={activeTab?.commitHash ?? null}
+							isFiltered={hasHistoryFilter}
 							onLoadMore={() => loadLog()}
 							onViewCommit={viewCommitDiff}
 							onCheckoutCommit={checkoutCommit}

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -7,6 +7,8 @@
 	import { projectState } from '$frontend/stores/core/projects.svelte';
 	import { showError, showInfo } from '$frontend/stores/ui/notification.svelte';
 	import { debug } from '$shared/utils/logger';
+	import { scale } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
 	import { clickOutside } from '$frontend/utils/click-outside';
 	import { settings } from '$frontend/stores/features/settings.svelte';
 	import ws, { onWsReconnect } from '$frontend/utils/ws';
@@ -5366,7 +5368,7 @@ ${bodies}`;
 								class="flex-1 bg-transparent border-none outline-none text-slate-900 dark:text-slate-100 text-xs placeholder:text-slate-500 dark:placeholder:text-slate-400"
 							/>
 							{#if historySearchQuery}
-								<button type="button" class="flex items-center justify-center w-5 h-5 bg-transparent border-none rounded text-slate-400 cursor-pointer hover:text-slate-600 dark:hover:text-slate-300" onclick={() => (historySearchQuery = '')} title="Clear search">
+								<button type="button" class="-my-1 flex items-center justify-center w-5 h-5 bg-transparent border-none rounded text-slate-400 cursor-pointer hover:text-slate-600 dark:hover:text-slate-300" onclick={() => (historySearchQuery = '')} title="Clear search">
 									<Icon name="lucide:x" class="w-3 h-3" />
 								</button>
 							{/if}
@@ -5386,9 +5388,12 @@ ${bodies}`;
 								{/if}
 							</button>
 							{#if showHistoryFilterMenu}
-								<div class="absolute right-0 top-full mt-1 w-64 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg p-3 z-20 space-y-3">
-									<div class="space-y-1.5">
-										<label class="text-3xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">Author</label>
+								<div
+									class="absolute right-0 top-full mt-1 w-64 origin-top-right bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg p-3 z-20 space-y-3"
+									transition:scale={{ duration: 130, easing: cubicOut, start: 0.95, opacity: 0 }}
+								>
+									<div class="space-y-1">
+										<label class="flex text-3xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">Author</label>
 										<select
 											value={historyAuthorFilter}
 											onchange={(e) => (historyAuthorFilter = e.currentTarget.value)}
@@ -5400,8 +5405,8 @@ ${bodies}`;
 											{/each}
 										</select>
 									</div>
-									<div class="space-y-1.5">
-										<label class="text-3xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">Branch</label>
+									<div class="space-y-1">
+										<label class="flex text-3xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">Branch</label>
 										<select
 											value={historyBranchFilter}
 											onchange={(e) => (historyBranchFilter = e.currentTarget.value)}
@@ -5414,9 +5419,9 @@ ${bodies}`;
 											{/each}
 										</select>
 									</div>
-									<div class="space-y-1.5">
+									<div class="space-y-1">
 										<div class="flex items-center gap-2">
-											<span class="text-3xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">Date range</span>
+											<span class="flex text-3xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">Date range</span>
 											{#if historyDateFrom || historyDateTo}
 												<button type="button" class="ml-auto text-3xs font-medium text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 bg-transparent border-none cursor-pointer p-0" onclick={() => { historyDateFrom = ''; historyDateTo = ''; }}>Reset</button>
 											{/if}
@@ -6330,7 +6335,7 @@ ${bodies}`;
 			</button>
 			<button
 				type="button"
-				class="inline-flex items-center gap-2 px-3 py-2 text-sm font-semibold rounded-lg transition-colors
+				class="flex items-center gap-2 px-3 py-2 text-sm font-semibold rounded-lg transition-colors
 					{mergeBranchName && !isMoreBusy
 						? 'bg-violet-600 text-white hover:bg-violet-700 cursor-pointer'
 						: 'bg-slate-200 dark:bg-slate-700 text-slate-400 dark:text-slate-500 cursor-not-allowed'}"

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -7,6 +7,7 @@
 	import { projectState } from '$frontend/stores/core/projects.svelte';
 	import { showError, showInfo } from '$frontend/stores/ui/notification.svelte';
 	import { debug } from '$shared/utils/logger';
+	import { clickOutside } from '$frontend/utils/click-outside';
 	import { settings } from '$frontend/stores/features/settings.svelte';
 	import ws, { onWsReconnect } from '$frontend/utils/ws';
 	import { acquireFileWatch } from '$frontend/utils/file-watch';
@@ -688,95 +689,6 @@
 		) ?? []
 	);
 
-	// History: distinct authors for the author filter dropdown
-	const historyAuthors = $derived([...new Set(commits.map(c => c.author))].sort((a, b) => a.localeCompare(b)));
-
-	const hasHistoryFilter = $derived(
-		historySearchQuery.trim() !== '' || historyAuthorFilter !== 'all' || historyDateFilter !== 'all' || historyBranchFilter !== 'current'
-	);
-
-	// Branch options for history filter (current + all locals)
-	const historyBranchOptions = $derived(
-		branchInfo?.local.map(b => b.name) ?? []
-	);
-
-	function matchesHistorySearch(c: GitCommit, q: string): boolean {
-		if (!q) return true;
-		const lower = q.toLowerCase();
-		return (
-			c.message.toLowerCase().includes(lower) ||
-			c.author.toLowerCase().includes(lower) ||
-			c.authorEmail.toLowerCase().includes(lower) ||
-			c.hash.toLowerCase().includes(lower) ||
-			c.hashShort.toLowerCase().includes(lower) ||
-			(c.refs?.join(' ').toLowerCase().includes(lower) ?? false)
-		);
-	}
-
-	function matchesHistoryDate(c: GitCommit, filter: typeof historyDateFilter): boolean {
-		if (filter === 'all') return true;
-		const t = new Date(c.date).getTime();
-		if (Number.isNaN(t)) return true;
-		const diff = Date.now() - t;
-		if (filter === 'today') return diff < 24 * 60 * 60 * 1000;
-		if (filter === 'week') return diff < 7 * 24 * 60 * 60 * 1000;
-		if (filter === 'month') return diff < 30 * 24 * 60 * 60 * 1000;
-		return true;
-	}
-
-	const filteredCommits = $derived.by(() => {
-		const q = historySearchQuery.trim();
-		const authorF = historyAuthorFilter;
-		const dateF = historyDateFilter;
-		if (!q && authorF === 'all' && dateF === 'all') return commits;
-		return commits.filter(c => {
-			if (!matchesHistorySearch(c, q)) return false;
-			if (authorF !== 'all' && c.author !== authorF) return false;
-			if (!matchesHistoryDate(c, dateF)) return false;
-			return true;
-		});
-	});
-
-	function filteredNestedCommits(nested: GitNestedRepoInfo): GitCommit[] {
-		const list = nestedCommits[nested.relPath] || [];
-		const q = historySearchQuery.trim();
-		const authorF = historyAuthorFilter;
-		const dateF = historyDateFilter;
-		if (!q && authorF === 'all' && dateF === 'all') return list;
-		return list.filter(c => {
-			if (!matchesHistorySearch(c, q)) return false;
-			if (authorF !== 'all' && c.author !== authorF) return false;
-			if (!matchesHistoryDate(c, dateF)) return false;
-			return true;
-		});
-	}
-
-	const filteredCommitHashes = $derived(new Set(filteredCommits.map(c => c.hash)));
-
-	function filteredNestedCommitHashes(nested: GitNestedRepoInfo): Set<string> {
-		return new Set(filteredNestedCommits(nested).map(c => c.hash));
-	}
-
-	function clearHistoryFilters() {
-		historySearchQuery = '';
-		historyAuthorFilter = 'all';
-		historyDateFilter = 'all';
-		historyBranchFilter = 'current';
-		showHistoryFilterMenu = false;
-		// reload current branch history
-		void loadLog(true);
-	}
-
-	let prevHistoryBranchFilter = $state<string>('current');
-	$effect(() => {
-		const current = historyBranchFilter;
-		if (!hasActiveProject || !projectId) return;
-		if (current !== prevHistoryBranchFilter) {
-			prevHistoryBranchFilter = current;
-			void loadLog(true);
-		}
-	});
-
 	function filteredNestedLocalBranches(nested: GitNestedRepoInfo): GitBranch[] {
 		const q = nestedSearchQuery(nested.relPath);
 		return nested.info.local.filter(b => !q || b.name.toLowerCase().includes(q.toLowerCase()));
@@ -1113,12 +1025,121 @@
 	let nestedLogHasMore = $state<Record<string, boolean>>({});
 	let logSkip = $state(0);
 	let nestedLogSkip = $state<Record<string, number>>({});
+	// Commits reachable from the log's current scope, which is what the client-side
+	// filters are narrowing — not the number loaded so far.
+	let logTotal = $state(0);
+	// Set when a page fails so the filter scan below can't retry it forever.
+	let logLoadFailed = $state(false);
+
 	// A commit detail to re-open once the log finishes loading (per-project restore).
 	let pendingSelectedCommitHash = $state<string | null>(null);
 	// A diff tab to re-open once its data source is loaded (per-project restore):
 	// for changes sections, once git status is in; for commit files, once the
 	// commit detail's file list is fetched.
 	let pendingActiveDiff = $state<GitActiveDiff | null>(null);
+
+	// ============================
+	// History search & filter
+	// ============================
+
+	// Search, author and period run over loaded commits; only the branch scope is
+	// a server-side query, so changing it re-fetches.
+	const historyAuthors = $derived(
+		[...new Set([...commits, ...Object.values(nestedCommits).flat()].map(c => c.author))]
+			.sort((a, b) => a.localeCompare(b))
+	);
+
+	const hasHistoryFilter = $derived(
+		historySearchQuery.trim() !== '' || historyAuthorFilter !== 'all' || historyDateFilter !== 'all' || historyBranchFilter !== 'current'
+	);
+
+	const historyBranchOptions = $derived(branchInfo?.local.map(b => b.name) ?? []);
+
+	/**
+	 * Scope params for `git:log`. A named branch belongs to the main repo, so
+	 * sub-repos follow only `all` — their refs are their own and the parent's
+	 * branch name usually doesn't resolve there.
+	 */
+	function historyLogScope(nested = false): { branch?: string; allBranches?: boolean } {
+		if (historyBranchFilter === 'all') return { allBranches: true };
+		if (historyBranchFilter === 'current' || nested) return {};
+		return { branch: historyBranchFilter };
+	}
+
+	function matchesHistorySearch(c: GitCommit, q: string): boolean {
+		if (!q) return true;
+		const lower = q.toLowerCase();
+		return (
+			c.message.toLowerCase().includes(lower) ||
+			c.author.toLowerCase().includes(lower) ||
+			c.authorEmail.toLowerCase().includes(lower) ||
+			c.hash.toLowerCase().includes(lower) ||
+			c.hashShort.toLowerCase().includes(lower) ||
+			(c.refs?.join(' ').toLowerCase().includes(lower) ?? false)
+		);
+	}
+
+	function matchesHistoryDate(c: GitCommit, filter: typeof historyDateFilter): boolean {
+		if (filter === 'all') return true;
+		const t = new Date(c.date).getTime();
+		if (Number.isNaN(t)) return true;
+		if (filter === 'today') {
+			const midnight = new Date();
+			midnight.setHours(0, 0, 0, 0);
+			return t >= midnight.getTime();
+		}
+		const days = filter === 'week' ? 7 : 30;
+		return Date.now() - t < days * 24 * 60 * 60 * 1000;
+	}
+
+	function applyHistoryFilters(list: GitCommit[]): GitCommit[] {
+		const q = historySearchQuery.trim();
+		const authorF = historyAuthorFilter;
+		const dateF = historyDateFilter;
+		if (!q && authorF === 'all' && dateF === 'all') return list;
+		return list.filter(c =>
+			matchesHistorySearch(c, q) &&
+			(authorF === 'all' || c.author === authorF) &&
+			matchesHistoryDate(c, dateF)
+		);
+	}
+
+	const filteredCommits = $derived(applyHistoryFilters(commits));
+
+	function filteredNestedCommits(nested: GitNestedRepoInfo): GitCommit[] {
+		return applyHistoryFilters(nestedCommits[nested.relPath] || []);
+	}
+
+	function resetHistoryFilters() {
+		historySearchQuery = '';
+		historyAuthorFilter = 'all';
+		historyDateFilter = 'all';
+		historyBranchFilter = 'current';
+		prevHistoryBranchFilter = 'current';
+		showHistoryFilterMenu = false;
+	}
+
+	/** Explicit "load more" — also clears the latch that halted the background scan. */
+	function loadMoreLog() {
+		logLoadFailed = false;
+		void loadLog();
+	}
+
+	function clearHistoryFilters() {
+		const needsReload = historyBranchFilter !== 'current';
+		resetHistoryFilters();
+		if (needsReload) void refreshAllLogs();
+	}
+
+	let prevHistoryBranchFilter = $state<string>('current');
+	$effect(() => {
+		const current = historyBranchFilter;
+		if (!hasActiveProject || !projectId) return;
+		if (current !== prevHistoryBranchFilter) {
+			prevHistoryBranchFilter = current;
+			void refreshAllLogs();
+		}
+	});
 
 	// Commit detail state — when set, History view shows a per-commit file list
 	// instead of the commit log. Cleared via the back button.
@@ -1386,15 +1407,17 @@
 			if (reset) {
 				logSkip = 0;
 				commits = [];
+				logTotal = 0;
+				logLoadFailed = false;
 			}
-			const branchParam = historyBranchFilter === 'current' ? undefined : historyBranchFilter === 'all' ? '--all' : historyBranchFilter;
-			const data = await ws.http('git:log', { projectId, limit: 50, skip: logSkip, ...(branchParam ? { branch: branchParam } : {}) });
+			const data = await ws.http('git:log', { projectId, limit: 50, skip: logSkip, ...historyLogScope() });
 			if (reset) {
 				commits = data.commits;
 			} else {
 				commits = [...commits, ...data.commits];
 			}
 			logHasMore = data.hasMore;
+			logTotal = data.total;
 			logSkip += data.commits.length;
 
 			// Re-open a previously-selected commit detail for this project, once
@@ -1407,20 +1430,32 @@
 				}
 			}
 		} catch (err) {
+			logLoadFailed = true;
 			debug.error('git', 'Failed to load log:', err);
 		} finally {
 			isLogLoading = false;
 		}
 	}
 
-	// Auto-load remaining pages when filtering to get accurate "Showing X of Y" for All branches
+	/**
+	 * Search, author and period match against commits already in memory, so a
+	 * filter pulls further pages in the background.
+	 *
+	 * Both guards are load-bearing. `logLoadFailed` stops the scan on the first
+	 * failed page: the effect tracks `isLogLoading`, so without it a page that
+	 * throws re-triggers the effect the moment it settles and the panel retries
+	 * four times a second forever. The page cap stops a one-character search from
+	 * walking an entire long-lived history 50 commits at a time, each page also
+	 * paying a full `rev-list --count` on the server.
+	 */
+	const HISTORY_SCAN_LIMIT = 1000;
+	const historyScanCapped = $derived(hasHistoryFilter && logHasMore && commits.length >= HISTORY_SCAN_LIMIT);
+
 	$effect(() => {
-		if (!hasHistoryFilter || !logHasMore || isLogLoading || commits.length === 0) return;
-		// Only auto-load for All branches or when search/author filter needs full scan
-		if (historyBranchFilter === 'all' || historySearchQuery.trim() !== '' || historyAuthorFilter !== 'all') {
-			const t = setTimeout(() => void loadLog(), 250);
-			return () => clearTimeout(t);
-		}
+		if (!hasHistoryFilter || !logHasMore || isLogLoading || logLoadFailed) return;
+		if (commits.length === 0 || commits.length >= HISTORY_SCAN_LIMIT) return;
+		const t = setTimeout(() => void loadLog(), 150);
+		return () => clearTimeout(t);
 	});
 
 	async function loadNestedLog(relPath: string, repoPath: string, reset = false) {
@@ -1430,7 +1465,7 @@
 		nestedIsLogLoading = { ...nestedIsLogLoading, [relPath]: true };
 		try {
 			const currentSkip = reset ? 0 : (nestedLogSkip[relPath] || 0);
-			const data = await ws.http('git:log', { projectId, repoPath, limit: 50, skip: currentSkip });
+			const data = await ws.http('git:log', { projectId, repoPath, limit: 50, skip: currentSkip, ...historyLogScope(true) });
 			if (reset) {
 				nestedCommits = { ...nestedCommits, [relPath]: data.commits };
 				nestedLogSkip = { ...nestedLogSkip, [relPath]: data.commits.length };
@@ -3662,6 +3697,13 @@ ${bodies}`;
 					commits = [];
 					staleSections = new Set();
 					logSkip = 0;
+					logHasMore = false;
+					logTotal = 0;
+					logLoadFailed = false;
+					// History filters are per-project: a branch name carried into the
+					// next project doesn't resolve there, so `git:log` fails and its
+					// History view stays empty for the rest of the session.
+					resetHistoryFilters();
 					selectedCommit = null;
 					expandedContributors = new Set();
 					contributorVisible = {};
@@ -4618,12 +4660,10 @@ ${bodies}`;
 					<GitLog
 						commits={filteredNested}
 						originalCommits={commitsList}
-						highlightHashes={filteredNestedCommitHashes(nested)}
 						searchQuery={historySearchQuery}
 						isLoading={nestedIsLogLoading[nested.relPath] || false}
 						hasMore={nestedLogHasMore[nested.relPath] || false}
 						activeHash={activeTab?.commitHash ?? null}
-						isFiltered={hasHistoryFilter}
 						onLoadMore={() => loadNestedLog(nested.relPath, nested.path)}
 						onViewCommit={(hash) => viewCommitDiff(hash, nested.path)}
 						onCheckoutCommit={(hash) => checkoutCommit(hash, nested.path)}
@@ -5297,7 +5337,7 @@ ${bodies}`;
 								</button>
 							{/if}
 						</div>
-						<div class="relative">
+						<div class="relative" use:clickOutside={() => (showHistoryFilterMenu = false)}>
 							<button
 								type="button"
 								class="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-lg border transition-colors cursor-pointer {hasHistoryFilter ? 'bg-violet-500/10 border-violet-500/30 text-violet-600 dark:text-violet-400' : 'bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700'}"
@@ -5312,7 +5352,6 @@ ${bodies}`;
 								{/if}
 							</button>
 							{#if showHistoryFilterMenu}
-								<button type="button" class="fixed inset-0 z-10 bg-transparent border-none cursor-default" onclick={() => (showHistoryFilterMenu = false)} aria-label="Close filter menu"></button>
 								<div class="absolute right-0 top-full mt-1 w-64 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg p-3 z-20 space-y-3">
 									<div class="space-y-1.5">
 										<label class="text-3xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">Author</label>
@@ -5365,10 +5404,10 @@ ${bodies}`;
 					</div>
 					{#if hasHistoryFilter}
 						<div class="flex items-center gap-2 text-3xs text-slate-500 dark:text-slate-400">
-							<span>Showing {filteredCommits.length} of {commits.length} commits</span>
-							{#if historyBranchFilter !== 'current'}<span>· {historyBranchFilter === 'all' ? 'all branches' : historyBranchFilter}</span>{/if}
-							{#if historySearchQuery}<span class="truncate">· "{historySearchQuery}"</span>{/if}
-							<button type="button" class="ml-auto text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 bg-transparent border-none cursor-pointer p-0 text-3xs font-medium" onclick={clearHistoryFilters}>Clear</button>
+							<span>{filteredCommits.length} of {commits.length} scanned{logTotal > commits.length ? ` · ${logTotal} total` : ''}</span>
+							{#if historyBranchFilter !== 'current'}<span class="truncate">· {historyBranchFilter === 'all' ? 'all branches' : historyBranchFilter}</span>{/if}
+							{#if historyScanCapped}<span class="text-amber-600 dark:text-amber-500">· scan limit reached</span>{/if}
+							<button type="button" class="ml-auto shrink-0 text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 bg-transparent border-none cursor-pointer p-0 text-3xs font-medium" onclick={clearHistoryFilters}>Clear</button>
 						</div>
 					{/if}
 				</div>
@@ -5382,9 +5421,9 @@ ${bodies}`;
 					{#if commits.length > 0 && filteredCommits.length === 0}
 						<div class="flex flex-col items-center justify-center gap-2 py-8 text-slate-500 text-xs">
 							<Icon name="lucide:search-x" class="w-6 h-6 opacity-30" />
-							<span>No commits match your filters</span>
-							{#if logHasMore}
-								<button type="button" class="px-3 py-1.5 text-xs font-medium rounded-md bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer border-none" onclick={() => loadLog()}>
+							<span>{isLogLoading || (logHasMore && !logLoadFailed && !historyScanCapped) ? 'Searching earlier commits…' : 'No commits match your filters'}</span>
+							{#if logHasMore && !isLogLoading}
+								<button type="button" class="px-3 py-1.5 text-xs font-medium rounded-md bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer border-none" onclick={loadMoreLog}>
 									Load more
 								</button>
 							{/if}
@@ -5394,12 +5433,10 @@ ${bodies}`;
 						<GitLog
 							commits={filteredCommits}
 							originalCommits={commits}
-							highlightHashes={filteredCommitHashes}
 							searchQuery={historySearchQuery}
 							isLoading={isLogLoading}
 							hasMore={logHasMore}
 							activeHash={activeTab?.commitHash ?? null}
-							isFiltered={hasHistoryFilter}
 							onLoadMore={() => loadLog()}
 							onViewCommit={viewCommitDiff}
 							onCheckoutCommit={checkoutCommit}

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -297,11 +297,23 @@
 	let branchesSubTab = $state<'local' | 'remote'>('local');
 
 	// History view state — search & filter
+	// `historySearchQuery` is what the input holds; `historySearchTerm` is the
+	// debounced copy everything downstream reads, so a keystroke doesn't re-filter
+	// and re-render the whole commit list.
 	let historySearchQuery = $state('');
+	let historySearchTerm = $state('');
 	let historyAuthorFilter = $state<string>('all');
-	let historyDateFilter = $state<'all' | 'today' | 'week' | 'month'>('all');
+	let historyDateFrom = $state('');
+	let historyDateTo = $state('');
 	let historyBranchFilter = $state<string>('current');
 	let showHistoryFilterMenu = $state(false);
+
+	$effect(() => {
+		const q = historySearchQuery;
+		if (q === historySearchTerm) return;
+		const t = setTimeout(() => (historySearchTerm = q), 200);
+		return () => clearTimeout(t);
+	});
 
 	// Per-nested-repo branches view state
 	let nestedSearchQueries = $state<Record<string, string>>({});
@@ -1050,7 +1062,13 @@
 	);
 
 	const hasHistoryFilter = $derived(
-		historySearchQuery.trim() !== '' || historyAuthorFilter !== 'all' || historyDateFilter !== 'all' || historyBranchFilter !== 'current'
+		historySearchTerm.trim() !== '' || historyAuthorFilter !== 'all' || historyDateFrom !== '' || historyDateTo !== '' || historyBranchFilter !== 'current'
+	);
+
+	// Only the client-side filters need more pages loaded; the branch scope is
+	// already a server-side query, so switching it just paginates as usual.
+	const historyNeedsScan = $derived(
+		historySearchTerm.trim() !== '' || historyAuthorFilter !== 'all' || historyDateFrom !== '' || historyDateTo !== ''
 	);
 
 	const historyBranchOptions = $derived(branchInfo?.local.map(b => b.name) ?? []);
@@ -1079,28 +1097,37 @@
 		);
 	}
 
-	function matchesHistoryDate(c: GitCommit, filter: typeof historyDateFilter): boolean {
-		if (filter === 'all') return true;
+	/** Local midnight bounds for the `yyyy-mm-dd` range inputs; `to` is inclusive. */
+	const historyDateBounds = $derived.by(() => {
+		const parse = (value: string, endOfDay: boolean) => {
+			if (!value) return null;
+			const [y, m, d] = value.split('-').map(Number);
+			if (!y || !m || !d) return null;
+			return endOfDay
+				? new Date(y, m - 1, d, 23, 59, 59, 999).getTime()
+				: new Date(y, m - 1, d).getTime();
+		};
+		return { from: parse(historyDateFrom, false), to: parse(historyDateTo, true) };
+	});
+
+	function matchesHistoryDate(c: GitCommit, bounds: { from: number | null; to: number | null }): boolean {
+		if (bounds.from === null && bounds.to === null) return true;
 		const t = new Date(c.date).getTime();
 		if (Number.isNaN(t)) return true;
-		if (filter === 'today') {
-			const midnight = new Date();
-			midnight.setHours(0, 0, 0, 0);
-			return t >= midnight.getTime();
-		}
-		const days = filter === 'week' ? 7 : 30;
-		return Date.now() - t < days * 24 * 60 * 60 * 1000;
+		if (bounds.from !== null && t < bounds.from) return false;
+		if (bounds.to !== null && t > bounds.to) return false;
+		return true;
 	}
 
 	function applyHistoryFilters(list: GitCommit[]): GitCommit[] {
-		const q = historySearchQuery.trim();
+		const q = historySearchTerm.trim();
 		const authorF = historyAuthorFilter;
-		const dateF = historyDateFilter;
-		if (!q && authorF === 'all' && dateF === 'all') return list;
+		const bounds = historyDateBounds;
+		if (!q && authorF === 'all' && bounds.from === null && bounds.to === null) return list;
 		return list.filter(c =>
 			matchesHistorySearch(c, q) &&
 			(authorF === 'all' || c.author === authorF) &&
-			matchesHistoryDate(c, dateF)
+			matchesHistoryDate(c, bounds)
 		);
 	}
 
@@ -1112,8 +1139,10 @@
 
 	function resetHistoryFilters() {
 		historySearchQuery = '';
+		historySearchTerm = '';
 		historyAuthorFilter = 'all';
-		historyDateFilter = 'all';
+		historyDateFrom = '';
+		historyDateTo = '';
 		historyBranchFilter = 'current';
 		prevHistoryBranchFilter = 'current';
 		showHistoryFilterMenu = false;
@@ -1395,7 +1424,7 @@
 		}
 	}
 
-	async function loadLog(reset = false) {
+	async function loadLog(reset = false, limit = 50) {
 		if (!projectId) return;
 		// Guard against concurrent loads. On restore both the explicit load and the
 		// reactive view effect can fire for the same view; without this they'd
@@ -1410,7 +1439,7 @@
 				logTotal = 0;
 				logLoadFailed = false;
 			}
-			const data = await ws.http('git:log', { projectId, limit: 50, skip: logSkip, ...historyLogScope() });
+			const data = await ws.http('git:log', { projectId, limit, skip: logSkip, ...historyLogScope() });
 			if (reset) {
 				commits = data.commits;
 			} else {
@@ -1444,17 +1473,22 @@
 	 * Both guards are load-bearing. `logLoadFailed` stops the scan on the first
 	 * failed page: the effect tracks `isLogLoading`, so without it a page that
 	 * throws re-triggers the effect the moment it settles and the panel retries
-	 * four times a second forever. The page cap stops a one-character search from
-	 * walking an entire long-lived history 50 commits at a time, each page also
-	 * paying a full `rev-list --count` on the server.
+	 * four times a second forever. The cap stops a one-character search from
+	 * walking an entire long-lived history, each page also paying a full
+	 * `rev-list --count` on the server. Pages are much larger than the ones
+	 * scrolling asks for: each one re-renders the list, so 50 at a time flickers.
 	 */
 	const HISTORY_SCAN_LIMIT = 1000;
-	const historyScanCapped = $derived(hasHistoryFilter && logHasMore && commits.length >= HISTORY_SCAN_LIMIT);
+	const HISTORY_SCAN_PAGE = 500;
+	const historyScanCapped = $derived(historyNeedsScan && logHasMore && commits.length >= HISTORY_SCAN_LIMIT);
+	// Stays true for the whole scan, so the empty state doesn't blink its message
+	// and its button in and out once per page.
+	const historyScanning = $derived(historyNeedsScan && logHasMore && !logLoadFailed && !historyScanCapped);
 
 	$effect(() => {
-		if (!hasHistoryFilter || !logHasMore || isLogLoading || logLoadFailed) return;
+		if (!historyNeedsScan || !logHasMore || isLogLoading || logLoadFailed) return;
 		if (commits.length === 0 || commits.length >= HISTORY_SCAN_LIMIT) return;
-		const t = setTimeout(() => void loadLog(), 150);
+		const t = setTimeout(() => void loadLog(false, HISTORY_SCAN_PAGE), 150);
 		return () => clearTimeout(t);
 	});
 
@@ -4660,7 +4694,7 @@ ${bodies}`;
 					<GitLog
 						commits={filteredNested}
 						originalCommits={commitsList}
-						searchQuery={historySearchQuery}
+						searchQuery={historySearchTerm}
 						isLoading={nestedIsLogLoading[nested.relPath] || false}
 						hasMore={nestedLogHasMore[nested.relPath] || false}
 						activeHash={activeTab?.commitHash ?? null}
@@ -5381,17 +5415,29 @@ ${bodies}`;
 										</select>
 									</div>
 									<div class="space-y-1.5">
-										<label class="text-3xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">Period</label>
-										<select
-											value={historyDateFilter}
-											onchange={(e) => (historyDateFilter = e.currentTarget.value as typeof historyDateFilter)}
-											class="w-full px-2.5 py-1.5 text-xs bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-md text-slate-900 dark:text-slate-100 outline-none focus:border-violet-500/40"
-										>
-											<option value="all">All time</option>
-											<option value="today">Today</option>
-											<option value="week">Last 7 days</option>
-											<option value="month">Last 30 days</option>
-										</select>
+										<div class="flex items-center gap-2">
+											<span class="text-3xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">Date range</span>
+											{#if historyDateFrom || historyDateTo}
+												<button type="button" class="ml-auto text-3xs font-medium text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 bg-transparent border-none cursor-pointer p-0" onclick={() => { historyDateFrom = ''; historyDateTo = ''; }}>Reset</button>
+											{/if}
+										</div>
+										<div class="flex items-center gap-1.5">
+											<input
+												type="date"
+												aria-label="From date"
+												bind:value={historyDateFrom}
+												max={historyDateTo || undefined}
+												class="min-w-0 flex-1 px-2 py-1.5 text-xs bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-md text-slate-900 dark:text-slate-100 outline-none focus:border-violet-500/40"
+											/>
+											<span class="text-3xs text-slate-400 shrink-0">to</span>
+											<input
+												type="date"
+												aria-label="To date"
+												bind:value={historyDateTo}
+												min={historyDateFrom || undefined}
+												class="min-w-0 flex-1 px-2 py-1.5 text-xs bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-md text-slate-900 dark:text-slate-100 outline-none focus:border-violet-500/40"
+											/>
+										</div>
 									</div>
 									{#if hasHistoryFilter}
 										<button type="button" class="w-full px-2.5 py-1.5 text-xs font-medium rounded-md bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors cursor-pointer border-none" onclick={clearHistoryFilters}>
@@ -5421,8 +5467,8 @@ ${bodies}`;
 					{#if commits.length > 0 && filteredCommits.length === 0}
 						<div class="flex flex-col items-center justify-center gap-2 py-8 text-slate-500 text-xs">
 							<Icon name="lucide:search-x" class="w-6 h-6 opacity-30" />
-							<span>{isLogLoading || (logHasMore && !logLoadFailed && !historyScanCapped) ? 'Searching earlier commits…' : 'No commits match your filters'}</span>
-							{#if logHasMore && !isLogLoading}
+							<span>{historyScanning ? 'Searching earlier commits…' : 'No commits match your filters'}</span>
+							{#if logHasMore && !historyScanning && !isLogLoading}
 								<button type="button" class="px-3 py-1.5 text-xs font-medium rounded-md bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer border-none" onclick={loadMoreLog}>
 									Load more
 								</button>
@@ -5433,7 +5479,7 @@ ${bodies}`;
 						<GitLog
 							commits={filteredCommits}
 							originalCommits={commits}
-							searchQuery={historySearchQuery}
+							searchQuery={historySearchTerm}
 							isLoading={isLogLoading}
 							hasMore={logHasMore}
 							activeHash={activeTab?.commitHash ?? null}

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -295,6 +295,12 @@
 	let branchesSearchQuery = $state('');
 	let branchesSubTab = $state<'local' | 'remote'>('local');
 
+	// History view state — search & filter
+	let historySearchQuery = $state('');
+	let historyAuthorFilter = $state<string>('all');
+	let historyDateFilter = $state<'all' | 'today' | 'week' | 'month'>('all');
+	let showHistoryFilterMenu = $state(false);
+
 	// Per-nested-repo branches view state
 	let nestedSearchQueries = $state<Record<string, string>>({});
 	let nestedRemoteSearchQueries = $state<Record<string, string>>({});
@@ -680,6 +686,71 @@
 			branchesSubTab !== 'remote' || !branchesSearchQuery || b.name.toLowerCase().includes(branchesSearchQuery.toLowerCase())
 		) ?? []
 	);
+
+	// History: distinct authors for the author filter dropdown
+	const historyAuthors = $derived([...new Set(commits.map(c => c.author))].sort((a, b) => a.localeCompare(b)));
+
+	const hasHistoryFilter = $derived(
+		historySearchQuery.trim() !== '' || historyAuthorFilter !== 'all' || historyDateFilter !== 'all'
+	);
+
+	function matchesHistorySearch(c: GitCommit, q: string): boolean {
+		if (!q) return true;
+		const lower = q.toLowerCase();
+		return (
+			c.message.toLowerCase().includes(lower) ||
+			c.author.toLowerCase().includes(lower) ||
+			c.authorEmail.toLowerCase().includes(lower) ||
+			c.hash.toLowerCase().includes(lower) ||
+			c.hashShort.toLowerCase().includes(lower) ||
+			(c.refs?.join(' ').toLowerCase().includes(lower) ?? false)
+		);
+	}
+
+	function matchesHistoryDate(c: GitCommit, filter: typeof historyDateFilter): boolean {
+		if (filter === 'all') return true;
+		const t = new Date(c.date).getTime();
+		if (Number.isNaN(t)) return true;
+		const diff = Date.now() - t;
+		if (filter === 'today') return diff < 24 * 60 * 60 * 1000;
+		if (filter === 'week') return diff < 7 * 24 * 60 * 60 * 1000;
+		if (filter === 'month') return diff < 30 * 24 * 60 * 60 * 1000;
+		return true;
+	}
+
+	const filteredCommits = $derived.by(() => {
+		const q = historySearchQuery.trim();
+		const authorF = historyAuthorFilter;
+		const dateF = historyDateFilter;
+		if (!q && authorF === 'all' && dateF === 'all') return commits;
+		return commits.filter(c => {
+			if (!matchesHistorySearch(c, q)) return false;
+			if (authorF !== 'all' && c.author !== authorF) return false;
+			if (!matchesHistoryDate(c, dateF)) return false;
+			return true;
+		});
+	});
+
+	function filteredNestedCommits(nested: GitNestedRepoInfo): GitCommit[] {
+		const list = nestedCommits[nested.relPath] || [];
+		const q = historySearchQuery.trim();
+		const authorF = historyAuthorFilter;
+		const dateF = historyDateFilter;
+		if (!q && authorF === 'all' && dateF === 'all') return list;
+		return list.filter(c => {
+			if (!matchesHistorySearch(c, q)) return false;
+			if (authorF !== 'all' && c.author !== authorF) return false;
+			if (!matchesHistoryDate(c, dateF)) return false;
+			return true;
+		});
+	}
+
+	function clearHistoryFilters() {
+		historySearchQuery = '';
+		historyAuthorFilter = 'all';
+		historyDateFilter = 'all';
+		showHistoryFilterMenu = false;
+	}
 
 	function filteredNestedLocalBranches(nested: GitNestedRepoInfo): GitBranch[] {
 		const q = nestedSearchQuery(nested.relPath);
@@ -4501,16 +4572,24 @@ ${bodies}`;
 
 		{#if !isCollapsed}
 			<div class="flex-1 min-h-0 flex flex-col">
-				<GitLog
-					commits={commitsList}
-					isLoading={nestedIsLogLoading[nested.relPath] || false}
-					hasMore={nestedLogHasMore[nested.relPath] || false}
-					activeHash={activeTab?.commitHash ?? null}
-					onLoadMore={() => loadNestedLog(nested.relPath, nested.path)}
-					onViewCommit={(hash) => viewCommitDiff(hash, nested.path)}
-					onCheckoutCommit={(hash) => checkoutCommit(hash, nested.path)}
-					getRemoteCommitUrl={(hash) => buildRemoteCommitUrl(hash, nested.path)}
-				/>
+				{@const filteredNested = filteredNestedCommits(nested)}
+				{#if commitsList.length > 0 && filteredNested.length === 0 && hasHistoryFilter}
+					<div class="flex flex-col items-center justify-center gap-1 py-6 text-slate-500 text-xs">
+						<Icon name="lucide:search-x" class="w-5 h-5 opacity-30" />
+						<span>No matches</span>
+					</div>
+				{:else}
+					<GitLog
+						commits={hasHistoryFilter ? filteredNested : commitsList}
+						isLoading={nestedIsLogLoading[nested.relPath] || false}
+						hasMore={nestedLogHasMore[nested.relPath] || false}
+						activeHash={activeTab?.commitHash ?? null}
+						onLoadMore={() => loadNestedLog(nested.relPath, nested.path)}
+						onViewCommit={(hash) => viewCommitDiff(hash, nested.path)}
+						onCheckoutCommit={(hash) => checkoutCommit(hash, nested.path)}
+						getRemoteCommitUrl={(hash) => buildRemoteCommitUrl(hash, nested.path)}
+					/>
+				{/if}
 			</div>
 		{/if}
 	</div>
@@ -5161,6 +5240,83 @@ ${bodies}`;
 			/>
 		{:else}
 			<div class="flex-1 flex flex-col min-h-0">
+				<!-- History search & filter bar -->
+				<div class="px-2 pt-2 pb-2 space-y-2 flex-shrink-0 border-b border-slate-200/50 dark:border-slate-800/50 bg-white/50 dark:bg-slate-900/50">
+					<div class="flex items-center gap-2">
+						<div class="flex-1 flex items-center gap-2 py-1.5 px-2.5 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-lg">
+							<Icon name="lucide:search" class="w-3.5 h-3.5 text-slate-500 dark:text-slate-400 shrink-0" />
+							<input
+								type="text"
+								bind:value={historySearchQuery}
+								placeholder="Search commits, author, hash..."
+								class="flex-1 bg-transparent border-none outline-none text-slate-900 dark:text-slate-100 text-xs placeholder:text-slate-500 dark:placeholder:text-slate-400"
+							/>
+							{#if historySearchQuery}
+								<button type="button" class="flex items-center justify-center w-5 h-5 bg-transparent border-none rounded text-slate-400 cursor-pointer hover:text-slate-600 dark:hover:text-slate-300" onclick={() => (historySearchQuery = '')} title="Clear search">
+									<Icon name="lucide:x" class="w-3 h-3" />
+								</button>
+							{/if}
+						</div>
+						<div class="relative">
+							<button
+								type="button"
+								class="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-lg border transition-colors cursor-pointer {hasHistoryFilter ? 'bg-violet-500/10 border-violet-500/30 text-violet-600 dark:text-violet-400' : 'bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700'}"
+								onclick={() => (showHistoryFilterMenu = !showHistoryFilterMenu)}
+								title="Filter history"
+								aria-label="Filter history"
+							>
+								<Icon name="lucide:sliders-horizontal" class="w-3.5 h-3.5" />
+								<span>Filter</span>
+								{#if hasHistoryFilter}
+									<span class="w-1.5 h-1.5 rounded-full bg-violet-600 dark:bg-violet-400"></span>
+								{/if}
+							</button>
+							{#if showHistoryFilterMenu}
+								<button type="button" class="fixed inset-0 z-10 bg-transparent border-none cursor-default" onclick={() => (showHistoryFilterMenu = false)} aria-label="Close filter menu"></button>
+								<div class="absolute right-0 top-full mt-1 w-64 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg p-3 z-20 space-y-3">
+									<div class="space-y-1.5">
+										<label class="text-3xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">Author</label>
+										<select
+											value={historyAuthorFilter}
+											onchange={(e) => (historyAuthorFilter = e.currentTarget.value)}
+											class="w-full px-2.5 py-1.5 text-xs bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-md text-slate-900 dark:text-slate-100 outline-none focus:border-violet-500/40"
+										>
+											<option value="all">All authors</option>
+											{#each historyAuthors as author (author)}
+												<option value={author}>{author}</option>
+											{/each}
+										</select>
+									</div>
+									<div class="space-y-1.5">
+										<label class="text-3xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">Period</label>
+										<select
+											value={historyDateFilter}
+											onchange={(e) => (historyDateFilter = e.currentTarget.value as typeof historyDateFilter)}
+											class="w-full px-2.5 py-1.5 text-xs bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-md text-slate-900 dark:text-slate-100 outline-none focus:border-violet-500/40"
+										>
+											<option value="all">All time</option>
+											<option value="today">Today</option>
+											<option value="week">Last 7 days</option>
+											<option value="month">Last 30 days</option>
+										</select>
+									</div>
+									{#if hasHistoryFilter}
+										<button type="button" class="w-full px-2.5 py-1.5 text-xs font-medium rounded-md bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors cursor-pointer border-none" onclick={clearHistoryFilters}>
+											Clear filters
+										</button>
+									{/if}
+								</div>
+							{/if}
+						</div>
+					</div>
+					{#if hasHistoryFilter}
+						<div class="flex items-center gap-2 text-3xs text-slate-500 dark:text-slate-400">
+							<span>Showing {filteredCommits.length} of {commits.length} commits</span>
+							{#if historySearchQuery}<span class="truncate">· "{historySearchQuery}"</span>{/if}
+							<button type="button" class="ml-auto text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 bg-transparent border-none cursor-pointer p-0 text-3xs font-medium" onclick={clearHistoryFilters}>Clear</button>
+						</div>
+					{/if}
+				</div>
 				<div
 					class="min-h-0 flex flex-col"
 					class:flex-none={mainLogHeight !== undefined}
@@ -5168,16 +5324,29 @@ ${bodies}`;
 					style:height={mainLogHeight ? `${mainLogHeight}px` : undefined}
 					style:max-height={mainLogHeight ? `${mainLogHeight}px` : undefined}
 				>
-					<GitLog
-						{commits}
-						isLoading={isLogLoading}
-						hasMore={logHasMore}
-						activeHash={activeTab?.commitHash ?? null}
-						onLoadMore={() => loadLog()}
-						onViewCommit={viewCommitDiff}
-						onCheckoutCommit={checkoutCommit}
-						getRemoteCommitUrl={buildRemoteCommitUrl}
-					/>
+					{#if commits.length > 0 && filteredCommits.length === 0}
+						<div class="flex flex-col items-center justify-center gap-2 py-8 text-slate-500 text-xs">
+							<Icon name="lucide:search-x" class="w-6 h-6 opacity-30" />
+							<span>No commits match your filters</span>
+							{#if logHasMore}
+								<button type="button" class="px-3 py-1.5 text-xs font-medium rounded-md bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer border-none" onclick={() => loadLog()}>
+									Load more
+								</button>
+							{/if}
+							<button type="button" class="text-xs font-medium text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 bg-transparent border-none cursor-pointer p-0" onclick={clearHistoryFilters}>Clear filters</button>
+						</div>
+					{:else}
+						<GitLog
+							commits={filteredCommits}
+							isLoading={isLogLoading}
+							hasMore={logHasMore}
+							activeHash={activeTab?.commitHash ?? null}
+							onLoadMore={() => loadLog()}
+							onViewCommit={viewCommitDiff}
+							onCheckoutCommit={checkoutCommit}
+							getRemoteCommitUrl={buildRemoteCommitUrl}
+						/>
+					{/if}
 				</div>
 				{#if branchInfo?.nested && branchInfo.nested.length > 0}
 					{#each branchInfo.nested as nested (nested.path)}


### PR DESCRIPTION
## Summary

Adds search and filtering to the Source Control → History tab: a search box over
message, author, email, hash and refs, plus a filter menu with an author picker,
a from/to date range, and a branch scope (current branch, a named local branch,
or every ref).

## Why

History listed commits with no way to narrow them. Finding a commit meant
scrolling until it appeared, and the log was always scoped to `HEAD` — a commit
on another branch couldn't be reached from this view at all.

The graph column is the constraint that shaped the implementation. A commit's
column and colour are how you tell which branch it sits on, so a filtered view
has to keep them. Building a graph from the visible subset alone doesn't: lanes
are allocated into the first free slot, so the moment the commits holding a lane
open are hidden, everything below collapses leftward and a commit visually jumps
branches.

## Changes

**Backend — branch scope:**
- `git-service.ts:474` — `getLog` takes an explicit `allBranches` flag. It's a
  flag, not a revision, so `assertSafeGitRevish` keeps guarding the `branch`
  argument against option-shaped values with no exemption.
- `ws/git/log.ts:35` — `allBranches` added to the `git:log` request schema.
- `git-service.test.ts:110` — branch scoping covered: `HEAD` default, named
  branch, `allBranches`, and `branch: '--all'` still rejected.

**Graph:**
- `GitLog.svelte:72` — the full history's graph is computed once, so filtering
  and typing never rebuild it.
- `GitLog.svelte:91` — `projectGraph` draws the filtered subset against that
  graph. Each visible commit keeps its row; only the connectors are recomputed,
  carrying a lane across a run of hidden rows when it stays open the whole way.
  That condition is what stops a recycled lane from splicing two unrelated
  branches together, and what keeps a merge whose parents collapse to the same
  visible ancestor from drawing a fork and a merge that don't exist.
- `GitLog.svelte:339` — the search highlight renders as `{ text, hl }` parts,
  matching `CommandPalette.svelte` / `HistoryView.svelte` / `HistoryModal.svelte`,
  so no user text goes through `{@html}`.

**Filtering:**
- `GitPanel.svelte:316` — the input holds `historySearchQuery`; everything
  downstream reads `historySearchTerm`, a 200ms-debounced copy, so a keystroke
  doesn't re-filter and re-render the list.
- `GitPanel.svelte:1103` — the date range is read at local midnight with `to`
  inclusive, so it means the dates picked rather than a rolling window.
- `GitPanel.svelte:1083` — sub-repos follow the all-branches scope but not a
  named branch, whose ref belongs to the parent repo.

**Paging:**
- `GitPanel.svelte:1072` — search, author and date match against loaded commits,
  so they pull further pages in the background. The branch scope doesn't: it's
  already a server-side query, so switching it just paginates as usual.
- `GitPanel.svelte:1464`, `:1483` — the scan stops on a failed page and caps at
  1000 commits, reported in the summary line next to the true total. Without the
  failure latch the effect retries four times a second indefinitely, because it
  tracks `isLogLoading` and `loadLog` swallows its error.
- `GitPanel.svelte:1488` — `historyScanning` holds steady for the whole run, so
  the empty state doesn't blink its message and button in and out once per page.

**Per-project state:**
- `GitPanel.svelte:3742` — the filters reset with the rest of the log state on a
  project switch. A branch name carried into the next project doesn't resolve
  there, so `git:log` fails and its History view stays empty for the session.

**UI:**
- `GitPanel.svelte:5376` — the filter menu dismisses via `clickOutside`, like
  every other menu in this panel.
- `GitPanel.svelte:5393` — and scales in, matching `GitMoreMenu.svelte:203` on
  duration so the two menus in this panel behave identically.

## Test plan

- `bun run check` — 0 errors, 0 warnings
- `bun run lint` — clean
- `bun run test` — 795 pass, 0 fail (includes 4 new `getLog` branch-scoping tests)
- Manual: searched, filtered by author and date range, and switched branch scope
  on a 705-commit repo (814 across all refs), checking that a commit on a side
  branch keeps its lane and colour when filtered.

## Follow-ups

`git log` takes `--author`, `--grep` and `--since` natively. Pushing the filters
server-side would make `total` correct for the filtered set, keep pagination
working, and remove the background scan entirely. It changes the shape of the
feature enough to belong in its own PR.