### PR TITLE
fix(git): make sub-repo discovery watcher-driven and guard every git action

### DIFF
--- a/backend/files/file-watcher.test.ts
+++ b/backend/files/file-watcher.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, mock, test, beforeAll, afterEach } from 'bun:test';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { execGit } from '../git/git-executor';
 import { clearNestedRepoCache, findNestedRepoPaths } from '../git/nested-repos';
+import { relative } from 'node:path';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -48,6 +49,16 @@ async function makeProject(): Promise<string> {
 	const dir = await mkdtemp(join(tmpdir(), 'clopen-watch-'));
 	tempRoots.push(dir);
 	return dir;
+}
+
+/** Wait until an async `predicate` holds, or fail after `timeout` ms. */
+async function waitForAsync(predicate: () => Promise<boolean>, timeout = 8000): Promise<void> {
+	const deadline = Date.now() + timeout;
+	while (Date.now() < deadline) {
+		if (await predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+	throw new Error('Timed out waiting for watcher-driven invalidation');
 }
 
 /** Wait until `predicate` holds, or fail after `timeout` ms. */
@@ -194,6 +205,41 @@ describe('FileWatcherManager', () => {
 		await writeFile(join(sub, '.git', 'index'), 'stand-in for a real index write');
 
 		await waitFor(() => gitRepoPathsFor('p7').includes(sub), 10000);
+	});
+
+	test('an edited .gitignore changes which sub-repos the panel lists', async () => {
+		// Discovery leans on this watcher instead of a short clock, so every
+		// signal that could change its answer has to reach it. `.gitignore` is
+		// the one with no other route: it carries no `.git` segment, so
+		// `routeGitEvent` passes it by, and `shouldIgnore` discards every
+		// dotfile. Without an explicit hook the repo set sits unchanged behind
+		// the watched-root TTL.
+		//
+		// Direction matters here. Going the other way — a repo that only becomes
+		// visible once the ignore rule is dropped — is not a test of this hook
+		// at all: an unreported repo's `.git` is one the watcher does not know,
+		// so its first event triggers the unknown-git-dir refresh, and the repo
+		// set gets invalidated by that path whether or not `.gitignore` is
+		// wired. Starting from a REPORTED repo keeps its git dir known and
+		// leaves the `.gitignore` write as the only signal in play.
+		const root = await makeProject();
+		await initRepo(root);
+		const theme = join(root, 'themes', 'mytheme');
+		await initRepo(theme);
+
+		expect(await fileWatcher.startWatching('p8', root)).toBe(true);
+		expect((await findNestedRepoPaths(root)).map((repo) => relative(root, repo))).toEqual([
+			join('themes', 'mytheme')
+		]);
+
+		// Space it out: the platform watchers coalesce bursts, and this write has
+		// to be seen on its own to mean anything.
+		await new Promise((resolve) => setTimeout(resolve, 400));
+		// `themes/` is now ignored, so the still-pristine repo inside it has to
+		// prove local work before it is listed — and it has none.
+		await writeFile(join(root, '.gitignore'), 'themes/\n');
+
+		await waitForAsync(async () => (await findNestedRepoPaths(root)).length === 0);
 	});
 
 	test('stops watching once the last viewer leaves', async () => {

--- a/backend/files/file-watcher.test.ts
+++ b/backend/files/file-watcher.test.ts
@@ -10,6 +10,8 @@
 
 import { describe, expect, mock, test, beforeAll, afterEach } from 'bun:test';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { execGit } from '../git/git-executor';
+import { clearNestedRepoCache, findNestedRepoPaths } from '../git/nested-repos';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -58,6 +60,19 @@ async function waitFor(predicate: () => boolean, timeout = 4000): Promise<void> 
 	throw new Error('Timed out waiting for watcher event');
 }
 
+function gitRepoPathsFor(projectId: string): string[] {
+	return emitted
+		.filter((e) => e.projectId === projectId && e.event === 'git:changed')
+		.flatMap((e) => e.payload.repoPaths as string[]);
+}
+
+async function initRepo(dir: string): Promise<void> {
+	await mkdir(dir, { recursive: true });
+	await execGit(['init', '-b', 'main', '.'], dir);
+	await execGit(['config', 'user.email', 'test@example.com'], dir);
+	await execGit(['config', 'user.name', 'Test'], dir);
+}
+
 function changesFor(projectId: string): string[] {
 	return emitted
 		.filter((e) => e.projectId === projectId && e.event === 'files:changed')
@@ -69,6 +84,7 @@ afterEach(async () => {
 		fileWatcher.releaseProject(projectId);
 	}
 	emitted.length = 0;
+	clearNestedRepoCache();
 	await Promise.all(tempRoots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
@@ -144,6 +160,40 @@ describe('FileWatcherManager', () => {
 
 		fileWatcher.clearDirtyFiles('p5');
 		expect(fileWatcher.getDirtyFiles('p5').size).toBe(0);
+	});
+
+	test('watches a sub-repo created while the project is already open', async () => {
+		// `findNestedRepoPaths` caches its walk for a few seconds, and the panel
+		// warms that cache constantly — every `git:status` and `git:branches`
+		// goes through it. `scheduleGitTargetsRefresh` then re-resolves 1.5s
+		// after an unknown `.git` shows up, well inside the TTL, so it would be
+		// answered from a walk taken before the new repo existed. The git dir
+		// would stay unaccounted for, `syncGitWatchers` would file it under
+		// `rejectedGitDirs` — which is permanent — and `routeGitEvent` would
+		// then refuse to schedule another refresh for it. The sub-repo would go
+		// unwatched for as long as the project stayed open.
+		const root = await makeProject();
+		await initRepo(root);
+
+		// Warm the cache the way the panel does, before the sub-repo exists.
+		expect(await findNestedRepoPaths(root)).toEqual([]);
+
+		expect(await fileWatcher.startWatching('p7', root)).toBe(true);
+
+		const sub = join(root, 'packages', 'widget');
+		await initRepo(sub);
+
+		// The refresh announces itself by emitting for the project root once the
+		// repo set has been re-resolved.
+		await waitFor(() => gitRepoPathsFor('p7').includes(root), 10000);
+
+		emitted.length = 0;
+		// Space this out: the platform watchers coalesce bursts, and this write
+		// has to be seen on its own to mean anything.
+		await new Promise((resolve) => setTimeout(resolve, 400));
+		await writeFile(join(sub, '.git', 'index'), 'stand-in for a real index write');
+
+		await waitFor(() => gitRepoPathsFor('p7').includes(sub), 10000);
 	});
 
 	test('stops watching once the last viewer leaves', async () => {

--- a/backend/files/file-watcher.test.ts
+++ b/backend/files/file-watcher.test.ts
@@ -205,27 +205,34 @@ describe('FileWatcherManager', () => {
 		await writeFile(join(sub, '.git', 'index'), 'stand-in for a real index write');
 
 		await waitFor(() => gitRepoPathsFor('p7').includes(sub), 10000);
-	});
+		// 20s, not bun's 5s default: this test cannot finish faster than the
+		// watcher's own debounces (1.5s to re-resolve git targets, 0.5s to emit)
+		// plus two `git init`s and the spacing write.
+	}, 20000);
 
-	test('an edited .gitignore changes which sub-repos the panel lists', async () => {
-		// Discovery leans on this watcher instead of a short clock, so every
-		// signal that could change its answer has to reach it. `.gitignore` is
-		// the one with no other route: it carries no `.git` segment, so
-		// `routeGitEvent` passes it by, and `shouldIgnore` discards every
-		// dotfile. Without an explicit hook the repo set sits unchanged behind
-		// the watched-root TTL.
+	test('the watcher forwards path events to sub-repo discovery', async () => {
+		// Discovery leans on this watcher instead of a short clock, so raw paths
+		// have to reach it. There are two forwarding points — the working-tree
+		// handler and the git dir handles, which are a separate event source and
+		// the only one for `.git` on Linux — and this pins that AT LEAST ONE of
+		// them is live. It deliberately does not pin which: the two overlap on a
+		// real filesystem, and asserting on one would only pass by accident of
+		// which handle the platform happened to report an event through.
 		//
-		// Direction matters here. Going the other way — a repo that only becomes
-		// visible once the ignore rule is dropped — is not a test of this hook
-		// at all: an unreported repo's `.git` is one the watcher does not know,
-		// so its first event triggers the unknown-git-dir refresh, and the repo
-		// set gets invalidated by that path whether or not `.gitignore` is
-		// wired. Starting from a REPORTED repo keeps its git dir known and
-		// leaves the `.gitignore` write as the only signal in play.
+		// Which path means what is pinned exactly, and without timing, by the
+		// `notifyPathChanged` tests in nested-repos.test.ts — `.gitignore`,
+		// `.git/info/exclude`, a `.git` appearing, and an ordinary write that
+		// must NOT invalidate anything.
+		//
+		// Direction matters. Going the other way — a repo that only becomes
+		// visible once an ignore rule is dropped — tests nothing: an unreported
+		// repo's `.git` is one the watcher does not know, so its first event
+		// triggers the unknown-git-dir refresh and the repo set is invalidated
+		// by that path whether or not anything is forwarded. Starting from a
+		// REPORTED repo keeps its git dir known.
 		const root = await makeProject();
 		await initRepo(root);
-		const theme = join(root, 'themes', 'mytheme');
-		await initRepo(theme);
+		await initRepo(join(root, 'themes', 'mytheme'));
 
 		expect(await fileWatcher.startWatching('p8', root)).toBe(true);
 		expect((await findNestedRepoPaths(root)).map((repo) => relative(root, repo))).toEqual([
@@ -240,7 +247,9 @@ describe('FileWatcherManager', () => {
 		await writeFile(join(root, '.gitignore'), 'themes/\n');
 
 		await waitForAsync(async () => (await findNestedRepoPaths(root)).length === 0);
-	});
+		// Same reason as the test above — the debounces alone outlast bun's 5s
+		// default.
+	}, 20000);
 
 	test('stops watching once the last viewer leaves', async () => {
 		const root = await makeProject();

--- a/backend/files/file-watcher.ts
+++ b/backend/files/file-watcher.ts
@@ -34,6 +34,7 @@ import { join, relative, normalize, sep } from 'node:path';
 import { ws } from '$backend/utils/ws';
 import { debug } from '$shared/utils/logger';
 import { resolveGitDirs, type GitDirTarget } from '$backend/git/git-dirs';
+import { clearNestedRepoCache } from '$backend/git/nested-repos';
 import type { FileChange } from '$shared/types/filesystem';
 
 /**
@@ -832,6 +833,14 @@ class FileWatcherManager {
 	 * Queue a re-resolve of the project's git directories, for when an event
 	 * arrives from a `.git` we do not know about — `git init` or `git clone` run
 	 * inside the project while it is open.
+	 *
+	 * This is the one signal that the project's repo SET changed, so it drops
+	 * the cached sub-repo walk first. Without that, `resolveGitDirs` answers
+	 * from a walk taken before the new repo existed, the git dir stays
+	 * unaccounted for, and `syncGitWatchers` files it under `rejectedGitDirs` —
+	 * which is permanent, and which `routeGitEvent` then uses to stop
+	 * scheduling refreshes for it. A repo created in an open project would
+	 * never be watched again.
 	 */
 	private scheduleGitTargetsRefresh(projectId: string, gitDirPath?: string): void {
 		const projectWatcher = this.watchers.get(projectId);
@@ -843,6 +852,7 @@ class FileWatcherManager {
 		projectWatcher.gitTargetsTimer = setTimeout(() => {
 			projectWatcher.gitTargetsTimer = null;
 			if (projectWatcher.closed) return;
+			clearNestedRepoCache(projectWatcher.projectPath);
 			void this.syncGitWatchers(projectId).then(() => {
 				if (projectWatcher.closed) return;
 				// The repo set itself changed, so tell clients: this is what flips a

--- a/backend/files/file-watcher.ts
+++ b/backend/files/file-watcher.ts
@@ -37,8 +37,8 @@ import { resolveGitDirs, type GitDirTarget } from '$backend/git/git-dirs';
 import {
 	beginWatchedDiscovery,
 	endWatchedDiscovery,
-	invalidateLocalWork,
-	invalidateRepoSet
+	invalidateRepoSet,
+	notifyPathChanged
 } from '$backend/git/nested-repos';
 import type { FileChange } from '$shared/types/filesystem';
 
@@ -166,20 +166,6 @@ export function isGitStateEvent(entryPath: string): boolean {
 /** Whether a project-relative path passes through a `.git` directory. */
 export function hasGitSegment(relativePath: string): boolean {
 	return relativePath.split('/').includes('.git');
-}
-
-/**
- * Whether a path is one of the files that decide which sub-repos count:
- * `.gitignore` (a tree the project ignores holds repos it must prove itself
- * to report) and `.gitmodules` (the user declaring a sub-repo outright).
- *
- * Editing either changes the reported repo set with no `.git` created or
- * removed, so nothing else in the watcher would notice — `hasGitSegment` is
- * false for both, and `shouldIgnore` discards every dotfile.
- */
-export function isRepoSetRuleFile(relativePath: string): boolean {
-	const basename = relativePath.split('/').pop();
-	return basename === '.gitignore' || basename === '.gitmodules';
 }
 
 /**
@@ -635,20 +621,15 @@ class FileWatcherManager {
 		// path: where the root watch is recursive it is the only thing that sees
 		// a sub-repo's git dir, so dropping it here is what left a commit made
 		// inside a nested repo completely unreported.
+		// Tell sub-repo discovery before anything below filters the path away.
+		// It decides for itself what a path means: `routeGitEvent` swallows every
+		// `.git` path and `shouldIgnore` every dotfile, so `.gitignore` — which
+		// moves the reported repo set — would otherwise never reach it.
+		notifyPathChanged(projectWatcher.projectPath, fullPath);
+
 		if (this.routeGitEvent(projectWatcher, relativePath, fullPath)) return;
 
-		// Last point these are visible: `shouldIgnore` below drops every dotfile.
-		if (isRepoSetRuleFile(relativePath)) {
-			invalidateRepoSet(projectWatcher.projectPath);
-		}
-
 		if (this.shouldIgnore(relativePath)) return;
-
-		// A write inside a sub-repo can flip whether it has anything to show,
-		// which is what decides whether one sitting in an ignored tree is listed.
-		// Cheap and scoped: only repos whose own path contains this file lose
-		// their verdict, and there are at most a few dozen of them.
-		invalidateLocalWork(fullPath);
 
 		// Determine change type
 		let changeType: 'created' | 'modified' | 'deleted';
@@ -830,7 +811,17 @@ class FileWatcherManager {
 			try {
 				const watcher = watch(dirToWatch, { recursive }, (_eventType, filename) => {
 					if (!filename) return;
-					const entryPath = relative(gitDirPath, join(dirToWatch, String(filename)));
+					const fullPath = join(dirToWatch, String(filename));
+
+					// These handles are their own event source: nothing here reaches
+					// `handleFileChange`, and on Linux — where `.git` is pruned from the
+					// recursive walk — they are the ONLY source for it. Discovery has to
+					// be told from here too, before `isGitStateEvent` filters, since that
+					// filter answers 'does the panel show this' and drops `info/exclude`,
+					// which discovery very much cares about.
+					notifyPathChanged(projectWatcher.projectPath, fullPath);
+
+					const entryPath = relative(gitDirPath, fullPath);
 					if (!isGitStateEvent(entryPath)) return;
 					this.emitGitChanged(projectWatcher.projectId, repoPath);
 				});
@@ -916,10 +907,6 @@ class FileWatcherManager {
 		const repoPath = projectWatcher.gitDirOwners.get(gitDirPath);
 		if (repoPath) {
 			if (isGitStateEvent(relative(gitDirPath, fullPath))) {
-				// A commit, stage or checkout here can flip whether this repo has
-				// anything to show, which is what decides if a sub-repo inside an
-				// ignored tree is listed at all.
-				invalidateLocalWork(repoPath);
 				this.emitGitChanged(projectWatcher.projectId, repoPath);
 			}
 		} else if (!projectWatcher.rejectedGitDirs.has(gitDirPath)) {
@@ -988,6 +975,10 @@ class FileWatcherManager {
 				projectId,
 				error: 'File watching stopped after repeated failures. Refresh to retry.'
 			});
+			// No more signals are coming, so sub-repo discovery must stop trusting
+			// this watcher and go back to re-deriving on its own clock. Without
+			// this the claim outlives the watcher that made it.
+			this.stopWatching(projectId);
 			return;
 		}
 

--- a/backend/files/file-watcher.ts
+++ b/backend/files/file-watcher.ts
@@ -34,7 +34,12 @@ import { join, relative, normalize, sep } from 'node:path';
 import { ws } from '$backend/utils/ws';
 import { debug } from '$shared/utils/logger';
 import { resolveGitDirs, type GitDirTarget } from '$backend/git/git-dirs';
-import { clearNestedRepoCache } from '$backend/git/nested-repos';
+import {
+	beginWatchedDiscovery,
+	endWatchedDiscovery,
+	invalidateLocalWork,
+	invalidateRepoSet
+} from '$backend/git/nested-repos';
 import type { FileChange } from '$shared/types/filesystem';
 
 /**
@@ -161,6 +166,20 @@ export function isGitStateEvent(entryPath: string): boolean {
 /** Whether a project-relative path passes through a `.git` directory. */
 export function hasGitSegment(relativePath: string): boolean {
 	return relativePath.split('/').includes('.git');
+}
+
+/**
+ * Whether a path is one of the files that decide which sub-repos count:
+ * `.gitignore` (a tree the project ignores holds repos it must prove itself
+ * to report) and `.gitmodules` (the user declaring a sub-repo outright).
+ *
+ * Editing either changes the reported repo set with no `.git` created or
+ * removed, so nothing else in the watcher would notice — `hasGitSegment` is
+ * false for both, and `shouldIgnore` discards every dotfile.
+ */
+export function isRepoSetRuleFile(relativePath: string): boolean {
+	const basename = relativePath.split('/').pop();
+	return basename === '.gitignore' || basename === '.gitmodules';
 }
 
 /**
@@ -351,6 +370,12 @@ class FileWatcherManager {
 			};
 			this.watchers.set(projectId, projectWatcher);
 
+			// From here on this watcher is the authority on when the project's
+			// sub-repo set and their working states change, so discovery can stop
+			// re-deriving them on a short clock. Paired with `endWatchedDiscovery`
+			// in `stopWatching`, which puts discovery back on the clock.
+			beginWatchedDiscovery(normalizedPath);
+
 			// Watch the root synchronously so events are never missed while the
 			// (async) subtree walk is still in progress.
 			if (!this.watchDir(projectWatcher, normalizedPath)) {
@@ -532,6 +557,9 @@ class FileWatcherManager {
 			}
 			projectWatcher.gitDirOwners.clear();
 
+			// No more signals from here, so discovery must not keep trusting them.
+			endWatchedDiscovery(projectWatcher.projectPath);
+
 			// Clear debounce timers
 			if (projectWatcher.debounceTimer) {
 				clearTimeout(projectWatcher.debounceTimer);
@@ -609,7 +637,18 @@ class FileWatcherManager {
 		// inside a nested repo completely unreported.
 		if (this.routeGitEvent(projectWatcher, relativePath, fullPath)) return;
 
+		// Last point these are visible: `shouldIgnore` below drops every dotfile.
+		if (isRepoSetRuleFile(relativePath)) {
+			invalidateRepoSet(projectWatcher.projectPath);
+		}
+
 		if (this.shouldIgnore(relativePath)) return;
+
+		// A write inside a sub-repo can flip whether it has anything to show,
+		// which is what decides whether one sitting in an ignored tree is listed.
+		// Cheap and scoped: only repos whose own path contains this file lose
+		// their verdict, and there are at most a few dozen of them.
+		invalidateLocalWork(fullPath);
 
 		// Determine change type
 		let changeType: 'created' | 'modified' | 'deleted';
@@ -852,7 +891,7 @@ class FileWatcherManager {
 		projectWatcher.gitTargetsTimer = setTimeout(() => {
 			projectWatcher.gitTargetsTimer = null;
 			if (projectWatcher.closed) return;
-			clearNestedRepoCache(projectWatcher.projectPath);
+			invalidateRepoSet(projectWatcher.projectPath);
 			void this.syncGitWatchers(projectId).then(() => {
 				if (projectWatcher.closed) return;
 				// The repo set itself changed, so tell clients: this is what flips a
@@ -877,6 +916,10 @@ class FileWatcherManager {
 		const repoPath = projectWatcher.gitDirOwners.get(gitDirPath);
 		if (repoPath) {
 			if (isGitStateEvent(relative(gitDirPath, fullPath))) {
+				// A commit, stage or checkout here can flip whether this repo has
+				// anything to show, which is what decides if a sub-repo inside an
+				// ignored tree is listed at all.
+				invalidateLocalWork(repoPath);
 				this.emitGitChanged(projectWatcher.projectId, repoPath);
 			}
 		} else if (!projectWatcher.rejectedGitDirs.has(gitDirPath)) {

--- a/backend/git/nested-repos.test.ts
+++ b/backend/git/nested-repos.test.ts
@@ -3,7 +3,15 @@ import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { execGit } from './git-executor';
-import { clearNestedRepoCache, findNestedRepoPaths, findRepoForFile } from './nested-repos';
+import {
+	beginWatchedDiscovery,
+	clearNestedRepoCache,
+	endWatchedDiscovery,
+	findNestedRepoPaths,
+	findRepoForFile,
+	invalidateLocalWork,
+	invalidateRepoSet
+} from './nested-repos';
 
 /**
  * Sub-repo detection used to walk the whole tree and report every directory
@@ -273,6 +281,144 @@ describe('walk cache', () => {
 		} finally {
 			await rm(other, { recursive: true, force: true });
 		}
+	});
+});
+
+describe('watcher-driven discovery', () => {
+	// Discovery used to be re-derived on every `git:status` and `git:branches`:
+	// an `fs.readdir` over the whole tree, a `git check-ignore` spawn per repo
+	// per depth level, then a `git status` spawn per repo inside an ignored
+	// tree. The panel fires that three or four times a second while staging,
+	// and on Windows every spawn pays for Defender.
+	//
+	// The file watcher already knows when any of it changes, so it — not a
+	// clock — decides when an answer is stale. These tests pin the contract
+	// both ways: a watched root reuses answers, and every signal that could
+	// change one puts it back.
+
+	/** Count git subcommands spawned while `run` executes. */
+	async function countSpawns<T>(run: () => Promise<T>): Promise<{ result: T; spawns: string[] }> {
+		const spawns: string[] = [];
+		const realSpawn = Bun.spawn;
+		// argv is [git, -c, safe.directory=…, <subcommand>, …]
+		// @ts-expect-error test instrumentation
+		Bun.spawn = (cmd: string[], options: unknown) => {
+			if (Array.isArray(cmd) && cmd[3]) spawns.push(cmd[3]);
+			// @ts-expect-error passthrough
+			return realSpawn(cmd, options);
+		};
+		try {
+			return { result: await run(), spawns };
+		} finally {
+			Bun.spawn = realSpawn;
+		}
+	}
+
+	test('a watched root answers a repeat call without touching git at all', async () => {
+		// The WordPress shape the detection policy was written for: every plugin
+		// is its own repo inside a tree the project ignores, so every one of them
+		// needs a `git status` to prove it has something to show. Unwatched, that
+		// is a spawn per plugin on every single call.
+		await writeFile(path.join(root, '.gitignore'), 'wp-content/plugins/\n');
+		for (const name of ['alpha', 'beta', 'gamma']) {
+			const plugin = path.join(root, 'wp-content/plugins', name);
+			await initRepo(plugin);
+			await addLocalWork(plugin);
+		}
+
+		beginWatchedDiscovery(root);
+		expect(await detected()).toEqual([
+			'wp-content/plugins/alpha',
+			'wp-content/plugins/beta',
+			'wp-content/plugins/gamma'
+		]);
+
+		const { result, spawns } = await countSpawns(() => detected());
+		expect(result).toEqual([
+			'wp-content/plugins/alpha',
+			'wp-content/plugins/beta',
+			'wp-content/plugins/gamma'
+		]);
+		expect(spawns).toEqual([]);
+	});
+
+	test('an unwatched root keeps probing live, so nothing can hide behind a guess', async () => {
+		// No watcher means no signal, and a cached "nothing to show" would hide a
+		// sub-repo the user is working in — the worst failure this module has.
+		await writeFile(path.join(root, '.gitignore'), 'themes/\n');
+		await initRepo(path.join(root, 'themes/mytheme'));
+		await addLocalWork(path.join(root, 'themes/mytheme'));
+
+		expect(await detected()).toEqual(['themes/mytheme']);
+
+		const { spawns } = await countSpawns(() => detected());
+		expect(spawns).toContain('status');
+	});
+
+	test('a write into a pristine sub-repo puts it back on the list', async () => {
+		// The transition the containment matching exists for. While `mytheme` is
+		// pristine it is deliberately unreported, so the watcher has never
+		// resolved a git dir for it and cannot name it. The only place it is
+		// known is the verdict cache holding the `false` that is about to be
+		// wrong — which is why invalidation matches by containment.
+		await writeFile(path.join(root, '.gitignore'), 'themes/\n');
+		await initRepo(path.join(root, 'themes/mytheme'));
+
+		beginWatchedDiscovery(root);
+		expect(await detected()).toEqual([]);
+
+		const edited = path.join(root, 'themes/mytheme/style.css');
+		await writeFile(edited, 'body { color: red }\n');
+		invalidateLocalWork(edited);
+
+		expect(await detected()).toEqual(['themes/mytheme']);
+	});
+
+	test('a sibling sub-repo keeps its verdict when one of them is written to', async () => {
+		await writeFile(path.join(root, '.gitignore'), 'themes/\n');
+		for (const name of ['alpha', 'beta']) {
+			const theme = path.join(root, 'themes', name);
+			await initRepo(theme);
+			await addLocalWork(theme);
+		}
+
+		beginWatchedDiscovery(root);
+		expect(await detected()).toEqual(['themes/alpha', 'themes/beta']);
+
+		const edited = path.join(root, 'themes/alpha/style.css');
+		await writeFile(edited, 'body {}\n');
+		invalidateLocalWork(edited);
+
+		// Only alpha is re-probed; beta answers from its cached verdict.
+		const { spawns } = await countSpawns(() => detected());
+		expect(spawns.filter((cmd) => cmd === 'status')).toHaveLength(1);
+	});
+
+	test('invalidating the repo set re-walks the tree', async () => {
+		beginWatchedDiscovery(root);
+		expect(await detected()).toEqual([]);
+
+		await initRepo(path.join(root, 'packages/widget'));
+		expect(await detected()).toEqual([]);
+
+		invalidateRepoSet(root);
+		expect(await detected()).toEqual(['packages/widget']);
+	});
+
+	test('losing the watcher drops every answer it was backing', async () => {
+		// Nothing will invalidate from here on, so a verdict kept across this
+		// boundary would never be corrected.
+		await writeFile(path.join(root, '.gitignore'), 'themes/\n');
+		await initRepo(path.join(root, 'themes/mytheme'));
+		await addLocalWork(path.join(root, 'themes/mytheme'));
+
+		beginWatchedDiscovery(root);
+		expect(await detected()).toEqual(['themes/mytheme']);
+
+		endWatchedDiscovery(root);
+		const { spawns } = await countSpawns(() => detected());
+		expect(spawns).toContain('check-ignore');
+		expect(spawns).toContain('status');
 	});
 });
 

--- a/backend/git/nested-repos.test.ts
+++ b/backend/git/nested-repos.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { execGit } from './git-executor';
-import { findNestedRepoPaths, findRepoForFile } from './nested-repos';
+import { clearNestedRepoCache, findNestedRepoPaths, findRepoForFile } from './nested-repos';
 
 /**
  * Sub-repo detection used to walk the whole tree and report every directory
@@ -53,6 +53,10 @@ async function detected(): Promise<string[]> {
 beforeEach(async () => {
 	root = await mkdtemp(path.join(tmpdir(), 'clopen-nested-'));
 	await initRepo(root);
+	// The walk is cached for seconds; these tests rebuild a project's layout in
+	// milliseconds. Without this a fixture would be asserted against the
+	// previous test's tree whenever mkdtemp hands back a reused path.
+	clearNestedRepoCache();
 });
 
 afterEach(async () => {
@@ -203,6 +207,72 @@ describe('findNestedRepoPaths', () => {
 		await initRepo(path.join(root, 'packages/widget/plugins/helper'));
 
 		expect(await detected()).toEqual(['packages/widget', 'packages/widget/plugins/helper']);
+	});
+});
+
+describe('walk cache', () => {
+	// The walk is the expensive half of discovery (readdir over the whole tree
+	// plus a `git check-ignore` spawn per level), and the Git panel fires it
+	// several times a second: staging triggers `git:status` and `git:branches`,
+	// and the `.git` watcher fires `git:changed` right behind them. On Windows
+	// each of those spawns is slow enough that the panel visibly froze.
+
+	test('reuses the walk instead of re-scanning the tree', async () => {
+		expect(await detected()).toEqual([]);
+
+		// Created after the walk was cached, so it must not be visible yet:
+		// this is what proves the second call did not re-scan.
+		await initRepo(path.join(root, 'packages/widget'));
+		expect(await detected()).toEqual([]);
+
+		clearNestedRepoCache();
+		expect(await detected()).toEqual(['packages/widget']);
+	});
+
+	test('still reports a cached provisional repo the moment it gains work', async () => {
+		// The reason only the walk is cached. A repo inside an ignored tree is
+		// held back until it has something to show; if the filtered list were
+		// cached too, the sub-repo an agent just wrote into would stay missing
+		// from the Changes tab for the rest of the TTL.
+		await writeFile(path.join(root, '.gitignore'), 'themes/\n');
+		await initRepo(path.join(root, 'themes/mytheme'));
+
+		expect(await detected()).toEqual([]);
+
+		await addLocalWork(path.join(root, 'themes/mytheme'));
+		expect(await detected()).toEqual(['themes/mytheme']);
+	});
+
+	test('callers arriving during a walk share it and get their own array', async () => {
+		await initRepo(path.join(root, 'packages/widget'));
+
+		const [first, second] = await Promise.all([
+			findNestedRepoPaths(root),
+			findNestedRepoPaths(root)
+		]);
+
+		expect(second).toEqual(first);
+		// Separate arrays — `git:status` mutates the list it is handed, and it
+		// runs concurrently with `git:branches` on the same root.
+		expect(second).not.toBe(first);
+	});
+
+	test('scopes clearing to one root', async () => {
+		const other = await mkdtemp(path.join(tmpdir(), 'clopen-nested-other-'));
+		try {
+			await initRepo(other);
+			expect(await detected()).toEqual([]);
+			await findNestedRepoPaths(other);
+
+			await initRepo(path.join(root, 'packages/widget'));
+			await initRepo(path.join(other, 'packages/widget'));
+
+			clearNestedRepoCache(root);
+			expect(await detected()).toEqual(['packages/widget']);
+			expect(await findNestedRepoPaths(other)).toEqual([]);
+		} finally {
+			await rm(other, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/backend/git/nested-repos.test.ts
+++ b/backend/git/nested-repos.test.ts
@@ -9,8 +9,8 @@ import {
 	endWatchedDiscovery,
 	findNestedRepoPaths,
 	findRepoForFile,
-	invalidateLocalWork,
-	invalidateRepoSet
+	invalidateRepoSet,
+	notifyPathChanged
 } from './nested-repos';
 
 /**
@@ -369,7 +369,7 @@ describe('watcher-driven discovery', () => {
 
 		const edited = path.join(root, 'themes/mytheme/style.css');
 		await writeFile(edited, 'body { color: red }\n');
-		invalidateLocalWork(edited);
+		notifyPathChanged(root, edited);
 
 		expect(await detected()).toEqual(['themes/mytheme']);
 	});
@@ -387,11 +387,86 @@ describe('watcher-driven discovery', () => {
 
 		const edited = path.join(root, 'themes/alpha/style.css');
 		await writeFile(edited, 'body {}\n');
-		invalidateLocalWork(edited);
+		notifyPathChanged(root, edited);
 
 		// Only alpha is re-probed; beta answers from its cached verdict.
 		const { spawns } = await countSpawns(() => detected());
 		expect(spawns.filter((cmd) => cmd === 'status')).toHaveLength(1);
+	});
+
+	test('a per-repo exclude file moves the boundary like .gitignore does', async () => {
+		// `.git/info/exclude` is obeyed by `git check-ignore` exactly like
+		// `.gitignore`, so it decides whether a sub-repo has to prove local work.
+		// The watcher deliberately filters it out of the panel's git-state
+		// events — the panel has nothing to show for it — so discovery has to
+		// recognise it by name rather than ride along with those.
+		await initRepo(path.join(root, 'themes/mytheme'));
+
+		beginWatchedDiscovery(root);
+		expect(await detected()).toEqual(['themes/mytheme']);
+
+		await mkdir(path.join(root, '.git/info'), { recursive: true });
+		const exclude = path.join(root, '.git/info/exclude');
+		await writeFile(exclude, 'themes/\n');
+		notifyPathChanged(root, exclude);
+
+		// Now inside an ignored tree and pristine, so it drops off the list.
+		expect(await detected()).toEqual([]);
+	});
+
+	test('a .git appearing is itself a repo-set change', async () => {
+		beginWatchedDiscovery(root);
+		expect(await detected()).toEqual([]);
+
+		const widget = path.join(root, 'packages/widget');
+		await initRepo(widget);
+		notifyPathChanged(root, path.join(widget, '.git'));
+
+		expect(await detected()).toEqual(['packages/widget']);
+	});
+
+	test('an ordinary write is not treated as a repo-set change', async () => {
+		// The counterweight to the rules above: if every path invalidated the
+		// walk, the cache would do nothing at all during a build.
+		beginWatchedDiscovery(root);
+		expect(await detected()).toEqual([]);
+
+		await initRepo(path.join(root, 'packages/widget'));
+		const ordinary = path.join(root, 'src/app.ts');
+		await mkdir(path.join(root, 'src'), { recursive: true });
+		await writeFile(ordinary, 'export {}\n');
+		notifyPathChanged(root, ordinary);
+
+		expect(await detected()).toEqual([]);
+	});
+
+	test('ignores signals for a root nobody is watching', async () => {
+		await initRepo(path.join(root, 'packages/widget'));
+		// Never claimed, so there is no cached answer a signal could correct and
+		// nothing here should pretend otherwise.
+		notifyPathChanged(root, path.join(root, '.gitignore'));
+		expect(await detected()).toEqual(['packages/widget']);
+	});
+
+	test('two watchers on one root: the first to leave does not revoke the claim', async () => {
+		// Two projects can be opened at the same directory. Releasing on the
+		// first close would put discovery back on the clock while a perfectly
+		// good signal source was still running.
+		await writeFile(path.join(root, '.gitignore'), 'themes/\n');
+		await initRepo(path.join(root, 'themes/mytheme'));
+		await addLocalWork(path.join(root, 'themes/mytheme'));
+
+		beginWatchedDiscovery(root);
+		beginWatchedDiscovery(root);
+		expect(await detected()).toEqual(['themes/mytheme']);
+
+		endWatchedDiscovery(root);
+		const stillWatched = await countSpawns(() => detected());
+		expect(stillWatched.spawns).toEqual([]);
+
+		endWatchedDiscovery(root);
+		const released = await countSpawns(() => detected());
+		expect(released.spawns).toContain('status');
 	});
 
 	test('invalidating the repo set re-walks the tree', async () => {

--- a/backend/git/nested-repos.ts
+++ b/backend/git/nested-repos.ts
@@ -77,6 +77,31 @@ const IGNORED_DESCENT_LEVELS = 1;
 const MAX_DEPTH = 12;
 
 /**
+ * Cache for nested repo discovery. On Windows `fs.readdir` + `git check-ignore`
+ * are noticeably slower (Bun.spawn + Defender scanning .git/index), so a short
+ * TTL avoids re-walking the same tree on every `git:status` / `git:branches`
+ * call triggered by Stage All, Stage, Unstage, etc. The status panel fires
+ * those in quick succession (stage → loadStatus + file watcher → git:changed),
+ * which previously walked the tree 3-4 times within a second.
+ *
+ * The walk result (found + provisional) is cached, but the provisional
+ * filtering (hasLocalWork / .gitmodules) is always re-evaluated: a repo
+ * inside an ignored tree becomes visible the moment it gains local work,
+ * which happens after the walk but before the next TTL expiry. Caching the
+ * filtered list would hide that new repo for up to 5s on Windows.
+ * Similarly, clearing the walk cache on filesystem changes is cheaper than
+ * caching a stale filtered answer.
+ */
+const NESTED_REPO_CACHE_TTL_MS = process.platform === 'win32' ? 5000 : 3000;
+interface NestedWalkCache {
+	found: string[];
+	provisional: string[];
+	expiresAt: number;
+}
+const nestedRepoWalkCache = new Map<string, NestedWalkCache>();
+const nestedRepoInflight = new Map<string, Promise<string[]>>();
+
+/**
  * Upper bound on reported sub-repos. A project with more than this is either
  * pathological or hit a detection hole; either way the UI cannot usefully show
  * them, so we stop and log instead of flooding it.
@@ -165,8 +190,56 @@ async function isRepoDir(dirPath: string): Promise<boolean> {
  * Find every nested git repo under `rootPath`, skipping dependency caches and
  * ignored trees (see the module comment for the exact policy). Does NOT scan
  * the repos — just returns their absolute paths, sorted for stable UI order.
+ *
+ * The filesystem walk is cached for a few seconds (longer on Windows) and
+ * concurrent callers for the same root share a single walk via inflight
+ * deduplication. The provisional → found filtering is re-run on every call
+ * so a newly-dirtied repo appears immediately.
  */
 export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
+	const now = Date.now();
+	const cachedWalk = nestedRepoWalkCache.get(rootPath);
+	if (cachedWalk && now < cachedWalk.expiresAt) {
+		return resolveProvisional(rootPath, cachedWalk.found, cachedWalk.provisional);
+	}
+	const inflight = nestedRepoInflight.get(rootPath);
+	if (inflight) return inflight;
+
+	const promise = (async (): Promise<string[]> => {
+		const walk = await walkNestedRepos(rootPath);
+		nestedRepoWalkCache.set(walk.key, { found: walk.found, provisional: walk.provisional, expiresAt: Date.now() + NESTED_REPO_CACHE_TTL_MS });
+		return resolveProvisional(rootPath, walk.found, walk.provisional);
+	})();
+
+	nestedRepoInflight.set(rootPath, promise);
+	try {
+		return await promise;
+	} finally {
+		nestedRepoInflight.delete(rootPath);
+	}
+}
+
+async function resolveProvisional(rootPath: string, found: string[], provisional: string[]): Promise<string[]> {
+	if (provisional.length === 0) {
+		const out = [...found];
+		out.sort();
+		return out;
+	}
+	const submodulePaths = await findSubmodulePaths(rootPath);
+	const isDeclared = (repoPath: string) =>
+		submodulePaths.has(path.relative(rootPath, repoPath).replace(/\\/g, '/'));
+	const verdicts = await Promise.all(
+		provisional.map(async (repoPath) => isDeclared(repoPath) || (await hasLocalWork(repoPath)))
+	);
+	const out = [...found];
+	provisional.forEach((repoPath, i) => {
+		if (verdicts[i]) out.push(repoPath);
+	});
+	out.sort();
+	return out;
+}
+
+async function walkNestedRepos(rootPath: string): Promise<{ key: string; found: string[]; provisional: string[] }> {
 	const found: string[] = [];
 	/** Repos found inside an ignored tree — reported only if they prove local work. */
 	const provisional: string[] = [];
@@ -278,22 +351,7 @@ export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
 		debug.warn('git', `Nested repo scan of ${rootPath} stopped at ${MAX_REPOS} repos`);
 	}
 
-	if (provisional.length > 0) {
-		// A submodule is the user declaring the sub-repo themselves, which
-		// outranks anything we could infer from its working tree.
-		const submodulePaths = await findSubmodulePaths(rootPath);
-		const isDeclared = (repoPath: string) =>
-			submodulePaths.has(path.relative(rootPath, repoPath).replace(/\\/g, '/'));
-		const verdicts = await Promise.all(
-			provisional.map(async (repoPath) => isDeclared(repoPath) || (await hasLocalWork(repoPath)))
-		);
-		provisional.forEach((repoPath, i) => {
-			if (verdicts[i]) found.push(repoPath);
-		});
-	}
-
-	found.sort();
-	return found;
+	return { key: rootPath, found, provisional };
 }
 
 /**
@@ -345,6 +403,17 @@ export async function findSubmodulePaths(rootPath: string): Promise<Set<string>>
 		out.add(s.path ?? s.name);
 	}
 	return out;
+}
+
+/** Clear the walk cache — primarily for tests. */
+export function clearNestedRepoCache(rootPath?: string): void {
+	if (rootPath) {
+		nestedRepoWalkCache.delete(rootPath);
+		nestedRepoInflight.delete(rootPath);
+	} else {
+		nestedRepoWalkCache.clear();
+		nestedRepoInflight.clear();
+	}
 }
 
 /**

--- a/backend/git/nested-repos.ts
+++ b/backend/git/nested-repos.ts
@@ -149,8 +149,14 @@ const nestedRepoWalkCache = new Map<string, WalkEntryCache>();
 const nestedRepoInflight = new Map<string, Promise<string[]>>();
 const localWorkCache = new Map<string, LocalWorkCache>();
 
-/** Project roots a live file watcher is currently feeding signals for. */
-const watchedRoots = new Set<string>();
+/**
+ * Project roots a live file watcher is feeding signals for, and how many
+ * watchers are doing so. Refcounted because two projects can be opened at the
+ * same directory: without it the first one to close would revoke the claim
+ * while the second is still reporting, and discovery would quietly go back to
+ * the clock while a perfectly good signal source was still running.
+ */
+const watchedRoots = new Map<string, number>();
 
 /**
  * The key every cache and the watched-root set is stored under. Callers reach
@@ -172,8 +178,12 @@ function isUnder(base: string, candidate: string): boolean {
 	return candidateKey === baseKey || candidateKey.startsWith(baseKey + '/');
 }
 
+function isWatched(rootPath: string): boolean {
+	return (watchedRoots.get(cacheKey(rootPath)) ?? 0) > 0;
+}
+
 function ttlFor(rootPath: string): number {
-	return watchedRoots.has(cacheKey(rootPath)) ? WATCHED_TTL_MS : UNWATCHED_TTL_MS;
+	return isWatched(rootPath) ? WATCHED_TTL_MS : UNWATCHED_TTL_MS;
 }
 
 /**
@@ -182,7 +192,8 @@ function ttlFor(rootPath: string): number {
  * short clock — and `hasLocalWork` verdicts become cacheable at all.
  */
 export function beginWatchedDiscovery(rootPath: string): void {
-	watchedRoots.add(cacheKey(rootPath));
+	const key = cacheKey(rootPath);
+	watchedRoots.set(key, (watchedRoots.get(key) ?? 0) + 1);
 }
 
 /**
@@ -190,8 +201,14 @@ export function beginWatchedDiscovery(rootPath: string): void {
  * because it was being invalidated, so the next call re-probes live.
  */
 export function endWatchedDiscovery(rootPath: string): void {
-	watchedRoots.delete(cacheKey(rootPath));
-	nestedRepoWalkCache.delete(cacheKey(rootPath));
+	const key = cacheKey(rootPath);
+	const remaining = (watchedRoots.get(key) ?? 0) - 1;
+	if (remaining > 0) {
+		watchedRoots.set(key, remaining);
+		return;
+	}
+	watchedRoots.delete(key);
+	nestedRepoWalkCache.delete(key);
 	for (const cachedRepoKey of Array.from(localWorkCache.keys())) {
 		if (isUnder(rootPath, cachedRepoKey)) localWorkCache.delete(cachedRepoKey);
 	}
@@ -204,6 +221,53 @@ export function endWatchedDiscovery(rootPath: string): void {
  */
 export function invalidateRepoSet(rootPath: string): void {
 	nestedRepoWalkCache.delete(cacheKey(rootPath));
+}
+
+/**
+ * Whether a changed path is one that can change WHICH repos are reported, as
+ * opposed to what is inside one.
+ *
+ * These live here rather than in the watcher on purpose. They are facts about
+ * the sub-repo policy at the top of this file, not about filesystem events, so
+ * extending that policy has to mean editing one place. Splitting them across
+ * the two files is what let discovery and its invalidation drift apart in the
+ * first place.
+ */
+function isRepoSetRule(changedPath: string): boolean {
+	const segments = cacheKey(changedPath).split('/');
+	const basename = segments[segments.length - 1];
+
+	// The repository itself appearing or vanishing.
+	if (basename === '.git') return true;
+
+	// Rule (2) and rule (3): what the project ignores, and what it declares.
+	if (basename === '.gitignore' || basename === '.gitmodules') return true;
+
+	// `.git/info/exclude` is a per-repo ignore file `git check-ignore` obeys
+	// exactly like `.gitignore`, so it moves the same boundary. The watcher
+	// filters it out of the panel's git-state events — correctly, the panel has
+	// nothing to show for it — which is precisely why discovery has to ask for
+	// it by name instead of riding along with those.
+	return (
+		basename === 'exclude' &&
+		segments[segments.length - 2] === 'info' &&
+		segments[segments.length - 3] === '.git'
+	);
+}
+
+/**
+ * A path under `rootPath` changed. The single entry point the file watcher
+ * uses: it forwards raw paths and this module decides what each one means, so
+ * no caller has to carry a copy of the sub-repo policy.
+ *
+ * Ignored entirely for a root nobody claimed — an unwatched root caches
+ * nothing that a signal could correct, and answering it here would only hide
+ * that fact.
+ */
+export function notifyPathChanged(rootPath: string, changedPath: string): void {
+	if (!isWatched(rootPath)) return;
+	if (isRepoSetRule(changedPath)) invalidateRepoSet(rootPath);
+	dropLocalWorkUnder(changedPath);
 }
 
 /**
@@ -221,7 +285,7 @@ export function invalidateRepoSet(rootPath: string): void {
  * Still scoped: a write in one sub-repo says nothing about its siblings, and
  * re-probing all of them is the cost this cache exists to avoid.
  */
-export function invalidateLocalWork(changedPath: string): void {
+function dropLocalWorkUnder(changedPath: string): void {
 	for (const cachedRepoKey of Array.from(localWorkCache.keys())) {
 		if (isUnder(cachedRepoKey, changedPath)) localWorkCache.delete(cachedRepoKey);
 	}
@@ -311,7 +375,7 @@ async function probeLocalWork(repoPath: string): Promise<boolean> {
  * hide a repo the user is working in.
  */
 async function hasLocalWork(rootPath: string, repoPath: string): Promise<boolean> {
-	if (!watchedRoots.has(cacheKey(rootPath))) return probeLocalWork(repoPath);
+	if (!isWatched(rootPath)) return probeLocalWork(repoPath);
 
 	const cached = localWorkCache.get(cacheKey(repoPath));
 	if (cached && Date.now() < cached.expiresAt) return cached.hasWork;
@@ -319,7 +383,7 @@ async function hasLocalWork(rootPath: string, repoPath: string): Promise<boolean
 	const hasWork = await probeLocalWork(repoPath);
 	// Re-read the flag: the watcher may have stopped while the probe ran, and a
 	// verdict nobody will invalidate must not be left behind.
-	if (watchedRoots.has(cacheKey(rootPath))) {
+	if (isWatched(rootPath)) {
 		localWorkCache.set(cacheKey(repoPath), { hasWork, expiresAt: Date.now() + WATCHED_TTL_MS });
 	}
 	return hasWork;

--- a/backend/git/nested-repos.ts
+++ b/backend/git/nested-repos.ts
@@ -77,41 +77,155 @@ const IGNORED_DESCENT_LEVELS = 1;
 const MAX_DEPTH = 12;
 
 /**
- * Cache for nested repo discovery. On Windows `fs.readdir` + `git check-ignore`
- * are noticeably slower (Bun.spawn + Defender scanning .git/index), so a short
- * TTL avoids re-walking the same tree on every `git:status` / `git:branches`
- * call triggered by Stage All, Stage, Unstage, etc. The status panel fires
- * those in quick succession (stage → loadStatus + file watcher → git:changed),
- * which previously walked the tree 3-4 times within a second.
+ * Discovery caching, and who is allowed to decide it is stale.
  *
- * Only the walk result (found + provisional) is cached. The provisional
- * filtering (hasLocalWork / .gitmodules) is re-run on every call, because a
- * repo inside an ignored tree becomes reportable the moment it gains local
- * work — which is exactly when the Changes tab needs it. Caching the filtered
- * list would hide that repo for the rest of the TTL.
+ * Every `git:status` / `git:branches` used to re-answer "which directories
+ * under this root are repos" from scratch: an `fs.readdir` over the whole tree
+ * plus a `git check-ignore` spawn per repo per depth level, then one
+ * `git status` per repo sitting inside an ignored tree. Measured on a real
+ * project that is 132ms and 7 spawns for the walk alone, and the panel fires it
+ * three or four times a second while staging. On Windows every spawn and every
+ * readdir also pays for Defender, which is what made Stage All look frozen.
  *
- * Only ONE filesystem signal invalidates an entry: the file watcher seeing an
- * event from a `.git` it does not know about, i.e. a `git init` or `git clone`
- * inside an open project. That path (`scheduleGitTargetsRefresh`) must not be
- * answered from a walk taken before the repo existed — it decides which git
- * dirs get watched at all, and rejects unaccounted-for ones permanently.
- * Everything else rides the TTL: a sub-repo DELETED while an entry is warm
- * stays listed for up to `NESTED_REPO_CACHE_TTL_MS`, which costs one failed
- * `git status` that the caller already skips.
+ * The answer barely ever changes, and the file watcher already knows exactly
+ * when it does. So the watcher, not a clock, is the invalidation authority:
  *
- * Note what is NOT cached: no file status ever is. Staged, unstaged, untracked
- * and conflicted entries come from a live `git status` per repo on every call,
- * so the Changes tab is never stale. The cache only answers "which directories
- * under this root are repos".
+ *   - `beginWatchedDiscovery` / `endWatchedDiscovery` — a root is "watched"
+ *     while a live watcher is feeding it signals.
+ *   - `invalidateRepoSet` — a `.git` appeared or vanished, or `.gitignore` /
+ *     `.gitmodules` changed. The set of repos may be different.
+ *   - `invalidateLocalWork` — something was written inside one repo, so only
+ *     that repo's "does it have work to show" verdict is suspect.
+ *
+ * THE SAFETY RULE, which every change here must preserve: **the watcher only
+ * ever makes an answer fresher, never staler.** A TTL is always the floor, so
+ * losing every signal degrades to re-walking on a timer — never to an answer
+ * that is wrong forever. That failure mode is not hypothetical: `resolveGitDirs`
+ * decides which git dirs get watched at all and rejects unaccounted-for ones
+ * permanently, so one stale walk there took a sub-repo out of the panel for the
+ * whole session.
+ *
+ * The two halves have different exposure, so they are cached separately:
+ *
+ *   - The WALK (which dirs hold a `.git`) is stable, and the signal for it —
+ *     a `.git` entry appearing — is one the watcher sees reliably on every
+ *     platform, because the repo's parent directory is watched. Long floor.
+ *   - LOCAL WORK (whether a repo inside an ignored tree has anything to show)
+ *     changes with ordinary file writes, and the watcher is blind inside the
+ *     directories it prunes by name. Cached ONLY for watched roots, where a
+ *     write lands as an invalidation; an unwatched caller (the snapshot
+ *     scanner, a CLI path) still probes live, exactly as before. Hiding a
+ *     sub-repo the user edits is the worst failure this module can produce, so
+ *     it does not get cached on a guess.
+ *
+ * What is never cached, at any point: file status. Staged, unstaged, untracked
+ * and conflicted entries come from a live `git status` per repo on every call.
+ * The Changes tab cannot go stale through this module.
  */
-const NESTED_REPO_CACHE_TTL_MS = process.platform === 'win32' ? 5000 : 3000;
-interface NestedWalkCache {
+
+/** Floor for a root nobody is invalidating — the clock is the only signal. */
+const UNWATCHED_TTL_MS = process.platform === 'win32' ? 5000 : 3000;
+
+/**
+ * Floor for a watched root. Long, because the watcher normally invalidates
+ * within milliseconds; this only bounds the damage if a signal is ever missed
+ * (a platform that drops an event, a watcher that faulted and is restarting).
+ */
+const WATCHED_TTL_MS = 60_000;
+
+interface WalkEntryCache {
 	found: string[];
 	provisional: string[];
 	expiresAt: number;
 }
-const nestedRepoWalkCache = new Map<string, NestedWalkCache>();
+
+/** Whether a sub-repo has anything the panel could show. Watched roots only. */
+interface LocalWorkCache {
+	hasWork: boolean;
+	expiresAt: number;
+}
+
+const nestedRepoWalkCache = new Map<string, WalkEntryCache>();
 const nestedRepoInflight = new Map<string, Promise<string[]>>();
+const localWorkCache = new Map<string, LocalWorkCache>();
+
+/** Project roots a live file watcher is currently feeding signals for. */
+const watchedRoots = new Set<string>();
+
+/**
+ * The key every cache and the watched-root set is stored under. Callers reach
+ * this module from both sides of a `path.normalize()` — the watcher normalises
+ * the project path before registering, `git:status` passes `project.path`
+ * straight through — and on Windows those differ by separator alone. Keying on
+ * the raw string would put them in two entries: the watcher would invalidate
+ * one while the panel read the other, silently turning the signal off.
+ * Values keep their native separators; only keys are folded.
+ */
+function cacheKey(inputPath: string): string {
+	return inputPath.replace(/\\/g, '/').replace(/\/+$/, '');
+}
+
+/** Whether `candidate` is `base` or sits underneath it. */
+function isUnder(base: string, candidate: string): boolean {
+	const baseKey = cacheKey(base);
+	const candidateKey = cacheKey(candidate);
+	return candidateKey === baseKey || candidateKey.startsWith(baseKey + '/');
+}
+
+function ttlFor(rootPath: string): number {
+	return watchedRoots.has(cacheKey(rootPath)) ? WATCHED_TTL_MS : UNWATCHED_TTL_MS;
+}
+
+/**
+ * Declare that a live file watcher will report changes for `rootPath`. Until
+ * `endWatchedDiscovery`, discovery may lean on those signals instead of the
+ * short clock — and `hasLocalWork` verdicts become cacheable at all.
+ */
+export function beginWatchedDiscovery(rootPath: string): void {
+	watchedRoots.add(cacheKey(rootPath));
+}
+
+/**
+ * The watcher for `rootPath` is gone. Drop everything that was only safe
+ * because it was being invalidated, so the next call re-probes live.
+ */
+export function endWatchedDiscovery(rootPath: string): void {
+	watchedRoots.delete(cacheKey(rootPath));
+	nestedRepoWalkCache.delete(cacheKey(rootPath));
+	for (const cachedRepoKey of Array.from(localWorkCache.keys())) {
+		if (isUnder(rootPath, cachedRepoKey)) localWorkCache.delete(cachedRepoKey);
+	}
+}
+
+/**
+ * The set of repos under `rootPath` may have changed — a `.git` appeared or
+ * vanished, or the rules that decide what counts (`.gitignore`, `.gitmodules`)
+ * were edited. Forces a fresh walk on the next call.
+ */
+export function invalidateRepoSet(rootPath: string): void {
+	nestedRepoWalkCache.delete(cacheKey(rootPath));
+}
+
+/**
+ * Something at or under `changedPath` moved, so the "has work to show" verdict
+ * of every cached repo containing it is suspect.
+ *
+ * Matching by containment rather than taking a repo path directly is what makes
+ * the important case work. A pristine sub-repo inside an ignored tree is NOT in
+ * the watcher's repo list — it is deliberately unreported until it has
+ * something to show, so the watcher has never resolved a git dir for it. The
+ * transition that must be caught is exactly the first write into it, and at
+ * that moment the only place it is known by name is this cache, holding the
+ * `false` verdict that is about to become wrong.
+ *
+ * Still scoped: a write in one sub-repo says nothing about its siblings, and
+ * re-probing all of them is the cost this cache exists to avoid.
+ */
+export function invalidateLocalWork(changedPath: string): void {
+	for (const cachedRepoKey of Array.from(localWorkCache.keys())) {
+		if (isUnder(cachedRepoKey, changedPath)) localWorkCache.delete(cachedRepoKey);
+	}
+}
 
 /**
  * Upper bound on reported sub-repos. A project with more than this is either
@@ -178,7 +292,7 @@ async function filterIgnored(repoRoot: string, relPaths: string[]): Promise<Set<
  * A repo we cannot read is reported as having work: hiding a sub-repo the user
  * edits is a far worse failure than showing one they do not care about.
  */
-async function hasLocalWork(repoPath: string): Promise<boolean> {
+async function probeLocalWork(repoPath: string): Promise<boolean> {
 	try {
 		const result = await execGit(['status', '--porcelain', '-z'], repoPath, { timeout: 15000 });
 		if (result.exitCode !== 0) return true;
@@ -186,6 +300,29 @@ async function hasLocalWork(repoPath: string): Promise<boolean> {
 	} catch {
 		return true;
 	}
+}
+
+/**
+ * `probeLocalWork` with the verdict remembered — but only under a root the
+ * watcher is invalidating, where a write inside the repo lands as an
+ * `invalidateLocalWork` before anyone can read a stale answer. Unwatched roots
+ * probe live every time: this is the verdict that decides whether a sub-repo is
+ * shown at all, and a cached "nothing to show" with no signal behind it would
+ * hide a repo the user is working in.
+ */
+async function hasLocalWork(rootPath: string, repoPath: string): Promise<boolean> {
+	if (!watchedRoots.has(cacheKey(rootPath))) return probeLocalWork(repoPath);
+
+	const cached = localWorkCache.get(cacheKey(repoPath));
+	if (cached && Date.now() < cached.expiresAt) return cached.hasWork;
+
+	const hasWork = await probeLocalWork(repoPath);
+	// Re-read the flag: the watcher may have stopped while the probe ran, and a
+	// verdict nobody will invalidate must not be left behind.
+	if (watchedRoots.has(cacheKey(rootPath))) {
+		localWorkCache.set(cacheKey(repoPath), { hasWork, expiresAt: Date.now() + WATCHED_TTL_MS });
+	}
+	return hasWork;
 }
 
 /** Whether `dirPath` is a git repo (`.git` is a dir for clones, a file for worktrees/submodules). */
@@ -209,7 +346,7 @@ async function isRepoDir(dirPath: string): Promise<boolean> {
  * so a newly-dirtied repo appears immediately.
  */
 export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
-	const cachedWalk = nestedRepoWalkCache.get(rootPath);
+	const cachedWalk = nestedRepoWalkCache.get(cacheKey(rootPath));
 	if (cachedWalk && Date.now() < cachedWalk.expiresAt) {
 		return resolveProvisional(rootPath, cachedWalk.found, cachedWalk.provisional);
 	}
@@ -218,32 +355,33 @@ export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
 	// starting a second one, but gets its own copy of the result: the array
 	// goes out to unrelated call sites, and one of them mutating it in place
 	// would corrupt the others.
-	const inflight = nestedRepoInflight.get(rootPath);
+	const inflight = nestedRepoInflight.get(cacheKey(rootPath));
 	if (inflight) return [...(await inflight)];
 
 	const promise = (async (): Promise<string[]> => {
 		const walk = await walkNestedRepos(rootPath);
-		nestedRepoWalkCache.set(rootPath, {
+		nestedRepoWalkCache.set(cacheKey(rootPath), {
 			found: walk.found,
 			provisional: walk.provisional,
-			expiresAt: Date.now() + NESTED_REPO_CACHE_TTL_MS
+			expiresAt: Date.now() + ttlFor(rootPath)
 		});
 		return resolveProvisional(rootPath, walk.found, walk.provisional);
 	})();
 
-	nestedRepoInflight.set(rootPath, promise);
+	nestedRepoInflight.set(cacheKey(rootPath), promise);
 	try {
 		return await promise;
 	} finally {
-		nestedRepoInflight.delete(rootPath);
+		nestedRepoInflight.delete(cacheKey(rootPath));
 	}
 }
 
 /**
  * Decide which provisional repos (those found inside an ignored tree) earn a
  * place in the result, and return the sorted list. Deliberately outside the
- * cache: a repo qualifies the moment it gains local work, so this runs against
- * the live working trees on every call even when the walk itself was cached.
+ * WALK cache: a repo qualifies the moment it gains local work, so a cached walk
+ * must never carry a cached verdict with it. The verdicts have their own,
+ * signal-backed cache — see `hasLocalWork`.
  */
 async function resolveProvisional(rootPath: string, found: string[], provisional: string[]): Promise<string[]> {
 	if (provisional.length === 0) {
@@ -255,7 +393,7 @@ async function resolveProvisional(rootPath: string, found: string[], provisional
 	const isDeclared = (repoPath: string) =>
 		submodulePaths.has(path.relative(rootPath, repoPath).replace(/\\/g, '/'));
 	const verdicts = await Promise.all(
-		provisional.map(async (repoPath) => isDeclared(repoPath) || (await hasLocalWork(repoPath)))
+		provisional.map(async (repoPath) => isDeclared(repoPath) || (await hasLocalWork(rootPath, repoPath)))
 	);
 	const out = [...found];
 	provisional.forEach((repoPath, i) => {
@@ -437,17 +575,24 @@ export async function findSubmodulePaths(rootPath: string): Promise<Set<string>>
 }
 
 /**
- * Drop cached walks so the next call re-scans the tree. Exists for tests, which
- * mutate a project's layout far faster than the TTL and would otherwise assert
- * against a walk from the previous fixture.
+ * Drop every cached answer so the next call re-scans and re-probes. Exists for
+ * tests, which mutate a project's layout far faster than any TTL and would
+ * otherwise assert against the previous fixture. Production code should reach
+ * for the targeted `invalidateRepoSet` / `invalidateLocalWork` instead, so one
+ * repo's churn does not throw away every other repo's answer.
  */
 export function clearNestedRepoCache(rootPath?: string): void {
 	if (rootPath) {
-		nestedRepoWalkCache.delete(rootPath);
-		nestedRepoInflight.delete(rootPath);
+		nestedRepoWalkCache.delete(cacheKey(rootPath));
+		nestedRepoInflight.delete(cacheKey(rootPath));
+		for (const cachedRepoKey of Array.from(localWorkCache.keys())) {
+			if (isUnder(rootPath, cachedRepoKey)) localWorkCache.delete(cachedRepoKey);
+		}
 	} else {
 		nestedRepoWalkCache.clear();
 		nestedRepoInflight.clear();
+		localWorkCache.clear();
+		watchedRoots.clear();
 	}
 }
 

--- a/backend/git/nested-repos.ts
+++ b/backend/git/nested-repos.ts
@@ -84,13 +84,17 @@ const MAX_DEPTH = 12;
  * those in quick succession (stage → loadStatus + file watcher → git:changed),
  * which previously walked the tree 3-4 times within a second.
  *
- * The walk result (found + provisional) is cached, but the provisional
- * filtering (hasLocalWork / .gitmodules) is always re-evaluated: a repo
- * inside an ignored tree becomes visible the moment it gains local work,
- * which happens after the walk but before the next TTL expiry. Caching the
- * filtered list would hide that new repo for up to 5s on Windows.
- * Similarly, clearing the walk cache on filesystem changes is cheaper than
- * caching a stale filtered answer.
+ * Only the walk result (found + provisional) is cached. The provisional
+ * filtering (hasLocalWork / .gitmodules) is re-run on every call, because a
+ * repo inside an ignored tree becomes reportable the moment it gains local
+ * work — which is exactly when the Changes tab needs it. Caching the filtered
+ * list would hide that repo for the rest of the TTL.
+ *
+ * Nothing invalidates the cache on filesystem events — the TTL is the only
+ * bound. A sub-repo created or deleted while an entry is warm is therefore up
+ * to `NESTED_REPO_CACHE_TTL_MS` late, which is acceptable for a list that only
+ * refreshes when the panel asks, and far cheaper than driving a whole-tree
+ * discovery walk off the `.git` watcher.
  */
 const NESTED_REPO_CACHE_TTL_MS = process.platform === 'win32' ? 5000 : 3000;
 interface NestedWalkCache {
@@ -197,17 +201,25 @@ async function isRepoDir(dirPath: string): Promise<boolean> {
  * so a newly-dirtied repo appears immediately.
  */
 export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
-	const now = Date.now();
 	const cachedWalk = nestedRepoWalkCache.get(rootPath);
-	if (cachedWalk && now < cachedWalk.expiresAt) {
+	if (cachedWalk && Date.now() < cachedWalk.expiresAt) {
 		return resolveProvisional(rootPath, cachedWalk.found, cachedWalk.provisional);
 	}
+
+	// A caller that arrives while a walk is running shares it instead of
+	// starting a second one, but gets its own copy of the result: the array
+	// goes out to unrelated call sites, and one of them mutating it in place
+	// would corrupt the others.
 	const inflight = nestedRepoInflight.get(rootPath);
-	if (inflight) return inflight;
+	if (inflight) return [...(await inflight)];
 
 	const promise = (async (): Promise<string[]> => {
 		const walk = await walkNestedRepos(rootPath);
-		nestedRepoWalkCache.set(walk.key, { found: walk.found, provisional: walk.provisional, expiresAt: Date.now() + NESTED_REPO_CACHE_TTL_MS });
+		nestedRepoWalkCache.set(rootPath, {
+			found: walk.found,
+			provisional: walk.provisional,
+			expiresAt: Date.now() + NESTED_REPO_CACHE_TTL_MS
+		});
 		return resolveProvisional(rootPath, walk.found, walk.provisional);
 	})();
 
@@ -219,6 +231,12 @@ export async function findNestedRepoPaths(rootPath: string): Promise<string[]> {
 	}
 }
 
+/**
+ * Decide which provisional repos (those found inside an ignored tree) earn a
+ * place in the result, and return the sorted list. Deliberately outside the
+ * cache: a repo qualifies the moment it gains local work, so this runs against
+ * the live working trees on every call even when the walk itself was cached.
+ */
 async function resolveProvisional(rootPath: string, found: string[], provisional: string[]): Promise<string[]> {
 	if (provisional.length === 0) {
 		const out = [...found];
@@ -239,7 +257,12 @@ async function resolveProvisional(rootPath: string, found: string[], provisional
 	return out;
 }
 
-async function walkNestedRepos(rootPath: string): Promise<{ key: string; found: string[]; provisional: string[] }> {
+/**
+ * The raw, uncached filesystem walk. Returns repos split into those reportable
+ * on structure alone and those still needing to prove local work — the split
+ * `findNestedRepoPaths` caches, because only the first half is stable.
+ */
+async function walkNestedRepos(rootPath: string): Promise<{ found: string[]; provisional: string[] }> {
 	const found: string[] = [];
 	/** Repos found inside an ignored tree — reported only if they prove local work. */
 	const provisional: string[] = [];
@@ -351,7 +374,7 @@ async function walkNestedRepos(rootPath: string): Promise<{ key: string; found: 
 		debug.warn('git', `Nested repo scan of ${rootPath} stopped at ${MAX_REPOS} repos`);
 	}
 
-	return { key: rootPath, found, provisional };
+	return { found, provisional };
 }
 
 /**
@@ -405,7 +428,11 @@ export async function findSubmodulePaths(rootPath: string): Promise<Set<string>>
 	return out;
 }
 
-/** Clear the walk cache — primarily for tests. */
+/**
+ * Drop cached walks so the next call re-scans the tree. Exists for tests, which
+ * mutate a project's layout far faster than the TTL and would otherwise assert
+ * against a walk from the previous fixture.
+ */
 export function clearNestedRepoCache(rootPath?: string): void {
 	if (rootPath) {
 		nestedRepoWalkCache.delete(rootPath);

--- a/backend/git/nested-repos.ts
+++ b/backend/git/nested-repos.ts
@@ -90,11 +90,19 @@ const MAX_DEPTH = 12;
  * work — which is exactly when the Changes tab needs it. Caching the filtered
  * list would hide that repo for the rest of the TTL.
  *
- * Nothing invalidates the cache on filesystem events — the TTL is the only
- * bound. A sub-repo created or deleted while an entry is warm is therefore up
- * to `NESTED_REPO_CACHE_TTL_MS` late, which is acceptable for a list that only
- * refreshes when the panel asks, and far cheaper than driving a whole-tree
- * discovery walk off the `.git` watcher.
+ * Only ONE filesystem signal invalidates an entry: the file watcher seeing an
+ * event from a `.git` it does not know about, i.e. a `git init` or `git clone`
+ * inside an open project. That path (`scheduleGitTargetsRefresh`) must not be
+ * answered from a walk taken before the repo existed — it decides which git
+ * dirs get watched at all, and rejects unaccounted-for ones permanently.
+ * Everything else rides the TTL: a sub-repo DELETED while an entry is warm
+ * stays listed for up to `NESTED_REPO_CACHE_TTL_MS`, which costs one failed
+ * `git status` that the caller already skips.
+ *
+ * Note what is NOT cached: no file status ever is. Staged, unstaged, untracked
+ * and conflicted entries come from a live `git status` per repo on every call,
+ * so the Changes tab is never stale. The cache only answers "which directories
+ * under this root are repos".
  */
 const NESTED_REPO_CACHE_TTL_MS = process.platform === 'win32' ? 5000 : 3000;
 interface NestedWalkCache {

--- a/backend/ws/git/status.ts
+++ b/backend/ws/git/status.ts
@@ -55,15 +55,18 @@ export const statusHandler = createRouter()
 			};
 		}
 
-		const status = await gitService.getStatus(project.path);
+		// Fetch outer status and nested repo list in parallel — the walk does
+		// not depend on the status result, and on Windows the walk (readdir +
+		// check-ignore spawns) is the dominant cost. Sharing the walk via the
+		// findNestedRepoPaths cache + inflight dedup also keeps concurrent
+		// callers (status + branches triggered together) from walking twice.
+		const [status, nestedRepoPathsRaw] = await Promise.all([
+			gitService.getStatus(project.path),
+			findNestedRepoPaths(project.path).catch(() => [] as string[])
+		]);
+		const nestedRepoPaths = nestedRepoPathsRaw ?? [];
 
-		// Also aggregate status from nested git repos living inside the
-		// project (e.g. a theme extracted into its own repo, listed in the
-		// parent's .gitignore). The outer repo's `git status` skips them
-		// entirely, so without this aggregation the Changes tab would not
-		// show edits the AI made inside the nested repo.
-		try {
-			const nestedRepoPaths = await findNestedRepoPaths(project.path);
+		if (nestedRepoPaths.length > 0) {
 			const nestedPrefixes = nestedRepoPaths.map(
 				(repoPath) => pathRelative(project.path, repoPath).replace(/\\/g, '/') + '/'
 			);
@@ -84,26 +87,33 @@ export const statusHandler = createRouter()
 				status.conflicted = status.conflicted.filter((f) => !underNested(f));
 			}
 
-			for (const repoPath of nestedRepoPaths) {
-				try {
-					const nestedStatus = await gitService.getStatus(repoPath);
-					const prefix = pathRelative(project.path, repoPath).replace(/\\/g, '/') + '/';
-					const withPrefix = (f: typeof nestedStatus.staged[number]) => ({
-						...f,
-						path: prefix + f.path,
-						oldPath: f.oldPath ? prefix + f.oldPath : undefined
-					});
-					status.staged.push(...nestedStatus.staged.map(withPrefix));
-					status.unstaged.push(...nestedStatus.unstaged.map(withPrefix));
-					status.untracked.push(...nestedStatus.untracked.map(withPrefix));
-					status.conflicted.push(...nestedStatus.conflicted.map(withPrefix));
-				} catch {
-					// Skip repos whose git status fails — don't break the
-					// whole response because one nested repo is broken.
-				}
+			// Fetch all nested statuses in parallel instead of sequentially.
+			// Each `git status` is a separate spawn; on Windows Defender scans
+			// .git/index per call, so sequential loops multiplied the wait.
+			const nestedStatuses = await Promise.all(
+				nestedRepoPaths.map(async (repoPath) => {
+					try {
+						const nestedStatus = await gitService.getStatus(repoPath);
+						return { repoPath, nestedStatus };
+					} catch {
+						return null;
+					}
+				})
+			);
+
+			for (const entry of nestedStatuses) {
+				if (!entry) continue;
+				const prefix = pathRelative(project.path, entry.repoPath).replace(/\\/g, '/') + '/';
+				const withPrefix = (f: typeof entry.nestedStatus.staged[number]) => ({
+					...f,
+					path: prefix + f.path,
+					oldPath: f.oldPath ? prefix + f.oldPath : undefined
+				});
+				status.staged.push(...entry.nestedStatus.staged.map(withPrefix));
+				status.unstaged.push(...entry.nestedStatus.unstaged.map(withPrefix));
+				status.untracked.push(...entry.nestedStatus.untracked.map(withPrefix));
+				status.conflicted.push(...entry.nestedStatus.conflicted.map(withPrefix));
 			}
-		} catch {
-			// If findNestedRepoPaths itself fails, just return outer status
 		}
 
 		return { isRepo: true, ...status };

--- a/backend/ws/git/status.ts
+++ b/backend/ws/git/status.ts
@@ -60,11 +60,11 @@ export const statusHandler = createRouter()
 		// check-ignore spawns) is the dominant cost. Sharing the walk via the
 		// findNestedRepoPaths cache + inflight dedup also keeps concurrent
 		// callers (status + branches triggered together) from walking twice.
-		const [status, nestedRepoPathsRaw] = await Promise.all([
+		const [status, nestedRepoPaths] = await Promise.all([
 			gitService.getStatus(project.path),
+			// Discovery failing must not cost the user the outer repo's status.
 			findNestedRepoPaths(project.path).catch(() => [] as string[])
 		]);
-		const nestedRepoPaths = nestedRepoPathsRaw ?? [];
 
 		if (nestedRepoPaths.length > 0) {
 			const nestedPrefixes = nestedRepoPaths.map(

--- a/frontend/components/git/ChangesSection.svelte
+++ b/frontend/components/git/ChangesSection.svelte
@@ -22,6 +22,12 @@
 		onViewDiff?: (file: GitFileChange, section: string) => void;
 		onResolve?: (path: string) => void;
 		aiChangesSet?: Set<string>;
+		/**
+		 * A bulk action is running against this section's repo. Every header
+		 * button is disabled and the triggering ones swap to a spinner: on
+		 * Windows the status refresh behind Stage All takes long enough that
+		 * without feedback the panel reads as frozen and invites a second click.
+		 */
 		busy?: boolean;
 	}
 
@@ -158,7 +164,7 @@
 						disabled={busy}
 					>
 						{#if busy}
-							<Icon name="lucide:loader-2" class="w-4 h-4 animate-spin" />
+							<Icon name="lucide:loader-circle" class="w-4 h-4 animate-spin" />
 						{:else}
 							<Icon name="lucide:minus" class="w-4 h-4" />
 						{/if}
@@ -169,10 +175,14 @@
 							type="button"
 							class="flex items-center justify-center w-7 h-7 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
 							onclick={(e) => { e.stopPropagation(); onDiscardAll?.(); }}
-							title="Discard All"
+							title={busy ? 'Working…' : 'Discard All'}
 							disabled={busy}
 						>
-							<Icon name="lucide:undo-2" class="w-4 h-4" />
+							{#if busy}
+								<Icon name="lucide:loader-circle" class="w-4 h-4 animate-spin" />
+							{:else}
+								<Icon name="lucide:undo-2" class="w-4 h-4" />
+							{/if}
 						</button>
 					{/if}
 					<button
@@ -183,7 +193,7 @@
 						disabled={busy}
 					>
 						{#if busy}
-							<Icon name="lucide:loader-2" class="w-4 h-4 animate-spin" />
+							<Icon name="lucide:loader-circle" class="w-4 h-4 animate-spin" />
 						{:else}
 							<Icon name="lucide:plus" class="w-4 h-4" />
 						{/if}

--- a/frontend/components/git/ChangesSection.svelte
+++ b/frontend/components/git/ChangesSection.svelte
@@ -22,6 +22,7 @@
 		onViewDiff?: (file: GitFileChange, section: string) => void;
 		onResolve?: (path: string) => void;
 		aiChangesSet?: Set<string>;
+		busy?: boolean;
 	}
 
 	let {
@@ -33,7 +34,8 @@
 		onStageAll, onUnstageAll, onDiscardAll,
 		onStash,
 		onViewDiff, onResolve,
-		aiChangesSet = new Set<string>()
+		aiChangesSet = new Set<string>(),
+		busy = false
 	}: Props = $props();
 
 	function isFileActive(filePath: string): boolean {
@@ -139,9 +141,10 @@
 				{#if onStash}
 					<button
 						type="button"
-						class="flex items-center justify-center w-7 h-7 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer"
+						class="flex items-center justify-center w-7 h-7 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
 						onclick={(e) => { e.stopPropagation(); onStash?.(); }}
 						title="Stash changes"
+						disabled={busy}
 					>
 						<Icon name="lucide:archive" class="w-3.5 h-3.5" />
 					</button>
@@ -149,30 +152,41 @@
 				{#if section === 'staged' && onUnstageAll}
 					<button
 						type="button"
-						class="flex items-center justify-center w-7 h-7 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer"
+						class="flex items-center justify-center w-7 h-7 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
 						onclick={(e) => { e.stopPropagation(); onUnstageAll?.(); }}
-						title="Unstage All"
+						title={busy ? 'Working…' : 'Unstage All'}
+						disabled={busy}
 					>
-						<Icon name="lucide:minus" class="w-4 h-4" />
+						{#if busy}
+							<Icon name="lucide:loader-2" class="w-4 h-4 animate-spin" />
+						{:else}
+							<Icon name="lucide:minus" class="w-4 h-4" />
+						{/if}
 					</button>
 				{:else if (section === 'unstaged' || section === 'untracked') && onStageAll}
 					{#if onDiscardAll}
 						<button
 							type="button"
-							class="flex items-center justify-center w-7 h-7 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer"
+							class="flex items-center justify-center w-7 h-7 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
 							onclick={(e) => { e.stopPropagation(); onDiscardAll?.(); }}
 							title="Discard All"
+							disabled={busy}
 						>
 							<Icon name="lucide:undo-2" class="w-4 h-4" />
 						</button>
 					{/if}
 					<button
 						type="button"
-						class="flex items-center justify-center w-7 h-7 rounded-md text-slate-400 hover:bg-emerald-500/10 hover:text-emerald-500 transition-colors bg-transparent border-none cursor-pointer"
+						class="flex items-center justify-center w-7 h-7 rounded-md text-slate-400 hover:bg-emerald-500/10 hover:text-emerald-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
 						onclick={(e) => { e.stopPropagation(); onStageAll?.(); }}
-						title="Stage All"
+						title={busy ? 'Working…' : 'Stage All'}
+						disabled={busy}
 					>
-						<Icon name="lucide:plus" class="w-4 h-4" />
+						{#if busy}
+							<Icon name="lucide:loader-2" class="w-4 h-4 animate-spin" />
+						{:else}
+							<Icon name="lucide:plus" class="w-4 h-4" />
+						{/if}
 					</button>
 				{/if}
 			</div>

--- a/frontend/components/git/ConflictResolver.svelte
+++ b/frontend/components/git/ConflictResolver.svelte
@@ -24,6 +24,13 @@
 		onResolveAllWithAI: () => void;
 		onAbortMerge: () => void;
 		onClose: () => void;
+		/**
+		 * A resolve or abort is already running against this repo. Both are
+		 * followed by a full status refresh, slow enough on Windows that the
+		 * dialog looks unchanged long enough to invite a second click — which
+		 * would resolve against a file the first call is still rewriting.
+		 */
+		busy?: boolean;
 	}
 
 	const {
@@ -35,7 +42,8 @@
 		onResolveWithAI,
 		onResolveAllWithAI,
 		onAbortMerge,
-		onClose
+		onClose,
+		busy = false
 	}: Props = $props();
 
 	let selectedPath = $state<string | null>(null);
@@ -276,6 +284,7 @@
 					type="button"
 					class="hidden md:flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-red-600 dark:text-red-400 bg-red-500/10 hover:bg-red-500/20 rounded-lg transition-colors cursor-pointer border-none"
 					onclick={onAbortMerge}
+					disabled={busy}
 					title="Abort the merge and discard all conflict resolutions"
 				>
 					<Icon name="lucide:octagon-x" class="w-4 h-4" />
@@ -622,7 +631,7 @@
 										? 'bg-violet-600 text-white hover:bg-violet-700 cursor-pointer'
 										: 'bg-slate-200 dark:bg-slate-700 text-slate-500 dark:text-slate-400 cursor-not-allowed'}"
 									onclick={applyGuidedResolution}
-									disabled={!allResolved}
+									disabled={!allResolved || busy}
 									title={allResolved
 										? 'Apply resolutions and stage file'
 										: 'Resolve all conflicts first'}
@@ -719,6 +728,7 @@
 									type="button"
 									class="flex items-center gap-1.5 px-3 py-1 text-xs md:text-sm font-semibold bg-violet-600 text-white rounded-md hover:bg-violet-700 transition-colors cursor-pointer border-none"
 									onclick={applyManualResolution}
+									disabled={busy}
 								>
 									<Icon name="lucide:check" class="w-3.5 h-3.5 md:w-4 md:h-4" />
 									Save &amp; Stage

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -1475,14 +1475,24 @@
 	// Staging Actions
 	// ============================
 
+	// Busy flags for staging operations — on Windows git status is slower
+	// (Bun.spawn + Defender scanning .git/index), so without a guard the user
+	// can double-click Stage All and queue two full walks. The flag disables
+	// the bulk buttons until the refresh finishes.
+	let isStagingBusy = $state(false);
+	let stagingFilePath = $state<string | null>(null);
+
 	async function stageFile(path: string) {
-		if (!projectId) return;
+		if (!projectId || isStagingBusy || stagingFilePath) return;
+		stagingFilePath = path;
 		try {
 			await ws.http('git:stage', { projectId, filePath: path });
 			await loadStatus();
 			await migrateActiveTabAfterStatusChange(path);
 		} catch (err) {
 			debug.error('git', 'Failed to stage file:', err);
+		} finally {
+			stagingFilePath = null;
 		}
 	}
 
@@ -1683,7 +1693,8 @@
 	}
 
 	async function stageAll() {
-		if (!projectId) return;
+		if (!projectId || isStagingBusy) return;
+		isStagingBusy = true;
 		try {
 			await ws.http('git:stage-all', { projectId });
 			await loadStatus();
@@ -1692,22 +1703,28 @@
 			}
 		} catch (err) {
 			debug.error('git', 'Failed to stage all:', err);
+		} finally {
+			isStagingBusy = false;
 		}
 	}
 
 	async function unstageFile(path: string) {
-		if (!projectId) return;
+		if (!projectId || isStagingBusy || stagingFilePath) return;
+		stagingFilePath = path;
 		try {
 			await ws.http('git:unstage', { projectId, filePath: path });
 			await loadStatus();
 			await migrateActiveTabAfterStatusChange(path);
 		} catch (err) {
 			debug.error('git', 'Failed to unstage file:', err);
+		} finally {
+			stagingFilePath = null;
 		}
 	}
 
 	async function unstageAll() {
-		if (!projectId) return;
+		if (!projectId || isStagingBusy) return;
+		isStagingBusy = true;
 		try {
 			await ws.http('git:unstage-all', { projectId });
 			await loadStatus();
@@ -1716,6 +1733,8 @@
 			}
 		} catch (err) {
 			debug.error('git', 'Failed to unstage all:', err);
+		} finally {
+			isStagingBusy = false;
 		}
 	}
 
@@ -5104,6 +5123,7 @@ ${bodies}`;
 				onStash={() => openStashPrompt('staged')}
 				onViewDiff={viewDiff}
 				{aiChangesSet}
+				busy={isStagingBusy}
 			/>
 
 			<!--
@@ -5128,6 +5148,7 @@ ${bodies}`;
 				onDiscardAll={discardAll}
 				onViewDiff={viewDiff}
 				{aiChangesSet}
+				busy={isStagingBusy}
 			/>
 
 			{#if mainStagedFiles.length === 0 && mainAllChanges.length === 0 && mainConflictedFiles.length === 0 && !isLoading && !(branchInfo?.nested?.length)}

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -28,6 +28,7 @@
 		setCommitDraft,
 		hasCommitDraft,
 		getGitOps,
+		runGitOp,
 		setGitOp,
 		type GitUiState,
 		type GitActiveDiff
@@ -189,17 +190,18 @@
 			type: 'error',
 			confirmText: 'Delete',
 			onConfirm: async () => {
-				if (!projectId) return;
-				const key = nestedRemoteBranchKey(remote, branch, repoPath);
-				deletingRemoteBranch = key;
-				try {
-					await ws.http('git:delete-remote-branch', { projectId, remote, branch, repoPath });
-					await loadBranches();
-				} catch (err) {
-					debug.error('git', 'Failed to delete remote branch:', err);
-				} finally {
-					deletingRemoteBranch = null;
-				}
+				await runGitOp(projectId, 'isBranching', async () => {
+					const key = nestedRemoteBranchKey(remote, branch, repoPath);
+					deletingRemoteBranch = key;
+					try {
+						await ws.http('git:delete-remote-branch', { projectId, remote, branch, repoPath });
+						await loadBranches();
+					} catch (err) {
+						debug.error('git', 'Failed to delete remote branch:', err);
+					} finally {
+						deletingRemoteBranch = null;
+					}
+				}, repoPath);
 			}
 		});
 	}
@@ -746,6 +748,7 @@
 		if (!projectId) return;
 		const name = nestedNewBranchName(nested.relPath).trim();
 		if (!name) return;
+		await runGitOp(projectId, 'isBranching', async () => {
 		try {
 			await ws.http('git:create-branch', { projectId, name, repoPath: nested.path });
 			showInfo('Branch Created', `Created "${name}" in ${nested.relPath}.`);
@@ -756,9 +759,10 @@
 			debug.error('git', 'Failed to create nested branch:', err);
 			showError('Create Branch Failed', err instanceof Error ? err.message : 'Unknown error');
 		}
+		}, nested.path);
 	}
 	async function handleSwitchNestedBranch(nested: GitNestedRepoInfo, name: string) {
-		if (!projectId) return;
+		await runGitOp(projectId, 'isBranching', async () => {
 		try {
 			await ws.http('git:switch-branch', { projectId, name, repoPath: nested.path });
 			showInfo('Switched Branch', `Switched to "${name}" in ${nested.relPath}.`);
@@ -767,6 +771,7 @@
 			debug.error('git', 'Failed to switch nested branch:', err);
 			showError('Switch Branch Failed', err instanceof Error ? err.message : 'Unknown error');
 		}
+		}, nested.path);
 	}
 	function handleDeleteNestedBranch(nested: GitNestedRepoInfo, name: string) {
 		requestConfirm({
@@ -775,27 +780,31 @@
 			type: 'error',
 			confirmText: 'Delete',
 			onConfirm: async () => {
-				if (!projectId) return;
-				try {
-					await ws.http('git:delete-branch', { projectId, name, repoPath: nested.path });
-					await loadBranches();
-				} catch (err) {
-					debug.error('git', 'Failed to delete nested branch:', err);
-					requestConfirm({
-						title: 'Force Delete Branch',
-						message: 'Branch is not fully merged. Force delete?',
-						type: 'error',
-						confirmText: 'Force Delete',
-						onConfirm: async () => {
-							try {
-								await ws.http('git:delete-branch', { projectId, name, force: true, repoPath: nested.path });
-								await loadBranches();
-							} catch (forceErr) {
-								showError('Force Delete Failed', forceErr instanceof Error ? forceErr.message : 'Unknown error');
+				await runGitOp(projectId, 'isBranching', async () => {
+					try {
+						await ws.http('git:delete-branch', { projectId, name, repoPath: nested.path });
+						await loadBranches();
+					} catch (err) {
+						debug.error('git', 'Failed to delete nested branch:', err);
+						requestConfirm({
+							title: 'Force Delete Branch',
+							message: 'Branch is not fully merged. Force delete?',
+							type: 'error',
+							confirmText: 'Force Delete',
+							// Its own guard: answered after the first attempt released.
+							onConfirm: async () => {
+								await runGitOp(projectId, 'isBranching', async () => {
+									try {
+										await ws.http('git:delete-branch', { projectId, name, force: true, repoPath: nested.path });
+										await loadBranches();
+									} catch (forceErr) {
+										showError('Force Delete Failed', forceErr instanceof Error ? forceErr.message : 'Unknown error');
+									}
+								}, nested.path);
 							}
-						}
-					});
-				}
+						});
+					}
+				}, nested.path);
 			}
 		});
 	}
@@ -813,6 +822,8 @@
 		const name = (nestedNewRemoteNames[relPath] ?? '').trim();
 		const url = (nestedNewRemoteUrls[relPath] ?? '').trim();
 		if (!name || !url) return;
+		const nestedPath = branchInfo?.nested?.find(entry => entry.relPath === relPath)?.path;
+		await runGitOp(projectId, 'isConfiguring', async () => {
 		nestedAddingRemote = { ...nestedAddingRemote, [relPath]: true };
 		try {
 			const nested = branchInfo?.nested?.find(n => n.relPath === relPath);
@@ -829,6 +840,7 @@
 		} finally {
 			nestedAddingRemote = { ...nestedAddingRemote, [relPath]: false };
 		}
+		}, nestedPath);
 	}
 
 	async function handleNestedSaveRemote(relPath: string) {
@@ -837,6 +849,8 @@
 		const newName = (nestedEditRemoteNames[relPath] ?? '').trim();
 		const newUrl = (nestedEditRemoteUrls[relPath] ?? '').trim();
 		if (!oldName || !newName || !newUrl) return;
+		const nestedPath = branchInfo?.nested?.find(entry => entry.relPath === relPath)?.path;
+		await runGitOp(projectId, 'isConfiguring', async () => {
 		nestedSavingRemote = { ...nestedSavingRemote, [relPath]: true };
 		try {
 			const nested = branchInfo?.nested?.find(n => n.relPath === relPath);
@@ -852,6 +866,7 @@
 		} finally {
 			nestedSavingRemote = { ...nestedSavingRemote, [relPath]: false };
 		}
+		}, nestedPath);
 	}
 
 	async function handleNestedRemoveRemote(name: string, relPath: string) {
@@ -861,21 +876,23 @@
 			type: 'warning',
 			confirmText: 'Remove',
 			onConfirm: async () => {
-				if (!projectId) return;
-				try {
-					const nested = branchInfo?.nested?.find(n => n.relPath === relPath);
-					await ws.http('git:remove-remote', { projectId, name, repoPath: nested?.path });
-					await loadBranches();
-					if (nested) await loadNestedRemotes(nested);
-				} catch (err) {
-					debug.error('git', 'Failed to remove remote:', err);
-				}
+				const nested = branchInfo?.nested?.find(entry => entry.relPath === relPath);
+				await runGitOp(projectId, 'isConfiguring', async () => {
+					try {
+						await ws.http('git:remove-remote', { projectId, name, repoPath: nested?.path });
+						await loadBranches();
+						if (nested) await loadNestedRemotes(nested);
+					} catch (err) {
+						debug.error('git', 'Failed to remove remote:', err);
+					}
+				}, nested?.path);
 			}
 		});
 	}
 
 	async function handleNestedFetchRemote(remote: string, relPath: string) {
-		if (!projectId) return;
+		const nestedPath = branchInfo?.nested?.find(entry => entry.relPath === relPath)?.path;
+		await runGitOp(projectId, 'isFetching', async () => {
 		nestedFetchingRemote = { ...nestedFetchingRemote, [relPath]: remote };
 		try {
 			const nested = branchInfo?.nested?.find(n => n.relPath === relPath);
@@ -887,6 +904,7 @@
 		} finally {
 			nestedFetchingRemote = { ...nestedFetchingRemote, [relPath]: null };
 		}
+		}, nestedPath);
 	}
 
 	interface BranchCommitState {
@@ -1309,7 +1327,7 @@
 	// ============================
 
 	async function handleInit() {
-		if (!projectId) return;
+		await runGitOp(projectId, 'isConfiguring', async () => {
 		isInitializing = true;
 		try {
 			await ws.http('git:init', { projectId, defaultBranch: 'main' });
@@ -1320,6 +1338,7 @@
 		} finally {
 			isInitializing = false;
 		}
+		});
 	}
 
 	// ============================
@@ -1684,22 +1703,24 @@
 			type: 'warning',
 			confirmText: 'Remove',
 			onConfirm: async () => {
-				if (!projectId) return;
-				try {
-					await ws.http('git:remove-remote', { projectId, name });
-					await loadRemotes();
-				} catch (err) {
-					debug.error('git', 'Failed to remove remote:', err);
-				}
+				await runGitOp(projectId, 'isConfiguring', async () => {
+					try {
+						await ws.http('git:remove-remote', { projectId, name });
+						await loadRemotes();
+					} catch (err) {
+						debug.error('git', 'Failed to remove remote:', err);
+					}
+				});
 			}
 		});
 	}
 
 	async function handleSaveRemote() {
-		if (!projectId || !editingRemote || !editRemoteName.trim() || !editRemoteUrl.trim()) return;
+		if (!editingRemote || !editRemoteName.trim() || !editRemoteUrl.trim()) return;
 		const oldName = editingRemote;
 		const newName = editRemoteName.trim();
 		const newUrl = editRemoteUrl.trim();
+		await runGitOp(projectId, 'isConfiguring', async () => {
 		savingRemote = true;
 		try {
 			await ws.http('git:edit-remote', { projectId, oldName, newName, newUrl });
@@ -1714,6 +1735,7 @@
 		} finally {
 			savingRemote = false;
 		}
+		});
 	}
 
 	// Mark a remote as the active one (drives branch ahead/behind, push target,
@@ -1725,7 +1747,7 @@
 	}
 
 	async function handleFetchRemote(remote: string) {
-		if (!projectId) return;
+		await runGitOp(projectId, 'isFetching', async () => {
 		fetchingRemote = remote;
 		try {
 			const result = await ws.http('git:fetch', { projectId, remote }) as { message: string };
@@ -1736,10 +1758,12 @@
 		} finally {
 			fetchingRemote = null;
 		}
+		});
 	}
 
 	async function handleAddRemote() {
-		if (!projectId || !newRemoteName.trim() || !newRemoteUrl.trim()) return;
+		if (!newRemoteName.trim() || !newRemoteUrl.trim()) return;
+		await runGitOp(projectId, 'isConfiguring', async () => {
 		addingRemote = true;
 		try {
 			await ws.http('git:add-remote', { projectId, name: newRemoteName.trim(), url: newRemoteUrl.trim() });
@@ -1754,10 +1778,11 @@
 		} finally {
 			addingRemote = false;
 		}
+		});
 	}
 
 	async function handlePushBranch(branch: string, repoPath?: string) {
-		if (!projectId) return;
+		await runGitOp(projectId, 'isPushing', async () => {
 		pushingBranch = branch;
 		try {
 			const result = await ws.http('git:push', { projectId, branch, repoPath }) as { success: boolean; message: string };
@@ -1768,6 +1793,7 @@
 		} finally {
 			pushingBranch = null;
 		}
+		}, repoPath);
 	}
 
 	// Push the current branch from the branch list. If the branch has
@@ -1798,7 +1824,7 @@
 	}
 
 	async function handlePushBranchForce(branch: string, repoPath?: string) {
-		if (!projectId) return;
+		await runGitOp(projectId, 'isPushing', async () => {
 		pushingBranch = branch;
 		try {
 			const result = await ws.http('git:push-advanced', {
@@ -1821,6 +1847,7 @@
 		} finally {
 			pushingBranch = null;
 		}
+		}, repoPath);
 	}
 
 	// Load all per-file diffs for a commit and open them as tabs so the
@@ -1860,7 +1887,7 @@
 	}
 
 	async function handleCherryPick(hash: string, repoPath?: string) {
-		if (!projectId) return;
+		await runGitOp(projectId, 'isMoreBusy', async () => {
 		try {
 			const result = await ws.http('git:cherry-pick', { projectId, hashes: [hash], repoPath }) as { success: boolean; message: string };
 			showInfo(result.success ? 'Cherry-picked' : 'Cherry-pick failed', result.message);
@@ -1871,6 +1898,7 @@
 		} catch (err) {
 			debug.error('git', 'Failed to cherry-pick:', err);
 		}
+		}, repoPath);
 	}
 
 	// The three bulk actions take an optional `repoPath` so a nested sub-repo
@@ -1934,14 +1962,15 @@
 			type: 'error',
 			confirmText: 'Discard',
 			onConfirm: async () => {
-				if (!projectId) return;
-				try {
-					await ws.http('git:discard', { projectId, filePath: path });
-					await loadStatus();
-					await migrateActiveTabAfterStatusChange(path);
-				} catch (err) {
-					debug.error('git', 'Failed to discard file:', err);
-				}
+				await runGitOp(projectId, 'isStaging', async () => {
+					try {
+						await ws.http('git:discard', { projectId, filePath: path });
+						await loadStatus();
+						await migrateActiveTabAfterStatusChange(path);
+					} catch (err) {
+						debug.error('git', 'Failed to discard file:', err);
+					}
+				});
 			}
 		});
 	}
@@ -2420,15 +2449,16 @@
 	// ============================
 
 	async function switchBranch(name: string) {
-		if (!projectId) return;
-		try {
-			await ws.http('git:switch-branch', { projectId, name });
-			await loadAll();
-			await refreshLogIfVisible();
-		} catch (err) {
-			debug.error('git', 'Failed to switch branch:', err);
-			showError('Switch Branch Failed', err instanceof Error ? err.message : 'Unknown error');
-		}
+		await runGitOp(projectId, 'isBranching', async () => {
+			try {
+				await ws.http('git:switch-branch', { projectId, name });
+				await loadAll();
+				await refreshLogIfVisible();
+			} catch (err) {
+				debug.error('git', 'Failed to switch branch:', err);
+				showError('Switch Branch Failed', err instanceof Error ? err.message : 'Unknown error');
+			}
+		});
 	}
 
 	function checkoutCommit(hash: string, repoPath?: string) {
@@ -2443,19 +2473,20 @@
 			type: 'warning',
 			confirmText: 'Checkout',
 			onConfirm: async () => {
-				if (!projectId) return;
-				try {
-					await ws.http('git:checkout-commit', { projectId, commitHash: hash, repoPath });
-					selectedCommit = null;
-					openTabs = [];
-					activeTabId = null;
-					await loadAll();
-					await refreshAllLogs();
-					showInfo('Commit Checked Out', `Checked out ${shortHash}. HEAD is now detached.`);
-				} catch (err) {
-					debug.error('git', 'Failed to checkout commit:', err);
-					showError('Checkout Failed', err instanceof Error ? err.message : 'Unknown error');
-				}
+				await runGitOp(projectId, 'isBranching', async () => {
+					try {
+						await ws.http('git:checkout-commit', { projectId, commitHash: hash, repoPath });
+						selectedCommit = null;
+						openTabs = [];
+						activeTabId = null;
+						await loadAll();
+						await refreshAllLogs();
+						showInfo('Commit Checked Out', `Checked out ${shortHash}. HEAD is now detached.`);
+					} catch (err) {
+						debug.error('git', 'Failed to checkout commit:', err);
+						showError('Checkout Failed', err instanceof Error ? err.message : 'Unknown error');
+					}
+				}, repoPath);
 			}
 		});
 	}
@@ -2506,15 +2537,16 @@
 		const parts = remoteBranch.split('/');
 		const localName = parts.slice(1).join('/');
 		if (repoPath) {
-			if (!projectId) return;
-			try {
-				await ws.http('git:create-branch', { projectId, name: localName, startPoint: remoteBranch, repoPath });
-				showInfo('Branch Created', `Checked out "${localName}" from ${remoteBranch}.`);
-				await loadBranches();
-			} catch (err) {
-				debug.error('git', 'Failed to checkout remote branch:', err);
-				showError('Checkout Failed', err instanceof Error ? err.message : 'Unknown error');
-			}
+			await runGitOp(projectId, 'isBranching', async () => {
+				try {
+					await ws.http('git:create-branch', { projectId, name: localName, startPoint: remoteBranch, repoPath });
+					showInfo('Branch Created', `Checked out "${localName}" from ${remoteBranch}.`);
+					await loadBranches();
+				} catch (err) {
+					debug.error('git', 'Failed to checkout remote branch:', err);
+					showError('Checkout Failed', err instanceof Error ? err.message : 'Unknown error');
+				}
+			}, repoPath);
 		} else {
 			await switchBranch(localName);
 		}
@@ -2635,17 +2667,22 @@
 	}
 
 	async function createBranch(name: string, repoPath?: string): Promise<boolean> {
-		if (!projectId) return false;
-		try {
-			await ws.http('git:create-branch', { projectId, name, repoPath });
-			showInfo('Branch Created', `Switched to "${name}".`);
-			await loadAll();
-			return true;
-		} catch (err) {
-			debug.error('git', 'Failed to create branch:', err);
-			showError('Create Branch Failed', err instanceof Error ? err.message : 'Unknown error');
-			return false;
-		}
+		// `runGitOp` reports whether it ran, not what the action returned, so the
+		// outcome callers branch on is captured here. A skipped run reads as
+		// failure, which is the honest answer: no branch was created.
+		let created = false;
+		await runGitOp(projectId, 'isBranching', async () => {
+			try {
+				await ws.http('git:create-branch', { projectId, name, repoPath });
+				showInfo('Branch Created', `Switched to "${name}".`);
+				await loadAll();
+				created = true;
+			} catch (err) {
+				debug.error('git', 'Failed to create branch:', err);
+				showError('Create Branch Failed', err instanceof Error ? err.message : 'Unknown error');
+			}
+		}, repoPath);
+		return created;
 	}
 
 	function getDefaultRemote(repoPath?: string): string {
@@ -2666,6 +2703,7 @@
 			inputPlaceholder: 'New branch name',
 			onConfirm: async (newName) => {
 				if (!newName || newName === oldName) return;
+				await runGitOp(projectId, 'isBranching', async () => {
 				try {
 					await ws.http('git:rename-branch', { projectId, oldName, newName, repoPath });
 					const pushed = repoPath
@@ -2686,6 +2724,7 @@
 					debug.error('git', 'Failed to rename branch:', err);
 					showError('Rename Branch Failed', err instanceof Error ? err.message : 'Unknown error');
 				}
+				}, repoPath);
 			}
 		});
 	}
@@ -2697,27 +2736,32 @@
 			type: 'error',
 			confirmText: 'Delete',
 			onConfirm: async () => {
-				if (!projectId) return;
-				try {
-					await ws.http('git:delete-branch', { projectId, name });
-					await loadBranches();
-				} catch (err) {
-					debug.error('git', 'Failed to delete branch:', err);
-					requestConfirm({
-						title: 'Force Delete Branch',
-						message: 'Branch is not fully merged. Force delete?',
-						type: 'error',
-						confirmText: 'Force Delete',
-						onConfirm: async () => {
-							try {
-								await ws.http('git:delete-branch', { projectId, name, force: true });
-			await Promise.all([loadBranches(), loadRemotes()]);
-							} catch (forceErr) {
-								showError('Force Delete Failed', forceErr instanceof Error ? forceErr.message : 'Unknown error');
+				await runGitOp(projectId, 'isBranching', async () => {
+					try {
+						await ws.http('git:delete-branch', { projectId, name });
+						await loadBranches();
+					} catch (err) {
+						debug.error('git', 'Failed to delete branch:', err);
+						requestConfirm({
+							title: 'Force Delete Branch',
+							message: 'Branch is not fully merged. Force delete?',
+							type: 'error',
+							confirmText: 'Force Delete',
+							// Its own guard: this dialog is answered long after the
+							// first attempt released the flag.
+							onConfirm: async () => {
+								await runGitOp(projectId, 'isBranching', async () => {
+									try {
+										await ws.http('git:delete-branch', { projectId, name, force: true });
+										await Promise.all([loadBranches(), loadRemotes()]);
+									} catch (forceErr) {
+										showError('Force Delete Failed', forceErr instanceof Error ? forceErr.message : 'Unknown error');
+									}
+								});
 							}
-						}
-					});
-				}
+						});
+					}
+				});
 			}
 		});
 	}
@@ -2962,15 +3006,9 @@
 	// More Git Actions (push variants, undo, npm version, maintenance)
 	// ============================
 
+	/** The More menu's slice of `runGitOp`, kept as a name its callers already use. */
 	async function runMore(fn: () => Promise<void>, repoPath?: string) {
-		const pid = projectId;
-		if (!pid || getGitOps(pid, repoPath).isMoreBusy) return;
-		setGitOp(pid, 'isMoreBusy', true, repoPath);
-		try {
-			await fn();
-		} finally {
-			setGitOp(pid, 'isMoreBusy', false, repoPath);
-		}
+		await runGitOp(projectId, 'isMoreBusy', fn, repoPath);
 	}
 
 	async function pushVariant(mode: 'with-tags' | 'all-tags' | 'force-lease' | 'force', label: string, repoPath?: string, branch?: string, remote?: string) {
@@ -3340,7 +3378,7 @@
 	// ============================
 
 	async function resolveConflict(filePath: string, resolution: 'ours' | 'theirs' | 'custom', customContent?: string) {
-		if (!projectId) return;
+		await runGitOp(projectId, 'isResolving', async () => {
 		try {
 			await ws.http('git:resolve-conflict', { projectId, filePath, resolution, customContent });
 			await loadConflicts();
@@ -3351,6 +3389,7 @@
 		} catch (err) {
 			debug.error('git', 'Failed to resolve conflict:', err);
 		}
+		});
 	}
 
 	function buildAIPromptForFile(file: GitConflictFile): string {
@@ -3421,7 +3460,7 @@ ${bodies}`;
 			type: 'error',
 			confirmText: 'Abort Merge',
 			onConfirm: async () => {
-				if (!projectId) return;
+				await runGitOp(projectId, 'isResolving', async () => {
 				try {
 					let targetRepoPath: string | undefined = undefined;
 					const anyConflictFile = conflictFiles[0]?.path || conflictInitialPath;
@@ -3437,6 +3476,7 @@ ${bodies}`;
 				} catch (err) {
 					debug.error('git', 'Failed to abort merge:', err);
 				}
+				});
 			}
 		});
 	}
@@ -3482,7 +3522,7 @@ ${bodies}`;
 	}
 
 	async function handleStashSave() {
-		if (!projectId) return;
+		await runGitOp(projectId, 'isStashing', async () => {
 		try {
 			await ws.http('git:stash-save', {
 				projectId,
@@ -3499,6 +3539,7 @@ ${bodies}`;
 			debug.error('git', 'Stash save failed:', err);
 			showError('Stash Failed', err instanceof Error ? err.message : 'Unknown error');
 		}
+		}, stashRepoPath);
 	}
 
 	/**
@@ -3530,8 +3571,13 @@ ${bodies}`;
 		return entry.repoPath ? `${entry.repoPath}::${entry.index}` : `${entry.index}`;
 	}
 
+	// Stash actions are addressed by POSITION, so a duplicate request is not a
+	// wasted round trip but a different stash: `git stash pop stash@{0}` twice
+	// pops stash@{0}, then whatever re-indexed into its place. The guard is what
+	// makes the second click impossible, and `isStashing` disables the section's
+	// buttons so it reads as busy rather than as nothing happening.
 	async function handleStashPop(entry: StashEntryExtended) {
-		if (!projectId) return;
+		await runGitOp(projectId, 'isStashing', async () => {
 		try {
 			const result = await ws.http('git:stash-pop', { projectId, index: entry.index, repoPath: entry.repoPath });
 			await Promise.all([loadStash(), loadStatus()]);
@@ -3552,6 +3598,7 @@ ${bodies}`;
 			const msg = err instanceof Error ? err.message : 'Unknown error';
 			showError('Stash Pop Failed', msg.replace(/^git stash pop failed:\s*/i, '').trim() || msg);
 		}
+		}, entry.repoPath);
 	}
 
 	async function handleStashDrop(entry: StashEntryExtended) {
@@ -3562,14 +3609,15 @@ ${bodies}`;
 			type: 'error',
 			confirmText: 'Drop',
 			onConfirm: async () => {
-				if (!projectId) return;
-				try {
-					await ws.http('git:stash-drop', { projectId, index: entry.index, repoPath: entry.repoPath });
-					await loadStash();
-				} catch (err) {
-					debug.error('git', 'Stash drop failed:', err);
-					showError('Stash Drop Failed', err instanceof Error ? err.message : 'Unknown error');
-				}
+				await runGitOp(projectId, 'isStashing', async () => {
+					try {
+						await ws.http('git:stash-drop', { projectId, index: entry.index, repoPath: entry.repoPath });
+						await loadStash();
+					} catch (err) {
+						debug.error('git', 'Stash drop failed:', err);
+						showError('Stash Drop Failed', err instanceof Error ? err.message : 'Unknown error');
+					}
+				}, entry.repoPath);
 			}
 		});
 	}
@@ -3678,7 +3726,8 @@ ${bodies}`;
 	}
 
 	async function handleCreateTag() {
-		if (!projectId || !newTagName.trim()) return;
+		if (!newTagName.trim()) return;
+		await runGitOp(projectId, 'isTagging', async () => {
 		try {
 			await ws.http('git:create-tag', {
 				projectId,
@@ -3695,6 +3744,7 @@ ${bodies}`;
 			debug.error('git', 'Create tag failed:', err);
 			showError('Create Tag Failed', err instanceof Error ? err.message : 'Unknown error');
 		}
+		}, tagRepoPath);
 	}
 
 	async function handleDeleteTag(name: string, repoPath?: string) {
@@ -3705,20 +3755,21 @@ ${bodies}`;
 			type: 'error',
 			confirmText: 'Delete',
 			onConfirm: async () => {
-				if (!projectId) return;
-				try {
-					await ws.http('git:delete-tag', { projectId, name, repoPath });
-					await loadTags();
-				} catch (err) {
-					debug.error('git', 'Delete tag failed:', err);
-					showError('Delete Tag Failed', err instanceof Error ? err.message : 'Unknown error');
-				}
+				await runGitOp(projectId, 'isTagging', async () => {
+					try {
+						await ws.http('git:delete-tag', { projectId, name, repoPath });
+						await loadTags();
+					} catch (err) {
+						debug.error('git', 'Delete tag failed:', err);
+						showError('Delete Tag Failed', err instanceof Error ? err.message : 'Unknown error');
+					}
+				}, repoPath);
 			}
 		});
 	}
 
 	async function handlePushTag(name: string, repoPath?: string) {
-		if (!projectId) return;
+		await runGitOp(projectId, 'isTagging', async () => {
 		try {
 			const result = await ws.http('git:push-tag', { projectId, name, repoPath });
 			if (!result.success) {
@@ -3730,6 +3781,7 @@ ${bodies}`;
 			debug.error('git', 'Push tag failed:', err);
 			showError('Push Tag Failed', err instanceof Error ? err.message : 'Unknown error');
 		}
+		}, repoPath);
 	}
 
 	async function copyTagHash(hash: string, e: MouseEvent) {
@@ -4232,7 +4284,7 @@ ${bodies}`;
 			</div>
 			{#if !branch.isCurrent}
 			<div class="flex items-center gap-1 shrink-0">
-				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handleSwitchNestedBranch(nested, branch.name); }} title="Switch to this branch"><Icon name="lucide:arrow-right" class="w-3.5 h-3.5" /></button>
+				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleSwitchNestedBranch(nested, branch.name); }} title="Switch to this branch" disabled={getGitOps(projectId, nested.path).isBranching}><Icon name="lucide:arrow-right" class="w-3.5 h-3.5" /></button>
 				{#if !nestedPushed.has(branch.name)}
 					{#if pushingBranch === branch.name}
 						<div class="flex items-center justify-center w-6 h-6 rounded-md text-emerald-500"><Icon name="lucide:loader-circle" class="w-3.5 h-3.5 animate-spin" /></div>
@@ -4241,7 +4293,7 @@ ${bodies}`;
 					{/if}
 				{/if}
 				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); mergeNestedBranch(branch.name, nested.path); }} title="Merge into current branch"><Icon name="lucide:git-merge" class="w-3.5 h-3.5" /></button>
-				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handleDeleteNestedBranch(nested, branch.name); }} title="Delete branch"><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
+				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleDeleteNestedBranch(nested, branch.name); }} title="Delete branch" disabled={getGitOps(projectId, nested.path).isBranching}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
 			</div>
 			{:else}
 			<div class="flex items-center gap-1 shrink-0">
@@ -4255,7 +4307,7 @@ ${bodies}`;
 				{#if branch.behind > 0}
 					<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handlePull(nested.path, getNestedSelectedRemote(nested)); }} title="Pull ({branch.behind} behind)"><Icon name="lucide:download" class="w-3.5 h-3.5" /></button>
 				{/if}
-				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-orange-500/10 hover:text-orange-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); renameBranch(branch.name, nested.path); }} title="Rename branch"><Icon name="lucide:pen-line" class="w-3.5 h-3.5" /></button>
+				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-orange-500/10 hover:text-orange-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); renameBranch(branch.name, nested.path); }} title="Rename branch" disabled={getGitOps(projectId, nested.path).isBranching}><Icon name="lucide:pen-line" class="w-3.5 h-3.5" /></button>
 			</div>
 			{/if}
 		</div>
@@ -4632,7 +4684,7 @@ ${bodies}`;
 													{/if}
 													<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); nestedEditingRemote = { ...nestedEditingRemote, [nested.relPath]: remoteName }; nestedEditRemoteNames = { ...nestedEditRemoteNames, [nested.relPath]: remoteName }; }} title="Edit remote"><Icon name="lucide:pencil" class="w-3.5 h-3.5" /></button>
 													<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); void handleNestedFetchRemote(remoteName, nested.relPath); }} title="Fetch"><Icon name="lucide:refresh-cw" class="w-3.5 h-3.5" /></button>
-													<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handleNestedRemoveRemote(remoteName, nested.relPath); }} title="Disconnect"><Icon name="lucide:unlink" class="w-3.5 h-3.5" /></button>
+													<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleNestedRemoveRemote(remoteName, nested.relPath); }} title="Disconnect" disabled={getGitOps(projectId, nested.path).isConfiguring}><Icon name="lucide:unlink" class="w-3.5 h-3.5" /></button>
 												</div>
 											{/if}
 										</div>
@@ -4652,9 +4704,9 @@ ${bodies}`;
 														<div class="flex items-center justify-center w-6 h-6 text-slate-400 shrink-0"><Icon name="lucide:loader-circle" class="w-3.5 h-3.5 animate-spin" /></div>
 													{:else}
 														<div class="flex items-center gap-1 shrink-0">
-															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); checkoutRemoteBranch(branch.name, nested.path); }} title="Checkout locally"><Icon name="lucide:arrow-right" class="w-3.5 h-3.5" /></button>
+															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); checkoutRemoteBranch(branch.name, nested.path); }} title="Checkout locally" disabled={getGitOps(projectId, nested.path).isBranching}><Icon name="lucide:arrow-right" class="w-3.5 h-3.5" /></button>
 															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); copyToClipboard(branch.name); }} title="Copy branch name"><Icon name="lucide:copy" class="w-3.5 h-3.5" /></button>
-															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handleDeleteRemoteBranch(remoteName, shortName, nested.path); }} title="Delete branch"><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
+															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleDeleteRemoteBranch(remoteName, shortName, nested.path); }} title="Delete branch" disabled={getGitOps(projectId, nested.path).isBranching}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
 														</div>
 													{/if}
 												</div>
