### PR TITLE
fix(ui): shrink the list in step with the sliding detail panel

### DIFF
--- a/frontend/components/containers/ContainerDetailLayer.svelte
+++ b/frontend/components/containers/ContainerDetailLayer.svelte
@@ -27,7 +27,18 @@
 	/** Space left above the sheet so the list behind it stays visible. */
 	const SHEET_TOP_GAP = 56;
 	/** The side panel's own width, so it slides exactly its own length. */
-	const PANEL_TRAVEL = 320;
+	const PANEL_WIDTH = 320;
+
+	/**
+	 * The panel claims its width over the same time it slides in, so the list
+	 * beside it gives way in step. Left to flex alone the list snaps to its
+	 * narrow size on the first frame and the panel slides onto a bare strip.
+	 */
+	const claimWidth = (_node: Element) => ({
+		duration: 240,
+		easing: cubicOut,
+		css: (t: number) => `width: ${PANEL_WIDTH * t}px`
+	});
 
 	let windowWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 1024);
 	let windowHeight = $state(typeof window !== 'undefined' ? window.innerHeight : 768);
@@ -60,10 +71,22 @@
 		<ContainerDetail sheet {entry} {canManage} {onClose} {onAction} />
 	</div>
 {:else}
+	<!-- Two elements, one motion: the outer takes the width away from the list
+	     while it clips, the inner slides its own length inside it. The inner is
+	     pinned to the right rather than laid out in flow so the clip always eats
+	     the left side, which is what keeps the panel's border against the list
+	     instead of sliding a gap in front of it. -->
 	<div
-		class="shrink-0 flex w-80"
-		transition:fly|global={{ x: PANEL_TRAVEL, duration: 240, easing: cubicOut, opacity: 1 }}
+		class="relative shrink-0 flex overflow-hidden"
+		style:width="{PANEL_WIDTH}px"
+		transition:claimWidth|global
 	>
-		<ContainerDetail {entry} {canManage} {onClose} {onAction} />
+		<div
+			class="absolute inset-y-0 right-0 flex"
+			style:width="{PANEL_WIDTH}px"
+			transition:fly|global={{ x: PANEL_WIDTH, duration: 240, easing: cubicOut, opacity: 1 }}
+		>
+			<ContainerDetail {entry} {canManage} {onClose} {onAction} />
+		</div>
 	</div>
 {/if}

--- a/frontend/components/containers/ContainersPane.svelte
+++ b/frontend/components/containers/ContainersPane.svelte
@@ -165,16 +165,6 @@
 					Shell
 				</button>
 			{/if}
