### PR TITLE
fix(palette): reset the highlight when the search query changes

### DIFF
--- a/frontend/components/common/overlay/CommandPalette.svelte
+++ b/frontend/components/common/overlay/CommandPalette.svelte
@@ -168,8 +168,19 @@
 				: projectState.projects;
 			return base.slice(0, 6);
 		}
+		const lowerQ = q.toLowerCase();
 		return projectState.projects
-			.map((p) => ({ p, match: bestFuzzyScore(q, [p.name, p.path]) }))
+			.map((p) => {
+				const nameScore = bestFuzzyScore(q, [p.name]);
+				// Path is only considered when the query appears as a contiguous
+				// substring (e.g. "laravel") — avoids false positives like "Dec"
+				// matching "D:\Project-Laravel\..." via scattered subsequence
+				// d → e → c.
+				const pathScore = p.path.toLowerCase().includes(lowerQ)
+					? bestFuzzyScore(q, [p.path])
+					: 0;
+				return { p, match: Math.max(nameScore, pathScore) };
+			})
 			.filter((x) => x.match > 0)
 			.map((x) => ({ p: x.p, score: x.match + usageBoost(`project-${x.p.id}`) }))
 			.sort((a, b) => b.score - a.score)
@@ -310,7 +321,18 @@
 		return all.filter((g) => g.items.length > 0);
 	});
 
-	// Keep the selection valid as the result set shrinks/grows while typing.
+	// Reset selection to top when the search query changes so the most relevant
+	// result (e.g. "New Chat Session" for "sess") is highlighted instead of
+	// retaining the previous index (e.g. a hovered file like
+	// "session-invalidation.ts").
+	$effect(() => {
+		void query;
+		void effectiveQuery;
+		selectedIndex = 0;
+	});
+
+	// Keep the selection valid as the result set shrinks/grows while typing
+	// (e.g. async file/session results arriving after debounce).
 	$effect(() => {
 		if (selectedIndex >= items.length) selectedIndex = Math.max(0, items.length - 1);
 	});

--- a/frontend/components/common/overlay/CommandPalette.svelte
+++ b/frontend/components/common/overlay/CommandPalette.svelte
@@ -168,19 +168,18 @@
 				: projectState.projects;
 			return base.slice(0, 6);
 		}
+		// Paths are long enough that almost any short query is a subsequence of
+		// them ("Dec" → "D:\Project-Laravel\..." via a scattered d → e → c), so
+		// the path only counts as a match when the query is a contiguous
+		// substring of it ("laravel"). Names are still matched fuzzily.
 		const lowerQ = q.toLowerCase();
 		return projectState.projects
-			.map((p) => {
-				const nameScore = bestFuzzyScore(q, [p.name]);
-				// Path is only considered when the query appears as a contiguous
-				// substring (e.g. "laravel") — avoids false positives like "Dec"
-				// matching "D:\Project-Laravel\..." via scattered subsequence
-				// d → e → c.
-				const pathScore = p.path.toLowerCase().includes(lowerQ)
-					? bestFuzzyScore(q, [p.path])
-					: 0;
-				return { p, match: Math.max(nameScore, pathScore) };
-			})
+			.map((p) => ({
+				p,
+				match: p.path.toLowerCase().includes(lowerQ)
+					? bestFuzzyScore(q, [p.name, p.path])
+					: bestFuzzyScore(q, [p.name])
+			}))
 			.filter((x) => x.match > 0)
 			.map((x) => ({ p: x.p, score: x.match + usageBoost(`project-${x.p.id}`) }))
 			.sort((a, b) => b.score - a.score)
@@ -321,13 +320,16 @@
 		return all.filter((g) => g.items.length > 0);
 	});
 
-	// Reset selection to top when the search query changes so the most relevant
-	// result (e.g. "New Chat Session" for "sess") is highlighted instead of
-	// retaining the previous index (e.g. a hovered file like
-	// "session-invalidation.ts").
+	// Every keystroke rebuilds `items`, so an index left behind by a hover or by
+	// arrow-key navigation points at a different row than the one the user was
+	// looking at — hovering a file, then typing "sess", kept the highlight on
+	// "session-invalidation.ts" instead of moving it to "New Chat Session".
+	// Track the two things that actually change the result set: `effectiveQuery`
+	// (so whitespace-only edits don't reset) and `fileOnly` (an "@" prefix
+	// leaves `effectiveQuery` untouched but swaps the whole list for files).
 	$effect(() => {
-		void query;
 		void effectiveQuery;
+		void fileOnly;
 		selectedIndex = 0;
 	});
 