@@ -4812,7 +4864,7 @@ ${bodies}`;
 									<button type="button" class="flex-1 px-2 py-1 text-xs font-medium rounded transition-colors cursor-pointer border-none {stashStagedOnly ? 'bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 shadow-sm' : 'bg-transparent text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}" onclick={() => stashStagedOnly = true}>Staged only</button>
 								</div>
 								<div class="flex gap-1.5">
-									<button type="button" class="flex-1 px-3 py-1.5 text-xs font-medium rounded-md bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer border-none" onclick={handleStashSave}>Stash Changes</button>
+									<button type="button" class="flex-1 px-3 py-1.5 text-xs font-medium rounded-md bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer border-none disabled:opacity-40 disabled:cursor-not-allowed" onclick={handleStashSave} disabled={getGitOps(projectId, nested.path).isStashing}>Stash Changes</button>
 									<button type="button" class="px-3 py-1.5 text-xs font-medium bg-transparent border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors cursor-pointer" onclick={() => { showStashSaveForm = false; stashMessage = ''; stashStagedOnly = false; stashRepoPath = undefined; }}>Cancel</button>
 								</div>
 							</div>
@@ -4851,8 +4903,8 @@ ${bodies}`;
 											</p>
 										</div>
 										<div class="flex items-center gap-1 shrink-0">