-
-			{#if result?.runtime}
-				<span
-					class="hidden lg:flex items-center gap-1.5 shrink-0 text-[11px] text-slate-400 dark:text-slate-600"
-					title="This list refreshes every couple of seconds while the panel is open"
-				>
-					<span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
-					live
-				</span>
-			{/if}
 		</div>
 
 		{#if containersStore.isLoading && !result}

--- a/frontend/components/ports/PortDetailLayer.svelte
+++ b/frontend/components/ports/PortDetailLayer.svelte
@@ -25,7 +25,18 @@
 	/** Space left above the sheet so the table behind it stays visible. */
 	const SHEET_TOP_GAP = 56;
 	/** The side panel's own width, so it slides exactly its own length. */
-	const PANEL_TRAVEL = 320;
+	const PANEL_WIDTH = 320;
+
+	/**
+	 * The panel claims its width over the same time it slides in, so the table
+	 * beside it gives way in step. Left to flex alone the table snaps to its
+	 * narrow size on the first frame and the panel slides onto a bare strip.
+	 */
+	const claimWidth = (_node: Element) => ({
+		duration: 240,
+		easing: cubicOut,
+		css: (t: number) => `width: ${PANEL_WIDTH * t}px`
+	});
 
 	let windowWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 1024);
 	let windowHeight = $state(typeof window !== 'undefined' ? window.innerHeight : 768);
@@ -58,11 +69,22 @@
 		<PortDetail sheet {entry} {onClose} />
 	</div>
 {:else}
+	<!-- Two elements, one motion: the outer takes the width away from the table
+	     while it clips, the inner slides its own length inside it. The inner is
+	     pinned to the right rather than laid out in flow so the clip always eats
+	     the left side, which is what keeps the panel's border against the table
+	     instead of sliding a gap in front of it. -->
 	<div
-		class="absolute top-0 right-0 bottom-0 flex w-[320px] z-10 will-change-transform"
-		style="backface-visibility: hidden; transform: translateZ(0);"
-		transition:fly|global={{ x: PANEL_TRAVEL, duration: 320, easing: cubicOut, opacity: 1 }}
+		class="relative shrink-0 flex overflow-hidden"
+		style:width="{PANEL_WIDTH}px"
+		transition:claimWidth|global
 	>
-		<PortDetail {entry} {onClose} />
+		<div
+			class="absolute inset-y-0 right-0 flex"
+			style:width="{PANEL_WIDTH}px"
+			transition:fly|global={{ x: PANEL_WIDTH, duration: 240, easing: cubicOut, opacity: 1 }}
+		>
+			<PortDetail {entry} {onClose} />
+		</div>
 	</div>
 {/if}

--- a/frontend/components/ports/PortDetailLayer.svelte
+++ b/frontend/components/ports/PortDetailLayer.svelte
@@ -59,8 +59,9 @@
 	</div>
 {:else}
 	<div
-		class="shrink-0 flex w-80"
-		transition:fly|global={{ x: PANEL_TRAVEL, duration: 240, easing: cubicOut, opacity: 1 }}
+		class="absolute top-0 right-0 bottom-0 flex w-[320px] z-10 will-change-transform"
+		style="backface-visibility: hidden; transform: translateZ(0);"
+		transition:fly|global={{ x: PANEL_TRAVEL, duration: 320, easing: cubicOut, opacity: 1 }}
 	>
 		<PortDetail {entry} {onClose} />
 	</div>

--- a/frontend/components/ports/PortsModal.svelte
+++ b/frontend/components/ports/PortsModal.svelte
@@ -102,10 +102,8 @@
 				<Icon name="lucide:loader-circle" class="w-5 h-5 animate-spin text-slate-400" />
 			</div>
 		{:else}
-			<div class="flex flex-1 min-h-0 relative bg-slate-50 dark:bg-slate-950 overflow-hidden">
-				<div class="port-list-wrap flex-1 min-h-0 flex flex-col overflow-hidden" class:detail-open={!!selected}>
-					<PortTable {canKill} onKill={(entry) => (pendingKill = entry)} />
-				</div>
+			<div class="flex flex-1 min-h-0 relative bg-slate-50 dark:bg-slate-950">
+				<PortTable {canKill} onKill={(entry) => (pendingKill = entry)} />
 				{#if selected}
 					<PortDetailLayer entry={selected} onClose={() => portsStore.select(null)} />
 				{/if}
@@ -113,19 +111,5 @@
 		{/if}
 	{/snippet}
 </Modal>
-
-<style>
-	@media (min-width: 768px) {
-		.port-list-wrap {
-			transition: margin-right 320ms cubic-bezier(0.16, 1, 0.3, 1);
-			margin-right: 0;
-			will-change: margin-right;
-			backface-visibility: hidden;
-		}
-		.port-list-wrap.detail-open {
-			margin-right: 320px;
-		}
-	}
-</style>
 
 <PortKillDialog bind:entry={pendingKill} />

--- a/frontend/components/ports/PortsModal.svelte
+++ b/frontend/components/ports/PortsModal.svelte
@@ -85,16 +85,6 @@
 					bind:value={portsStore.search}
 				/>
 			</div>
-
-			{#if result}
-				<span
-					class="hidden sm:flex items-center gap-1.5 shrink-0 text-[11px] text-slate-400 dark:text-slate-600"
-					title="This table refreshes about once a second while the panel is open"
-				>
-					<span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
-					live
-				</span>
-			{/if}
 		</div>
 
 		{#if portsStore.isLoading && !result}

--- a/frontend/components/ports/PortsModal.svelte
+++ b/frontend/components/ports/PortsModal.svelte
@@ -102,8 +102,10 @@
 				<Icon name="lucide:loader-circle" class="w-5 h-5 animate-spin text-slate-400" />
 			</div>
 		{:else}
-			<div class="flex flex-1 min-h-0 relative bg-slate-50 dark:bg-slate-950">
-				<PortTable {canKill} onKill={(entry) => (pendingKill = entry)} />
+			<div class="flex flex-1 min-h-0 relative bg-slate-50 dark:bg-slate-950 overflow-hidden">
+				<div class="port-list-wrap flex-1 min-h-0 flex flex-col overflow-hidden" class:detail-open={!!selected}>
+					<PortTable {canKill} onKill={(entry) => (pendingKill = entry)} />
+				</div>
 				{#if selected}
 					<PortDetailLayer entry={selected} onClose={() => portsStore.select(null)} />
 				{/if}
@@ -111,5 +113,19 @@
 		{/if}
 	{/snippet}
 </Modal>
+
+<style>
+	@media (min-width: 768px) {
+		.port-list-wrap {
+			transition: margin-right 320ms cubic-bezier(0.16, 1, 0.3, 1);
+			margin-right: 0;
+			will-change: margin-right;
+			backface-visibility: hidden;
+		}
+		.port-list-wrap.detail-open {
+			margin-right: 320px;
+		}
+	}
+</style>
 
 <PortKillDialog bind:entry={pendingKill} />

--- a/frontend/components/ports/main/PortTable.svelte
+++ b/frontend/components/ports/main/PortTable.svelte
@@ -23,22 +23,9 @@
 	const result = $derived(portsStore.result);
 	const total = $derived(result?.entries.length ?? 0);
 	const shown = $derived(portsStore.entries.length);
-
-	const hasDetail = $derived(portsStore.selected !== null);
-	// tanpa gap: saat detail terbuka, padding kanan di-nol-kan supaya
-	// list menempel langsung ke border-l detail (w-[320px] == margin 320px).
-	// p-3 = 0.75rem (12px di 16px), jadi pad 0.75rem ↔ 0 sinkron dengan
-	// margin-right dan fly 240ms. Mobile tetap 0.75rem via !important di bawah.
-	const padRight = $derived(hasDetail ? '0px' : '0.75rem');
 </script>
 
-<div
-	class="port-table flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 p-3"
-	style:padding-right={padRight}
-	style:transition="padding-right 320ms cubic-bezier(0.16, 1, 0.3, 1)"
-	style:will-change="padding-right"
-	style:backface-visibility="hidden"
->
+<div class="flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 p-3">
 	{#if result?.error}
 		<div
 			class="flex items-start gap-2.5 p-3 rounded-lg bg-red-500/10 text-red-700 dark:text-red-400"
@@ -115,12 +102,3 @@
 		</section>
 	{/if}
 </div>
-
-<style>
-	/* Mobile: detail adalah bottom-sheet, jangan hilangkan padding kanan */
-	@media (max-width: 767px) {
-		.port-table {
-			padding-right: 0.75rem !important;
-		}
-	}
-</style>

--- a/frontend/components/ports/main/PortTable.svelte
+++ b/frontend/components/ports/main/PortTable.svelte
@@ -23,9 +23,22 @@
 	const result = $derived(portsStore.result);
 	const total = $derived(result?.entries.length ?? 0);
 	const shown = $derived(portsStore.entries.length);
+
+	const hasDetail = $derived(portsStore.selected !== null);
+	// tanpa gap: saat detail terbuka, padding kanan di-nol-kan supaya
+	// list menempel langsung ke border-l detail (w-[320px] == margin 320px).
+	// p-3 = 0.75rem (12px di 16px), jadi pad 0.75rem ↔ 0 sinkron dengan
+	// margin-right dan fly 240ms. Mobile tetap 0.75rem via !important di bawah.
+	const padRight = $derived(hasDetail ? '0px' : '0.75rem');
 </script>
 
-<div class="flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 p-3">
+<div
+	class="port-table flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 p-3"
+	style:padding-right={padRight}
+	style:transition="padding-right 320ms cubic-bezier(0.16, 1, 0.3, 1)"
+	style:will-change="padding-right"
+	style:backface-visibility="hidden"
+>
 	{#if result?.error}
 		<div
 			class="flex items-start gap-2.5 p-3 rounded-lg bg-red-500/10 text-red-700 dark:text-red-400"
@@ -102,3 +115,12 @@
 		</section>
 	{/if}
 </div>
+
+<style>
+	/* Mobile: detail adalah bottom-sheet, jangan hilangkan padding kanan */
+	@media (max-width: 767px) {
+		.port-table {
+			padding-right: 0.75rem !important;
+		}
+	}
+</style>

--- a/frontend/components/ssh-client/main/PortsPanel.svelte
+++ b/frontend/components/ssh-client/main/PortsPanel.svelte
@@ -67,28 +67,12 @@
 		{/if}
 	</div>
 
-	<div class="flex flex-1 min-h-0 relative overflow-hidden">
-		<div class="port-list-wrap flex-1 min-h-0 flex flex-col overflow-hidden" class:detail-open={!!selected}>
-			<PortTable {canKill} onKill={(entry) => (pendingKill = entry)} />
-		</div>
+	<div class="flex flex-1 min-h-0 relative">
+		<PortTable {canKill} onKill={(entry) => (pendingKill = entry)} />
 		{#if selected}
 			<PortDetailLayer entry={selected} onClose={() => portsStore.select(null)} />
 		{/if}
 	</div>
 </div>
-
-<style>
-	@media (min-width: 768px) {
-		.port-list-wrap {
-			transition: margin-right 320ms cubic-bezier(0.16, 1, 0.3, 1);
-			margin-right: 0;
-			will-change: margin-right;
-			backface-visibility: hidden;
-		}
-		.port-list-wrap.detail-open {
-			margin-right: 320px;
-		}
-	}
-</style>
 
 <PortKillDialog bind:entry={pendingKill} />

--- a/frontend/components/ssh-client/main/PortsPanel.svelte
+++ b/frontend/components/ssh-client/main/PortsPanel.svelte
@@ -67,12 +67,28 @@
 		{/if}
 	</div>
 
-	<div class="flex flex-1 min-h-0 relative">
-		<PortTable {canKill} onKill={(entry) => (pendingKill = entry)} />
+	<div class="flex flex-1 min-h-0 relative overflow-hidden">
+		<div class="port-list-wrap flex-1 min-h-0 flex flex-col overflow-hidden" class:detail-open={!!selected}>
+			<PortTable {canKill} onKill={(entry) => (pendingKill = entry)} />
+		</div>
 		{#if selected}
 			<PortDetailLayer entry={selected} onClose={() => portsStore.select(null)} />
 		{/if}
 	</div>
 </div>
+
+<style>
+	@media (min-width: 768px) {
+		.port-list-wrap {
+			transition: margin-right 320ms cubic-bezier(0.16, 1, 0.3, 1);
+			margin-right: 0;
+			will-change: margin-right;
+			backface-visibility: hidden;
+		}
+		.port-list-wrap.detail-open {
+			margin-right: 320px;
+		}
+	}
+</style>
 
 <PortKillDialog bind:entry={pendingKill} />

--- a/frontend/components/ssh-client/main/PortsPanel.svelte
+++ b/frontend/components/ssh-client/main/PortsPanel.svelte
@@ -25,7 +25,6 @@
 	let pendingKill = $state<PortEntry | null>(null);
 
 	const selected = $derived(portsStore.selected);
-	const result = $derived(portsStore.result);
 	/** Reading is open to every member; stopping a process is not. */
 	const canKill = $derived(authStore.isAdmin);
 
@@ -55,16 +54,6 @@
 				bind:value={portsStore.search}
 			/>
 		</div>
-
-		{#if result}
-			<span
-				class="hidden sm:flex items-center gap-1.5 shrink-0 text-[11px] text-slate-400 dark:text-slate-600"
-				title="This table refreshes about once a second while the tab is open"
-			>
-				<span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
-				live
-			</span>
-		{/if}
 	</div>
 
 	<div class="flex flex-1 min-h-0 relative">


### PR DESCRIPTION
## Summary
Opening a row's details in Ports or Containers no longer snaps the list to its
narrow width ahead of the panel — the list and the panel now move as one
motion. Also drops the "live" badge beside the search input.

## Why
`PortDetailLayer` and `ContainerDetailLayer` render as flex siblings of their
list. The moment a row is selected the list's `flex-1` recomputes on the first
frame, so it reached its final narrow width instantly while the panel still had
240ms of `fly` left to travel. For that whole 240ms a 320px strip of bare
background sat where the panel was about to land.

The panel's width and its travel were also two independent numbers: `w-80`
(20rem) against a hardcoded `PANEL_TRAVEL = 320`. They agree only at a 16px
root font size; anywhere else the panel over- or under-shot its own width.

Separately, the "live" badge restated what the panel already shows — rows
appearing and disappearing on their own is the evidence that the view is live —
while taking toolbar width the search input can use on a narrow screen.

## Changes
- `frontend/components/ports/PortDetailLayer.svelte`,
  `frontend/components/containers/ContainerDetailLayer.svelte` — the desktop
  branch is now a clipping wrapper whose width a `claimWidth` transition
  animates 0→320 over the same 240ms `cubicOut` as the fly, with the panel
  pinned `absolute inset-y-0 right-0` inside it. `PANEL_TRAVEL` becomes
  `PANEL_WIDTH` and feeds both the width and the travel.
- `frontend/components/ports/PortsModal.svelte`,
  `frontend/components/ssh-client/main/PortsPanel.svelte`,
  `frontend/components/containers/ContainersPane.svelte` — remove the "live"
  badge. `PortsPanel`'s `result` derived had no other reader once it was gone.

## Notes
- Pinning the panel to the right rather than leaving it in flow is what makes
  the clip eat the *left* side, so the panel's `border-l` stays against the list
  the whole way instead of carrying a gap in front of it. Relying on
  `justify-end` for that would be fragile — flex overflow direction under
  end-alignment isn't something to bet a layout on.
- Because the list stays a plain flex sibling, nothing else changes: no wrapper
  elements in `PortsModal` / `PortsPanel` / `ContainersPane`, no `<style>`
  blocks, and `PortTable` / `ContainerTable` stay unaware of the detail state.
- Mobile is untouched — below 768px the detail is a bottom sheet and never takes
  width from the list.

## Test plan
- [x] `bun run check` — clean
- [x] `bun run lint` — clean
- [x] Manual: Ports modal, SSH Client → Ports tab, Containers modal — open *and*
      close a row, light and dark, desktop and <768px