--- a/frontend/utils/fuzzy.test.ts
+++ b/frontend/utils/fuzzy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { bestFuzzyScore, fuzzyMatch } from './fuzzy';
+
+/** Command-palette entries the scorer has to keep reachable. */
+const DARK_MODE = ['Toggle Dark Mode', 'Switch between light and dark themes', 'theme', 'dark'];
+const NEW_SESSION = ['New Chat Session', 'Start a fresh session', 'chat', 'session', 'new'];
+
+describe('fuzzyMatch', () => {
+	test('scores a contiguous substring far above a scattered subsequence', () => {
+		const substring = fuzzyMatch('dark', 'Toggle Dark Mode');
+		const subsequence = fuzzyMatch('dkm', 'Toggle Dark Mode');
+		expect(substring!.score).toBeGreaterThan(100);
+		expect(subsequence!.score).toBeGreaterThan(0);
+		expect(subsequence!.score).toBeLessThan(substring!.score);
+	});
+
+	test('rewards a match at a word boundary over one mid-word', () => {
+		const atBoundary = fuzzyMatch('mode', 'Dark Mode')!.score;
+		const midWord = fuzzyMatch('ode', 'Dark Mode')!.score;
+		expect(atBoundary).toBeGreaterThan(midWord);
+	});
+
+	test('returns null when a query character is missing or out of order', () => {
+		expect(fuzzyMatch('xyz', 'Toggle Dark Mode')).toBeNull();
+		expect(fuzzyMatch('edom', 'Dark Mode')).toBeNull();
+	});
+
+	test('reports the matched positions in order', () => {
+		expect(fuzzyMatch('dm', 'Dark Mode')!.positions).toEqual([0, 5]);
+	});
+});
+
+describe('bestFuzzyScore', () => {
+	test('takes the strongest candidate, not the first', () => {
+		expect(bestFuzzyScore('session', NEW_SESSION)).toBe(
+			Math.max(...NEW_SESSION.map((t) => fuzzyMatch('session', t)?.score ?? 0))
+		);
+	});
+
+	test('returns 0 for an empty query and for a non-match', () => {
+		expect(bestFuzzyScore('   ', DARK_MODE)).toBe(0);
+		expect(bestFuzzyScore('zzz', DARK_MODE)).toBe(0);
+	});
+
+	test('ignores null and undefined candidates', () => {
+		expect(bestFuzzyScore('dark', [undefined, null, 'Toggle Dark Mode'])).toBeGreaterThan(0);
+	});
+
+	/**
+	 * Short initialisms score in the low twenties, so any global score floor
+	 * (a `>= 50` cutoff, say) silently turns the palette into `String.includes`
+	 * and drops every abbreviation and typo. Weak matches on one long candidate
+	 * are the caller's problem to filter, not this function's.
+	 */
+	test('keeps initialisms and typos reachable', () => {
+		expect(bestFuzzyScore('dm', DARK_MODE)).toBeGreaterThan(0);
+		expect(bestFuzzyScore('ncs', NEW_SESSION)).toBeGreaterThan(0);
+		expect(bestFuzzyScore('setings', ['Open Settings'])).toBeGreaterThan(0);
+		expect(bestFuzzyScore('containr', ['Containers'])).toBeGreaterThan(0);
+	});
+});