-											<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-emerald-500/10 hover:text-emerald-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handleStashPop(entry); }} title="Pop"><Icon name="lucide:archive-restore" class="w-3.5 h-3.5" /></button>
-											<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handleStashDrop(entry); }} title="Drop"><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
+											<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-emerald-500/10 hover:text-emerald-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashPop(entry); }} title="Pop" disabled={getGitOps(projectId, nested.path).isStashing}><Icon name="lucide:archive-restore" class="w-3.5 h-3.5" /></button>
+											<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashDrop(entry); }} title="Drop" disabled={getGitOps(projectId, nested.path).isStashing}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
 										</div>
 									</div>
 									{#if stashExpanded}
@@ -4962,7 +5014,7 @@ ${bodies}`;
 												? 'bg-violet-600 text-white hover:bg-violet-700'
 												: 'bg-slate-200 dark:bg-slate-700 text-slate-400 dark:text-slate-500 cursor-not-allowed'}"
 										onclick={handleCreateTag}
-										disabled={!newTagName.trim()}
+										disabled={!newTagName.trim() || getGitOps(projectId, nested.path).isTagging}
 									>
 										Create Tag
 									</button>
@@ -5016,6 +5068,7 @@ ${bodies}`;
 											type="button"
 											class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer"
 											onclick={() => handlePushTag(tag.name, nested.path)}
+											disabled={getGitOps(projectId, nested.path).isTagging}
 											title="Push tag to remote"
 										>
 											<Icon name="lucide:arrow-up-from-line" class="w-3.5 h-3.5" />
@@ -5024,6 +5077,7 @@ ${bodies}`;
 											type="button"
 											class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer"
 											onclick={() => handleDeleteTag(tag.name, nested.path)}
+											disabled={getGitOps(projectId, nested.path).isTagging}
 											title="Delete tag"
 										>
 											<Icon name="lucide:trash-2" class="w-3.5 h-3.5" />
@@ -5612,7 +5666,7 @@ ${bodies}`;
 											</div>
 											{#if !branch.isCurrent}
 											<div class="flex items-center gap-1 shrink-0">
-												<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); switchBranch(branch.name); }} title="Switch to this branch"><Icon name="lucide:arrow-right" class="w-3.5 h-3.5" /></button>
+												<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); switchBranch(branch.name); }} title="Switch to this branch" disabled={ops.isBranching}><Icon name="lucide:arrow-right" class="w-3.5 h-3.5" /></button>
 												{#if !pushedBranchNames.has(branch.name)}
 													{#if pushingBranch === branch.name}
 														<div class="flex items-center justify-center w-6 h-6 rounded-md text-emerald-500"><Icon name="lucide:loader-circle" class="w-3.5 h-3.5 animate-spin" /></div>
@@ -5621,7 +5675,7 @@ ${bodies}`;
 													{/if}
 												{/if}
 												<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); mergeBranch(branch.name); }} title="Merge into current branch"><Icon name="lucide:git-merge" class="w-3.5 h-3.5" /></button>
-												<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); deleteBranch(branch.name); }} title="Delete branch"><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
+												<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); deleteBranch(branch.name); }} title="Delete branch" disabled={ops.isBranching}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
 										</div>
 										{:else}
 										<div class="flex items-center gap-1 shrink-0">
@@ -5635,7 +5689,7 @@ ${bodies}`;
 											{#if branch.behind > 0}
 												<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handlePull(); }} title="Pull ({branch.behind} behind)"><Icon name="lucide:download" class="w-3.5 h-3.5" /></button>
 											{/if}
-											<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-orange-500/10 hover:text-orange-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); renameBranch(branch.name); }} title="Rename branch"><Icon name="lucide:pen-line" class="w-3.5 h-3.5" /></button>
+											<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-orange-500/10 hover:text-orange-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); renameBranch(branch.name); }} title="Rename branch" disabled={ops.isBranching}><Icon name="lucide:pen-line" class="w-3.5 h-3.5" /></button>
 										</div>
 										{/if}
 										</div>