--- a/frontend/utils/fuzzy.ts
+++ b/frontend/utils/fuzzy.ts
@@ -65,6 +65,11 @@ export function fuzzyMatch(query: string, text: string): FuzzyMatch | null {
  * Best fuzzy score across several candidate strings (e.g. label, description,
  * keywords). Returns 0 when none of them match, so callers can treat `> 0` as
  * "matched".
+ *
+ * Only scores that correspond to a contiguous substring (100+) or a strong
+ * fuzzy hit (>= 50) are considered. This prevents low-score subsequence
+ * matches like "Dec" → "D:\\Project-Laravel\\..." (score ~19) from
+ * polluting palette results while keeping exact/prefix hits (score 100+).
  */
 export function bestFuzzyScore(query: string, texts: (string | undefined | null)[]): number {
 	if (!query.trim()) return 0;
@@ -72,7 +77,7 @@ export function bestFuzzyScore(query: string, texts: (string | undefined | null)
 	for (const text of texts) {
 		if (!text) continue;
 		const m = fuzzyMatch(query, text);
-		if (m && m.score > best) best = m.score;
+		if (m && m.score > best && m.score >= 50) best = m.score;
 	}
 	return best;
 }

--- a/frontend/utils/fuzzy.ts
+++ b/frontend/utils/fuzzy.ts
@@ -66,10 +66,11 @@ export function fuzzyMatch(query: string, text: string): FuzzyMatch | null {
  * keywords). Returns 0 when none of them match, so callers can treat `> 0` as
  * "matched".
  *
- * Only scores that correspond to a contiguous substring (100+) or a strong
- * fuzzy hit (>= 50) are considered. This prevents low-score subsequence
- * matches like "Dec" → "D:\\Project-Laravel\\..." (score ~19) from
- * polluting palette results while keeping exact/prefix hits (score 100+).
+ * No score floor is applied here: a two- or three-character initialism
+ * ("dm" → "Toggle Dark Mode") legitimately scores in the low twenties, so any
+ * global cutoff would collapse this into `String.includes`. Callers that need
+ * to reject weak subsequence hits on a specific candidate (long filesystem
+ * paths, say) should filter that candidate out before scoring it.
  */
 export function bestFuzzyScore(query: string, texts: (string | undefined | null)[]): number {
 	if (!query.trim()) return 0;
@@ -77,7 +78,7 @@ export function bestFuzzyScore(query: string, texts: (string | undefined | null)
 	for (const text of texts) {
 		if (!text) continue;
 		const m = fuzzyMatch(query, text);
-		if (m && m.score > best && m.score >= 50) best = m.score;
+		if (m && m.score > best) best = m.score;
 	}
 	return best;
 }


### PR DESCRIPTION
## Summary
Reset the Command Palette's highlighted row whenever a new search rebuilds
the result list, and stop project paths from matching queries they only
contain as a scattered subsequence.

## Why
Hovering a row or moving through the list with the arrow keys writes that
row's index to `selectedIndex`. Typing then rebuilds the results, but the
only guard was an out-of-bounds clamp — an index that still fit the new
list survived. Hovering a file and typing `sess` left the highlight on
`session-invalidation.ts` while `New Chat Session` sat unhighlighted at the
top, so Enter opened the wrong result.

Project matching had a second, unrelated cause of noise: it scored `p.path`
fuzzily, and paths are long enough that almost any short query is a
subsequence of one. `Dec` matched `D:\Project-Laravel\...` through a
scattered d → e → c and pushed an unrelated project into the results.

## Changes
- `frontend/components/common/overlay/CommandPalette.svelte:325-333` — new
  `$effect` resetting `selectedIndex` to 0 when the result set is rebuilt
  from a new search. It tracks `effectiveQuery` (trimmed, so whitespace-only
  edits don't move the highlight) and `fileOnly` (an `@` prefix swaps the
  list for files without changing the query text). The existing clamp stays
  for async file/session results arriving after the debounce.
- `frontend/components/common/overlay/CommandPalette.svelte:171-181` — the
  project path is scored only when the query is a contiguous substring of
  it; names stay fuzzy, so initialisms and typos still match.
- `frontend/utils/fuzzy.ts:65-76` — document why `bestFuzzyScore()` applies
  no global score floor: short initialisms legitimately score in the low
  twenties, so any cutoff collapses the palette into `String.includes`.
- `frontend/utils/fuzzy.test.ts` — new, 8 tests pinning the scorer's
  contract.

## Test plan
- `bun run check` — 0 errors, 0 warnings
- `bun run lint` — clean
- `bun run test` — 803 pass, 17 skip, 0 fail
- Manual: open the palette (`Ctrl+K`), hover a file at index 3-4, type
  `sess` → highlight moves to the top row; arrow keys and hover still move
  the selection afterwards; `@`-prefixed file-only mode resets on the
  prefix itself; `dm`, `ncs`, `setings` still find their commands.

## Follow-ups
`items` is grouped project → action → setting → file → session regardless of
score, so index 0 is the first *project* match even when an action scored
120 against its 21. Making the initial selection follow the global score is
a separate change.