@@ -5775,7 +5829,7 @@ ${bodies}`;
 													{/if}
 													<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); editingRemote = remote.name; editRemoteName = remote.name; editRemoteUrl = remote.fetchUrl || remote.pushUrl || ''; }} title="Edit remote"><Icon name="lucide:pencil" class="w-3.5 h-3.5" /></button>
 													<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handleFetchRemote(remote.name); }} title="Fetch"><Icon name="lucide:refresh-cw" class="w-3.5 h-3.5" /></button>
-													<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handleRemoveRemote(remote.name); }} title="Disconnect"><Icon name="lucide:unlink" class="w-3.5 h-3.5" /></button>
+													<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleRemoveRemote(remote.name); }} title="Disconnect" disabled={ops.isConfiguring}><Icon name="lucide:unlink" class="w-3.5 h-3.5" /></button>
 												</div>
 											{/if}
 										</div>
@@ -5795,9 +5849,9 @@ ${bodies}`;
 														<div class="flex items-center justify-center w-6 h-6 text-slate-400 shrink-0"><Icon name="lucide:loader-circle" class="w-3.5 h-3.5 animate-spin" /></div>
 													{:else}
 														<div class="flex items-center gap-1 shrink-0">
-															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); checkoutRemoteBranch(branch.name); }} title="Checkout locally"><Icon name="lucide:arrow-right" class="w-3.5 h-3.5" /></button>
+															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); checkoutRemoteBranch(branch.name); }} title="Checkout locally" disabled={ops.isBranching}><Icon name="lucide:arrow-right" class="w-3.5 h-3.5" /></button>
 															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); copyToClipboard(branch.name); }} title="Copy branch name"><Icon name="lucide:copy" class="w-3.5 h-3.5" /></button>
-															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handleDeleteRemoteBranch(remote.name, shortName); }} title="Delete branch"><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
+															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleDeleteRemoteBranch(remote.name, shortName); }} title="Delete branch" disabled={ops.isBranching}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
 														</div>
 													{/if}
 												</div>
@@ -5867,7 +5921,7 @@ ${bodies}`;
 												? 'bg-violet-600 text-white hover:bg-violet-700'
 												: 'bg-slate-200 dark:bg-slate-700 text-slate-400 dark:text-slate-500 cursor-not-allowed'}"
 										onclick={handleCreateTag}
-										disabled={!newTagName.trim()}
+										disabled={!newTagName.trim() || ops.isTagging}
 									>
 										Create Tag
 									</button>
@@ -5928,6 +5982,7 @@ ${bodies}`;
 												type="button"
 												class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer"
 												onclick={() => handlePushTag(tag.name)}
+												disabled={ops.isTagging}
 												title="Push tag to remote"
 											>
 												<Icon name="lucide:arrow-up-from-line" class="w-3.5 h-3.5" />
@@ -5936,6 +5991,7 @@ ${bodies}`;
 												type="button"
 												class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer"
 												onclick={() => handleDeleteTag(tag.name)}
+												disabled={ops.isTagging}
 												title="Delete tag"
 											>
 												<Icon name="lucide:trash-2" class="w-3.5 h-3.5" />
@@ -5972,7 +6028,7 @@ ${bodies}`;
 									<button type="button" class="flex-1 px-2 py-1 text-xs font-medium rounded transition-colors cursor-pointer border-none {!stashStagedOnly ? 'bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 shadow-sm' : 'bg-transparent text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}" onclick={() => stashStagedOnly = false}>All changes</button>
 									<button type="button" class="flex-1 px-2 py-1 text-xs font-medium rounded transition-colors cursor-pointer border-none {stashStagedOnly ? 'bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 shadow-sm' : 'bg-transparent text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}" onclick={() => stashStagedOnly = true}>Staged only</button>
 								</div>
-								<div class="flex gap-1.5"><button type="button" class="flex-1 px-3 py-1.5 text-xs font-medium rounded-md bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer border-none" onclick={handleStashSave}>Stash Changes</button><button type="button" class="px-3 py-1.5 text-xs font-medium bg-transparent border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors cursor-pointer" onclick={() => { showStashSaveForm = false; stashMessage = ''; stashStagedOnly = false; stashRepoPath = undefined; }}>Cancel</button></div>
+								<div class="flex gap-1.5"><button type="button" class="flex-1 px-3 py-1.5 text-xs font-medium rounded-md bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer border-none disabled:opacity-40 disabled:cursor-not-allowed" onclick={handleStashSave} disabled={ops.isStashing}>Stash Changes</button><button type="button" class="px-3 py-1.5 text-xs font-medium bg-transparent border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors cursor-pointer" onclick={() => { showStashSaveForm = false; stashMessage = ''; stashStagedOnly = false; stashRepoPath = undefined; }}>Cancel</button></div>
 							</div>
 						{:else}
 							<button type="button" class="flex items-center justify-center gap-2 w-full py-2 px-3 border border-dashed border-slate-300 dark:border-slate-600 rounded-lg text-xs text-slate-500 hover:text-violet-600 hover:border-violet-400 transition-colors cursor-pointer bg-transparent" onclick={() => { stashStagedOnly = false; stashRepoPath = undefined; showStashSaveForm = true; }}><Icon name="lucide:plus" class="w-3.5 h-3.5" /><span>Stash Current Changes</span></button>
@@ -6010,8 +6066,8 @@ ${bodies}`;
 												</p>
 											</div>
 											<div class="flex items-center gap-1 shrink-0">
-												<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-emerald-500/10 hover:text-emerald-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handleStashPop(entry); }} title="Pop"><Icon name="lucide:archive-restore" class="w-3.5 h-3.5" /></button>
-												<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handleStashDrop(entry); }} title="Drop"><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
+												<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-emerald-500/10 hover:text-emerald-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashPop(entry); }} title="Pop" disabled={ops.isStashing}><Icon name="lucide:archive-restore" class="w-3.5 h-3.5" /></button>
+												<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashDrop(entry); }} title="Drop" disabled={ops.isStashing}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
 											</div>
 										</div>
 										{#if stashExpanded}
@@ -6400,6 +6456,7 @@ ${bodies}`;
 		onResolveWithAI={resolveWithAI}
 		onResolveAllWithAI={resolveAllWithAI}
 		onAbortMerge={abortMerge}
+		busy={ops.isResolving}
 		onClose={() => {
 			showConflictResolver = false;
 			conflictInitialPath = null;

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -1475,16 +1475,19 @@
 	// Staging Actions
 	// ============================
 
-	// Busy flags for staging operations — on Windows git status is slower
-	// (Bun.spawn + Defender scanning .git/index), so without a guard the user
-	// can double-click Stage All and queue two full walks. The flag disables
-	// the bulk buttons until the refresh finishes.
-	let isStagingBusy = $state(false);
-	let stagingFilePath = $state<string | null>(null);
+	// Files with a stage/unstage request in flight. Each of those costs a full
+	// `loadStatus()`, which on Windows is slow enough (Bun.spawn + Defender
+	// scanning .git/index) that an impatient second click on the same row
+	// would queue a second round trip for work already under way. Guarding per
+	// path rather than globally keeps staging several files in quick
+	// succession working — dropping those clicks silently is worse than the
+	// duplicate refresh it would avoid. Plain Set, not $state: nothing renders
+	// from it, it is only read inside these handlers.
+	const stagingFiles = new Set<string>();
 
 	async function stageFile(path: string) {
-		if (!projectId || isStagingBusy || stagingFilePath) return;
-		stagingFilePath = path;
+		if (!projectId || stagingFiles.has(path)) return;
+		stagingFiles.add(path);
 		try {
 			await ws.http('git:stage', { projectId, filePath: path });
 			await loadStatus();
@@ -1492,7 +1495,7 @@
 		} catch (err) {
 			debug.error('git', 'Failed to stage file:', err);
 		} finally {
-			stagingFilePath = null;
+			stagingFiles.delete(path);
 		}
 	}
 
@@ -1692,11 +1695,17 @@
 		}
 	}
 
-	async function stageAll() {
-		if (!projectId || isStagingBusy) return;
-		isStagingBusy = true;
+	// The three bulk actions take an optional `repoPath` so a nested sub-repo
+	// runs — and shows its spinner — independently of the outer repo. The busy
+	// flag lives in the shared git-op store keyed by (projectId, repoPath), the
+	// same place push/pull/commit keep theirs, so a bulk stage started in one
+	// project clears the right flag even if the user switches away mid-flight.
+	async function stageAll(repoPath?: string) {
+		const pid = projectId;
+		if (!pid || getGitOps(pid, repoPath).isStaging) return;
+		setGitOp(pid, 'isStaging', true, repoPath);
 		try {
-			await ws.http('git:stage-all', { projectId });
+			await ws.http('git:stage-all', { projectId: pid, repoPath });
 			await loadStatus();
 			if (activeTab && activeTab.section !== 'commit') {
 				await migrateActiveTabAfterStatusChange(activeTab.filePath);
@@ -1704,13 +1713,13 @@
 		} catch (err) {
 			debug.error('git', 'Failed to stage all:', err);
 		} finally {
-			isStagingBusy = false;
+			setGitOp(pid, 'isStaging', false, repoPath);
 		}
 	}
 
 	async function unstageFile(path: string) {
-		if (!projectId || isStagingBusy || stagingFilePath) return;
-		stagingFilePath = path;
+		if (!projectId || stagingFiles.has(path)) return;
+		stagingFiles.add(path);
 		try {
 			await ws.http('git:unstage', { projectId, filePath: path });
 			await loadStatus();
@@ -1718,15 +1727,16 @@
 		} catch (err) {
 			debug.error('git', 'Failed to unstage file:', err);
 		} finally {
-			stagingFilePath = null;
+			stagingFiles.delete(path);
 		}
 	}
 
-	async function unstageAll() {
-		if (!projectId || isStagingBusy) return;
-		isStagingBusy = true;
+	async function unstageAll(repoPath?: string) {
+		const pid = projectId;
+		if (!pid || getGitOps(pid, repoPath).isStaging) return;
+		setGitOp(pid, 'isStaging', true, repoPath);
 		try {
-			await ws.http('git:unstage-all', { projectId });
+			await ws.http('git:unstage-all', { projectId: pid, repoPath });
 			await loadStatus();
 			if (activeTab && activeTab.section !== 'commit') {
 				await migrateActiveTabAfterStatusChange(activeTab.filePath);
@@ -1734,7 +1744,7 @@
 		} catch (err) {
 			debug.error('git', 'Failed to unstage all:', err);
 		} finally {
-			isStagingBusy = false;
+			setGitOp(pid, 'isStaging', false, repoPath);
 		}
 	}
 
@@ -1758,22 +1768,26 @@
 		});
 	}
 
-	async function discardAll() {
+	async function discardAll(repoPath?: string) {
 		requestConfirm({
 			title: 'Discard All Changes',
 			message: 'Discard ALL changes? This cannot be undone.',
 			type: 'error',
 			confirmText: 'Discard All',
 			onConfirm: async () => {
-				if (!projectId) return;
+				const pid = projectId;
+				if (!pid || getGitOps(pid, repoPath).isStaging) return;
+				setGitOp(pid, 'isStaging', true, repoPath);
 				try {
-					await ws.http('git:discard-all', { projectId });
+					await ws.http('git:discard-all', { projectId: pid, repoPath });
 					await loadStatus();
 					if (activeTab && activeTab.section !== 'commit') {
 						await migrateActiveTabAfterStatusChange(activeTab.filePath);
 					}
 				} catch (err) {
 					debug.error('git', 'Failed to discard all:', err);
+				} finally {
+					setGitOp(pid, 'isStaging', false, repoPath);
 				}
 			}
 		});
@@ -4239,10 +4253,11 @@ ${bodies}`;
 						activeFilePath={activeTab?.filePath}
 						activeSection={activeTab?.section ?? null}
 						onUnstage={(path) => unstageFile(path)}
-						onUnstageAll={async () => { if (projectId) { try { await ws.http('git:unstage-all', { projectId, repoPath: nested.path }); await loadStatus(); } catch (err) { debug.error('git', 'Failed to unstage all in nested repo:', err); } } }}
+						onUnstageAll={() => unstageAll(nested.path)}
 						onStash={() => openStashPrompt('staged', nested.path)}
 						onViewDiff={(file, sec) => viewDiff(file, sec)}
 						{aiChangesSet}
+						busy={getGitOps(projectId, nested.path).isStaging}
 					/>
 					<ChangesSection
 						title="Changes"
@@ -4252,11 +4267,12 @@ ${bodies}`;
 						activeFilePath={activeTab?.filePath}
 						activeSection={activeTab?.section ?? null}
 						onStage={(path) => stageFile(path)}
-						onStageAll={async () => { if (projectId) { try { await ws.http('git:stage-all', { projectId, repoPath: nested.path }); await loadStatus(); } catch (err) { debug.error('git', 'Failed to stage all in nested repo:', err); } } }}
+						onStageAll={() => stageAll(nested.path)}
 						onDiscard={(path) => discardFile(path)}
-						onDiscardAll={async () => { if (projectId) { try { await ws.http('git:discard-all', { projectId, repoPath: nested.path }); await loadStatus(); } catch (err) { debug.error('git', 'Failed to discard all in nested repo:', err); } } }}
+						onDiscardAll={() => discardAll(nested.path)}
 						onViewDiff={(file, sec) => viewDiff(file, sec)}
 						{aiChangesSet}
+						busy={getGitOps(projectId, nested.path).isStaging}
 					/>
 					{#if nestedTotalChanges === 0 && !isLoading}
 						<div class="flex flex-col items-center justify-center gap-2 py-6 text-slate-500 text-xs">
@@ -5123,7 +5139,7 @@ ${bodies}`;
 				onStash={() => openStashPrompt('staged')}
 				onViewDiff={viewDiff}
 				{aiChangesSet}
-				busy={isStagingBusy}
+				busy={ops.isStaging}
 			/>
 
 			<!--
@@ -5148,7 +5164,7 @@ ${bodies}`;
 				onDiscardAll={discardAll}
 				onViewDiff={viewDiff}
 				{aiChangesSet}
-				busy={isStagingBusy}
+				busy={ops.isStaging}
 			/>
 
 			{#if mainStagedFiles.length === 0 && mainAllChanges.length === 0 && mainConflictedFiles.length === 0 && !isLoading && !(branchInfo?.nested?.length)}

--- a/frontend/stores/features/git-workspace.svelte.ts
+++ b/frontend/stores/features/git-workspace.svelte.ts
@@ -119,11 +119,15 @@ export function applyGeneratedCommitMessage(projectId: string, message: string):
 // ============================================================
 //
 // Busy state for the action-bar buttons (commit / push / pull / fetch / more /
-// AI generation). Keyed by projectId so an operation started for one project
-// keeps its spinner — and clears the right project's flag — regardless of which
-// project is active when it resolves.
+// AI generation) and the Changes section's bulk buttons (stage/unstage/discard
+// all). Keyed by projectId — and by repoPath for anything a nested sub-repo can
+// run on its own — so an operation started for one project keeps its spinner,
+// and clears the right project's flag, regardless of which project is active
+// when it resolves.
 export interface GitOpFlags {
 	isCommitting: boolean;
+	/** A bulk stage/unstage/discard is running against this repo. */
+	isStaging: boolean;
 	isPushing: boolean;
 	isPulling: boolean;
 	isFetching: boolean;
@@ -135,6 +139,7 @@ export interface GitOpFlags {
 
 const NO_OPS: GitOpFlags = Object.freeze({
 	isCommitting: false,
+	isStaging: false,
 	isPushing: false,
 	isPulling: false,
 	isFetching: false,

--- a/frontend/stores/features/git-workspace.svelte.ts
+++ b/frontend/stores/features/git-workspace.svelte.ts
@@ -135,6 +135,16 @@ export interface GitOpFlags {
 	isGenerating: boolean;
 	isGeneratingBranch: boolean;
 	isCreatingBranch: boolean;
+	/** Stash save / pop / drop. */
+	isStashing: boolean;
+	/** Tag create / delete / push. */
+	isTagging: boolean;
+	/** Branch switch / create / rename / delete, and commit checkout. */
+	isBranching: boolean;
+	/** Conflict resolution and merge abort. */
+	isResolving: boolean;
+	/** Repo setup that is not a working-tree change: init, remote add/edit/remove. */
+	isConfiguring: boolean;
 }
 
 const NO_OPS: GitOpFlags = Object.freeze({
@@ -146,7 +156,12 @@ const NO_OPS: GitOpFlags = Object.freeze({
 	isMoreBusy: false,
 	isGenerating: false,
 	isGeneratingBranch: false,
-	isCreatingBranch: false
+	isCreatingBranch: false,
+	isStashing: false,
+	isTagging: false,
+	isBranching: false,
+	isResolving: false,
+	isConfiguring: false
 });
 
 const gitOps = $state<Record<string, GitOpFlags>>({});
@@ -167,6 +182,43 @@ export function setGitOp(projectId: string, key: keyof GitOpFlags, value: boolea
 	const opKey = getOpKey(projectId, repoPath);
 	const current = gitOps[opKey] ?? NO_OPS;
 	gitOps[opKey] = { ...current, [key]: value };
+}
+
+/**
+ * Run one git action while its flag is held, and skip it entirely if that flag
+ * is already set. Returns whether the action ran.
+ *
+ * Every mutating git action in the panel goes through this. Hand-rolling the
+ * check-set-try-finally at each call site is how they drifted apart: of the
+ * panel's fifty mutating handlers, most held no flag at all, so a second click
+ * during a slow refresh fired the request twice. That was merely wasteful for
+ * something idempotent like `git add`, and destructive for anything addressed
+ * by position — `git stash pop stash@{0}` twice pops two different stashes,
+ * because the list re-indexes under the second call.
+ *
+ * The flag is per (projectId, repoPath), so a nested sub-repo runs
+ * independently of its parent and an action started in one project clears the
+ * right flag even if the user switches away mid-flight.
+ *
+ * Callers must render the flag — a disabled button or a spinner. A guard that
+ * nothing displays turns a double-click into a click that silently does
+ * nothing, which is worse than the duplicate request it prevents.
+ */
+export async function runGitOp(
+	projectId: string | null | undefined,
+	key: keyof GitOpFlags,
+	action: () => Promise<void>,
+	repoPath?: string
+): Promise<boolean> {
+	if (!projectId) return false;
+	if (getGitOps(projectId, repoPath)[key]) return false;
+	setGitOp(projectId, key, true, repoPath);
+	try {
+		await action();
+		return true;
+	} finally {
+		setGitOp(projectId, key, false, repoPath);
+	}
 }
 
 let snapshotProvider: (() => GitUiState) | null = null;


### PR DESCRIPTION
## Summary
Stage All / Unstage All / Discard All froze the Git panel for seconds on Windows
with no feedback. Two things were behind it, and both turned out to be general
rather than specific to staging: the panel re-derived the project's sub-repo list
on every request, and almost none of its git actions held a busy flag. Discovery
is now derived once and kept current by the file watcher, and every mutating
action runs behind one guard that the UI actually renders.

## Why
Staging fires `git:status` and `git:branches` back to back (`stage → loadStatus`),
and the `.git` watcher fires `git:changed` right behind them. Each of those
answered "which directories under this root are repos" from scratch: an
`fs.readdir` over the whole tree, a `git check-ignore` spawn per repo per depth
level, then a `git status` spawn per repo sitting inside an ignored tree.
Measured on a real project that is 132ms and 7 spawns for the walk alone, three
or four times a second while staging. On Windows every spawn and every readdir
also pays for Defender, which is what made the panel read as frozen.

That answer barely ever changes, and the file watcher already knows exactly when
it does. **The safety rule the design turns on: the watcher only ever makes an
answer fresher, never staler.** A TTL stays underneath as the floor, so losing
every signal degrades to re-walking on a timer rather than to an answer that is
wrong forever. That failure mode is not hypothetical — see the first bullet under
Discovery.

The frozen panel also invited a second click, which is where the second problem
surfaced. Of fifty mutating handlers only nineteen held a flag, each hand-rolling
its own check-set-try-finally. For something idempotent a second click cost a
duplicate round trip. For anything addressed by **position** it changed what the
action did: `git stash pop stash@{0}` twice does not pop one stash twice — the
first removes it, the list re-indexes, and the second applies what used to be
`stash@{1}`, onto a working tree that just changed. Stash pop had no guard, no
confirmation dialog, and no disabled state on its button.

## Changes

**Discovery (`backend/git/nested-repos.ts`) — one owner, one entry point:**
- `:267` — `notifyPathChanged(rootPath, changedPath)` is the only thing the
  watcher calls for path events. It forwards raw paths; this module decides what
  each one means, so no caller carries a copy of the sub-repo policy.
- `:236` — the rules live here, next to the policy they serve: a `.git`
  appearing or vanishing, `.gitignore`, `.gitmodules`, and `.git/info/exclude`
  (obeyed by `git check-ignore` exactly like `.gitignore`, and deliberately
  filtered out of the panel's git-state events, so discovery asks for it by name).
- `:194` — `beginWatchedDiscovery` / `endWatchedDiscovery`, refcounted: two
  projects can be opened at the same directory, and the first to close must not
  revoke the second's claim.
- `invalidateRepoSet` exists for the watcher's own git-dir re-resolve.
  `resolveGitDirs` reads this list to decide which git dirs to watch at all and
  rejects unaccounted-for ones **permanently**, so answering it from a stale walk
  took a sub-repo out of the panel for the whole session.
- `:377` — local-work verdicts are cached **only** under a watched root. The
  watcher is blind inside the directories it prunes by name, and a cached
  "nothing to show" with no signal behind it would hide a sub-repo the user is
  working in — the worst failure this module can produce. Unwatched callers (the
  snapshot scanner, CLI paths) probe live exactly as before.
- Cache keys are separator-folded. Callers arrive from both sides of a
  `path.normalize()` — the watcher normalises before registering, `git:status`
  passes `project.path` straight through — and on Windows those differ by
  separator alone, which would have put them in two entries and silently switched
  the signal off.

**Watcher (`backend/files/file-watcher.ts`) — forwards, decides nothing:**
- `:628` — working-tree events forward before anything filters them.
  `routeGitEvent` swallows every `.git` path and `shouldIgnore` every dotfile, so
  `.gitignore` would otherwise never reach discovery.
- `:822` — the git dir handles forward too. They are a separate event source that
  never reaches `handleFileChange`, and on Linux, where `.git` is pruned from the
  recursive walk, they are the **only** source for it.
- A watcher that exhausted its restart budget now tears down. It announced
  `files:watch-error` and returned, so discovery went on trusting a signal source
  that had stopped.

**Status (`backend/ws/git/status.ts`):**
- `:63` — fetch the outer status and the nested repo list in parallel.
- `:93` — fetch the nested repos' statuses in parallel rather than in sequence.

**Busy state (`frontend/stores/features/git-workspace.svelte.ts`):**
- `:207` — `runGitOp` runs one action while its flag is set and skips it if the
  flag is already up, keyed by `(projectId, repoPath)` like everything else in
  that store. `runMore` becomes a thin delegate, leaving one implementation of
  the guard rather than twenty.
- `:139` — `isStashing`, `isTagging`, `isBranching`, `isResolving` and
  `isConfiguring` join the existing flags, one per UI surface.

**All fifty mutating handlers (`GitPanel.svelte`):**
- Every one now runs through `runGitOp`. Two guards go where the work happens
  rather than around the dialog requesting it — the force-delete-branch
  confirmation is answered long after the first attempt released its flag, so it
  takes its own.
- `:1683` — per-file stage/unstage is guarded by the file's own path, so a repeat
  click on one row is coalesced without dropping clicks on other rows.
- `createBranch` reports whether the branch was created, which the runner does
  not carry, so it captures that in a local; a skipped run reads as failure.

**Rendering the guards:**
- Stash, tag, branch, remote and checkout buttons disable while their surface is
  busy; `ChangesSection` and `ConflictResolver` (`:33`) take a `busy` prop. A
  guard nothing displays turns a double-click into a click that silently does
  nothing, which is worse than the duplicate request it prevents.

## What is never cached
File status. Staged, unstaged, untracked and conflicted entries come from a live
`git status` per repo on every call. The Changes tab cannot go stale through this
change.

## Known limit
A global gitignore (`core.excludesFile`) lives outside the project, so no watcher
can see it. Only the TTL floor covers it.

## Test plan
- `bun run check` — 0 errors
- `bun run lint` — 0 errors
- `bun test` — 812 pass, 0 fail

  New coverage in `nested-repos.test.ts` pins each rule without timing:
  `.gitignore`, `.git/info/exclude`, a `.git` appearing, an unwatched root,
  refcounting, and — as the counterweight — an ordinary write that must NOT
  invalidate anything, so the cache is not useless during a build. It also pins
  that a watched root answers a repeat call with zero git spawns while an
  unwatched one keeps probing live.

  `file-watcher.test.ts` covers a sub-repo created while the project is already
  open (verified to time out without the invalidation) and that the watcher
  forwards path events at all. The latter pins that at least one forwarding point
  is live, not which one — the two overlap on a real filesystem and it passes
  with either removed; exact per-path behaviour is the unit tests' job. Both
  carry an explicit 20s timeout because their lower bound is the watcher's own
  debounces, past bun's 5s default.

  `runGitOp` is not unit-tested: it lives in a `.svelte.ts` module, and runes do
  not evaluate under `bun test` in this repo — no store has tests for that reason.

- Measured, eight sub-repos inside an ignored tree, one Stage All round of four
  calls: **32 `git status` spawns → 0**.
- Manual: Stage All / Unstage All / Discard All on a Windows repo with nested
  repos — the clicked button spins immediately, the section's other bulk actions
  are disabled, a second click is ignored, status refreshes once. Double-clicking
  Stash Pop applies one stash, not two. Stash / tag / branch / checkout buttons
  disable while their action runs. Staging several individual files in quick
  succession still stages all of them. `git init` in a subfolder of an open
  project still lights up the panel. macOS unchanged.