### PR TITLE
feat(containers): manage containers on local and SSH hosts

### DIFF
--- a/.scratch/check-extras.ts
+++ b/.scratch/check-extras.ts
@@ -1,0 +1,25 @@
+import { containerArgv } from '/Users/platkadigital/Codes/MyriaLabs/clopen/backend/containers/runtime';
+import { parseDiskUsage, parseStats, parseDockerNetworks, parseNetworkMembership, linkUsage } from '/Users/platkadigital/Codes/MyriaLabs/clopen/backend/containers/parse';
+import { HostContainerScanner } from '/Users/platkadigital/Codes/MyriaLabs/clopen/backend/containers/scan';
+import { LocalCommandRunner, localPlatform } from '/Users/platkadigital/Codes/MyriaLabs/clopen/backend/host/runner';
+
+const platform = localPlatform();
+const runner = new LocalCommandRunner();
+
+const df = await runner.run(containerArgv('docker', platform, ['system', 'df', '--format', '{{json .}}']), 60000);
+console.log('df exit', df.code);
+for (const row of parseDiskUsage(df.stdout, 'docker').rows) {
+  console.log(' ', row.kind.padEnd(12), 'total', String(row.total).padEnd(5), 'active', String(row.active).padEnd(4), 'size', row.size.padEnd(10), 'reclaimable', row.reclaimable);
+}
+
+const scanner = new HostContainerScanner('local', 'this machine', runner, platform);
+const started = Date.now();
+const result = await scanner.scan();
+console.log('scan with networks in', Date.now() - started, 'ms | networks:', result.networks.length);
+for (const net of result.networks.slice(0, 4)) console.log('  -', net.name.padEnd(28), net.driver, '| predefined', net.predefined, '| usedBy', net.usedBy.join(',') || '(none)');
+console.log('  unused networks:', result.networks.filter(n => !n.predefined && n.usedBy.length === 0).length);
+
+const target = result.entries.find((e) => e.state === 'running')!;
+const t0 = Date.now();
+const stats = await runner.run(containerArgv('docker', platform, ['stats', '--no-stream', '--format', '{{json .}}', target.id]), 30000);
+console.log('stats exit', stats.code, 'in', Date.now() - t0, 'ms ->', JSON.stringify(parseStats(stats.stdout)));

--- a/backend/auth/permissions.ts
+++ b/backend/auth/permissions.ts
@@ -46,6 +46,13 @@ export const ADMIN_ONLY_ROUTES = new Set([
 	// Port manager — anyone signed in may see what is listening, but ending a
 	// process can take down another member's work, so stopping is admin-only.
 	'ports:kill',
+	// Containers — anyone signed in may see what is running, but starting or
+	// stopping one takes down whatever it serves for everyone else. Opening a
+	// shell inside a container is gated separately, in the PtyKit authorize.
+	'containers:action',
+	'containers:remove',
+	'containers:prune',
+	'containers:prune-dismiss',
 	// Stack — binary installation is an admin-only operation.
 	'stack:status',
 	'stack:status-all',

--- a/backend/containers/actions.ts
+++ b/backend/containers/actions.ts
@@ -1,0 +1,316 @@
+/**
+ * Containers — starting, stopping, removing, and clearing up after.
+ *
+ * Every action addresses a container or an image by its full id, and a volume
+ * or a network by its name, and every one of those is checked against a
+ * pattern before it reaches a command line. Names arrive over a socket, and an
+ * argument that begins with a dash is a flag; `assertContainerId` and
+ * `assertResourceName` are the gate that stops one becoming the other. Nothing
+ * here ever runs through `sudo`: an account that may not talk to the runtime is
+ * told so.
+ */
+
+import type {
+	ContainerAction,
+	ContainerActionResult,
+	ContainerDetail,
+	ContainerResourceKind,
+	ContainerRuntime,
+	ContainerStats,
+	PruneKind,
+	PruneOutcome
+} from '$shared/types/containers';
+import { CONTAINER_TIMEOUTS } from '$shared/types/containers';
+import { containerMonitor } from './monitor';
+import { invalidateDiskUsage } from './disk-usage';
+import { containerArgv, detectRuntime, firstProblem, tryRun } from './runtime';
+import { parseInspect, parsePruneOutput, parseStats } from './parse';
+import { debug } from '$shared/utils/logger';
+
+/** Both runtimes identify a container or an image with hex. */
+const CONTAINER_ID = /^[a-f0-9]{12,64}$/i;
+/** An image id may carry the digest algorithm that produced it. */
+const IMAGE_ID = /^(sha256:)?[a-f0-9]{12,64}$/i;
+/**
+ * The character set both runtimes allow in a volume or network name. Anchored
+ * at both ends and required to start with an alphanumeric, so nothing that
+ * could be read as a flag or a path ever gets through.
+ */
+const RESOURCE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$/;
+
+export function isContainerId(value: string): boolean {
+	return CONTAINER_ID.test(value);
+}
+
+export function assertContainerId(value: string): string {
+	if (!isContainerId(value)) throw new Error('That is not a container id.');
+	return value;
+}
+
+/** Validate whatever identifies a resource of this kind, or refuse it. */
+export function assertResourceId(kind: ContainerResourceKind, value: string): string {
+	const ok =
+		kind === 'container'
+			? CONTAINER_ID.test(value)
+			: kind === 'image'
+				? IMAGE_ID.test(value)
+				: RESOURCE_NAME.test(value);
+	if (!ok) throw new Error(`That is not a ${kind} Clopen can address.`);
+	return value;
+}
+
+
+/** The argv for each action, which is where `remove` stops being one word. */
+function actionArgv(action: ContainerAction, containerId: string): string[] {
+	switch (action) {
+		case 'remove':
+			return ['rm', containerId];
+		case 'force-remove':
+			// The runtime stops it first. Offered separately from `remove` so the
+			// confirmation can say that outright rather than surprising anyone.
+			return ['rm', '--force', containerId];
+		default:
+			return [action, containerId];
+	}
+}
+
+export async function runContainerAction(
+	hostId: string,
+	containerId: string,
+	action: ContainerAction
+): Promise<ContainerActionResult> {
+	assertContainerId(containerId);
+
+	const result = await containerMonitor.withHost(hostId, async (runner, platform) => {
+		const info = await detectRuntime(hostId, runner, platform);
+		if (info.problem !== 'none' || !info.runtime) {
+			return { ok: false, error: 'This host has no container runtime available right now.' };
+		}
+
+		const outcome = await tryRun(
+			runner,
+			containerArgv(info.runtime, platform, actionArgv(action, containerId)),
+			CONTAINER_TIMEOUTS.action
+		);
+		if (outcome.code === 0) return { ok: true, error: null };
+
+		const reason = firstProblem(outcome.stderr, outcome.stdout, outcome.code);
+		debug.warn('containers', `${action} failed for ${containerId} on ${hostId}: ${reason}`);
+		return { ok: false, error: reason };
+	});
+
+	// The table is a second or two old at most, but an action is the one moment
+	// a user expects it to be instant.
+	containerMonitor.invalidate(hostId);
+	// Starting and stopping do not move the disk figures enough to be worth
+	// re-measuring for; removing a container does.
+	if (action === 'remove' || action === 'force-remove') invalidateDiskUsage(hostId);
+	return result;
+}
+
+/** The argv that removes one resource of each kind. */
+function removeArgv(kind: ContainerResourceKind, id: string, force: boolean): string[] {
+	switch (kind) {
+		case 'container':
+			return force ? ['rm', '--force', id] : ['rm', id];
+		case 'image':
+			return force ? ['image', 'rm', '--force', id] : ['image', 'rm', id];
+		case 'volume':
+			return force ? ['volume', 'rm', '--force', id] : ['volume', 'rm', id];
+		case 'network':
+			return ['network', 'rm', id];
+	}
+}
+
+/**
+ * Remove one image, volume or network.
+ *
+ * Deliberately not forgiving: the runtime refuses to remove anything still in
+ * use, and that refusal is passed straight through rather than being retried
+ * with `--force`. A volume a running container has mounted is not a volume the
+ * user meant to delete, whatever the button said.
+ */
+export async function removeResource(
+	hostId: string,
+	kind: ContainerResourceKind,
+	id: string,
+	force = false
+): Promise<ContainerActionResult> {
+	assertResourceId(kind, id);
+
+	const result = await containerMonitor.withHost(hostId, async (runner, platform) => {
+		const info = await detectRuntime(hostId, runner, platform);
+		if (info.problem !== 'none' || !info.runtime) {
+			return { ok: false, error: 'This host has no container runtime available right now.' };
+		}
+
+		const outcome = await tryRun(
+			runner,
+			containerArgv(info.runtime, platform, removeArgv(kind, id, force)),
+			CONTAINER_TIMEOUTS.action
+		);
+		if (outcome.code === 0) return { ok: true, error: null };
+
+		const reason = firstProblem(outcome.stderr, outcome.stdout, outcome.code);
+		debug.warn('containers', `could not remove ${kind} ${id} on ${hostId}: ${reason}`);
+		return { ok: false, error: reason };
+	});
+
+	containerMonitor.invalidate(hostId);
+	invalidateDiskUsage(hostId);
+	return result;
+}
+
+/**
+ * The argv for a sweep.
+ *
+ * `volumes` is the one place the two runtimes had to be reconciled rather than
+ * passed through. Podman's `volume prune` removes every unused volume; Docker's
+ * removes only the anonymous ones unless it is given `--all`, which older
+ * Docker does not have. So Docker is asked with `--all` and falls back without
+ * it, and both runtimes end up meaning the same thing — which is what the
+ * confirmation says they mean.
+ */
+function pruneArgv(kind: PruneKind, runtime: ContainerRuntime): string[] {
+	switch (kind) {
+		case 'containers':
+			return ['container', 'prune', '--force'];
+		case 'dangling-images':
+			return ['image', 'prune', '--force'];
+		case 'images':
+			return ['image', 'prune', '--all', '--force'];
+		case 'volumes':
+			return runtime === 'docker'
+				? ['volume', 'prune', '--all', '--force']
+				: ['volume', 'prune', '--force'];
+		case 'networks':
+			return ['network', 'prune', '--force'];
+		case 'build-cache':
+			return ['builder', 'prune', '--force'];
+	}
+}
+
+/** True when a command failed because the runtime is too old for a flag. */
+function unknownFlag(stderr: string): boolean {
+	return /unknown flag|unknown shorthand|flag provided but not defined|unrecognized option/i.test(
+		stderr
+	);
+}
+
+/**
+ * Run a set of sweeps, one after another.
+ *
+ * Sequential rather than parallel: both runtimes serialise this work behind
+ * their own lock anyway, and on an SSH host every one of these is a command on
+ * a shared connection. A failure in one kind does not stop the rest — a host
+ * with no build cache should not cost the user their volume sweep.
+ */
+export async function pruneResources(hostId: string, kinds: PruneKind[]): Promise<PruneOutcome[]> {
+	const outcomes = await containerMonitor.withHost(hostId, async (runner, platform) => {
+		const info = await detectRuntime(hostId, runner, platform);
+		if (info.problem !== 'none' || !info.runtime) {
+			return kinds.map((kind) => ({
+				kind,
+				ok: false,
+				removed: 0,
+				reclaimed: null,
+				error: 'This host has no container runtime available right now.'
+			}));
+		}
+		const runtime = info.runtime;
+
+		const results: PruneOutcome[] = [];
+		for (const kind of kinds) {
+			let outcome = await tryRun(
+				runner,
+				containerArgv(runtime, platform, pruneArgv(kind, runtime)),
+				CONTAINER_TIMEOUTS.prune
+			);
+
+			// Docker before 23 has no `volume prune --all`, and removed every unused
+			// volume without it. Dropping the flag there keeps the meaning identical.
+			if (outcome.code !== 0 && kind === 'volumes' && unknownFlag(outcome.stderr)) {
+				outcome = await tryRun(
+					runner,
+					containerArgv(runtime, platform, ['volume', 'prune', '--force']),
+					CONTAINER_TIMEOUTS.prune
+				);
+			}
+
+			if (outcome.code !== 0) {
+				const error = firstProblem(outcome.stderr, outcome.stdout, outcome.code);
+				debug.warn('containers', `prune ${kind} failed on ${hostId}: ${error}`);
+				results.push({ kind, ok: false, removed: 0, reclaimed: null, error });
+				continue;
+			}
+
+			const { removed, reclaimed } = parsePruneOutput(outcome.stdout);
+			results.push({ kind, ok: true, removed, reclaimed, error: null });
+		}
+		return results;
+	});
+
+	containerMonitor.invalidate(hostId);
+	// A sweep is exactly when these numbers move, and showing the figures it was
+	// meant to fix would read as the sweep having done nothing.
+	invalidateDiskUsage(hostId);
+	return outcomes;
+}
+
+/**
+ * One sample of what a container is consuming, read when asked for.
+ *
+ * Not polled and not part of the listing: `stats` samples over a window and
+ * takes a second or more even with `--no-stream`, which is fine for a question
+ * someone asked and far too expensive for a table that ticks.
+ */
+export async function readStats(hostId: string, containerId: string): Promise<ContainerStats | null> {
+	assertContainerId(containerId);
+
+	return containerMonitor.withHost(hostId, async (runner, platform) => {
+		const info = await detectRuntime(hostId, runner, platform);
+		if (info.problem !== 'none' || !info.runtime) return null;
+
+		const result = await tryRun(
+			runner,
+			containerArgv(info.runtime, platform, [
+				'stats',
+				'--no-stream',
+				'--format',
+				info.runtime === 'docker' ? '{{json .}}' : 'json',
+				containerId
+			]),
+			CONTAINER_TIMEOUTS.stats
+		);
+		if (result.code !== 0) {
+			debug.log('containers', `stats failed for ${containerId}:`, result.stderr);
+			return null;
+		}
+		return parseStats(result.stdout);
+	});
+}
+
+/** Everything `inspect` knows, read only when a detail pane asks for it. */
+export async function inspectContainer(
+	hostId: string,
+	containerId: string
+): Promise<ContainerDetail | null> {
+	assertContainerId(containerId);
+
+	return containerMonitor.withHost(hostId, async (runner, platform) => {
+		const info = await detectRuntime(hostId, runner, platform);
+		if (info.problem !== 'none' || !info.runtime) return null;
+
+		const result = await tryRun(
+			runner,
+			containerArgv(info.runtime, platform, ['inspect', '--format', '{{json .}}', containerId]),
+			CONTAINER_TIMEOUTS.inspect
+		);
+		if (result.code !== 0) {
+			debug.log('containers', `inspect failed for ${containerId}:`, result.stderr);
+			return null;
+		}
+		return parseInspect(result.stdout);
+	});
+}
+

--- a/backend/containers/disk-usage.test.ts
+++ b/backend/containers/disk-usage.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { isDiskUsageStale } from './disk-usage';
+import {
+	CONTAINER_TIMEOUTS,
+	DISK_USAGE_STALE_MS,
+	TRANSPORT_GRACE_MS,
+	type ContainerDiskUsage
+} from '$shared/types/containers';
+
+const NOW = Date.parse('2026-09-01T12:00:00.000Z');
+
+function reading(measuredAt: string | null): ContainerDiskUsage {
+	return { rows: [], error: null, measuredAt };
+}
+
+describe('isDiskUsageStale', () => {
+	test('a reading taken just now is still good', () => {
+		expect(isDiskUsageStale(reading(new Date(NOW - 1_000).toISOString()), NOW)).toBe(false);
+	});
+
+	test('a reading goes stale once it passes the window', () => {
+		const justInside = new Date(NOW - DISK_USAGE_STALE_MS + 1_000).toISOString();
+		const justOutside = new Date(NOW - DISK_USAGE_STALE_MS - 1_000).toISOString();
+		expect(isDiskUsageStale(reading(justInside), NOW)).toBe(false);
+		expect(isDiskUsageStale(reading(justOutside), NOW)).toBe(true);
+	});
+
+	test('having no reading at all is stale', () => {
+		expect(isDiskUsageStale(null, NOW)).toBe(true);
+	});
+
+	test('a reading that did not say when it was taken is stale', () => {
+		// Rather than being treated as current, which would pin a number that
+		// nothing would ever replace.
+		expect(isDiskUsageStale(reading(null), NOW)).toBe(true);
+		expect(isDiskUsageStale(reading('not a date'), NOW)).toBe(true);
+	});
+
+	test('a reading stamped in the future is not treated as stale', () => {
+		// A host whose clock runs ahead should not make the panel re-measure on
+		// every open — the invalidation after a prune is what keeps it honest.
+		expect(isDiskUsageStale(reading(new Date(NOW + 60_000).toISOString()), NOW)).toBe(false);
+	});
+});
+
+describe('command budgets', () => {
+	// The bug this guards against: the transport gave up at 30s while the backend
+	// was still allowed 300s for a prune, so a sweep that was still deleting came
+	// back as six failures and the user was invited to run it again.
+	test('every command budget leaves room for the transport to outlast it', () => {
+		for (const [name, budget] of Object.entries(CONTAINER_TIMEOUTS)) {
+			expect(budget + TRANSPORT_GRACE_MS, `${name} must outlast its command`).toBeGreaterThan(
+				budget
+			);
+		}
+	});
+
+	test('a full scan is allowed more than any single listing it runs', () => {
+		expect(CONTAINER_TIMEOUTS.scan).toBeGreaterThan(CONTAINER_TIMEOUTS.list);
+	});
+
+	test('a prune is allowed the longest, because it walks what it deletes', () => {
+		const others = Object.entries(CONTAINER_TIMEOUTS)
+			.filter(([name]) => name !== 'prune')
+			.map(([, budget]) => budget);
+		expect(CONTAINER_TIMEOUTS.prune).toBeGreaterThan(Math.max(...others));
+	});
+});

--- a/backend/containers/disk-usage.ts
+++ b/backend/containers/disk-usage.ts
@@ -1,0 +1,170 @@
+/**
+ * Containers — what the host is holding, measured off the request path.
+ *
+ * `system df` is the one container command whose cost is set by how much disk
+ * the host holds rather than by how many containers it runs. The daemon walks
+ * every image layer and stats every file in every volume to answer it. On a
+ * developer machine with a few hundred volumes on a virtualised filesystem that
+ * is over a minute, and the volumes are almost all of it — measured on one such
+ * host: images 2.6s, containers 0.4s, build cache 0.3s, volumes 47s.
+ *
+ * That is too long to hold a request open for, and there is no shorter way to
+ * ask: the runtimes' own CLIs expose no way to measure part of it, and reaching
+ * for the Engine API's type filter would mean talking to a unix socket directly
+ * rather than through the one CommandRunner that makes a local host and an SSH
+ * host the same code.
+ *
+ * So the measurement is a background job. Asking for it returns whatever was
+ * last measured — immediately, however old — and starts a fresh reading only if
+ * the old one has gone stale. The fresh reading is pushed to whoever asked when
+ * it lands. Nothing ever waits on a command whose duration is set by someone
+ * else's disk.
+ *
+ * A host's reading outlives its connection. Clearing it on teardown would mean
+ * the monitor importing this module while this one imports the monitor, to save
+ * one small object per host that has ever been opened — and a reading that
+ * survives a reconnect is re-measured by the staleness check anyway.
+ */
+
+import type { ContainerDiskUsage } from '$shared/types/containers';
+import { DISK_USAGE_STALE_MS, DISK_USAGE_TIMEOUT_MS } from '$shared/types/containers';
+import { containerMonitor } from './monitor';
+import { containerArgv, detectRuntime, firstProblem, tryRun } from './runtime';
+import { parseDiskUsage } from './parse';
+import { ws } from '../utils/ws';
+import { debug } from '$shared/utils/logger';
+
+interface HostUsage {
+	/** The last completed reading, kept until something invalidates it. */
+	last: ContainerDiskUsage | null;
+	/** Users to push the in-flight reading to when it lands. */
+	waiting: Set<string>;
+	measuring: boolean;
+}
+
+const hosts = new Map<string, HostUsage>();
+
+function stateFor(hostId: string): HostUsage {
+	const existing = hosts.get(hostId);
+	if (existing) return existing;
+	const created: HostUsage = { last: null, waiting: new Set(), measuring: false };
+	hosts.set(hostId, created);
+	return created;
+}
+
+/**
+ * Whether a reading is old enough to be worth paying for another one.
+ *
+ * A reading with no usable stamp counts as stale: it came from somewhere that
+ * did not say when it was taken, and guessing that it is current would pin a
+ * wrong number on screen until something invalidated it.
+ */
+export function isDiskUsageStale(usage: ContainerDiskUsage | null, now: number): boolean {
+	if (!usage?.measuredAt) return true;
+	const measuredAt = Date.parse(usage.measuredAt);
+	if (Number.isNaN(measuredAt)) return true;
+	return now - measuredAt >= DISK_USAGE_STALE_MS;
+}
+
+/** Run the measurement itself. Slow by nature, so nothing calls this directly. */
+async function measure(hostId: string): Promise<ContainerDiskUsage> {
+	const measuredAt = new Date().toISOString();
+
+	return containerMonitor.withHost(hostId, async (runner, platform) => {
+		const info = await detectRuntime(hostId, runner, platform);
+		if (info.problem !== 'none' || !info.runtime) {
+			return {
+				rows: [],
+				error: 'This host has no container runtime available right now.',
+				measuredAt
+			};
+		}
+
+		const result = await tryRun(
+			runner,
+			containerArgv(info.runtime, platform, [
+				'system',
+				'df',
+				'--format',
+				info.runtime === 'docker' ? '{{json .}}' : 'json'
+			]),
+			DISK_USAGE_TIMEOUT_MS
+		);
+		if (result.code !== 0) {
+			return {
+				rows: [],
+				error: firstProblem(result.stderr, result.stdout, result.code),
+				measuredAt
+			};
+		}
+		return { ...parseDiskUsage(result.stdout, info.runtime), measuredAt };
+	});
+}
+
+/**
+ * Start a reading if one is warranted, and register the caller for the result.
+ *
+ * A second caller arriving while a reading is in flight joins that one rather
+ * than starting a second: two dialogs open on the same host must not make the
+ * daemon walk the same disk twice.
+ */
+function startMeasuring(hostId: string, userId: string): void {
+	const state = stateFor(hostId);
+	state.waiting.add(userId);
+	if (state.measuring) return;
+	state.measuring = true;
+
+	void (async () => {
+		let usage: ContainerDiskUsage;
+		try {
+			usage = await measure(hostId);
+		} catch (error) {
+			debug.warn('containers', `could not measure disk usage on ${hostId}:`, error);
+			usage = {
+				rows: [],
+				error: error instanceof Error ? error.message : String(error),
+				measuredAt: new Date().toISOString()
+			};
+		}
+
+		// A reading that failed is still a reading: caching it stops a broken host
+		// being re-measured on every open. An invalidate clears it either way.
+		state.last = usage;
+		state.measuring = false;
+
+		const waiting = [...state.waiting];
+		state.waiting.clear();
+		for (const id of waiting) {
+			ws.emit.user(id, 'containers:disk-usage-measured', { hostId, usage });
+		}
+	})();
+}
+
+/**
+ * What the dialog gets when it opens: the last reading, and whether a fresh one
+ * is on its way.
+ *
+ * `force` is the Re-check button — the one case where someone has decided the
+ * cached answer is not good enough and is willing to wait for a new one.
+ */
+export function requestDiskUsage(
+	hostId: string,
+	userId: string,
+	force = false
+): { usage: ContainerDiskUsage | null; measuring: boolean } {
+	const state = stateFor(hostId);
+	if (force || isDiskUsageStale(state.last, Date.now())) startMeasuring(hostId, userId);
+	return { usage: state.last, measuring: state.measuring };
+}
+
+/**
+ * Drop a host's reading, because something changed what it would say.
+ *
+ * Called after a prune or a removal: that is exactly when these numbers move,
+ * and showing the figures the sweep was meant to fix would read as the sweep
+ * having done nothing.
+ */
+export function invalidateDiskUsage(hostId: string): void {
+	const state = hosts.get(hostId);
+	if (state) state.last = null;
+}

--- a/backend/containers/logs.ts
+++ b/backend/containers/logs.ts
@@ -1,0 +1,335 @@
+/**
+ * Containers — following a container's output.
+ *
+ * `docker logs -f` never returns, which is the one thing the shared
+ * `CommandRunner` cannot carry: locally it buffers a command to completion, and
+ * remotely it queues commands one at a time on a connection the terminal and
+ * file browser share — a follow would sit at the head of that queue forever. So
+ * a stream gets its own channel on both transports, and pays for it with hard
+ * limits: a bounded number of streams per host, and a bounded ring buffer per
+ * stream so a container writing a megabyte a second cannot grow this process's
+ * memory without limit.
+ *
+ * Output is coalesced and flushed on a short interval rather than pushed per
+ * chunk. A build log arrives in hundreds of tiny writes, and one WebSocket
+ * frame each would cost more than the log is worth.
+ */
+
+import type { Client as SshClient, ClientChannel } from 'ssh2';
+import { CONTAINER_LOG_BUFFER_LINES } from '$shared/types/containers';
+import { LOCAL_HOST_ID } from '$shared/types/host';
+import { containerMonitor } from './monitor';
+import { assertContainerId } from './actions';
+import { containerArgv, detectRuntime } from './runtime';
+import { localPlatform, type ProbePlatform } from '../host/runner';
+import { detectRemotePlatform } from '../host/runner';
+import { shellQuote } from '../ssh/connect';
+import { sshClientPool, type SshLease } from '../ssh/client-pool';
+import { sshConnectionQueries } from '../database/queries';
+import { ws } from '../utils/ws';
+import { debug } from '$shared/utils/logger';
+
+/** Lines asked for when a stream opens, so the view is not blank. */
+const TAIL_LINES = 500;
+/**
+ * Streams a single host may have open at once.
+ *
+ * Bounded for SSH's sake: every follow holds an exec channel, and sshd's
+ * `MaxSessions` is ten by default — shared with the terminal, the file browser
+ * and the port scan. Three leaves room for all of them.
+ */
+const MAX_STREAMS_PER_HOST = 3;
+/** How often buffered output is pushed to the client. */
+const FLUSH_INTERVAL_MS = 120;
+
+interface LogStream {
+	id: string;
+	hostId: string;
+	containerId: string;
+	userId: string;
+	/** The last N lines, so a reopened view is not empty while it waits. */
+	buffer: string[];
+	pending: string;
+	flushTimer: ReturnType<typeof setInterval> | null;
+	stop: () => void;
+	stopped: boolean;
+}
+
+const streams = new Map<string, LogStream>();
+
+/** One stream per user per container: a second tab joins the first. */
+function streamIdFor(userId: string, hostId: string, containerId: string): string {
+	return `${userId}:${hostId}:${containerId}`;
+}
+
+function countForHost(hostId: string): number {
+	let count = 0;
+	for (const stream of streams.values()) if (stream.hostId === hostId) count++;
+	return count;
+}
+
+/**
+ * Keep the ring bounded, counting lines rather than bytes so a trim never cuts
+ * a line in half. The buffer holds lines without their newlines, so a chunk's
+ * first piece continues whatever line the previous chunk left open — output
+ * arrives in arbitrary slices, not conveniently at line boundaries.
+ */
+function appendToBuffer(stream: LogStream, text: string): void {
+	const lines = text.split('\n');
+	if (stream.buffer.length > 0) {
+		stream.buffer[stream.buffer.length - 1] += lines.shift() ?? '';
+	}
+	for (const line of lines) stream.buffer.push(line);
+	if (stream.buffer.length > CONTAINER_LOG_BUFFER_LINES) {
+		stream.buffer.splice(0, stream.buffer.length - CONTAINER_LOG_BUFFER_LINES);
+	}
+}
+
+function push(stream: LogStream, text: string): void {
+	if (!text) return;
+	appendToBuffer(stream, text);
+	stream.pending += text;
+}
+
+function flush(stream: LogStream): void {
+	if (!stream.pending) return;
+	const data = stream.pending;
+	stream.pending = '';
+	ws.emit.user(stream.userId, 'containers:log-chunk', {
+		streamId: stream.id,
+		hostId: stream.hostId,
+		containerId: stream.containerId,
+		data
+	});
+}
+
+function finish(stream: LogStream, error: string | null): void {
+	if (stream.stopped) return;
+	stream.stopped = true;
+	flush(stream);
+	if (stream.flushTimer) clearInterval(stream.flushTimer);
+	streams.delete(stream.id);
+	ws.emit.user(stream.userId, 'containers:log-chunk', {
+		streamId: stream.id,
+		hostId: stream.hostId,
+		containerId: stream.containerId,
+		data: '',
+		done: true,
+		error
+	});
+}
+
+export interface StartedLogStream {
+	streamId: string;
+	/** Whatever the ring already holds, for a view that is joining late. */
+	backlog: string;
+}
+
+/**
+ * Start following a container, or join the stream already following it.
+ *
+ * The container is verified against a fresh listing first: the id arrived from
+ * a client, and a stream is a process held open on someone's machine.
+ */
+export async function startLogStream(
+	hostId: string,
+	containerId: string,
+	userId: string
+): Promise<StartedLogStream> {
+	assertContainerId(containerId);
+
+	const id = streamIdFor(userId, hostId, containerId);
+	const existing = streams.get(id);
+	// Rejoined with the newlines the buffer strips, or the whole backlog would
+	// arrive as one enormous line.
+	if (existing) return { streamId: id, backlog: existing.buffer.join('\n') };
+
+	const container = await containerMonitor.findContainer(hostId, containerId);
+	if (!container) throw new Error('That container no longer exists on this host.');
+
+	if (countForHost(hostId) >= MAX_STREAMS_PER_HOST) {
+		throw new Error(
+			`Already following ${MAX_STREAMS_PER_HOST} logs on this host. Close one before opening another.`
+		);
+	}
+
+	const stream: LogStream = {
+		id,
+		hostId,
+		containerId,
+		userId,
+		buffer: [],
+		pending: '',
+		flushTimer: null,
+		stop: () => undefined,
+		stopped: false
+	};
+	streams.set(id, stream);
+
+	stream.flushTimer = setInterval(() => flush(stream), FLUSH_INTERVAL_MS);
+	stream.flushTimer.unref?.();
+
+	try {
+		if (hostId === LOCAL_HOST_ID) await followLocal(stream);
+		else await followRemote(stream);
+	} catch (error) {
+		finish(stream, error instanceof Error ? error.message : String(error));
+		throw error;
+	}
+
+	debug.log('containers', `following logs for ${container.name} on ${hostId}`);
+	return { streamId: id, backlog: '' };
+}
+
+/** The argv both transports run, once the runtime is known. */
+async function logArgv(
+	hostId: string,
+	containerId: string,
+	platform: ProbePlatform
+): Promise<string[]> {
+	const info = await containerMonitor.withHost(hostId, (runner) =>
+		detectRuntime(hostId, runner, platform)
+	);
+	if (info.problem !== 'none' || !info.runtime) {
+		throw new Error('This host has no container runtime available right now.');
+	}
+	return containerArgv(info.runtime, platform, [
+		'logs',
+		'--follow',
+		'--tail',
+		String(TAIL_LINES),
+		containerId
+	]);
+}
+
+async function followLocal(stream: LogStream): Promise<void> {
+	const platform = localPlatform();
+	const argv = await logArgv(stream.hostId, stream.containerId, platform);
+
+	const child = Bun.spawn(argv, { stdout: 'pipe', stderr: 'pipe', stdin: 'ignore' });
+	stream.stop = () => {
+		try {
+			child.kill();
+		} catch {
+			// Already gone.
+		}
+	};
+
+	// `docker logs` writes a container's stdout and stderr to its own two
+	// streams; a reader wants them interleaved exactly as the container wrote
+	// them, so both are pumped into the same buffer.
+	void pump(child.stdout, stream);
+	void pump(child.stderr, stream);
+	void child.exited.then((code) => {
+		finish(stream, code === 0 || stream.stopped ? null : `The log command exited with status ${code}.`);
+	});
+}
+
+async function pump(readable: ReadableStream<Uint8Array> | null, stream: LogStream): Promise<void> {
+	if (!readable) return;
+	const decoder = new TextDecoder();
+	const reader = readable.getReader();
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done || stream.stopped) return;
+			if (value) push(stream, decoder.decode(value, { stream: true }));
+		}
+	} catch (error) {
+		debug.log('containers', 'log stream ended:', error);
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+async function followRemote(stream: LogStream): Promise<void> {
+	const connection = sshConnectionQueries.get(stream.hostId);
+	if (!connection) throw new Error('That SSH host no longer exists.');
+
+	const platform = await containerMonitor.withHost(stream.hostId, (runner) =>
+		detectRemotePlatform(stream.hostId, runner)
+	);
+	const argv = await logArgv(stream.hostId, stream.containerId, platform);
+	// Its own lease, not the shared queued runner: this channel never closes on
+	// its own, and everything behind it in that queue would wait forever.
+	const lease = await sshClientPool.acquire(stream.hostId);
+
+	try {
+		const channel = await openExec(lease.client, argv.map(shellQuote).join(' '));
+		let released = false;
+		const release = (): void => {
+			if (released) return;
+			released = true;
+			lease.release();
+		};
+
+		stream.stop = () => {
+			try {
+				channel.close();
+			} catch {
+				// Already gone.
+			}
+			release();
+		};
+
+		const decoder = new TextDecoder();
+		channel.on('data', (chunk: Buffer) => push(stream, decoder.decode(chunk, { stream: true })));
+		channel.stderr.on('data', (chunk: Buffer) => push(stream, decoder.decode(chunk, { stream: true })));
+		channel.on('close', () => {
+			release();
+			finish(stream, null);
+		});
+		channel.on('error', (error: Error) => {
+			release();
+			finish(stream, error.message);
+		});
+	} catch (error) {
+		lease.release();
+		throw error;
+	}
+}
+
+function openExec(client: SshClient, command: string): Promise<ClientChannel> {
+	return new Promise((resolve, reject) => {
+		client.exec(command, (error, channel) => {
+			if (error) reject(error);
+			else resolve(channel);
+		});
+	});
+}
+
+/** Stop one stream, if it belongs to this user. */
+export function stopLogStream(streamId: string, userId: string): void {
+	const stream = streams.get(streamId);
+	if (!stream || stream.userId !== userId) return;
+	stream.stop();
+	finish(stream, null);
+}
+
+/** Stop every stream a user holds, when their socket goes away. */
+export function stopLogStreamsForUser(userId: string): void {
+	for (const stream of [...streams.values()]) {
+		if (stream.userId === userId) {
+			stream.stop();
+			finish(stream, null);
+		}
+	}
+}
+
+/** Stop everything, when the process is shutting down. */
+export function stopAllLogStreams(): void {
+	for (const stream of [...streams.values()]) {
+		stream.stop();
+		finish(stream, null);
+	}
+}
+
+/** Stop every stream on a host, when its connection is edited or deleted. */
+export function stopLogStreamsForHost(hostId: string): void {
+	for (const stream of [...streams.values()]) {
+		if (stream.hostId === hostId) {
+			stream.stop();
+			finish(stream, null);
+		}
+	}
+}

--- a/backend/containers/monitor.ts
+++ b/backend/containers/monitor.ts
@@ -1,0 +1,410 @@
+/**
+ * Containers — keeping the list live.
+ *
+ * The same contract the port table runs on, for the same reason: neither Docker
+ * nor Podman offers a portable way to be *told* that a container's state
+ * changed. Docker has an event stream, Podman has a different one, neither
+ * exists on a host that has only the other, and both would need a channel held
+ * open per host. Polling a `ps` is one cheap command, works identically on both
+ * runtimes and over both transports, and earns its keep by being quiet:
+ *
+ * - A watched host is listed every two seconds locally, every four over SSH,
+ *   where each scan is a round trip on the connection the terminal and file
+ *   browser are also using.
+ * - Results are diffed server-side and pushed only when something actually
+ *   changed, so a host whose containers are steady costs no traffic at all.
+ * - With no panel open, the only work is the sidebar count on this machine, and
+ *   only when this machine has a runtime at all.
+ * - A remote host is scanned only while its tab is open, on a lease borrowed
+ *   from the pool the terminal and file browser already keep warm.
+ */
+
+import type { ContainerScanResult } from '$shared/types/containers';
+import { LOCAL_HOST_ID } from '$shared/types/host';
+import { HostContainerScanner } from './scan';
+import { forgetContainerPortIndex, noteContainerScan } from './port-index';
+import { containerArgv, detectRuntime, forgetRuntime, tryRun } from './runtime';
+import {
+	LocalCommandRunner,
+	SshCommandRunner,
+	detectRemotePlatform,
+	localPlatform,
+	type CommandRunner,
+	type ProbePlatform
+} from '../host/runner';
+import { sshClientPool, type SshLease } from '../ssh/client-pool';
+import { sshConnectionQueries } from '../database/queries';
+import { ws } from '../utils/ws';
+import { debug } from '$shared/utils/logger';
+
+/**
+ * Panel open on this machine.
+ *
+ * Slower than the port table's one second, on purpose. A listing costs more —
+ * on a machine with a few dozen containers it is well over a hundred
+ * milliseconds, where a warm port scan is tens — and containers change state
+ * far less often than sockets do. Two seconds still reads as live.
+ */
+const WATCH_INTERVAL_MS = 2_000;
+/** Panel open on an SSH host, paced to stay out of the terminal's way. */
+const REMOTE_WATCH_INTERVAL_MS = 4_000;
+/** Panel closed: only the sidebar count on this machine. */
+const BADGE_INTERVAL_MS = 15_000;
+
+interface HostState {
+	scanner: HostContainerScanner;
+	runner: CommandRunner;
+	platform: ProbePlatform;
+	lease: SshLease | null;
+	/** User ids currently looking at this host. */
+	watchers: Set<string>;
+	timer: ReturnType<typeof setInterval> | null;
+	last: ContainerScanResult | null;
+	signature: string;
+	scanning: boolean;
+}
+
+/**
+ * What a client would notice changing. Excludes the timestamp and the status
+ * text's own clock — `Up 3 minutes` becomes `Up 4 minutes` on its own — so an
+ * idle host produces an identical signature tick after tick and nothing is sent.
+ */
+function signatureOf(result: ContainerScanResult): string {
+	if (result.error) return `error:${result.error}`;
+	const containers = result.entries
+		.map(
+			(entry) =>
+				`${entry.id}|${entry.state}|${entry.health}|${entry.name}|${entry.image}|${entry.ports
+					.map((port) => `${port.protocol}${port.hostPort ?? '-'}:${port.containerPort}`)
+					.join('/')}`
+		)
+		.join('\n');
+	const images = result.images.map((image) => image.key).join(',');
+	const volumes = result.volumes.map((volume) => `${volume.key}:${volume.usedBy.length}`).join(',');
+	return `${result.runtime ?? 'none'}:${result.runtimeProblem}\n${containers}\n${images}\n${volumes}`;
+}
+
+class ContainerMonitor {
+	private hosts = new Map<string, HostState>();
+	/**
+	 * Hosts being set up right now. Creating a host acquires an SSH lease, so two
+	 * concurrent callers would each take one and only the last would be kept —
+	 * the other then leaks for the life of the process.
+	 */
+	private opening = new Map<string, Promise<HostState>>();
+	private badgeTimer: ReturnType<typeof setInterval> | null = null;
+	private badgeCount = 0;
+
+	// -- host lifecycle ------------------------------------------------------
+
+	private async ensureHost(hostId: string): Promise<HostState> {
+		const existing = this.hosts.get(hostId);
+		if (existing) return existing;
+
+		const opening = this.opening.get(hostId);
+		if (opening) return opening;
+
+		const created = this.createHost(hostId)
+			.then((state) => {
+				// Another caller may have finished first; keep theirs and let this
+				// one's lease go rather than overwriting it.
+				const settled = this.hosts.get(hostId);
+				if (settled) {
+					state.lease?.release();
+					return settled;
+				}
+				this.hosts.set(hostId, state);
+				return state;
+			})
+			.finally(() => {
+				this.opening.delete(hostId);
+			});
+
+		this.opening.set(hostId, created);
+		return created;
+	}
+
+	private async createHost(hostId: string): Promise<HostState> {
+		if (hostId === LOCAL_HOST_ID) {
+			const runner = new LocalCommandRunner();
+			const platform = localPlatform();
+			return {
+				scanner: new HostContainerScanner(hostId, 'this machine', runner, platform),
+				runner,
+				platform,
+				lease: null,
+				watchers: new Set(),
+				timer: null,
+				last: null,
+				signature: '',
+				scanning: false
+			};
+		}
+
+		const connection = sshConnectionQueries.get(hostId);
+		if (!connection) throw new Error('That SSH host no longer exists.');
+
+		const lease = await sshClientPool.acquire(hostId);
+		try {
+			const runner = new SshCommandRunner(connection.name, lease.client);
+			const platform = await detectRemotePlatform(hostId, runner);
+			return {
+				scanner: new HostContainerScanner(hostId, connection.name, runner, platform),
+				runner,
+				platform,
+				lease,
+				watchers: new Set(),
+				timer: null,
+				last: null,
+				signature: '',
+				scanning: false
+			};
+		} catch (error) {
+			lease.release();
+			throw error;
+		}
+	}
+
+	private disposeHost(hostId: string): void {
+		const state = this.hosts.get(hostId);
+		if (!state) return;
+		if (state.timer) clearInterval(state.timer);
+		state.lease?.release();
+		this.hosts.delete(hostId);
+		if (hostId !== LOCAL_HOST_ID) {
+			forgetRuntime(hostId);
+			forgetContainerPortIndex(hostId);
+		}
+	}
+
+	// -- scanning ------------------------------------------------------------
+
+	/**
+	 * Run one scan and push it to watchers if anything changed. Overlapping ticks
+	 * are dropped rather than queued: a slow host would otherwise build a backlog
+	 * of listings that are all stale by the time they run.
+	 */
+	private async tick(hostId: string): Promise<void> {
+		const state = this.hosts.get(hostId);
+		if (!state || state.scanning) return;
+
+		state.scanning = true;
+		try {
+			const result = await state.scanner.scan();
+			state.last = result;
+			// The port table reads this for free while a Containers panel is open.
+			noteContainerScan(result);
+
+			if (hostId === LOCAL_HOST_ID) this.publishBadge(countRunning(result));
+
+			const signature = signatureOf(result);
+			if (signature === state.signature) return;
+			state.signature = signature;
+
+			for (const userId of state.watchers) {
+				ws.emit.user(userId, 'containers:changed', { result });
+			}
+		} catch (error) {
+			debug.warn('containers', `scan failed for ${hostId}:`, error);
+		} finally {
+			state.scanning = false;
+		}
+	}
+
+	private ensureTimer(hostId: string): void {
+		const state = this.hosts.get(hostId);
+		if (!state || state.timer) return;
+		state.timer = setInterval(
+			() => {
+				void this.tick(hostId);
+			},
+			hostId === LOCAL_HOST_ID ? WATCH_INTERVAL_MS : REMOTE_WATCH_INTERVAL_MS
+		);
+		// A poll for a panel nobody is looking at must not hold the process open.
+		state.timer.unref?.();
+	}
+
+	// -- public API ----------------------------------------------------------
+
+	/** Start watching a host for a user, and return the first listing immediately. */
+	async watch(hostId: string, userId: string): Promise<ContainerScanResult> {
+		const state = await this.ensureHost(hostId);
+
+		state.watchers.add(userId);
+
+		// Scan through the scanner's own guard, so this first read cannot run
+		// alongside a tick on the same connection.
+		const result = state.last ?? (await state.scanner.scan());
+		state.last = result;
+		state.signature = signatureOf(result);
+		noteContainerScan(result);
+		if (hostId === LOCAL_HOST_ID) this.publishBadge(countRunning(result));
+
+		this.ensureTimer(hostId);
+		return result;
+	}
+
+	/** Stop watching. The host is torn down once nobody is left looking. */
+	unwatch(hostId: string, userId: string): void {
+		const state = this.hosts.get(hostId);
+		if (!state) return;
+
+		state.watchers.delete(userId);
+		if (state.watchers.size > 0) return;
+
+		// The local host keeps its scanner: the badge ticker reuses it, and the
+		// image catalogue would otherwise be re-read from scratch on every open.
+		if (hostId === LOCAL_HOST_ID) {
+			if (state.timer) clearInterval(state.timer);
+			state.timer = null;
+			return;
+		}
+		this.disposeHost(hostId);
+	}
+
+	/** A one-shot listing, for a host the caller is not watching. */
+	async scanOnce(hostId: string): Promise<ContainerScanResult> {
+		const existing = this.hosts.get(hostId);
+		if (existing) return existing.scanner.scan();
+
+		const state = await this.createHost(hostId);
+		try {
+			return await state.scanner.scan();
+		} finally {
+			// The lease goes back, but the runtime answer stays: it is keyed by host
+			// with its own expiry, and an action that lists then acts would
+			// otherwise re-probe the host twice for something that cannot have
+			// changed in between.
+			state.lease?.release();
+		}
+	}
+
+	/** The runner and platform for a host, so an action can reuse the transport. */
+	async withHost<T>(
+		hostId: string,
+		fn: (runner: CommandRunner, platform: ProbePlatform) => Promise<T>
+	): Promise<T> {
+		const existing = this.hosts.get(hostId);
+		if (existing) {
+			// Take a lease of this operation's own, rather than riding the watch's.
+			// A prune or a disk reading outlives the panel that started it — that is
+			// the point of them — and closing that panel ends the watch, releases
+			// its lease, and leaves the pool free to sweep the connection out from
+			// under a command that is still running. Refcounting the transport for
+			// the length of the operation is what makes closing the panel harmless.
+			const lease = existing.lease ? await sshClientPool.acquire(hostId) : null;
+			try {
+				return await fn(existing.runner, existing.platform);
+			} finally {
+				lease?.release();
+			}
+		}
+
+		const state = await this.createHost(hostId);
+		try {
+			return await fn(state.runner, state.platform);
+		} finally {
+			state.lease?.release();
+		}
+	}
+
+	/**
+	 * Force the next tick to push, after an action that changed the list. The
+	 * image and volume catalogue is dropped too: starting a container is exactly
+	 * when a volume's "in use" answer changes.
+	 */
+	invalidate(hostId: string): void {
+		const state = this.hosts.get(hostId);
+		if (!state) return;
+		state.signature = '';
+		state.scanner.invalidateCatalog();
+		void this.tick(hostId);
+	}
+
+	/** Whether a container exists on a host — the check before exec or logs. */
+	async findContainer(hostId: string, containerId: string) {
+		const result = await this.scanOnce(hostId);
+		return result.entries.find((entry) => entry.id === containerId) ?? null;
+	}
+
+	// -- sidebar count -------------------------------------------------------
+
+	private publishBadge(count: number): void {
+		if (count === this.badgeCount) return;
+		this.badgeCount = count;
+		ws.emit.global('containers:badge', { count });
+	}
+
+	/**
+	 * The count behind the sidebar dot: containers running on this machine.
+	 *
+	 * Deliberately not a scan. The badge runs forever, whether or not anyone ever
+	 * opens the panel, and a scan reads the image and volume catalogues too — on
+	 * a developer's machine that is hundreds of volumes listed every fifteen
+	 * seconds to produce a single number. `ps --quiet` answers the actual
+	 * question and nothing else.
+	 *
+	 * Returned as well as published, because a client that has just loaded needs
+	 * the current number and pushes only carry changes — a page refresh would
+	 * otherwise sit at zero until something happened to move it.
+	 */
+	async refreshBadge(): Promise<number> {
+		const local = this.hosts.get(LOCAL_HOST_ID);
+		// A watched panel is already listing; reuse what it last saw.
+		if (local?.timer && local.last) return countRunning(local.last);
+
+		try {
+			const state = await this.ensureHost(LOCAL_HOST_ID);
+			const info = await detectRuntime(LOCAL_HOST_ID, state.runner, state.platform);
+			// No runtime is a real answer, and a cached one: zero costs no command.
+			if (info.problem !== 'none' || !info.runtime) {
+				this.publishBadge(0);
+				return 0;
+			}
+
+			const result = await tryRun(
+				state.runner,
+				containerArgv(info.runtime, state.platform, ['ps', '--quiet', '--filter', 'status=running']),
+				10_000
+			);
+			if (result.code !== 0) return this.badgeCount;
+
+			const count = result.stdout.split('\n').filter((line) => line.trim().length > 0).length;
+			this.publishBadge(count);
+			return count;
+		} catch (error) {
+			debug.warn('containers', 'badge count failed:', error);
+			return this.badgeCount;
+		}
+	}
+
+	/**
+	 * The periodic count. A machine with no runtime costs one cached lookup and
+	 * no command at all, because the runtime probe remembers that answer.
+	 */
+	private async badgeTick(): Promise<void> {
+		const local = this.hosts.get(LOCAL_HOST_ID);
+		if (local?.timer) return; // A watched panel already refreshes the count.
+		await this.refreshBadge();
+	}
+
+	start(): void {
+		if (this.badgeTimer) return;
+		this.badgeTimer = setInterval(() => {
+			void this.badgeTick();
+		}, BADGE_INTERVAL_MS);
+		this.badgeTimer.unref?.();
+	}
+
+	stop(): void {
+		if (this.badgeTimer) clearInterval(this.badgeTimer);
+		this.badgeTimer = null;
+		for (const hostId of [...this.hosts.keys()]) this.disposeHost(hostId);
+	}
+}
+
+function countRunning(result: ContainerScanResult): number {
+	return result.entries.filter((entry) => entry.state === 'running').length;
+}
+
+export const containerMonitor = new ContainerMonitor();

--- a/backend/containers/parse.test.ts
+++ b/backend/containers/parse.test.ts
@@ -1,0 +1,599 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	healthFrom,
+	linkUsage,
+	normaliseState,
+	parseDiskUsage,
+	parseDockerNetworks,
+	parseNetworkMembership,
+	parsePodmanNetworks,
+	parsePruneOutput,
+	parseStats,
+	parseDockerImages,
+	parseDockerPortsField,
+	parseDockerPs,
+	parseDockerVolumes,
+	parseInspect,
+	parseMounts,
+	parsePodmanImages,
+	parsePodmanPs,
+	parsePodmanVolumes,
+	parseTimestamp
+} from './parse';
+
+/**
+ * Fixtures are shaped like real runtime output but describe an invented host,
+ * so nothing about a contributor's own machine ends up in the repository.
+ */
+
+describe('parseTimestamp', () => {
+	test('reads Docker’s Go layout, dropping the zone abbreviation nothing can parse', () => {
+		expect(parseTimestamp('2026-08-25 09:02:11 +0700 WIB')).toBe('2026-08-25T02:02:11.000Z');
+	});
+
+	test('reads RFC 3339 as Podman prints it', () => {
+		expect(parseTimestamp('2026-08-25T09:02:11.123456789+07:00')).toBe('2026-08-25T02:02:11.123Z');
+	});
+
+	test('reads a Unix epoch in seconds and in milliseconds', () => {
+		expect(parseTimestamp(1787_000_000)).toBe(new Date(1787_000_000_000).toISOString());
+		expect(parseTimestamp(1787_000_000_000)).toBe(new Date(1787_000_000_000).toISOString());
+	});
+
+	test('reports nothing rather than a wrong date', () => {
+		expect(parseTimestamp('mar. août 25 09:02:11 2026')).toBeNull();
+		expect(parseTimestamp('')).toBeNull();
+		expect(parseTimestamp(null)).toBeNull();
+		// Go's zero time, which both runtimes print for a container never started.
+		expect(parseTimestamp('0001-01-01T00:00:00Z')).toBeNull();
+	});
+});
+
+describe('normaliseState', () => {
+	test('takes the runtime’s own word when there is one', () => {
+		expect(normaliseState('running', '')).toBe('running');
+		expect(normaliseState('exited', '')).toBe('exited');
+	});
+
+	test('translates Podman’s vocabulary', () => {
+		expect(normaliseState('stopped', '')).toBe('exited');
+		expect(normaliseState('configured', '')).toBe('created');
+	});
+
+	test('falls back to the status text, for a Docker too old to have a State column', () => {
+		expect(normaliseState(null, 'Up 3 hours (healthy)')).toBe('running');
+		expect(normaliseState(null, 'Up 2 days (Paused)')).toBe('paused');
+		expect(normaliseState(null, 'Exited (0) 4 minutes ago')).toBe('exited');
+	});
+
+	test('says unknown rather than guessing', () => {
+		expect(normaliseState('teleporting', 'something else')).toBe('unknown');
+	});
+});
+
+describe('healthFrom', () => {
+	test('reads the verdict out of the status text', () => {
+		expect(healthFrom('Up 3 hours (healthy)')).toBe('healthy');
+		expect(healthFrom('Up 3 hours (unhealthy)')).toBe('unhealthy');
+		expect(healthFrom('Up 8 seconds (health: starting)')).toBe('starting');
+	});
+
+	test('prefers an explicit field when the runtime provides one', () => {
+		expect(healthFrom(null, 'unhealthy')).toBe('unhealthy');
+	});
+
+	test('says none when the image declares no healthcheck', () => {
+		expect(healthFrom('Up 3 hours')).toBe('none');
+	});
+});
+
+describe('parseDockerPortsField', () => {
+	test('reads a published mapping', () => {
+		expect(parseDockerPortsField('0.0.0.0:8080->80/tcp')).toEqual([
+			{ hostAddress: '0.0.0.0', hostPort: 8080, containerPort: 80, protocol: 'tcp' }
+		]);
+	});
+
+	test('folds the IPv6 twin of a mapping into one binding', () => {
+		const bindings = parseDockerPortsField('0.0.0.0:8080->80/tcp, :::8080->80/tcp');
+		expect(bindings).toHaveLength(1);
+		expect(bindings[0].hostAddress).toBe('0.0.0.0');
+	});
+
+	test('expands a published range so no reachable port is hidden', () => {
+		const bindings = parseDockerPortsField('0.0.0.0:8000-8002->8000-8002/tcp');
+		expect(bindings.map((binding) => binding.hostPort)).toEqual([8000, 8001, 8002]);
+	});
+
+	test('keeps a port exposed but not published, with no host port', () => {
+		expect(parseDockerPortsField('9000/tcp')).toEqual([
+			{ hostAddress: null, hostPort: null, containerPort: 9000, protocol: 'tcp' }
+		]);
+	});
+
+	test('reads udp and a loopback-only binding', () => {
+		expect(parseDockerPortsField('127.0.0.1:5353->53/udp')).toEqual([
+			{ hostAddress: '127.0.0.1', hostPort: 5353, containerPort: 53, protocol: 'udp' }
+		]);
+	});
+
+	test('reports nothing for an empty column', () => {
+		expect(parseDockerPortsField('')).toEqual([]);
+		expect(parseDockerPortsField(null)).toEqual([]);
+	});
+});
+
+describe('parseDockerPs', () => {
+	const output = [
+		JSON.stringify({
+			ID: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678901234567890abcdefabcdef',
+			Names: 'shop-api-1',
+			Image: 'shop/api:2.1',
+			State: 'running',
+			Status: 'Up 3 hours (healthy)',
+			Ports: '0.0.0.0:8080->80/tcp, :::8080->80/tcp',
+			CreatedAt: '2026-08-25 09:02:11 +0700 WIB',
+			Labels: 'com.docker.compose.project=shop,com.docker.compose.service=api',
+			Command: '"nginx -g daemon off;"',
+			Mounts: 'shop-assets'
+		}),
+		JSON.stringify({
+			ID: 'bb22cc33dd44ee55ff6600112233445566778899aabbccddeeff001122334455',
+			Names: 'shop-db-1',
+			Image: 'postgres:16',
+			State: 'exited',
+			Status: 'Exited (0) 4 minutes ago',
+			Ports: '',
+			CreatedAt: '2026-08-24 18:40:00 +0700 WIB',
+			Labels: 'com.docker.compose.project=shop,com.docker.compose.service=db',
+			Command: '"postgres"',
+			Mounts: 'shop-data'
+		}),
+		'a warning the daemon printed on its way out',
+		''
+	].join('\n');
+
+	const entries = parseDockerPs(output, 'local');
+
+	test('reads every container and ignores anything that is not a row', () => {
+		expect(entries).toHaveLength(2);
+	});
+
+	test('keys the row by host and id, so two hosts never collide', () => {
+		expect(entries[0].key).toBe(`local:${entries[0].id}`);
+		expect(entries[0].shortId).toBe('a1b2c3d4e5f6');
+	});
+
+	test('reads state, health and the compose labels', () => {
+		expect(entries[0]).toMatchObject({
+			name: 'shop-api-1',
+			image: 'shop/api:2.1',
+			state: 'running',
+			health: 'healthy',
+			composeProject: 'shop',
+			composeService: 'api'
+		});
+	});
+
+	test('reads the published port, folded across address families', () => {
+		expect(entries[0].ports).toEqual([
+			{ hostAddress: '0.0.0.0', hostPort: 8080, containerPort: 80, protocol: 'tcp' }
+		]);
+	});
+
+	test('leaves a stopped container with no start time rather than inventing one', () => {
+		expect(entries[1]).toMatchObject({ state: 'exited', startedAt: null, ports: [] });
+	});
+});
+
+describe('parsePodmanPs', () => {
+	const output = JSON.stringify([
+		{
+			Id: 'cc33dd44ee55ff6600112233445566778899aabbccddeeff00112233445566aa',
+			Names: ['shop-api'],
+			Image: 'docker.io/shop/api:2.1',
+			State: 'running',
+			Status: '',
+			StartedAt: 1787_000_000,
+			Created: '2026-08-25T09:02:11.123456789+07:00',
+			Command: ['nginx', '-g', 'daemon off;'],
+			Labels: { 'com.docker.compose.project': 'shop', 'com.docker.compose.service': 'api' },
+			Ports: [{ host_ip: '0.0.0.0', container_port: 80, host_port: 8080, range: 1, protocol: 'tcp' }],
+			Mounts: ['shop-assets'],
+			IsInfra: false
+		},
+		{
+			Id: 'dd44ee55ff6600112233445566778899aabbccddeeff00112233445566aabbcc',
+			Names: ['shop-pod-infra'],
+			Image: 'localhost/podman-pause:5.0',
+			State: 'running',
+			IsInfra: true
+		}
+	]);
+
+	const entries = parsePodmanPs(output, 'vps-1');
+
+	test('drops the pod infra container, which is plumbing rather than a workload', () => {
+		expect(entries).toHaveLength(1);
+		expect(entries[0].name).toBe('shop-api');
+	});
+
+	test('joins the argv Podman reports as an array', () => {
+		expect(entries[0].command).toBe('nginx -g daemon off;');
+	});
+
+	test('reads structured ports', () => {
+		expect(entries[0].ports).toEqual([
+			{ hostAddress: '0.0.0.0', hostPort: 8080, containerPort: 80, protocol: 'tcp' }
+		]);
+	});
+
+	test('writes a status line when Podman leaves the field empty', () => {
+		expect(entries[0].statusText.startsWith('Up ')).toBe(true);
+	});
+
+	test('expands Podman’s port range shorthand', () => {
+		const ranged = parsePodmanPs(
+			JSON.stringify([
+				{
+					Id: 'ee55ff6600112233445566778899aabbccddeeff00112233445566aabbccdd11',
+					Names: ['range-demo'],
+					Image: 'demo',
+					State: 'running',
+					Ports: [{ host_ip: '', container_port: 8000, host_port: 8000, range: 3, protocol: 'tcp' }]
+				}
+			]),
+			'vps-1'
+		);
+		expect(ranged[0].ports.map((port) => port.hostPort)).toEqual([8000, 8001, 8002]);
+	});
+});
+
+describe('images and volumes', () => {
+	test('reads Docker’s image rows and marks the danglers', () => {
+		const images = parseDockerImages(
+			[
+				JSON.stringify({
+					ID: 'sha256:aaa111',
+					Repository: 'shop/api',
+					Tag: '2.1',
+					Size: '184MB',
+					CreatedAt: '2026-08-20 11:00:00 +0700 WIB'
+				}),
+				JSON.stringify({ ID: 'sha256:bbb222', Repository: '<none>', Tag: '<none>', Size: '92MB' })
+			].join('\n')
+		);
+		expect(images).toHaveLength(2);
+		expect(images[0]).toMatchObject({ repository: 'shop/api', tag: '2.1', dangling: false });
+		expect(images[1].dangling).toBe(true);
+	});
+
+	test('splits Podman’s fully qualified names into repository and tag', () => {
+		const images = parsePodmanImages(
+			JSON.stringify([
+				{ Id: 'aaa111', Names: ['docker.io/shop/api:2.1'], Size: 184_000_000, Created: 1787_000_000 },
+				{ Id: 'ccc333', Names: ['localhost:5000/internal/tool'], Size: 1_000 }
+			])
+		);
+		expect(images[0]).toMatchObject({ repository: 'docker.io/shop/api', tag: '2.1', size: '184MB' });
+		// A registry port is not a tag: `localhost:5000/internal/tool` has none.
+		expect(images[1]).toMatchObject({ repository: 'localhost:5000/internal/tool', tag: 'latest' });
+	});
+
+	test('reads volumes from either runtime', () => {
+		expect(
+			parseDockerVolumes(JSON.stringify({ Name: 'shop-data', Driver: 'local', Mountpoint: '/var/lib/docker/volumes/shop-data/_data' }))
+		).toEqual([
+			{
+				key: 'shop-data',
+				name: 'shop-data',
+				driver: 'local',
+				mountpoint: '/var/lib/docker/volumes/shop-data/_data',
+				createdAt: null,
+				usedBy: []
+			}
+		]);
+
+		expect(
+			parsePodmanVolumes(
+				JSON.stringify([{ Name: 'shop-data', Driver: 'local', Mountpoint: '/home/deploy/.local/share/containers/storage/volumes/shop-data/_data', CreatedAt: '2026-08-01T10:00:00Z' }])
+			)[0]
+		).toMatchObject({ name: 'shop-data', createdAt: '2026-08-01T10:00:00.000Z' });
+	});
+});
+
+describe('linkUsage', () => {
+	test('names the containers using each image and volume', () => {
+		const listing = JSON.stringify({
+			ID: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678901234567890abcdefabcdef',
+			Names: 'shop-api-1',
+			Image: 'shop/api:2.1',
+			State: 'running',
+			Status: 'Up 3 hours',
+			Mounts: 'shop-assets,shop-data'
+		});
+		const entries = parseDockerPs(listing, 'local');
+		const images = parseDockerImages(
+			JSON.stringify({ ID: 'sha256:aaa111', Repository: 'shop/api', Tag: '2.1', Size: '184MB' })
+		);
+		const volumes = parseDockerVolumes(
+			[
+				JSON.stringify({ Name: 'shop-assets', Driver: 'local' }),
+				JSON.stringify({ Name: 'orphan-cache', Driver: 'local' })
+			].join('\n')
+		);
+
+		linkUsage(entries, images, volumes, parseMounts(listing, 'docker'));
+
+		expect(images[0].usedBy).toEqual(['shop-api-1']);
+		expect(volumes[0].usedBy).toEqual(['shop-api-1']);
+		expect(volumes[1].usedBy).toEqual([]);
+	});
+
+	test('matches a Podman image name against a container’s fully qualified one', () => {
+		const entries = parsePodmanPs(
+			JSON.stringify([
+				{
+					Id: 'cc33dd44ee55ff6600112233445566778899aabbccddeeff00112233445566aa',
+					Names: ['shop-api'],
+					Image: 'docker.io/shop/api:2.1',
+					State: 'running'
+				}
+			]),
+			'vps-1'
+		);
+		const images = parsePodmanImages(
+			JSON.stringify([{ Id: 'aaa111', Names: ['shop/api:2.1'], Size: 1000 }])
+		);
+
+		linkUsage(entries, images, [], new Map());
+		expect(images[0].usedBy).toEqual(['shop-api']);
+	});
+});
+
+describe('parseInspect', () => {
+	const output = JSON.stringify({
+		Id: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678901234567890abcdefabcdef',
+		Name: '/shop-api-1',
+		Created: '2026-08-25T02:02:11.000Z',
+		Image: 'sha256:aaa111',
+		RestartCount: 2,
+		Path: '/docker-entrypoint.sh',
+		State: {
+			Status: 'running',
+			Running: true,
+			StartedAt: '2026-08-25T02:02:12.000Z',
+			FinishedAt: '0001-01-01T00:00:00Z',
+			ExitCode: 0,
+			Pid: 4210,
+			Health: { Status: 'healthy' }
+		},
+		Config: {
+			Image: 'shop/api:2.1',
+			Cmd: ['nginx', '-g', 'daemon off;'],
+			Env: ['NODE_ENV=production'],
+			WorkingDir: '/srv/app',
+			User: 'app',
+			Labels: { 'com.docker.compose.project': 'shop' }
+		},
+		HostConfig: { RestartPolicy: { Name: 'unless-stopped' } },
+		NetworkSettings: {
+			Networks: { shop_default: { IPAddress: '172.19.0.4' } },
+			Ports: {
+				'80/tcp': [
+					{ HostIp: '0.0.0.0', HostPort: '8080' },
+					{ HostIp: '::', HostPort: '8080' }
+				],
+				'9000/tcp': null
+			}
+		},
+		Mounts: [{ Type: 'volume', Name: 'shop-assets', Source: '/var/lib/docker/volumes/shop-assets/_data', Destination: '/srv/app/public', RW: true }]
+	});
+
+	const detail = parseInspect(output);
+
+	test('reads the container, with the slash Docker prefixes its name with removed', () => {
+		expect(detail?.name).toBe('shop-api-1');
+	});
+
+	test('reads state, health, pid and restart policy', () => {
+		expect(detail).toMatchObject({
+			state: 'running',
+			health: 'healthy',
+			pid: 4210,
+			restartCount: 2,
+			restartPolicy: 'unless-stopped',
+			workingDir: '/srv/app',
+			user: 'app'
+		});
+	});
+
+	test('reports Go’s zero time as no finish time at all', () => {
+		expect(detail?.finishedAt).toBeNull();
+		expect(detail?.startedAt).toBe('2026-08-25T02:02:12.000Z');
+	});
+
+	test('reads published and merely exposed ports, folding the address families', () => {
+		expect(detail?.ports).toEqual([
+			{ hostAddress: '0.0.0.0', hostPort: 8080, containerPort: 80, protocol: 'tcp' },
+			{ hostAddress: null, hostPort: null, containerPort: 9000, protocol: 'tcp' }
+		]);
+	});
+
+	test('reads networks and mounts', () => {
+		expect(detail?.networks).toEqual([{ name: 'shop_default', ipAddress: '172.19.0.4' }]);
+		expect(detail?.mounts[0]).toMatchObject({
+			destination: '/srv/app/public',
+			readOnly: false,
+			kind: 'volume'
+		});
+	});
+
+	test('reports nothing for output that names no container', () => {
+		expect(parseInspect('')).toBeNull();
+		expect(parseInspect('[]')).toBeNull();
+	});
+});
+
+describe('networks', () => {
+	test('reads Docker’s network rows and marks the runtime’s own', () => {
+		const networks = parseDockerNetworks(
+			[
+				JSON.stringify({
+					ID: '52048fed8d9d867057ed8a5f05cfad27ac99835640e621b2b844aba0292d21a0',
+					Name: 'shop_default',
+					Driver: 'bridge',
+					Scope: 'local',
+					Internal: 'false',
+					CreatedAt: '2026-05-15 15:40:00.397 +0700 WIB'
+				}),
+				JSON.stringify({ ID: '5f57c31f263f', Name: 'bridge', Driver: 'bridge', Scope: 'local' })
+			].join('\n')
+		);
+
+		expect(networks[0]).toMatchObject({
+			name: 'shop_default',
+			driver: 'bridge',
+			internal: false,
+			predefined: false
+		});
+		// `bridge` cannot be removed on any host, so it is never offered as such.
+		expect(networks[1].predefined).toBe(true);
+	});
+
+	test('reads Podman’s lower-case field names', () => {
+		const networks = parsePodmanNetworks(
+			JSON.stringify([
+				{ name: 'shop_default', id: 'aa11bb22', driver: 'bridge', created: '2026-05-15T15:40:00Z' },
+				{ name: 'podman', id: 'cc33dd44', driver: 'bridge' }
+			])
+		);
+		expect(networks[0]).toMatchObject({ name: 'shop_default', id: 'aa11bb22', predefined: false });
+		expect(networks[1].predefined).toBe(true);
+	});
+
+	test('names the containers attached to each network', () => {
+		const listing = JSON.stringify({
+			ID: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678901234567890abcdefabcdef',
+			Names: 'shop-api-1',
+			Image: 'shop/api:2.1',
+			State: 'running',
+			Status: 'Up 3 hours',
+			Networks: 'shop_default'
+		});
+		const entries = parseDockerPs(listing, 'local');
+		const networks = parseDockerNetworks(
+			[
+				JSON.stringify({ ID: 'aa11', Name: 'shop_default', Driver: 'bridge' }),
+				JSON.stringify({ ID: 'bb22', Name: 'orphan_net', Driver: 'bridge' })
+			].join('\n')
+		);
+
+		linkUsage(entries, [], [], new Map(), networks, parseNetworkMembership(listing, 'docker'));
+
+		expect(networks[0].usedBy).toEqual(['shop-api-1']);
+		expect(networks[1].usedBy).toEqual([]);
+	});
+});
+
+describe('parsePruneOutput', () => {
+	test('reads what Docker removed and the space it freed', () => {
+		const output = [
+			'Deleted Volumes:',
+			'shop-cache',
+			'a78f6fd7e8b9d8bd121d1e36bb05900293bd4c6f30f9a3565b2bf96c3294fced',
+			'',
+			'Total reclaimed space: 1.24GB'
+		].join('\n');
+		expect(parsePruneOutput(output)).toEqual({ removed: 2, reclaimed: '1.24GB' });
+	});
+
+	test('does not count an untag as a deletion', () => {
+		// `image prune` lists the tag it dropped beside the layer it deleted;
+		// counting both would report twice as much work as it did.
+		const output = [
+			'Deleted Images:',
+			'untagged: shop/api:2.1',
+			'deleted: sha256:aaa111',
+			'',
+			'Total reclaimed space: 184MB'
+		].join('\n');
+		expect(parsePruneOutput(output)).toEqual({ removed: 1, reclaimed: '184MB' });
+	});
+
+	test('reports no space rather than a made-up figure when the runtime is silent', () => {
+		// Podman prints the ids it removed and nothing else.
+		expect(parsePruneOutput('aa11bb22\ncc33dd44\n')).toEqual({ removed: 2, reclaimed: null });
+	});
+
+	test('reads a sweep that found nothing', () => {
+		expect(parsePruneOutput('Total reclaimed space: 0B\n')).toEqual({
+			removed: 0,
+			reclaimed: '0B'
+		});
+	});
+});
+
+describe('parseDiskUsage', () => {
+	test('reads Docker’s four resource lines', () => {
+		const usage = parseDiskUsage(
+			[
+				JSON.stringify({ Type: 'Images', TotalCount: '66', Active: '19', Size: '32.91GB', Reclaimable: '12.27GB (37%)' }),
+				JSON.stringify({ Type: 'Containers', TotalCount: '23', Active: '9', Size: '840.6MB', Reclaimable: '702MB (83%)' }),
+				JSON.stringify({ Type: 'Local Volumes', TotalCount: '327', Active: '13', Size: '25.16GB', Reclaimable: '24.47GB (97%)' }),
+				JSON.stringify({ Type: 'Build Cache', TotalCount: '38', Active: '0', Size: '1.969GB', Reclaimable: '1.24GB' })
+			].join('\n'),
+			'docker'
+		);
+
+		expect(usage.rows.map((row) => row.kind)).toEqual([
+			'images',
+			'containers',
+			'volumes',
+			'build-cache'
+		]);
+		expect(usage.rows[2]).toMatchObject({ total: 327, active: 13, reclaimable: '24.47GB (97%)' });
+	});
+
+	test('formats Podman’s raw byte counts', () => {
+		const usage = parseDiskUsage(
+			JSON.stringify([{ Type: 'Images', Total: 5, Active: 2, Size: 184_000_000, Reclaimable: 92_000_000 }]),
+			'podman'
+		);
+		expect(usage.rows[0]).toMatchObject({ kind: 'images', size: '184MB', reclaimable: '92MB' });
+	});
+});
+
+describe('parseStats', () => {
+	test('reads a Docker sample', () => {
+		const stats = parseStats(
+			JSON.stringify({
+				BlockIO: '17MB / 120MB',
+				CPUPerc: '0.05%',
+				MemPerc: '1.84%',
+				MemUsage: '36.12MiB / 1.913GiB',
+				NetIO: '878kB / 2.18MB',
+				PIDs: '6'
+			})
+		);
+		expect(stats).toEqual({
+			cpuPercent: 0.05,
+			memoryUsage: '36.12MiB / 1.913GiB',
+			memoryPercent: 1.84,
+			networkIO: '878kB / 2.18MB',
+			blockIO: '17MB / 120MB',
+			pids: 6
+		});
+	});
+
+	test('joins the usage and limit Podman reports separately', () => {
+		const stats = parseStats(
+			JSON.stringify([{ cpu_percent: '1.20%', mem_usage: '36MB', MemLimit: '2GB', pids: 6 }])
+		);
+		expect(stats).toMatchObject({ cpuPercent: 1.2, memoryUsage: '36MB / 2GB', pids: 6 });
+	});
+
+	test('reports nothing for a container that gave no sample', () => {
+		expect(parseStats('')).toBeNull();
+	});
+});

--- a/backend/containers/parse.ts
+++ b/backend/containers/parse.ts
@@ -1,0 +1,905 @@
+/**
+ * Containers — turning two runtimes' output into one model.
+ *
+ * Docker and Podman answer the same questions in different words. Docker's CLI
+ * speaks Go templates and prints one JSON object per line; Podman prints a JSON
+ * array with its own field names, its own timestamps (sometimes an epoch,
+ * sometimes RFC 3339) and structured ports where Docker has a string. Every one
+ * of those differences is resolved here, so nothing downstream — not the
+ * scanner, not the WebSocket layer, not the UI — ever asks which runtime it is
+ * looking at.
+ *
+ * Everything in this file is a pure function over command output, which is what
+ * makes the awkward parts (a locale-formatted date, a port range, a compose
+ * label) testable without a container runtime anywhere near the test.
+ */
+
+import type {
+	ContainerDetail,
+	ContainerDiskUsage,
+	ContainerDiskUsageRow,
+	ContainerEntry,
+	ContainerHealth,
+	ContainerImageEntry,
+	ContainerNetworkEntry,
+	ContainerPortBinding,
+	ContainerState,
+	ContainerStats,
+	ContainerVolumeEntry
+} from '$shared/types/containers';
+
+/** Parse NDJSON, skipping anything that is not an object — warnings, banners. */
+function readJsonLines(stdout: string): Record<string, unknown>[] {
+	const rows: Record<string, unknown>[] = [];
+	for (const line of stdout.split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed.startsWith('{')) continue;
+		try {
+			const value = JSON.parse(trimmed);
+			if (value && typeof value === 'object') rows.push(value as Record<string, unknown>);
+		} catch {
+			// A truncated line is one row lost, not a failed scan.
+		}
+	}
+	return rows;
+}
+
+/** Parse a JSON array, tolerating the empty output an idle host produces. */
+function readJsonArray(stdout: string): Record<string, unknown>[] {
+	const trimmed = stdout.trim();
+	if (!trimmed) return [];
+	try {
+		const value = JSON.parse(trimmed);
+		if (Array.isArray(value)) return value.filter((row) => row && typeof row === 'object');
+		if (value && typeof value === 'object') return [value as Record<string, unknown>];
+	} catch {
+		// Podman prints an array; if it printed something else, say nothing.
+	}
+	return [];
+}
+
+function str(value: unknown): string | null {
+	if (typeof value === 'string') return value.trim() || null;
+	if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+	return null;
+}
+
+function num(value: unknown): number | null {
+	if (typeof value === 'number' && Number.isFinite(value)) return value;
+	if (typeof value === 'string' && value.trim()) {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? parsed : null;
+	}
+	return null;
+}
+
+/**
+ * A timestamp from either runtime, as an ISO string or null.
+ *
+ * Docker prints `2026-08-25 09:02:11 +0700 WIB` — a Go time layout whose
+ * trailing zone abbreviation no `Date` can parse, and whose abbreviation is
+ * locale-dependent besides. The offset that precedes it is unambiguous, so the
+ * date is rebuilt from the parts and the abbreviation dropped. Podman prints
+ * RFC 3339, or a Unix epoch in older versions. Anything else reports null
+ * rather than a date that would be quietly wrong.
+ */
+export function parseTimestamp(value: unknown): string | null {
+	if (value === null || value === undefined) return null;
+
+	if (typeof value === 'number') {
+		if (!Number.isFinite(value) || value <= 0) return null;
+		// Seconds below ~year 33658, milliseconds above it.
+		const date = new Date(value > 1e12 ? value : value * 1000);
+		return Number.isNaN(date.getTime()) ? null : date.toISOString();
+	}
+
+	if (typeof value !== 'string') return null;
+	const text = value.trim();
+	if (!text) return null;
+	// Go's zero time: what both runtimes print for a container that never ran.
+	if (text.startsWith('0001-01-01')) return null;
+
+	if (/^\d+$/.test(text)) return parseTimestamp(Number(text));
+
+	// Deliberately the only accepted shape. `new Date` as a fallback looks
+	// harmless and is not: handed a French `mar. août 25 09:02:11 2026` it
+	// returns 25 March without complaint, which is how a wrong date reaches a
+	// user's screen looking exactly like a right one.
+	const match = text.match(
+		/^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})(\.\d+)?\s*(Z|[+-]\d{2}:?\d{2})?/
+	);
+	if (!match) return null;
+
+	const [, day, time, fraction, zone] = match;
+	// A zone with no colon (`+0700`) is Go's spelling; ISO wants `+07:00`.
+	const offset = zone && zone !== 'Z' && !zone.includes(':')
+		? `${zone.slice(0, 3)}:${zone.slice(3)}`
+		: (zone ?? '');
+	const date = new Date(`${day}T${time}${fraction ?? ''}${offset}`);
+	return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+/**
+ * The lifecycle state, from whichever field the runtime filled in.
+ *
+ * Docker before 20.10 has no `State` column at all, so the status text is the
+ * fallback: `Up 3 hours` and `Exited (0) 2 days ago` are the same sentence the
+ * daemon would have put in `State`.
+ */
+export function normaliseState(state: string | null, statusText: string | null): ContainerState {
+	const value = (state ?? '').trim().toLowerCase();
+	switch (value) {
+		case 'running':
+		case 'paused':
+		case 'restarting':
+		case 'created':
+		case 'exited':
+		case 'dead':
+		case 'removing':
+			return value;
+		case 'stopped':
+			// Podman's word for what Docker calls `exited`.
+			return 'exited';
+		case 'configured':
+			// Podman's word for a container that has never run.
+			return 'created';
+	}
+
+	const status = (statusText ?? '').trim().toLowerCase();
+	if (status.startsWith('up')) return status.includes('(paused)') ? 'paused' : 'running';
+	if (status.startsWith('exited')) return 'exited';
+	if (status.startsWith('created')) return 'created';
+	if (status.startsWith('restarting')) return 'restarting';
+	if (status.startsWith('removal') || status.startsWith('removing')) return 'removing';
+	if (status.startsWith('dead')) return 'dead';
+	return 'unknown';
+}
+
+/** The healthcheck verdict, which both runtimes report inside the status text. */
+export function healthFrom(statusText: string | null, explicit?: unknown): ContainerHealth {
+	const direct = (str(explicit) ?? '').toLowerCase();
+	if (direct === 'healthy' || direct === 'unhealthy' || direct === 'starting') return direct;
+
+	const status = (statusText ?? '').toLowerCase();
+	if (status.includes('(healthy)')) return 'healthy';
+	if (status.includes('(unhealthy)')) return 'unhealthy';
+	if (status.includes('health: starting')) return 'starting';
+	return 'none';
+}
+
+/**
+ * Docker's `Ports` column: a comma-separated list mixing published mappings
+ * (`0.0.0.0:8080->80/tcp`), the IPv6 mapping that shadows them (`:::8080->…`)
+ * and bare exposed ports (`9000/tcp`). Ranges appear collapsed
+ * (`0.0.0.0:8000-8002->8000-8002/tcp`) and are expanded, because a row that
+ * says "8000" when the host also holds 8001 is the kind of half-truth this
+ * feature exists to remove.
+ */
+export function parseDockerPortsField(value: string | null): ContainerPortBinding[] {
+	if (!value) return [];
+	const bindings: ContainerPortBinding[] = [];
+
+	for (const part of value.split(',')) {
+		const text = part.trim();
+		if (!text) continue;
+
+		const mapped = text.match(/^(.*):(\d+)(?:-(\d+))?->(\d+)(?:-(\d+))?\/(tcp|udp)$/i);
+		if (mapped) {
+			const [, address, hostStart, hostEnd, containerStart, containerEnd, protocol] = mapped;
+			const spanHost = Number(hostEnd ?? hostStart) - Number(hostStart);
+			const spanContainer = Number(containerEnd ?? containerStart) - Number(containerStart);
+			const span = Math.min(Math.max(spanHost, spanContainer), MAX_PORT_RANGE);
+			for (let offset = 0; offset <= span; offset++) {
+				bindings.push({
+					hostAddress: address || null,
+					hostPort: Number(hostStart) + offset,
+					containerPort: Number(containerStart) + offset,
+					protocol: protocol.toLowerCase() as 'tcp' | 'udp'
+				});
+			}
+			continue;
+		}
+
+		const exposed = text.match(/^(\d+)(?:-(\d+))?\/(tcp|udp)$/i);
+		if (exposed) {
+			const [, start, end, protocol] = exposed;
+			const span = Math.min(Number(end ?? start) - Number(start), MAX_PORT_RANGE);
+			for (let offset = 0; offset <= span; offset++) {
+				bindings.push({
+					hostAddress: null,
+					hostPort: null,
+					containerPort: Number(start) + offset,
+					protocol: protocol.toLowerCase() as 'tcp' | 'udp'
+				});
+			}
+		}
+	}
+
+	return dedupeBindings(bindings);
+}
+
+/** A published range is expanded, but not without bound. */
+const MAX_PORT_RANGE = 64;
+
+/**
+ * Docker publishes on IPv4 and IPv6 separately, so the same mapping arrives
+ * twice under two addresses. The pair is one binding to a reader, so the second
+ * address is folded into the first rather than repeated.
+ */
+function dedupeBindings(bindings: ContainerPortBinding[]): ContainerPortBinding[] {
+	const seen = new Map<string, ContainerPortBinding>();
+	for (const binding of bindings) {
+		const key = `${binding.protocol}:${binding.hostPort ?? 'none'}:${binding.containerPort}`;
+		const existing = seen.get(key);
+		if (!existing) {
+			seen.set(key, binding);
+			continue;
+		}
+		// Prefer the address that says something: `0.0.0.0` over `::`.
+		if (existing.hostAddress === '::' && binding.hostAddress && binding.hostAddress !== '::') {
+			seen.set(key, binding);
+		}
+	}
+	// Published ports first, in port order; the merely exposed ones after, since
+	// they are the ones nobody can reach from outside the host.
+	return [...seen.values()].sort(
+		(a, b) =>
+			Number(a.hostPort === null) - Number(b.hostPort === null) ||
+			(a.hostPort ?? 0) - (b.hostPort ?? 0) ||
+			a.containerPort - b.containerPort
+	);
+}
+
+/** Podman's structured ports, including its `range` shorthand. */
+function parsePodmanPorts(value: unknown): ContainerPortBinding[] {
+	if (!Array.isArray(value)) return [];
+	const bindings: ContainerPortBinding[] = [];
+
+	for (const raw of value) {
+		if (!raw || typeof raw !== 'object') continue;
+		const row = raw as Record<string, unknown>;
+		const containerPort = num(row.container_port ?? row.containerPort);
+		if (containerPort === null) continue;
+		const hostPort = num(row.host_port ?? row.hostPort);
+		const protocol = (str(row.protocol) ?? 'tcp').toLowerCase() === 'udp' ? 'udp' : 'tcp';
+		const span = Math.min(Math.max((num(row.range) ?? 1) - 1, 0), MAX_PORT_RANGE);
+
+		for (let offset = 0; offset <= span; offset++) {
+			bindings.push({
+				hostAddress: str(row.host_ip ?? row.hostIP) ?? null,
+				hostPort: hostPort === null || hostPort === 0 ? null : hostPort + offset,
+				containerPort: containerPort + offset,
+				protocol
+			});
+		}
+	}
+
+	return dedupeBindings(bindings);
+}
+
+/** Docker's `Labels` column: `k=v,k=v`. Podman hands over an object already. */
+function parseLabels(value: unknown): Map<string, string> {
+	const labels = new Map<string, string>();
+
+	if (value && typeof value === 'object' && !Array.isArray(value)) {
+		for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+			const text = str(raw);
+			if (text !== null) labels.set(key, text);
+		}
+		return labels;
+	}
+
+	const text = str(value);
+	if (!text) return labels;
+	for (const pair of text.split(',')) {
+		const index = pair.indexOf('=');
+		if (index <= 0) continue;
+		labels.set(pair.slice(0, index).trim(), pair.slice(index + 1).trim());
+	}
+	return labels;
+}
+
+const COMPOSE_PROJECT_LABELS = ['com.docker.compose.project', 'io.podman.compose.project'];
+const COMPOSE_SERVICE_LABELS = ['com.docker.compose.service', 'io.podman.compose.service'];
+
+function firstLabel(labels: Map<string, string>, keys: string[]): string | null {
+	for (const key of keys) {
+		const value = labels.get(key);
+		if (value) return value;
+	}
+	return null;
+}
+
+function shortId(id: string): string {
+	return id.length > 12 ? id.slice(0, 12) : id;
+}
+
+/**
+ * A status line for a runtime that did not write one.
+ *
+ * Podman's JSON leaves `Status` empty in some versions, and an empty cell in
+ * the column a user reads first is worse than a sentence assembled from the
+ * state and the start time — which is exactly how Docker builds its own.
+ */
+function synthesiseStatus(state: ContainerState, startedAt: string | null, exitCode: number | null): string {
+	if (state === 'running' || state === 'paused') {
+		const suffix = state === 'paused' ? ' (Paused)' : '';
+		if (!startedAt) return `Up${suffix}`;
+		return `Up ${describeSpan(Date.parse(startedAt))}${suffix}`;
+	}
+	if (state === 'exited') return exitCode === null ? 'Exited' : `Exited (${exitCode})`;
+	return state.charAt(0).toUpperCase() + state.slice(1);
+}
+
+/** `3 hours`, `2 days` — the coarse span both runtimes print. */
+function describeSpan(since: number, now = Date.now()): string {
+	const seconds = Math.max(1, Math.round((now - since) / 1000));
+	if (seconds < 60) return `${seconds} seconds`;
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 48) return `${hours} hour${hours === 1 ? '' : 's'}`;
+	const days = Math.round(hours / 24);
+	return `${days} day${days === 1 ? '' : 's'}`;
+}
+
+/** `docker ps --all --no-trunc --format {{json .}}`. */
+export function parseDockerPs(stdout: string, hostId: string): ContainerEntry[] {
+	return readJsonLines(stdout)
+		.map((row): ContainerEntry | null => {
+			const id = str(row.ID ?? row.Id);
+			if (!id) return null;
+
+			const statusText = str(row.Status) ?? '';
+			const state = normaliseState(str(row.State), statusText);
+			const labels = parseLabels(row.Labels);
+			// `Names` carries every name a container answers to; the first is the
+			// one the runtime itself prints.
+			const name = (str(row.Names) ?? '').split(',')[0].trim() || shortId(id);
+
+			return {
+				key: `${hostId}:${id}`,
+				id,
+				shortId: shortId(id),
+				name,
+				image: str(row.Image) ?? 'unknown',
+				state,
+				statusText: statusText || synthesiseStatus(state, null, null),
+				health: healthFrom(statusText),
+				createdAt: parseTimestamp(row.CreatedAt),
+				startedAt: null,
+				ports: parseDockerPortsField(str(row.Ports)),
+				composeProject: firstLabel(labels, COMPOSE_PROJECT_LABELS),
+				composeService: firstLabel(labels, COMPOSE_SERVICE_LABELS),
+				command: str(row.Command),
+				canManage: state !== 'removing'
+			};
+		})
+		.filter((entry): entry is ContainerEntry => entry !== null);
+}
+
+/** `podman ps --all --no-trunc --format json`. */
+export function parsePodmanPs(stdout: string, hostId: string): ContainerEntry[] {
+	return readJsonArray(stdout)
+		.filter((row) => row.IsInfra !== true)
+		.map((row): ContainerEntry | null => {
+			const id = str(row.Id ?? row.ID);
+			if (!id) return null;
+
+			const names = Array.isArray(row.Names) ? row.Names.map(str).filter(Boolean) : [str(row.Names)];
+			const startedAt = parseTimestamp(row.StartedAt);
+			const state = normaliseState(str(row.State), str(row.Status));
+			const labels = parseLabels(row.Labels);
+			const command = Array.isArray(row.Command)
+				? row.Command.map((part) => str(part) ?? '').join(' ').trim() || null
+				: str(row.Command);
+
+			return {
+				key: `${hostId}:${id}`,
+				id,
+				shortId: shortId(id),
+				name: (names[0] as string | null) ?? shortId(id),
+				image: str(row.Image) ?? 'unknown',
+				state,
+				statusText: str(row.Status) ?? synthesiseStatus(state, startedAt, num(row.ExitCode)),
+				health: healthFrom(str(row.Status), row.Health ?? row.HealthStatus),
+				createdAt: parseTimestamp(row.Created ?? row.CreatedAt),
+				startedAt: state === 'running' || state === 'paused' ? startedAt : null,
+				ports: parsePodmanPorts(row.Ports),
+				composeProject: firstLabel(labels, COMPOSE_PROJECT_LABELS),
+				composeService: firstLabel(labels, COMPOSE_SERVICE_LABELS),
+				command,
+				canManage: state !== 'removing'
+			};
+		})
+		.filter((entry): entry is ContainerEntry => entry !== null);
+}
+
+/** Bytes as the runtimes print them, for a Podman size that arrives as a number. */
+function humanSize(bytes: number | null): string {
+	if (bytes === null) return 'unknown';
+	const units = ['B', 'kB', 'MB', 'GB', 'TB'];
+	let value = bytes;
+	let unit = 0;
+	while (value >= 1000 && unit < units.length - 1) {
+		value /= 1000;
+		unit++;
+	}
+	return `${value >= 10 || unit === 0 ? Math.round(value) : value.toFixed(1)}${units[unit]}`;
+}
+
+/** `docker images --format {{json .}}`. */
+export function parseDockerImages(stdout: string): ContainerImageEntry[] {
+	return readJsonLines(stdout)
+		.map((row): ContainerImageEntry | null => {
+			const id = str(row.ID ?? row.Id);
+			if (!id) return null;
+			const repository = str(row.Repository) ?? '<none>';
+			const tag = str(row.Tag) ?? '<none>';
+			return {
+				key: `${id}:${repository}:${tag}`,
+				id,
+				repository,
+				tag,
+				size: str(row.Size) ?? 'unknown',
+				createdAt: parseTimestamp(row.CreatedAt),
+				dangling: repository === '<none>' && tag === '<none>',
+				usedBy: []
+			};
+		})
+		.filter((entry): entry is ContainerImageEntry => entry !== null);
+}
+
+/** `podman images --format json`. One row per repo:tag, like Docker's table. */
+export function parsePodmanImages(stdout: string): ContainerImageEntry[] {
+	const images: ContainerImageEntry[] = [];
+
+	for (const row of readJsonArray(stdout)) {
+		const id = str(row.Id ?? row.ID);
+		if (!id) continue;
+		const size = humanSize(num(row.Size));
+		const createdAt = parseTimestamp(row.Created ?? row.CreatedAt);
+		const tags = Array.isArray(row.Names)
+			? row.Names.map(str).filter((tag): tag is string => tag !== null)
+			: Array.isArray(row.RepoTags)
+				? row.RepoTags.map(str).filter((tag): tag is string => tag !== null)
+				: [];
+
+		if (tags.length === 0) {
+			images.push({
+				key: `${id}:<none>:<none>`,
+				id,
+				repository: '<none>',
+				tag: '<none>',
+				size,
+				createdAt,
+				dangling: true,
+				usedBy: []
+			});
+			continue;
+		}
+
+		for (const tag of tags) {
+			const at = tag.lastIndexOf(':');
+			// A registry port (`localhost:5000/app`) also contains a colon, so the
+			// split only counts when nothing after it looks like a path.
+			const hasTag = at > 0 && !tag.slice(at + 1).includes('/');
+			images.push({
+				key: `${id}:${tag}`,
+				id,
+				repository: hasTag ? tag.slice(0, at) : tag,
+				tag: hasTag ? tag.slice(at + 1) : 'latest',
+				size,
+				createdAt,
+				dangling: false,
+				usedBy: []
+			});
+		}
+	}
+
+	return images;
+}
+
+/** `docker volume ls --format {{json .}}`. Docker reports no creation time. */
+export function parseDockerVolumes(stdout: string): ContainerVolumeEntry[] {
+	return readJsonLines(stdout)
+		.map((row): ContainerVolumeEntry | null => {
+			const name = str(row.Name);
+			if (!name) return null;
+			return {
+				key: name,
+				name,
+				driver: str(row.Driver) ?? 'local',
+				mountpoint: str(row.Mountpoint),
+				createdAt: parseTimestamp(row.CreatedAt),
+				usedBy: []
+			};
+		})
+		.filter((entry): entry is ContainerVolumeEntry => entry !== null);
+}
+
+/** `podman volume ls --format json`. */
+export function parsePodmanVolumes(stdout: string): ContainerVolumeEntry[] {
+	return readJsonArray(stdout)
+		.map((row): ContainerVolumeEntry | null => {
+			const name = str(row.Name);
+			if (!name) return null;
+			return {
+				key: name,
+				name,
+				driver: str(row.Driver) ?? 'local',
+				mountpoint: str(row.Mountpoint),
+				createdAt: parseTimestamp(row.CreatedAt),
+				usedBy: []
+			};
+		})
+		.filter((entry): entry is ContainerVolumeEntry => entry !== null);
+}
+
+/**
+ * The networks the runtime creates and owns.
+ *
+ * Listed so they can be shown, and named so they are never offered as
+ * something to delete: a `network rm bridge` fails on every host, and an action
+ * that can only fail should not be on screen.
+ */
+const PREDEFINED_NETWORKS = new Set(['bridge', 'host', 'none', 'podman', 'ingress', 'docker_gwbridge']);
+
+/** `docker network ls --no-trunc --format {{json .}}`. */
+export function parseDockerNetworks(stdout: string): ContainerNetworkEntry[] {
+	return readJsonLines(stdout)
+		.map((row): ContainerNetworkEntry | null => {
+			const id = str(row.ID ?? row.Id);
+			const name = str(row.Name);
+			if (!id || !name) return null;
+			return {
+				key: id,
+				id,
+				name,
+				driver: str(row.Driver) ?? 'bridge',
+				scope: str(row.Scope) ?? 'local',
+				internal: row.Internal === true || str(row.Internal) === 'true',
+				createdAt: parseTimestamp(row.CreatedAt),
+				usedBy: [],
+				predefined: PREDEFINED_NETWORKS.has(name)
+			};
+		})
+		.filter((entry): entry is ContainerNetworkEntry => entry !== null);
+}
+
+/**
+ * `podman network ls --format json`. Podman spells its network fields in
+ * lower case where Docker capitalises them, so both spellings are read.
+ */
+export function parsePodmanNetworks(stdout: string): ContainerNetworkEntry[] {
+	return readJsonArray(stdout)
+		.map((row): ContainerNetworkEntry | null => {
+			const id = str(row.id ?? row.ID ?? row.Id);
+			const name = str(row.name ?? row.Name);
+			if (!name) return null;
+			return {
+				// Podman's rootless networks have no id in some versions; the name is
+				// unique either way and is what `network rm` takes.
+				key: id ?? name,
+				id: id ?? name,
+				name,
+				driver: str(row.driver ?? row.Driver) ?? 'bridge',
+				scope: str(row.scope ?? row.Scope) ?? 'local',
+				internal: row.internal === true || row.Internal === true,
+				createdAt: parseTimestamp(row.created ?? row.Created ?? row.CreatedAt),
+				usedBy: [],
+				predefined: PREDEFINED_NETWORKS.has(name)
+			};
+		})
+		.filter((entry): entry is ContainerNetworkEntry => entry !== null);
+}
+
+/**
+ * Which containers use each image and volume.
+ *
+ * Computed from the container list already in hand rather than asked of the
+ * runtime: a second round trip per image would cost more than the answer is
+ * worth, and the answer is exact either way.
+ */
+export function linkUsage(
+	entries: ContainerEntry[],
+	images: ContainerImageEntry[],
+	volumes: ContainerVolumeEntry[],
+	mountsByContainer: Map<string, string[]>,
+	networks: ContainerNetworkEntry[] = [],
+	networksByContainer: Map<string, string[]> = new Map()
+): void {
+	for (const image of images) {
+		const tagged = `${image.repository}:${image.tag}`;
+		image.usedBy = entries
+			.filter((entry) => {
+				const used = entry.image;
+				if (used === tagged || used === image.repository) return true;
+				// Podman prints fully qualified names; Docker's short form is a suffix.
+				if (used.endsWith(`/${tagged}`)) return true;
+				return used.startsWith(image.id) || image.id.startsWith(used);
+			})
+			.map((entry) => entry.name);
+	}
+
+	for (const volume of volumes) {
+		volume.usedBy = entries
+			.filter((entry) => (mountsByContainer.get(entry.id) ?? []).includes(volume.name))
+			.map((entry) => entry.name);
+	}
+
+	for (const network of networks) {
+		network.usedBy = entries
+			.filter((entry) => (networksByContainer.get(entry.id) ?? []).includes(network.name))
+			.map((entry) => entry.name);
+	}
+}
+
+/** The networks each container is attached to, from either runtime's `ps`. */
+export function parseNetworkMembership(
+	stdout: string,
+	runtime: 'docker' | 'podman'
+): Map<string, string[]> {
+	const membership = new Map<string, string[]>();
+	const rows = runtime === 'docker' ? readJsonLines(stdout) : readJsonArray(stdout);
+
+	for (const row of rows) {
+		const id = str(row.ID ?? row.Id);
+		if (!id) continue;
+		const raw = row.Networks;
+		const names = Array.isArray(raw)
+			? raw.map((name) => str(name)).filter((name): name is string => name !== null)
+			: (str(raw) ?? '')
+					.split(',')
+					.map((name) => name.trim())
+					.filter(Boolean);
+		membership.set(id, names);
+	}
+
+	return membership;
+}
+
+/** The volume names each container mounts, from either runtime's `ps` output. */
+export function parseMounts(stdout: string, runtime: 'docker' | 'podman'): Map<string, string[]> {
+	const mounts = new Map<string, string[]>();
+	const rows = runtime === 'docker' ? readJsonLines(stdout) : readJsonArray(stdout);
+
+	for (const row of rows) {
+		const id = str(row.ID ?? row.Id);
+		if (!id) continue;
+		const raw = row.Mounts;
+		const names = Array.isArray(raw)
+			? raw
+					.map((mount) =>
+						typeof mount === 'string' ? mount : str((mount as Record<string, unknown>)?.Name)
+					)
+					.filter((name): name is string => name !== null)
+			: (str(raw) ?? '')
+					.split(',')
+					.map((name) => name.trim())
+					.filter(Boolean);
+		mounts.set(id, names);
+	}
+
+	return mounts;
+}
+
+/**
+ * `inspect --format {{json .}}` from either runtime.
+ *
+ * Podman deliberately mirrors Docker's inspect schema, so one reader serves
+ * both. Fields either runtime may omit are reported as null rather than
+ * defaulted, because "this host did not say" and "zero" are different answers.
+ */
+export function parseInspect(stdout: string): ContainerDetail | null {
+	const rows = stdout.trim().startsWith('[') ? readJsonArray(stdout) : readJsonLines(stdout);
+	const row = rows[0];
+	if (!row) return null;
+
+	const id = str(row.Id ?? row.ID);
+	if (!id) return null;
+
+	const state = (row.State ?? {}) as Record<string, unknown>;
+	const config = (row.Config ?? {}) as Record<string, unknown>;
+	const hostConfig = (row.HostConfig ?? {}) as Record<string, unknown>;
+	const networkSettings = (row.NetworkSettings ?? {}) as Record<string, unknown>;
+	const health = (state.Health ?? {}) as Record<string, unknown>;
+
+	const statusText = str(state.Status);
+	const command = Array.isArray(config.Cmd)
+		? config.Cmd.map((part) => str(part) ?? '').join(' ').trim() || null
+		: str(row.Path);
+
+	const networks: ContainerDetail['networks'] = [];
+	const rawNetworks = (networkSettings.Networks ?? {}) as Record<string, unknown>;
+	for (const [name, raw] of Object.entries(rawNetworks)) {
+		const value = (raw ?? {}) as Record<string, unknown>;
+		networks.push({ name, ipAddress: str(value.IPAddress) });
+	}
+
+	const mounts: ContainerDetail['mounts'] = [];
+	if (Array.isArray(row.Mounts)) {
+		for (const raw of row.Mounts) {
+			const mount = (raw ?? {}) as Record<string, unknown>;
+			const destination = str(mount.Destination);
+			if (!destination) continue;
+			mounts.push({
+				source: str(mount.Source) ?? str(mount.Name) ?? '',
+				destination,
+				readOnly: mount.RW === false || mount.ReadOnly === true,
+				kind: str(mount.Type) ?? 'bind'
+			});
+		}
+	}
+
+	const ports: ContainerPortBinding[] = [];
+	const rawPorts = (networkSettings.Ports ?? {}) as Record<string, unknown>;
+	for (const [spec, raw] of Object.entries(rawPorts)) {
+		const match = spec.match(/^(\d+)\/(tcp|udp)$/i);
+		if (!match) continue;
+		const containerPort = Number(match[1]);
+		const protocol = match[2].toLowerCase() as 'tcp' | 'udp';
+		if (!Array.isArray(raw) || raw.length === 0) {
+			ports.push({ hostAddress: null, hostPort: null, containerPort, protocol });
+			continue;
+		}
+		for (const binding of raw) {
+			const value = (binding ?? {}) as Record<string, unknown>;
+			ports.push({
+				hostAddress: str(value.HostIp) ?? null,
+				hostPort: num(value.HostPort),
+				containerPort,
+				protocol
+			});
+		}
+	}
+
+	const labels: ContainerDetail['labels'] = [];
+	for (const [key, value] of parseLabels(config.Labels)) labels.push({ key, value });
+	labels.sort((a, b) => a.key.localeCompare(b.key));
+
+	const restartPolicy = (hostConfig.RestartPolicy ?? {}) as Record<string, unknown>;
+
+	return {
+		id,
+		// Docker prefixes the name with a slash; nobody reads it that way.
+		name: (str(row.Name) ?? shortId(id)).replace(/^\//, ''),
+		image: str(config.Image) ?? str((row.Image as unknown) ?? null) ?? 'unknown',
+		imageId: str(row.Image),
+		command,
+		createdAt: parseTimestamp(row.Created),
+		startedAt: parseTimestamp(state.StartedAt),
+		finishedAt: parseTimestamp(state.FinishedAt),
+		state: normaliseState(statusText, statusText),
+		health: healthFrom(null, health.Status),
+		exitCode: num(state.ExitCode),
+		restartCount: num(row.RestartCount),
+		restartPolicy: str(restartPolicy.Name),
+		pid: num(state.Pid),
+		workingDir: str(config.WorkingDir),
+		user: str(config.User),
+		networks,
+		mounts,
+		ports: dedupeBindings(ports),
+		env: Array.isArray(config.Env)
+			? config.Env.map((line) => str(line)).filter((line): line is string => line !== null)
+			: [],
+		labels
+	};
+}
+
+/**
+ * What a `prune` actually did.
+ *
+ * Both runtimes print a list of what went and, usually, a total. "Usually" is
+ * the problem: Docker states the space it freed and Podman often does not, and
+ * Docker's image prune lists untag operations alongside deletions. So the space
+ * is reported when the runtime gives it and left null when it does not — a
+ * reclaimed figure invented here would be the least trustworthy number on the
+ * screen.
+ */
+export function parsePruneOutput(stdout: string): { removed: number; reclaimed: string | null } {
+	let reclaimed: string | null = null;
+	let removed = 0;
+
+	for (const raw of stdout.split('\n')) {
+		const line = raw.trim();
+		if (!line) continue;
+
+		const total = line.match(/^Total reclaimed space:\s*(.+)$/i);
+		if (total) {
+			reclaimed = total[1].trim();
+			continue;
+		}
+
+		// Section headers Docker prints above each list.
+		if (/^deleted [a-z ]+:$/i.test(line) || /^deleted:?$/i.test(line)) continue;
+		// `untagged: repo:tag` is a name being dropped, not a thing being deleted;
+		// counting it would report twice as many removals as actually happened.
+		if (/^untagged:/i.test(line)) continue;
+
+		removed++;
+	}
+
+	return { removed, reclaimed };
+}
+
+/** Map either runtime's word for a resource onto the four this feature knows. */
+function diskUsageKind(type: string): ContainerDiskUsageRow['kind'] | null {
+	const value = type.trim().toLowerCase();
+	if (value.startsWith('image')) return 'images';
+	if (value.startsWith('container')) return 'containers';
+	if (value.includes('volume')) return 'volumes';
+	if (value.includes('cache')) return 'build-cache';
+	return null;
+}
+
+/**
+ * `system df`, which is the only honest answer to "what would cleaning up get
+ * me back". Docker prints one JSON object per resource with human sizes;
+ * Podman prints an array, and in some versions gives the sizes as raw bytes.
+ */
+/** The reading itself; the caller stamps it with when it was taken. */
+export function parseDiskUsage(
+	stdout: string,
+	runtime: 'docker' | 'podman'
+): Omit<ContainerDiskUsage, 'measuredAt'> {
+	const rows = runtime === 'docker' ? readJsonLines(stdout) : readJsonArray(stdout);
+	const parsed: ContainerDiskUsageRow[] = [];
+
+	for (const row of rows) {
+		const kind = diskUsageKind(str(row.Type ?? row.type) ?? '');
+		if (!kind) continue;
+
+		const sizeRaw = row.Size ?? row.size;
+		const reclaimableRaw = row.Reclaimable ?? row.reclaimable;
+
+		parsed.push({
+			kind,
+			total: num(row.TotalCount ?? row.Total ?? row.total),
+			active: num(row.Active ?? row.active),
+			size: typeof sizeRaw === 'number' ? humanSize(sizeRaw) : (str(sizeRaw) ?? 'unknown'),
+			reclaimable:
+				typeof reclaimableRaw === 'number'
+					? humanSize(reclaimableRaw)
+					: (str(reclaimableRaw) ?? 'unknown')
+		});
+	}
+
+	return { rows: parsed, error: null };
+}
+
+/** A percentage a runtime printed as `1.84%`. */
+function percent(value: unknown): number | null {
+	const text = str(value);
+	if (!text) return null;
+	const parsed = Number.parseFloat(text.replace('%', ''));
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * One `stats --no-stream` sample.
+ *
+ * The two runtimes agree on almost nothing here — Docker capitalises, Podman
+ * has used at least three spellings across its versions — so every field is
+ * looked up under each name it has been known by, and anything still missing
+ * stays null rather than becoming a zero that reads like a measurement.
+ */
+export function parseStats(stdout: string): ContainerStats | null {
+	const rows = stdout.trim().startsWith('[') ? readJsonArray(stdout) : readJsonLines(stdout);
+	const row = rows[0];
+	if (!row) return null;
+
+	const memUsage = str(row.MemUsage ?? row.mem_usage ?? row.MemoryUsage);
+	const memLimit = str(row.MemLimit ?? row.mem_limit);
+
+	return {
+		cpuPercent: percent(row.CPUPerc ?? row.CPU ?? row.cpu_percent ?? row.cpu),
+		// Podman reports usage and limit separately where Docker prints one string.
+		memoryUsage: memUsage && memLimit && !memUsage.includes('/') ? `${memUsage} / ${memLimit}` : memUsage,
+		memoryPercent: percent(row.MemPerc ?? row.mem_percent ?? row.MemPercent),
+		networkIO: str(row.NetIO ?? row.net_io ?? row.NetInput),
+		blockIO: str(row.BlockIO ?? row.block_io),
+		pids: num(row.PIDs ?? row.pids ?? row.PIDS)
+	};
+}

--- a/backend/containers/port-index.test.ts
+++ b/backend/containers/port-index.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import type { ContainerScanResult } from '$shared/types/containers';
+import { addressesOverlap, containerPortIndex, noteContainerScan } from './port-index';
+import { parseDockerPs } from './parse';
+
+function scanOf(listing: string, hostId: string): ContainerScanResult {
+	return {
+		hostId,
+		scannedAt: '2026-08-25T02:02:11.000Z',
+		runtime: 'docker',
+		runtimeVersion: '27.0.0',
+		runtimeProblem: 'none',
+		entries: parseDockerPs(listing, hostId),
+		images: [],
+		volumes: [],
+		networks: [],
+		limitations: [],
+		error: null
+	};
+}
+
+describe('the index the port table reads', () => {
+	const listing = [
+		JSON.stringify({
+			ID: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678901234567890abcdefabcdef',
+			Names: 'shop-api-1',
+			Image: 'shop/api:2.1',
+			State: 'running',
+			Status: 'Up 3 hours',
+			Ports: '0.0.0.0:8080->80/tcp, :::8080->80/tcp, 9000/tcp'
+		}),
+		JSON.stringify({
+			ID: 'bb22cc33dd44ee55ff6600112233445566778899aabbccddeeff001122334455',
+			Names: 'shop-db-1',
+			Image: 'postgres:16',
+			State: 'exited',
+			Status: 'Exited (0) 4 minutes ago',
+			Ports: '0.0.0.0:5432->5432/tcp'
+		})
+	].join('\n');
+
+	// The index is process-wide state keyed by host, so each test uses its own.
+	noteContainerScan(scanOf(listing, 'index-test'));
+	const index = containerPortIndex('index-test');
+
+	test('maps a published port to the container that publishes it', () => {
+		expect(index.get('tcp:8080')?.ref).toMatchObject({
+			name: 'shop-api-1',
+			image: 'shop/api:2.1',
+			containerPort: 80,
+			runtime: 'docker'
+		});
+	});
+
+	test('carries the address the mapping was published on', () => {
+		// One address, not two: the IPv6 twin Docker prints for every published
+		// port was already folded into its IPv4 partner when the row was parsed,
+		// because they are one mapping to anyone reading the table.
+		expect(index.get('tcp:8080')?.addresses).toEqual(['0.0.0.0']);
+	});
+
+	test('ignores a port that is exposed but not published — it holds nothing', () => {
+		expect(index.has('tcp:9000')).toBe(false);
+	});
+
+	test('ignores a stopped container, which is holding no host port at all', () => {
+		expect(index.has('tcp:5432')).toBe(false);
+	});
+
+	test('reports an empty index for a host that has never been scanned', () => {
+		expect(containerPortIndex('never-scanned').size).toBe(0);
+	});
+});
+
+describe('addressesOverlap', () => {
+	test('a wildcard on either side matches anything', () => {
+		expect(addressesOverlap(['*'], ['127.0.0.1'])).toBe(true);
+		expect(addressesOverlap(['192.168.1.5'], ['0.0.0.0'])).toBe(true);
+		expect(addressesOverlap(['::1', '127.0.0.1'], ['::'])).toBe(true);
+	});
+
+	test('a shared address matches', () => {
+		expect(addressesOverlap(['127.0.0.1', '::1'], ['127.0.0.1'])).toBe(true);
+	});
+
+	test('two disjoint addresses do not', () => {
+		// A container published on loopback must not claim an unrelated process
+		// holding the same port on a LAN address.
+		expect(addressesOverlap(['192.168.1.5'], ['127.0.0.1'])).toBe(false);
+	});
+});

--- a/backend/containers/port-index.ts
+++ b/backend/containers/port-index.ts
@@ -1,0 +1,198 @@
+/**
+ * Containers — what the port table needs to know about them.
+ *
+ * A published container port is the one case where the process holding a socket
+ * is not the thing a user means. On Linux the listener is `docker-proxy`; with
+ * the userland proxy disabled there is no listening socket at all and the port
+ * is reached through a firewall rule, so the port scan cannot see it however
+ * hard it looks. Either way the answer is the container, and only the runtime
+ * can give it.
+ *
+ * So the port scan reads this index — and refreshes it through the transport it
+ * already holds open for that host, rather than making the container monitor
+ * open a second SSH lease for a host nobody is watching. The read is
+ * deliberately synchronous and may be a few seconds stale: a port table that
+ * ticks every second must never wait on a `docker ps`, and a mapping that
+ * appears one tick late is invisible next to one that made the whole table
+ * stutter.
+ */
+
+import type { ContainerScanResult } from '$shared/types/containers';
+import type { PortContainerRef } from '$shared/types/ports';
+import type { CommandRunner, ProbePlatform } from '../host/runner';
+import { containerArgv, detectRuntime, tryRun } from './runtime';
+import { parseDockerPs, parsePodmanPs } from './parse';
+import { debug } from '$shared/utils/logger';
+
+/** How stale the index may get before a port scan asks for a refresh. */
+const TTL_MS = 5_000;
+
+/**
+ * One published port, as the port table needs it: who publishes it, and on
+ * which addresses — the second half matters because a mapping with no listening
+ * socket has no row to borrow an address from.
+ */
+export interface ContainerPortMapping {
+	ref: PortContainerRef;
+	addresses: string[];
+}
+
+/** Keyed `protocol:hostPort`. */
+export type ContainerPortIndex = Map<string, ContainerPortMapping>;
+
+interface HostIndex {
+	index: ContainerPortIndex;
+	readAt: number;
+	refreshing: boolean;
+}
+
+const hosts = new Map<string, HostIndex>();
+
+function buildIndex(result: ContainerScanResult): ContainerPortIndex {
+	const index: ContainerPortIndex = new Map();
+	if (!result.runtime) return index;
+
+	for (const entry of result.entries) {
+		// Only a running container holds a host port. A stopped one still lists
+		// its mappings, and claiming those would blame it for someone else's port.
+		if (entry.state !== 'running' && entry.state !== 'paused') continue;
+
+		for (const binding of entry.ports) {
+			if (binding.hostPort === null) continue;
+			const key = `${binding.protocol}:${binding.hostPort}`;
+			const address = binding.hostAddress || '*';
+
+			// The same mapping arrives once per address family; the second one adds
+			// an address to the first rather than becoming a second row.
+			const existing = index.get(key);
+			if (existing) {
+				if (!existing.addresses.includes(address)) existing.addresses.push(address);
+				continue;
+			}
+
+			index.set(key, {
+				ref: {
+					runtime: result.runtime,
+					id: entry.id,
+					shortId: entry.shortId,
+					name: entry.name,
+					image: entry.image,
+					containerPort: binding.containerPort
+				},
+				addresses: [address]
+			});
+		}
+	}
+
+	return index;
+}
+
+/**
+ * Feed a full container scan into the index.
+ *
+ * Called by the container monitor for every scan it runs, so a host whose
+ * Containers panel is open never pays for a second listing to keep its ports
+ * annotated.
+ */
+export function noteContainerScan(result: ContainerScanResult, now = Date.now()): void {
+	hosts.set(result.hostId, {
+		index: buildIndex(result),
+		readAt: now,
+		refreshing: hosts.get(result.hostId)?.refreshing ?? false
+	});
+}
+
+/** The mappings last seen on a host, keyed `protocol:hostPort`. */
+export function containerPortIndex(hostId: string): ContainerPortIndex {
+	return hosts.get(hostId)?.index ?? new Map();
+}
+
+/**
+ * Refresh a host's index in the background, using the caller's own transport.
+ *
+ * Costs nothing on a host with no runtime: `detectRuntime` remembers that
+ * answer, so this returns before running anything.
+ */
+export function refreshContainerPortIndex(
+	hostId: string,
+	runner: CommandRunner,
+	platform: ProbePlatform,
+	now = Date.now()
+): void {
+	const existing = hosts.get(hostId);
+	if (existing?.refreshing) return;
+	if (existing && now - existing.readAt < TTL_MS) return;
+
+	const state: HostIndex = existing ?? { index: new Map(), readAt: 0, refreshing: false };
+	state.refreshing = true;
+	hosts.set(hostId, state);
+
+	void (async () => {
+		try {
+			const info = await detectRuntime(hostId, runner, platform, now);
+			if (info.problem !== 'none' || !info.runtime) {
+				state.index = new Map();
+				return;
+			}
+
+			// Running containers only: the index exists to explain live ports.
+			const listing = await tryRun(
+				runner,
+				containerArgv(info.runtime, platform, [
+					'ps',
+					'--no-trunc',
+					'--format',
+					info.runtime === 'docker' ? '{{json .}}' : 'json'
+				]),
+				15_000
+			);
+			if (listing.code !== 0) return;
+
+			const entries =
+				info.runtime === 'docker'
+					? parseDockerPs(listing.stdout, hostId)
+					: parsePodmanPs(listing.stdout, hostId);
+
+			state.index = buildIndex({
+				hostId,
+				scannedAt: new Date(now).toISOString(),
+				runtime: info.runtime,
+				runtimeVersion: info.version,
+				runtimeProblem: 'none',
+				entries,
+				images: [],
+				volumes: [],
+				networks: [],
+				limitations: [],
+				error: null
+			});
+		} catch (error) {
+			debug.log('containers', `could not refresh the port index for ${hostId}:`, error);
+		} finally {
+			state.readAt = Date.now();
+			state.refreshing = false;
+		}
+	})();
+}
+
+/**
+ * Whether a socket's addresses and a mapping's could be the same thing.
+ *
+ * Almost always they are: a published port and its proxy socket cannot both
+ * exist on a host without being the same path to the same container, because
+ * the second bind would fail. The exception is narrow and real — a container
+ * published on loopback while an unrelated process holds the same port on a LAN
+ * address — and claiming that process for the container would be a confident
+ * lie. A wildcard on either side overlaps everything, which is the common case.
+ */
+export function addressesOverlap(sockets: string[], mapped: string[]): boolean {
+	const wildcard = (address: string): boolean =>
+		address === '*' || address === '0.0.0.0' || address === '::' || address === '';
+	if (sockets.some(wildcard) || mapped.some(wildcard)) return true;
+	return sockets.some((address) => mapped.includes(address));
+}
+
+/** Drop a host's index when its connection goes away. */
+export function forgetContainerPortIndex(hostId: string): void {
+	hosts.delete(hostId);
+}

--- a/backend/containers/prune-job.test.ts
+++ b/backend/containers/prune-job.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { dismissPrune, pruneJobFor, resetPruneJobs, startPrune } from './prune-job';
+import type { PruneKind, PruneOutcome } from '$shared/types/containers';
+
+const HOST = 'local';
+const USER = 'user-1';
+
+/** A sweep the test finishes by hand, so a job can be observed mid-flight. */
+function deferredSweep() {
+	let finish: (outcomes: PruneOutcome[]) => void = () => {};
+	let fail: (error: Error) => void = () => {};
+	let calls = 0;
+	const sweep = (): Promise<PruneOutcome[]> => {
+		calls += 1;
+		return new Promise<PruneOutcome[]>((resolve, reject) => {
+			finish = resolve;
+			fail = reject;
+		});
+	};
+	return {
+		sweep,
+		get calls() {
+			return calls;
+		},
+		finish: (outcomes: PruneOutcome[] = []) => finish(outcomes),
+		fail: (error: Error) => fail(error)
+	};
+}
+
+/** Let the job's own `.then` chain run before asserting on what it wrote. */
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+const outcome = (kind: PruneKind): PruneOutcome => ({
+	kind,
+	ok: true,
+	removed: 3,
+	reclaimed: '1.2GB',
+	error: null
+});
+
+beforeEach(() => resetPruneJobs());
+
+describe('startPrune', () => {
+	test('a started sweep is running and carries what it is sweeping', () => {
+		const driver = deferredSweep();
+		const job = startPrune(HOST, ['volumes'], USER, driver.sweep);
+
+		expect(job.hostId).toBe(HOST);
+		expect(job.kinds).toEqual(['volumes']);
+		expect(job.finishedAt).toBeNull();
+		expect(job.outcomes).toBeNull();
+		expect(driver.calls).toBe(1);
+	});
+
+	test('asking again while one runs returns that job and starts nothing', () => {
+		const driver = deferredSweep();
+		const first = startPrune(HOST, ['volumes'], USER, driver.sweep);
+		// The case this guards: a user who lost track of the first sweep. Two
+		// prunes racing on the same disk report two sets of half-true numbers.
+		const second = startPrune(HOST, ['images'], 'user-2', driver.sweep);
+
+		expect(second).toBe(first);
+		expect(second.kinds).toEqual(['volumes']);
+		expect(driver.calls).toBe(1);
+	});
+
+	test('a finished sweep keeps its outcomes for whoever reads next', async () => {
+		const driver = deferredSweep();
+		startPrune(HOST, ['volumes'], USER, driver.sweep);
+		driver.finish([outcome('volumes')]);
+		await settle();
+
+		const job = pruneJobFor(HOST, USER);
+		expect(job?.finishedAt).not.toBeNull();
+		expect(job?.outcomes).toEqual([outcome('volumes')]);
+	});
+
+	test('a sweep that throws finishes as a failure rather than staying running', async () => {
+		const driver = deferredSweep();
+		startPrune(HOST, ['volumes', 'images'], USER, driver.sweep);
+		driver.fail(new Error('daemon went away'));
+		await settle();
+
+		const job = pruneJobFor(HOST, USER);
+		// Left running, the host would refuse every later sweep forever.
+		expect(job?.finishedAt).not.toBeNull();
+		expect(job?.outcomes).toHaveLength(2);
+		expect(job?.outcomes?.every((entry) => !entry.ok)).toBe(true);
+		expect(job?.outcomes?.[0]?.error).toBe('daemon went away');
+	});
+
+	test('a new sweep may start once the last one finished', async () => {
+		const first = deferredSweep();
+		startPrune(HOST, ['volumes'], USER, first.sweep);
+		first.finish([outcome('volumes')]);
+		await settle();
+
+		const second = deferredSweep();
+		const job = startPrune(HOST, ['images'], USER, second.sweep);
+		expect(job.kinds).toEqual(['images']);
+		expect(job.finishedAt).toBeNull();
+		expect(second.calls).toBe(1);
+	});
+
+	test('each host sweeps independently', () => {
+		const local = deferredSweep();
+		const remote = deferredSweep();
+		startPrune('local', ['volumes'], USER, local.sweep);
+		startPrune('ssh-host', ['images'], USER, remote.sweep);
+
+		expect(pruneJobFor('local', USER)?.kinds).toEqual(['volumes']);
+		expect(pruneJobFor('ssh-host', USER)?.kinds).toEqual(['images']);
+	});
+});
+
+describe('pruneJobFor', () => {
+	test('a host that never swept has no job', () => {
+		expect(pruneJobFor(HOST, USER)).toBeNull();
+	});
+
+	test('a sweep started by someone else is still found', () => {
+		const driver = deferredSweep();
+		startPrune(HOST, ['volumes'], 'user-1', driver.sweep);
+		// The refresh-and-second-device case: whoever looks sees the real state.
+		expect(pruneJobFor(HOST, 'user-2')?.kinds).toEqual(['volumes']);
+	});
+});
+
+describe('dismissPrune', () => {
+	test('a finished report is forgotten once acknowledged', async () => {
+		const driver = deferredSweep();
+		startPrune(HOST, ['volumes'], USER, driver.sweep);
+		driver.finish([outcome('volumes')]);
+		await settle();
+
+		dismissPrune(HOST);
+		expect(pruneJobFor(HOST, USER)).toBeNull();
+	});
+
+	test('a running sweep is never dismissed', () => {
+		const driver = deferredSweep();
+		startPrune(HOST, ['volumes'], USER, driver.sweep);
+
+		dismissPrune(HOST);
+		// Forgetting it here would hand the next caller a second concurrent sweep.
+		expect(pruneJobFor(HOST, USER)?.finishedAt).toBeNull();
+	});
+});

--- a/backend/containers/prune-job.ts
+++ b/backend/containers/prune-job.ts
@@ -1,0 +1,129 @@
+/**
+ * Containers — a cleanup sweep that outlives the dialog that started it.
+ *
+ * A prune is the longest thing this feature does. Sweeping a few hundred unused
+ * volumes is minutes of the daemon unlinking files, and nothing about closing a
+ * modal should change that: the runtime carries on regardless, so the only
+ * question is whether Clopen still knows what it is doing.
+ *
+ * Keeping that in the browser answered it badly. Component state dies with the
+ * modal, so a sweep that finished while it was closed left no trace; store
+ * state dies with a refresh, so the button came back enabled while the daemon
+ * was still deleting and invited a second sweep on top of the first; and
+ * neither was ever visible to a second device looking at the same host.
+ *
+ * So the job belongs to the host. Starting one returns the job, asking for it
+ * returns whatever is current, and the result is pushed to everyone attached
+ * when it lands. A host may only have one sweep at a time — asking again while
+ * one runs hands back the running job rather than starting a second.
+ */
+
+import type { PruneJob, PruneKind, PruneOutcome } from '$shared/types/containers';
+import { pruneResources } from './actions';
+import { ws } from '../utils/ws';
+import { debug } from '$shared/utils/logger';
+
+interface HostJob {
+	job: PruneJob;
+	/** Users to push the result to, and to notify when it lands. */
+	attached: Set<string>;
+}
+
+const hosts = new Map<string, HostJob>();
+
+/** True while the host's last job has not finished. */
+function isRunning(entry: HostJob | undefined): boolean {
+	return entry !== undefined && entry.job.finishedAt === null;
+}
+
+/**
+ * Start a sweep, or hand back the one already running.
+ *
+ * Never starts a second sweep on a host: two prunes racing on the same disk
+ * produce two sets of half-true numbers, and the caller asking again is far
+ * more likely to have lost track of the first than to actually want another.
+ */
+export function startPrune(
+	hostId: string,
+	kinds: PruneKind[],
+	userId: string,
+	/** The sweep itself, taken as an argument so it can be driven in a test. */
+	sweep: (hostId: string, kinds: PruneKind[]) => Promise<PruneOutcome[]> = pruneResources
+): PruneJob {
+	const existing = hosts.get(hostId);
+	if (isRunning(existing)) {
+		existing!.attached.add(userId);
+		return existing!.job;
+	}
+
+	const entry: HostJob = {
+		job: {
+			hostId,
+			kinds,
+			startedAt: new Date().toISOString(),
+			finishedAt: null,
+			outcomes: null
+		},
+		attached: new Set([userId])
+	};
+	hosts.set(hostId, entry);
+
+	void (async () => {
+		let outcomes;
+		try {
+			outcomes = await sweep(hostId, kinds);
+		} catch (error) {
+			debug.warn('containers', `prune failed on ${hostId}:`, error);
+			const message = error instanceof Error ? error.message : String(error);
+			outcomes = kinds.map((kind) => ({
+				kind,
+				ok: false,
+				removed: 0,
+				reclaimed: null,
+				error: message
+			}));
+		}
+
+		entry.job.outcomes = outcomes;
+		entry.job.finishedAt = new Date().toISOString();
+
+		// Everyone who attached hears how it went, whether or not their dialog is
+		// still open — that is what makes closing it safe.
+		for (const id of entry.attached) {
+			ws.emit.user(id, 'containers:prune-changed', { job: entry.job });
+		}
+	})();
+
+	return entry.job;
+}
+
+/**
+ * The host's current sweep, or the last one whose result nobody has seen yet.
+ *
+ * Attaches the caller either way, so a dialog opened halfway through a sweep is
+ * told when it ends without having to poll for it.
+ */
+export function pruneJobFor(hostId: string, userId: string): PruneJob | null {
+	const entry = hosts.get(hostId);
+	if (!entry) return null;
+	entry.attached.add(userId);
+	return entry.job;
+}
+
+/**
+ * Forget a finished sweep, once someone has actually read the result.
+ *
+ * Explicit rather than timed: the report is the only record of what a sweep
+ * removed, and dropping it on a schedule would mean a user who stepped away
+ * comes back to a panel that quietly pretends nothing happened. A running job
+ * is never dismissed — there is nothing to acknowledge yet.
+ */
+export function dismissPrune(hostId: string): void {
+	const entry = hosts.get(hostId);
+	if (entry && !isRunning(entry)) hosts.delete(hostId);
+}
+
+/** Drop every remembered job. Only for tests, which must not share a registry. */
+export function resetPruneJobs(): void {
+	hosts.clear();
+}

--- a/backend/containers/pty-backend.ts
+++ b/backend/containers/pty-backend.ts
@@ -1,0 +1,337 @@
+/**
+ * Containers — a PtyKit backend whose "process" is a shell inside a container.
+ *
+ * `PtyBackend` is the seam PtyKit already uses to talk to bun-pty, and the SSH
+ * client has shown it will just as happily front a remote channel. A container
+ * shell is the third case, and the only one that has to be both: on this
+ * machine it is `docker exec -it` under a real pty, and on a saved SSH host it
+ * is the same command run through an exec channel with a pty requested. One
+ * backend serves both so the local and remote shells are not two features that
+ * drift apart — the only difference is which of the two `open` paths runs.
+ *
+ * Two things are deliberately not trusted here. The target is decoded from the
+ * session namespace, which the server stamps and `authorize` has already
+ * checked, so a client cannot name one host and open a shell on another. And
+ * the container is verified against a live listing before anything is spawned,
+ * because an id that existed when the panel rendered may since have been
+ * removed and reused.
+ */
+
+import type {
+	PtyBackend,
+	PtyDisposable,
+	PtyExitEvent,
+	PtyProcessHandle,
+	PtySpawnOptions
+} from '@myrialabs/ptykit/core';
+import { loadBackend } from '@myrialabs/ptykit/core';
+import type { ClientChannel } from 'ssh2';
+import { LOCAL_HOST_ID } from '$shared/types/host';
+import { containerMonitor } from './monitor';
+import { containerArgv, detectRuntime } from './runtime';
+import { isContainerId } from './actions';
+import { detectRemotePlatform, localPlatform } from '../host/runner';
+import { shellQuote } from '../ssh/connect';
+import { sshClientPool, type SshLease } from '../ssh/client-pool';
+import { sshConnectionQueries } from '../database/queries';
+import { debug } from '$shared/utils/logger';
+
+/**
+ * The `file` PtyKit passes to `spawn`. PtyKit hands `shell` through untouched,
+ * so this is the one per-session channel available to name the target — and the
+ * value is stamped server-side (never taken from the client) in
+ * ws/containers/tunnel.ts.
+ */
+const TARGET_PREFIX = 'clopen-container:';
+
+export interface ContainerTarget {
+	hostId: string;
+	containerId: string;
+}
+
+export function encodeContainerTarget(target: ContainerTarget): string {
+	return `${TARGET_PREFIX}${target.hostId}:${target.containerId}`;
+}
+
+function decodeContainerTarget(file: string): ContainerTarget {
+	if (!file.startsWith(TARGET_PREFIX)) {
+		throw new Error('Container shells must name a container.');
+	}
+	const rest = file.slice(TARGET_PREFIX.length);
+	const split = rest.lastIndexOf(':');
+	if (split <= 0) throw new Error('Container shells must name a container.');
+	return { hostId: rest.slice(0, split), containerId: rest.slice(split + 1) };
+}
+
+/**
+ * Pick a shell inside the container without a probe round trip.
+ *
+ * Images built on Alpine have no `bash` and images built on Debian usually do;
+ * asking first would cost an extra exec and still race a container that is
+ * shutting down. `sh` is the one binary a container image can be relied on to
+ * have, so it is used to choose — and then replaced, so the user's shell is the
+ * process, not a child of one.
+ */
+const SHELL_PICK = 'if command -v bash >/dev/null 2>&1; then exec bash; else exec sh; fi';
+
+const ANSI_DIM = '\u001b[2m';
+const ANSI_RED = '\u001b[31m';
+const ANSI_RESET = '\u001b[0m';
+
+/** Terminals expect CRLF; a lone \n leaves the cursor mid-line. */
+function terminalLine(text: string): string {
+	return `${text.replace(/\n/g, '\r\n')}\r\n`;
+}
+
+/** Distinct per-session ids so the tab list can tell sessions apart. */
+let nextSyntheticPid = 1;
+
+class ContainerShellHandle implements PtyProcessHandle {
+	readonly pid: number;
+	cols: number;
+	rows: number;
+
+	private readonly dataListeners = new Set<(data: string) => void>();
+	private readonly exitListeners = new Set<(event: PtyExitEvent) => void>();
+	private readonly pendingInput: string[] = [];
+
+	/** Set on this machine: the real pty running `docker exec`. */
+	private local: PtyProcessHandle | null = null;
+	/** Set on a saved SSH host: the exec channel running the same command. */
+	private channel: ClientChannel | null = null;
+	private lease: SshLease | null = null;
+	private finished = false;
+
+	constructor(target: ContainerTarget, options: PtySpawnOptions) {
+		this.pid = nextSyntheticPid++;
+		this.cols = options.cols;
+		this.rows = options.rows;
+		// Deferred by one microtask on purpose: PtyKit subscribes to `onData` only
+		// after `spawn` returns, so anything emitted from this constructor — the
+		// "Attaching…" line, or an immediate failure — would go to nobody.
+		queueMicrotask(() => void this.open(target, options));
+	}
+
+	private emitData(data: string): void {
+		for (const listener of this.dataListeners) listener(data);
+	}
+
+	private finish(exitCode: number, signal?: string | number): void {
+		if (this.finished) return;
+		this.finished = true;
+		this.lease?.release();
+		this.lease = null;
+		for (const listener of this.exitListeners) listener({ exitCode, signal });
+	}
+
+	private fail(message: string, exitCode = 1): void {
+		this.emitData(terminalLine(`${ANSI_RED}${message}${ANSI_RESET}`));
+		this.finish(exitCode);
+	}
+
+	private async open(target: ContainerTarget, options: PtySpawnOptions): Promise<void> {
+		if (!isContainerId(target.containerId)) {
+			this.fail('That is not a container id.');
+			return;
+		}
+
+		let container;
+		try {
+			container = await containerMonitor.findContainer(target.hostId, target.containerId);
+		} catch (error) {
+			this.fail(error instanceof Error ? error.message : String(error));
+			return;
+		}
+		if (!container) {
+			this.fail('That container no longer exists on this host.');
+			return;
+		}
+		if (container.state !== 'running') {
+			// Stated rather than attempted: `exec` on a stopped container fails with
+			// a message about the daemon, which reads like a bug rather than the
+			// obvious thing it is.
+			this.fail(`${container.name} is not running, so there is nothing to attach to.`);
+			return;
+		}
+
+		this.emitData(terminalLine(`${ANSI_DIM}Attaching to ${container.name}…${ANSI_RESET}`));
+
+		try {
+			if (target.hostId === LOCAL_HOST_ID) await this.openLocal(target, options);
+			else await this.openRemote(target, options);
+		} catch (error) {
+			this.fail(error instanceof Error ? error.message : String(error));
+		}
+	}
+
+	/** The argv both paths run: an interactive shell inside the container. */
+	private async execArgv(target: ContainerTarget, platform: ReturnType<typeof localPlatform>): Promise<string[]> {
+		const info = await containerMonitor.withHost(target.hostId, (runner) =>
+			detectRuntime(target.hostId, runner, platform)
+		);
+		if (info.problem !== 'none' || !info.runtime) {
+			throw new Error('This host has no container runtime available right now.');
+		}
+		// `locale: null` because this one is a shell a person types into: forcing
+		// the C locale on it would break every non-ASCII character they enter.
+		return containerArgv(
+			info.runtime,
+			platform,
+			['exec', '--interactive', '--tty', target.containerId, 'sh', '-c', SHELL_PICK],
+			{ locale: null }
+		);
+	}
+
+	private async openLocal(target: ContainerTarget, options: PtySpawnOptions): Promise<void> {
+		const argv = await this.execArgv(target, localPlatform());
+		if (this.finished) return;
+
+		// PtyKit's own backend, borrowed: this is a real local process and deserves
+		// the real pty, rather than a second implementation of one.
+		const backend = await loadBackend();
+		if (this.finished) return;
+
+		const handle = backend.spawn(argv[0], argv.slice(1), {
+			...options,
+			cols: this.cols,
+			rows: this.rows
+		});
+		this.local = handle;
+
+		handle.onData((data) => this.emitData(data));
+		handle.onExit((event) => {
+			this.local = null;
+			this.finish(event.exitCode, event.signal);
+		});
+
+		for (const queued of this.pendingInput) handle.write(queued);
+		this.pendingInput.length = 0;
+		handle.resize(this.cols, this.rows);
+	}
+
+	private async openRemote(target: ContainerTarget, options: PtySpawnOptions): Promise<void> {
+		const connection = sshConnectionQueries.get(target.hostId);
+		if (!connection) throw new Error('That SSH host no longer exists.');
+
+		const platform = await containerMonitor.withHost(target.hostId, (runner) =>
+			detectRemotePlatform(target.hostId, runner)
+		);
+		const argv = await this.execArgv(target, platform);
+		if (this.finished) return;
+
+		// Its own lease rather than the shared queued runner: this channel stays
+		// open for as long as the shell does, and everything queued behind it
+		// would wait just as long.
+		const lease = await sshClientPool.acquire(target.hostId);
+		if (this.finished) {
+			lease.release();
+			return;
+		}
+		this.lease = lease;
+
+		const command = argv.map(shellQuote).join(' ');
+		const term = options.name ?? 'xterm-256color';
+
+		await new Promise<void>((resolve, reject) => {
+			lease.client.exec(
+				command,
+				{ pty: { term, cols: this.cols, rows: this.rows, width: 0, height: 0 } },
+				(error, channel) => {
+					if (error) {
+						reject(new Error(`Could not open a shell in the container: ${error.message}`));
+						return;
+					}
+					if (this.finished) {
+						channel.end();
+						resolve();
+						return;
+					}
+
+					this.channel = channel;
+
+					channel.on('data', (chunk: Buffer) => this.emitData(chunk.toString('utf8')));
+					channel.stderr.on('data', (chunk: Buffer) => this.emitData(chunk.toString('utf8')));
+					channel.on('close', (code?: number, signal?: string) => {
+						this.channel = null;
+						this.finish(typeof code === 'number' ? code : 0, signal);
+					});
+					channel.on('error', (channelError: Error) => {
+						this.emitData(terminalLine(`${ANSI_RED}${channelError.message}${ANSI_RESET}`));
+					});
+
+					for (const queued of this.pendingInput) channel.write(queued);
+					this.pendingInput.length = 0;
+					channel.setWindow(this.rows, this.cols, 0, 0);
+					debug.log('containers', `shell opened in ${target.containerId} on ${connection.name}`);
+					resolve();
+				}
+			);
+		});
+	}
+
+	write(data: string): void {
+		if (this.finished) return;
+		if (this.local) {
+			this.local.write(data);
+			return;
+		}
+		if (this.channel) {
+			this.channel.write(data);
+			return;
+		}
+		this.pendingInput.push(data);
+	}
+
+	resize(cols: number, rows: number): void {
+		this.cols = cols;
+		this.rows = rows;
+		this.local?.resize(cols, rows);
+		this.channel?.setWindow(rows, cols, 0, 0);
+	}
+
+	kill(signal?: string): void {
+		const local = this.local;
+		this.local = null;
+		try {
+			local?.kill(signal);
+		} catch {
+			// Already gone.
+		}
+
+		// SSH has no signal to send an exec channel, so closing it is the kill:
+		// the remote `docker exec` sees its pty go away and exits, taking the
+		// shell inside the container with it.
+		const channel = this.channel;
+		this.channel = null;
+		try {
+			channel?.end();
+		} catch {
+			// Already gone.
+		}
+
+		this.finish(0);
+	}
+
+	onData(listener: (data: string) => void): PtyDisposable {
+		this.dataListeners.add(listener);
+		return { dispose: () => this.dataListeners.delete(listener) };
+	}
+
+	onExit(listener: (event: PtyExitEvent) => void): PtyDisposable {
+		this.exitListeners.add(listener);
+		return { dispose: () => this.exitListeners.delete(listener) };
+	}
+}
+
+/**
+ * PtyKit's backend contract, satisfied by container shells. The name has to be
+ * one of PtyKit's two known backend identifiers — it is only used for
+ * diagnostics, and the session engine never branches on it.
+ */
+export const containerPtyBackend: PtyBackend = {
+	name: 'node-pty',
+	experimental: false,
+	spawn(file: string, _args: string[], options: PtySpawnOptions): PtyProcessHandle {
+		return new ContainerShellHandle(decodeContainerTarget(file), options);
+	}
+};

--- a/backend/containers/pty.ts
+++ b/backend/containers/pty.ts
@@ -1,0 +1,114 @@
+/**
+ * Containers — the PtyKit session engine for shells inside containers.
+ *
+ * A third `PtyKitManager` alongside the local-terminal and SSH ones, differing
+ * only in its injected backend. Everything downstream — scrollback, serialized
+ * reattach, collaborative rooms, reconnect after a dropped socket — is PtyKit's
+ * and is not reimplemented here.
+ *
+ * The namespace is `container:<hostId>:<containerId>`. That is the whole
+ * security design: it is the only statement of intent the client makes,
+ * `authorize` checks it, and the spawn target is derived from it rather than
+ * from anything else in the frame — so a client cannot ask for a container on a
+ * host it may not reach. It also scopes the collaborative room to one
+ * container, which is what a second admin opening the same shell should join.
+ *
+ * A shell inside a container is usually root inside it and can reach every
+ * volume that container mounts, so `authorize` requires an admin. Reading the
+ * list, the detail and the logs stays open to any member.
+ */
+
+import { PtyKitManager } from '@myrialabs/ptykit/core';
+import { createPtyKitServer } from '@myrialabs/ptykit/server';
+import { LOCAL_HOST_ID } from '$shared/types/host';
+import { sshConnectionQueries } from '../database/queries';
+import { containerPtyBackend } from './pty-backend';
+import { isContainerId } from './actions';
+
+const NAMESPACE_PREFIX = 'container:';
+
+export function containerNamespaceFor(hostId: string, containerId: string): string {
+	return `${NAMESPACE_PREFIX}${hostId}:${containerId}`;
+}
+
+/** The target a namespace refers to, or null when it is not one of ours. */
+export function targetFromNamespace(
+	namespace: string
+): { hostId: string; containerId: string } | null {
+	if (!namespace.startsWith(NAMESPACE_PREFIX)) return null;
+	const rest = namespace.slice(NAMESPACE_PREFIX.length);
+	const split = rest.lastIndexOf(':');
+	if (split <= 0) return null;
+
+	const hostId = rest.slice(0, split);
+	const containerId = rest.slice(split + 1);
+	if (!hostId || !isContainerId(containerId)) return null;
+	return { hostId, containerId };
+}
+
+/**
+ * Container shells outlive a browser refresh the same way local and remote
+ * ones do, so the settings mirror the other two managers. Env injection is
+ * omitted: the environment that matters belongs to the container, not to this
+ * process.
+ */
+export const containerPtyKitManager = new PtyKitManager({
+	backend: containerPtyBackend,
+	scrollback: 5000,
+	idleTtl: null,
+	retainExitedMs: 5 * 60_000
+});
+
+export const containerPtyKitServer = createPtyKitServer(containerPtyKitManager, {
+	room: (ctx) => ctx.namespace,
+	authorize: (ctx) => {
+		const userId = ctx.conn.data.userId;
+		const isAdmin = ctx.conn.data.isAdmin === true;
+		if (typeof userId !== 'string' || !userId) return false;
+		// A container shell can do anything the container can, so it is gated the
+		// same way stopping a port is.
+		if (!isAdmin) return false;
+
+		const target = targetFromNamespace(ctx.namespace);
+		if (!target) return false;
+		if (target.hostId === LOCAL_HOST_ID) return true;
+
+		return sshConnectionQueries.getForUser(target.hostId, userId, isAdmin) !== null;
+	}
+});
+
+/** Kill every container shell open on a host. */
+export function killContainerSessionsForHost(hostId: string): number {
+	let killed = 0;
+	const prefix = `${NAMESPACE_PREFIX}${hostId}:`;
+	// PtyKit lists per namespace and a namespace names one container, so every
+	// container that has a shell open on this host is asked in turn.
+	for (const namespace of listNamespaces()) {
+		if (!namespace.startsWith(prefix)) continue;
+		for (const session of containerPtyKitManager.list(namespace)) {
+			containerPtyKitManager.killSession(session.sessionId, 'SIGKILL');
+			killed++;
+		}
+	}
+	return killed;
+}
+
+/**
+ * Namespaces with at least one live session.
+ *
+ * PtyKit's manager lists sessions per namespace and does not enumerate the
+ * namespaces themselves, so they are tracked here as sessions are created —
+ * which is also what lets a host-wide teardown find them.
+ */
+const namespaces = new Set<string>();
+
+export function rememberNamespace(namespace: string): void {
+	if (targetFromNamespace(namespace)) namespaces.add(namespace);
+}
+
+function listNamespaces(): string[] {
+	for (const namespace of [...namespaces]) {
+		if (containerPtyKitManager.list(namespace).length === 0) namespaces.delete(namespace);
+	}
+	return [...namespaces];
+}

--- a/backend/containers/runtime.ts
+++ b/backend/containers/runtime.ts
@@ -1,0 +1,218 @@
+/**
+ * Containers — which runtime this host has, decided by asking it.
+ *
+ * There is no setting for this and no toggle in the UI. A host either answers
+ * `docker`, or answers `podman`, or has neither, and any of those three is a
+ * fact Clopen can establish in one command. Docker is asked first because a
+ * machine with both almost always means Podman installed alongside a Docker
+ * that is actually in use; if Docker cannot answer, Podman is asked and used.
+ *
+ * The failure modes matter as much as the success. "No runtime installed",
+ * "installed but the daemon is not running" and "installed but this account may
+ * not talk to the socket" need three different things from the user, and
+ * reporting all three as "no containers" would be a lie the user cannot debug.
+ * Clopen never runs any of this through `sudo`.
+ */
+
+import type { ContainerRuntime, ContainerRuntimeInfo } from '$shared/types/containers';
+import { posixArgv, type CommandRunner, type ProbePlatform, type RunResult } from '../host/runner';
+import { debug } from '$shared/utils/logger';
+
+/** How long a working runtime is trusted before it is asked again. */
+const OK_TTL_MS = 10 * 60_000;
+/**
+ * How long a broken or missing one is. Short on purpose: someone who has just
+ * started Docker Desktop should see the panel come alive without reopening it.
+ */
+const PROBLEM_TTL_MS = 20_000;
+
+interface CachedRuntime {
+	info: ContainerRuntimeInfo;
+	expiresAt: number;
+}
+
+const cache = new Map<string, CachedRuntime>();
+
+/**
+ * Build the argv for a runtime command on this platform.
+ *
+ * POSIX hosts go through `env` for a predictable PATH and a C locale — a
+ * non-interactive SSH session routinely lacks `/usr/local/bin`, which is
+ * exactly where Docker Desktop and Homebrew put these binaries, and a localised
+ * date is one nothing can parse. Windows has neither problem and no `env`, so
+ * the argv is passed through untouched.
+ */
+export function containerArgv(
+	runtime: ContainerRuntime,
+	platform: ProbePlatform,
+	args: string[],
+	options: { locale?: string | null } = {}
+): string[] {
+	const argv = [runtime, ...args];
+	return platform === 'win32' ? argv : posixArgv(argv, options);
+}
+
+/**
+ * Run a runtime command, reporting a missing binary as a failed command rather
+ * than an exception. `Bun.spawn` throws when the executable does not exist,
+ * which is a normal answer here — most hosts have no container runtime at all.
+ */
+export async function tryRun(
+	runner: CommandRunner,
+	argv: string[],
+	timeoutMs?: number
+): Promise<RunResult> {
+	try {
+		return await runner.run(argv, timeoutMs);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return { stdout: '', stderr: message, code: 127 };
+	}
+}
+
+const NOT_INSTALLED = /not found|no such file|not recognized|executablenotfound|enoent/i;
+const PERMISSION_DENIED = /permission denied|dial unix.*permission|got permission denied/i;
+const DAEMON_DOWN =
+	/cannot connect to the docker daemon|is the docker daemon running|cannot connect to podman|connection refused|no such host|error during connect|the system cannot find the file specified/i;
+
+/** Turn a failed probe into the reason a user can act on. */
+function classify(result: RunResult): ContainerRuntimeInfo['problem'] {
+	const text = `${result.stderr}\n${result.stdout}`;
+	if (PERMISSION_DENIED.test(text)) return 'permission-denied';
+	if (DAEMON_DOWN.test(text)) return 'daemon-unreachable';
+	if (result.code === 127 || NOT_INSTALLED.test(text)) return 'not-installed';
+	// An exit code with nothing recognisable in it is still not a usable runtime;
+	// treat it as unreachable, which is the reading that invites a retry.
+	return 'daemon-unreachable';
+}
+
+/** The first line of a runtime's error, which is the part worth showing. */
+function firstLine(text: string): string | null {
+	const line = text
+		.split('\n')
+		.map((value) => value.trim())
+		.find((value) => value.length > 0);
+	return line ?? null;
+}
+
+/**
+ * Ask one runtime whether it is usable.
+ *
+ * `version` is the probe because it is the only command that talks to the
+ * daemon while doing nothing to it, and because its failure text is what names
+ * the three problems apart.
+ */
+async function probe(
+	runtime: ContainerRuntime,
+	runner: CommandRunner,
+	platform: ProbePlatform
+): Promise<ContainerRuntimeInfo> {
+	const result = await tryRun(runner, containerArgv(runtime, platform, ['version', '--format', '{{json .}}']), 10_000);
+
+	if (result.code !== 0) {
+		return {
+			runtime: null,
+			version: null,
+			problem: classify(result),
+			detail: firstLine(result.stderr) ?? firstLine(result.stdout)
+		};
+	}
+
+	let version: string | null = null;
+	try {
+		const parsed = JSON.parse(result.stdout.trim()) as {
+			Server?: { Version?: string };
+			Client?: { Version?: string };
+		};
+		version = parsed.Server?.Version ?? parsed.Client?.Version ?? null;
+	} catch {
+		// A version string Clopen cannot read does not make the runtime unusable.
+	}
+
+	return { runtime, version, problem: 'none', detail: null };
+}
+
+/**
+ * The runtime this host has, cached.
+ *
+ * Cached because the answer costs a round trip on an SSH connection the
+ * terminal and file browser are also using, and it cannot change between two
+ * ticks of a one-second poll.
+ */
+export async function detectRuntime(
+	hostId: string,
+	runner: CommandRunner,
+	platform: ProbePlatform,
+	now = Date.now()
+): Promise<ContainerRuntimeInfo> {
+	const cached = cache.get(hostId);
+	if (cached && cached.expiresAt > now) return cached.info;
+
+	const docker = await probe('docker', runner, platform);
+	let info = docker;
+
+	if (docker.problem !== 'none') {
+		const podman = await probe('podman', runner, platform);
+		// A runtime that is installed but unhappy is more useful to report than
+		// one that is simply absent — it is the one the user can fix.
+		info = podman.problem === 'none' || docker.problem === 'not-installed' ? podman : docker;
+	}
+
+	if (info.problem !== 'none') {
+		debug.log('containers', `no usable runtime on ${runner.label}: ${info.problem}`);
+	}
+
+	cache.set(hostId, {
+		info,
+		expiresAt: now + (info.problem === 'none' ? OK_TTL_MS : PROBLEM_TTL_MS)
+	});
+	return info;
+}
+
+/**
+ * Drop a host's cached answer, so the next scan asks again.
+ *
+ * Called when a command fails in a way that says the daemon went away: the
+ * cached "docker works" would otherwise keep a panel showing an empty table for
+ * ten minutes after Docker Desktop was quit.
+ */
+export function forgetRuntime(hostId: string): void {
+	cache.delete(hostId);
+}
+
+/** True when a command failed because the runtime itself became unusable. */
+export function looksLikeRuntimeFailure(result: RunResult): boolean {
+	if (result.code === 0) return false;
+	const text = `${result.stderr}\n${result.stdout}`;
+	return NOT_INSTALLED.test(text) || PERMISSION_DENIED.test(text) || DAEMON_DOWN.test(text);
+}
+
+/** The sentence shown when a host has no usable runtime. */
+export function limitationFor(info: ContainerRuntimeInfo, hostLabel: string): string {
+	switch (info.problem) {
+		case 'not-installed':
+			return `No container runtime found on ${hostLabel}. Install Docker or Podman and it will appear here — nothing needs configuring.`;
+		case 'daemon-unreachable':
+			return `A container runtime is installed on ${hostLabel} but is not running${
+				info.detail ? `: ${info.detail}` : '.'
+			}`;
+		case 'permission-denied':
+			return `This account may not talk to the container runtime on ${hostLabel}. Add it to the runtime's group, or use a rootless runtime — Clopen never runs commands through sudo.`;
+		default:
+			return '';
+	}
+}
+
+/**
+ * The line of a failure worth showing.
+ *
+ * The runtimes write several lines when they refuse something, and the first is
+ * the reason — "volume is in use", "image has dependent child images". The rest
+ * is usually the id repeated back.
+ */
+export function firstProblem(stderr: string, stdout: string, code: number): string {
+	const line =
+		stderr.trim().split('\n')[0] || stdout.trim().split('\n')[0] || `exit status ${code}`;
+	// Both runtimes prefix errors with a level that means nothing to a reader.
+	return line.replace(/^(Error(:| response from daemon:)|ERRO\[\d+\])\s*/i, '').trim() || line;
+}

--- a/backend/containers/scan.ts
+++ b/backend/containers/scan.ts
@@ -1,0 +1,293 @@
+/**
+ * Containers — one host, one scan, one table.
+ *
+ * Held per watched host so the runtime probe and the image/volume catalogue
+ * survive between ticks. That is what keeps a live panel down to a single
+ * command per tick: the container list is what changes second to second, while
+ * images and volumes change when someone builds or prunes, and re-reading them
+ * every tick would triple the cost of the view for an answer that is almost
+ * always identical.
+ */
+
+import type {
+	ContainerEntry,
+	ContainerImageEntry,
+	ContainerLimitation,
+	ContainerNetworkEntry,
+	ContainerScanResult,
+	ContainerVolumeEntry
+} from '$shared/types/containers';
+import type { CommandRunner, ProbePlatform } from '../host/runner';
+import {
+	containerArgv,
+	detectRuntime,
+	forgetRuntime,
+	limitationFor,
+	looksLikeRuntimeFailure,
+	tryRun
+} from './runtime';
+import {
+	linkUsage,
+	parseDockerImages,
+	parseDockerNetworks,
+	parseDockerPs,
+	parseDockerVolumes,
+	parseMounts,
+	parseNetworkMembership,
+	parsePodmanImages,
+	parsePodmanNetworks,
+	parsePodmanPs,
+	parsePodmanVolumes
+} from './parse';
+import { debug } from '$shared/utils/logger';
+import { CONTAINER_TIMEOUTS } from '$shared/types/containers';
+
+/** How long the image and volume lists are reused before being read again. */
+const CATALOG_TTL_MS = 15_000;
+
+/** Running first, then everything that could be started, then the wreckage. */
+const STATE_ORDER: Record<ContainerEntry['state'], number> = {
+	running: 0,
+	paused: 1,
+	restarting: 2,
+	created: 3,
+	exited: 4,
+	removing: 5,
+	dead: 6,
+	unknown: 7
+};
+
+interface Catalog {
+	images: ContainerImageEntry[];
+	volumes: ContainerVolumeEntry[];
+	networks: ContainerNetworkEntry[];
+	limitations: ContainerLimitation[];
+	readAt: number;
+}
+
+export class HostContainerScanner {
+	private catalog: Catalog | null = null;
+	/**
+	 * A scan already running. Callers join it rather than starting a second one:
+	 * a remote scan can outlast the poll interval, and two in flight would double
+	 * the SSH channels for the same answer.
+	 */
+	private inFlight: Promise<ContainerScanResult> | null = null;
+
+	constructor(
+		private readonly hostId: string,
+		private readonly hostName: string,
+		private readonly runner: CommandRunner,
+		private readonly platform: ProbePlatform
+	) {}
+
+	/** Read this host, joining a scan already in progress rather than racing it. */
+	async scan(now = Date.now()): Promise<ContainerScanResult> {
+		if (this.inFlight) return this.inFlight;
+		this.inFlight = this.runScan(now).finally(() => {
+			this.inFlight = null;
+		});
+		return this.inFlight;
+	}
+
+	private empty(
+		scannedAt: string,
+		limitations: ContainerLimitation[],
+		error: string | null = null
+	): ContainerScanResult {
+		return {
+			hostId: this.hostId,
+			scannedAt,
+			runtime: null,
+			runtimeVersion: null,
+			runtimeProblem: 'none',
+			entries: [],
+			images: [],
+			volumes: [],
+			networks: [],
+			limitations,
+			error
+		};
+	}
+
+	private async runScan(now: number): Promise<ContainerScanResult> {
+		const scannedAt = new Date(now).toISOString();
+
+		const info = await detectRuntime(this.hostId, this.runner, this.platform, now);
+		if (info.problem !== 'none' || !info.runtime) {
+			const message = limitationFor(info, this.hostName);
+			return {
+				...this.empty(scannedAt, message ? [{ code: problemCode(info.problem), message }] : []),
+				runtimeProblem: info.problem
+			};
+		}
+
+		const runtime = info.runtime;
+		const listing = await tryRun(
+			this.runner,
+			containerArgv(runtime, this.platform, [
+				'ps',
+				'--all',
+				'--no-trunc',
+				'--format',
+				runtime === 'docker' ? '{{json .}}' : 'json'
+			]),
+			CONTAINER_TIMEOUTS.list
+		);
+
+		if (listing.code !== 0) {
+			// The runtime answered `version` and then refused to list: it went away
+			// between the two, so the cached "this host has docker" must go too.
+			if (looksLikeRuntimeFailure(listing)) forgetRuntime(this.hostId);
+			const reason = listing.stderr.trim() || listing.stdout.trim() || `exit status ${listing.code}`;
+			return {
+				...this.empty(scannedAt, [], reason),
+				runtime,
+				runtimeVersion: info.version
+			};
+		}
+
+		const entries =
+			runtime === 'docker'
+				? parseDockerPs(listing.stdout, this.hostId)
+				: parsePodmanPs(listing.stdout, this.hostId);
+
+		entries.sort(
+			(a, b) =>
+				STATE_ORDER[a.state] - STATE_ORDER[b.state] ||
+				(a.composeProject ?? '').localeCompare(b.composeProject ?? '') ||
+				a.name.localeCompare(b.name)
+		);
+
+		const catalog = await this.readCatalog(runtime, now);
+		linkUsage(
+			entries,
+			catalog.images,
+			catalog.volumes,
+			parseMounts(listing.stdout, runtime),
+			catalog.networks,
+			parseNetworkMembership(listing.stdout, runtime)
+		);
+
+		return {
+			hostId: this.hostId,
+			scannedAt,
+			runtime,
+			runtimeVersion: info.version,
+			runtimeProblem: 'none',
+			entries,
+			images: catalog.images,
+			volumes: catalog.volumes,
+			networks: catalog.networks,
+			limitations: catalog.limitations,
+			error: null
+		};
+	}
+
+	/**
+	 * Images, volumes and networks, re-read only when the cached set has aged
+	 * out. A failure here degrades those tabs and nothing else — the container
+	 * list is the point of the view and must not disappear because `volume ls`
+	 * did.
+	 */
+	private async readCatalog(runtime: 'docker' | 'podman', now: number): Promise<Catalog> {
+		if (this.catalog && now - this.catalog.readAt < CATALOG_TTL_MS) return this.catalog;
+
+		const limitations: ContainerLimitation[] = [];
+		const format = runtime === 'docker' ? '{{json .}}' : 'json';
+
+		const imagesResult = await tryRun(
+			this.runner,
+			containerArgv(runtime, this.platform, ['images', '--format', format]),
+			CONTAINER_TIMEOUTS.list
+		);
+		let images: ContainerImageEntry[] = this.catalog?.images ?? [];
+		if (imagesResult.code === 0) {
+			images =
+				runtime === 'docker'
+					? parseDockerImages(imagesResult.stdout)
+					: parsePodmanImages(imagesResult.stdout);
+		} else {
+			debug.log('containers', `images unavailable on ${this.hostName}:`, imagesResult.stderr);
+			limitations.push({
+				code: 'images-unavailable',
+				message: `${this.hostName} did not return an image list${
+					imagesResult.stderr.trim() ? `: ${imagesResult.stderr.trim().split('\n')[0]}` : '.'
+				}`
+			});
+		}
+
+		const volumesResult = await tryRun(
+			this.runner,
+			containerArgv(runtime, this.platform, ['volume', 'ls', '--format', format]),
+			CONTAINER_TIMEOUTS.list
+		);
+		let volumes: ContainerVolumeEntry[] = this.catalog?.volumes ?? [];
+		if (volumesResult.code === 0) {
+			volumes =
+				runtime === 'docker'
+					? parseDockerVolumes(volumesResult.stdout)
+					: parsePodmanVolumes(volumesResult.stdout);
+		} else {
+			debug.log('containers', `volumes unavailable on ${this.hostName}:`, volumesResult.stderr);
+			limitations.push({
+				code: 'volumes-unavailable',
+				message: `${this.hostName} did not return a volume list${
+					volumesResult.stderr.trim() ? `: ${volumesResult.stderr.trim().split('\n')[0]}` : '.'
+				}`
+			});
+		}
+
+		const networksResult = await tryRun(
+			this.runner,
+			containerArgv(runtime, this.platform, ['network', 'ls', '--format', format]),
+			CONTAINER_TIMEOUTS.list
+		);
+		let networks: ContainerNetworkEntry[] = this.catalog?.networks ?? [];
+		if (networksResult.code === 0) {
+			networks =
+				runtime === 'docker'
+					? parseDockerNetworks(networksResult.stdout)
+					: parsePodmanNetworks(networksResult.stdout);
+		} else {
+			debug.log('containers', `networks unavailable on ${this.hostName}:`, networksResult.stderr);
+			limitations.push({
+				code: 'networks-unavailable',
+				message: `${this.hostName} did not return a network list${
+					networksResult.stderr.trim() ? `: ${networksResult.stderr.trim().split('\n')[0]}` : '.'
+				}`
+			});
+		}
+
+		images.sort(
+			(a, b) => Number(a.dangling) - Number(b.dangling) || a.repository.localeCompare(b.repository)
+		);
+		volumes.sort((a, b) => a.name.localeCompare(b.name));
+		// The runtime's own networks last: they are furniture, not something the
+		// user made, and they can never be acted on.
+		networks.sort(
+			(a, b) => Number(a.predefined) - Number(b.predefined) || a.name.localeCompare(b.name)
+		);
+
+		this.catalog = { images, volumes, networks, limitations, readAt: now };
+		return this.catalog;
+	}
+
+	/** Force the next scan to re-read images and volumes, after an action. */
+	invalidateCatalog(): void {
+		this.catalog = null;
+	}
+}
+
+function problemCode(
+	problem: 'none' | 'not-installed' | 'daemon-unreachable' | 'permission-denied'
+): ContainerLimitation['code'] {
+	switch (problem) {
+		case 'not-installed':
+			return 'no-runtime';
+		case 'permission-denied':
+			return 'permission-denied';
+		default:
+			return 'daemon-unreachable';
+	}
+}

--- a/backend/host/runner.ts
+++ b/backend/host/runner.ts
@@ -1,15 +1,19 @@
 /**
- * Port manager — one command interface, two transports.
+ * Host commands — one command interface, two transports.
  *
- * Every probe in this feature is a small POSIX/Windows command, and the same
- * probe has to run on the machine hosting Clopen and on a saved SSH host. So
- * the probes are written once against `CommandRunner` and the transport is
- * swapped underneath: `Bun.spawn` locally, an exec channel remotely.
+ * Every host-scoped feature in Clopen — the port table, and the container list
+ * that followed it — is built out of small POSIX/Windows commands, and the same
+ * command has to run on the machine hosting Clopen and on a saved SSH host. So
+ * they are written once against `CommandRunner` and the transport is swapped
+ * underneath: `Bun.spawn` locally, an exec channel remotely.
  *
  * Commands are argv arrays rather than shell strings. Locally that removes
  * quoting from the picture entirely; remotely each argument is quoted by
- * `shellQuote` on the way out, so a hostile process name in an argument can
- * never turn into a second command.
+ * `shellQuote` on the way out, so a hostile process or container name in an
+ * argument can never turn into a second command.
+ *
+ * This lives outside `ports/` because `local` is not a special case and neither
+ * is any one feature: whatever asks a host a question asks it through here.
  */
 
 import type { Client as SshClient } from 'ssh2';
@@ -34,9 +38,14 @@ const PROBE_PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
  * arguments stay arguments — while fixing both problems a bare command has on
  * a remote host: a PATH too narrow to find the tool, and a locale that renders
  * dates in words nothing can parse.
+ *
+ * `locale: null` drops the `LC_ALL=C` half. A probe wants a machine-readable
+ * locale; an interactive shell opened through the same PATH fix does not —
+ * forcing C on one would leave the user unable to type a non-ASCII character.
  */
-export function posixArgv(argv: string[]): string[] {
-	return ['env', 'LC_ALL=C', `PATH=${PROBE_PATH}`, ...argv];
+export function posixArgv(argv: string[], options: { locale?: string | null } = {}): string[] {
+	const locale = options.locale === undefined ? 'C' : options.locale;
+	return ['env', ...(locale === null ? [] : [`LC_ALL=${locale}`]), `PATH=${PROBE_PATH}`, ...argv];
 }
 
 export interface RunResult {
@@ -171,7 +180,7 @@ export async function detectRemotePlatform(cacheKey: string, runner: CommandRunn
 			else if (name.includes('bsd')) platform = 'linux';
 		}
 	} catch (error) {
-		debug.log('ports', `uname failed on ${runner.label}:`, error);
+		debug.log('host', `uname failed on ${runner.label}:`, error);
 	}
 
 	// No `uname` usually means a Windows host answering over OpenSSH, where the

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -65,6 +65,8 @@ import { authQueries } from './database/queries';
 import { authRateLimiter } from './auth';
 import { sessionCleanupScheduler } from './auth/session-cleanup';
 import { portMonitor } from './ports/monitor';
+import { containerMonitor } from './containers/monitor';
+import { stopAllLogStreams as stopAllContainerLogStreams } from './containers/logs';
 import { uploadTempCleanup } from './http/upload-temp-cleanup';
 import { ws as wsServer } from './utils/ws';
 import { messageRateLimiter } from './ws/message-rate-limiter';
@@ -274,6 +276,10 @@ async function startServer() {
 		// terminal sessions running there are no session-born ports to count, so
 		// the tick skips the scan entirely.
 		portMonitor.start();
+		// Sidebar count for the container manager: containers running on this
+		// machine. Idle-cheap too — a machine with no runtime is remembered as
+		// having none, so the tick costs a cached lookup and no command at all.
+		containerMonitor.start();
 	} catch (error) {
 		console.error('❌ Database initialization failed — refusing to start:', error);
 		console.error(`   Data directory: ${SERVER_ENV.DATA_DIR}`);
@@ -339,6 +345,9 @@ async function gracefulShutdown() {
 		uploadTempCleanup.dispose();
 		// Stop port polling and release any SSH leases it holds
 		portMonitor.stop();
+		// Same for the container list, and the log streams it may still be pumping
+		stopAllContainerLogStreams();
+		containerMonitor.stop();
 		// Close MCP remote server (before engines, as they may still reference it)
 		await closeMcpServer();
 		// Cleanup browser preview sessions

--- a/backend/ports/attribute.ts
+++ b/backend/ports/attribute.ts
@@ -22,7 +22,7 @@
  */
 
 import type { PortOrigin, PortProcess, PortSocket } from '$shared/types/ports';
-import type { ProbePlatform } from './runner';
+import type { ProbePlatform } from '../host/runner';
 import { ptyKitManager } from '../terminal/ptykit';
 import { projectQueries } from '../database/queries';
 import { collectOwnedPorts, ownedPortKey, type OwnedPort } from './registry';

--- a/backend/ports/kill.ts
+++ b/backend/ports/kill.ts
@@ -19,7 +19,7 @@
 
 import type { PortKillResult, PortOwnerFeature } from '$shared/types/ports';
 import { parsePsOutput, unixPsArgv } from './processes';
-import type { CommandRunner, ProbePlatform } from './runner';
+import type { CommandRunner, ProbePlatform } from '../host/runner';
 import { sshForwardManager } from '../ssh/forwards';
 import { connectionManager } from '../db-client/connection-manager';
 import { debug } from '$shared/utils/logger';

--- a/backend/ports/monitor.ts
+++ b/backend/ports/monitor.ts
@@ -33,7 +33,7 @@ import {
 	localPlatform,
 	type CommandRunner,
 	type ProbePlatform
-} from './runner';
+} from '../host/runner';
 import { sshClientPool, type SshLease } from '../ssh/client-pool';
 import { forgetClopenRootPid } from './ssh-lineage';
 import { sshConnectionQueries } from '../database/queries';

--- a/backend/ports/processes.ts
+++ b/backend/ports/processes.ts
@@ -19,7 +19,7 @@
  */
 
 import type { PortLimitation, PortProcess } from '$shared/types/ports';
-import type { CommandRunner, ProbePlatform } from './runner';
+import type { CommandRunner, ProbePlatform } from '../host/runner';
 import { debug } from '$shared/utils/logger';
 
 /** How often the whole table is re-read, so exited pids stop being reported. */

--- a/backend/ports/scan-host.ts
+++ b/backend/ports/scan-host.ts
@@ -8,9 +8,12 @@
 
 import os from 'node:os';
 import type {
+	PortContainerRef,
 	PortEntry,
+	PortIpVersion,
 	PortKillBlockedReason,
 	PortLimitation,
+	PortOrigin,
 	PortPeer,
 	PortProtocol,
 	PortScanResult,
@@ -22,7 +25,12 @@ import { ProcessTable } from './processes';
 import { attribute, buildContext, groupListenerPids } from './attribute';
 import { collectExposedPorts } from './registry';
 import { resolveClopenPids } from './ssh-lineage';
-import type { CommandRunner, ProbePlatform } from './runner';
+import {
+	addressesOverlap,
+	containerPortIndex,
+	refreshContainerPortIndex
+} from '../containers/port-index';
+import type { CommandRunner, ProbePlatform } from '../host/runner';
 
 /** Who the scan is running as, which decides what it may signal. */
 export interface ScanPrincipal {
@@ -49,6 +57,18 @@ const NO_CLOPEN_LINEAGE: PortLimitation = {
 	message:
 		'Nothing listening here belongs to Clopen’s own SSH connection. If you started a server from a Clopen terminal on this host and it is not listed under “Started from Clopen”, this host does not let Clopen read a process’s environment.'
 };
+
+/** How a published port describes itself: by the container, not the proxy. */
+function containerOrigin(ref: PortContainerRef): PortOrigin {
+	return {
+		kind: 'container',
+		// The runtime states this outright — there is nothing to infer.
+		confidence: 'certain',
+		label: ref.name,
+		detail: `${ref.image} · container port ${ref.containerPort}`,
+		containerId: ref.id
+	};
+}
 
 function protocolPortKey(protocol: PortProtocol, port: number): string {
 	return `${protocol}:${port}`;
@@ -184,6 +204,11 @@ export class HostPortScanner {
 		});
 		const peers = collectPeers(sockets);
 		const exposed = this.isLocal ? collectExposedPorts() : new Map<number, string>();
+		// Read now, refresh behind us: a table that ticks every second must never
+		// wait on a `docker ps`, and a mapping that lands one tick late is
+		// invisible next to one that made the whole table stutter.
+		const containers = containerPortIndex(this.hostId);
+		refreshContainerPortIndex(this.hostId, this.runner, this.platform, now);
 
 		// Bucket the listening sockets per protocol+port first; a port is the
 		// unit the user thinks in, and the addresses under it are detail.
@@ -196,6 +221,8 @@ export class HostPortScanner {
 		}
 
 		const entries: PortEntry[] = [];
+		/** Mappings that found a socket to sit on; the rest get their own row. */
+		const annotated = new Set<string>();
 
 		for (const [key, bucket] of buckets) {
 			const { protocol, port } = bucket[0];
@@ -218,19 +245,27 @@ export class HostPortScanner {
 				const representative = groupSockets[0];
 				const pid = owner === -1 ? null : owner;
 				const process = pid !== null ? (processes.get(pid) ?? null) : null;
-				const origin = attribute({ ...representative, pid }, context);
+				const attributed = attribute({ ...representative, pid }, context);
+				// A published container port outranks whatever holds the socket: the
+				// listener is the runtime's own proxy, and signalling it would either
+				// fail or be undone by the daemon a moment later. Clopen's own
+				// listeners are the exception — those it does know better.
+				const candidate = attributed.kind === 'clopen' ? undefined : containers.get(key);
+				const groupAddresses = unique(groupSockets.map((socket) => socket.address));
+				const mapping =
+					candidate && addressesOverlap(groupAddresses, candidate.addresses) ? candidate : undefined;
+				if (mapping) annotated.add(key);
+				const origin = mapping ? containerOrigin(mapping.ref) : attributed;
 				const ownerUser = process?.user ?? representative.user;
-				const { canKill, reason } = this.killability(
-					pid,
-					ownerUser,
-					origin.ownerFeature === 'server'
-				);
+				const { canKill, reason } = mapping
+					? { canKill: false, reason: 'managed-by-container' as PortKillBlockedReason }
+					: this.killability(pid, ownerUser, origin.ownerFeature === 'server');
 
 				entries.push({
 					key: `${this.hostId}:${key}:${pid ?? 'unknown'}`,
 					protocol,
 					port,
-					addresses: unique(groupSockets.map((socket) => socket.address)).sort(),
+					addresses: [...groupAddresses].sort(),
 					ipVersions: unique(groupSockets.map((socket) => socket.ipVersion)).sort(),
 					pid,
 					process,
@@ -239,10 +274,44 @@ export class HostPortScanner {
 					peers: peers.get(key) ?? [],
 					peerCount: (peers.get(key) ?? []).length,
 					publicUrl: exposed.get(port) ?? null,
+					container: mapping?.ref ?? null,
 					canKill,
 					killBlockedReason: reason
 				});
 			}
+		}
+
+		// Mappings with no socket behind them still get a row. Docker publishes
+		// through a firewall rule when its userland proxy is off, and Podman's
+		// rootless networking often leaves nothing for the probe to find either —
+		// so without this the port a user can actually reach would be missing from
+		// the one table that claims to list what is reachable.
+		for (const [mappingKey, mapping] of containers) {
+			if (annotated.has(mappingKey)) continue;
+			const [protocolText, portText] = mappingKey.split(':');
+			const port = Number(portText);
+			if (!Number.isFinite(port)) continue;
+			const protocol = protocolText === 'udp' ? 'udp' : 'tcp';
+
+			entries.push({
+				key: `${this.hostId}:${mappingKey}:container`,
+				protocol,
+				port,
+				addresses: [...mapping.addresses].sort(),
+				ipVersions: unique(
+					mapping.addresses.map((address): PortIpVersion => (address.includes(':') ? 'v6' : 'v4'))
+				).sort(),
+				pid: null,
+				process: null,
+				workerPids: [],
+				origin: containerOrigin(mapping.ref),
+				peers: peers.get(mappingKey) ?? [],
+				peerCount: (peers.get(mappingKey) ?? []).length,
+				publicUrl: exposed.get(port) ?? null,
+				container: mapping.ref,
+				canKill: false,
+				killBlockedReason: 'managed-by-container'
+			});
 		}
 
 		entries.sort((a, b) => a.port - b.port || a.protocol.localeCompare(b.protocol));

--- a/backend/ports/scan.test.ts
+++ b/backend/ports/scan.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import type { CommandRunner } from './runner';
+import type { CommandRunner } from '../host/runner';
 import {
 	parseLsof,
 	parseNetstatUnix,

--- a/backend/ports/scan.ts
+++ b/backend/ports/scan.ts
@@ -24,7 +24,7 @@ import type {
 	PortSocket,
 	PortSocketState
 } from '$shared/types/ports';
-import { posixArgv, type CommandRunner, type ProbePlatform } from './runner';
+import { posixArgv, type CommandRunner, type ProbePlatform } from '../host/runner';
 import { debug } from '$shared/utils/logger';
 
 /** Per-host memory of which probe answered, held by the host's scanner. */

--- a/backend/ports/ssh-lineage.ts
+++ b/backend/ports/ssh-lineage.ts
@@ -35,7 +35,7 @@
  */
 
 import type { PortProcess } from '$shared/types/ports';
-import { posixArgv, type CommandRunner, type ProbePlatform } from './runner';
+import { posixArgv, type CommandRunner, type ProbePlatform } from '../host/runner';
 import { parsePsOutput } from './processes';
 import { debug } from '$shared/utils/logger';
 

--- a/backend/ws/containers/actions.ts
+++ b/backend/ws/containers/actions.ts
@@ -1,0 +1,156 @@
+/**
+ * Containers — changing something. Admin only, all of it.
+ *
+ * The routes are listed in ADMIN_ONLY_ROUTES; these handlers still check host
+ * access against the caller's real role rather than a hardcoded one, because a
+ * gate that trusts its caller is no gate at all.
+ *
+ * Stopping a container takes down whatever it serves, for everyone — the same
+ * reason stopping a port is admin-only — and removing an image or a volume
+ * takes down something nobody can bring back by pressing start.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { LOCAL_HOST_ID } from '$shared/types/host';
+import { removeResource, runContainerAction } from '../../containers/actions';
+import { dismissPrune, pruneJobFor, startPrune } from '../../containers/prune-job';
+import { requireHostAccess } from './list';
+import { containerMonitor } from '../../containers/monitor';
+import { sshConnectionQueries } from '../../database/queries';
+import { ws } from '../../utils/ws';
+
+function requireManageAccess(conn: Parameters<typeof ws.getUserId>[0], hostId: string): void {
+	if (hostId === LOCAL_HOST_ID) return;
+	sshConnectionQueries.ensureAccess(hostId, ws.getUserId(conn), ws.getRole(conn) === 'admin');
+}
+
+const ACTIONS = [
+	t.Literal('start'),
+	t.Literal('stop'),
+	t.Literal('restart'),
+	t.Literal('pause'),
+	t.Literal('unpause'),
+	t.Literal('remove'),
+	t.Literal('force-remove')
+];
+
+const PRUNE_KINDS = [
+	t.Literal('containers'),
+	t.Literal('dangling-images'),
+	t.Literal('images'),
+	t.Literal('volumes'),
+	t.Literal('networks'),
+	t.Literal('build-cache')
+];
+
+export const containersActionHandler = createRouter()
+	.http(
+		'containers:action',
+		{
+			data: t.Object({
+				hostId: t.String({ minLength: 1 }),
+				containerId: t.String({ minLength: 12 }),
+				action: t.Union(ACTIONS)
+			}),
+			response: t.Any()
+		},
+		async ({ data, conn }) => {
+			requireManageAccess(conn, data.hostId);
+
+			// Re-read before acting rather than trusting the row the client clicked:
+			// a listing is a second or two old, and a container can be removed and
+			// its name reused in that time.
+			const container = await containerMonitor.findContainer(data.hostId, data.containerId);
+			if (!container) {
+				return { result: { ok: false, error: null }, gone: true };
+			}
+			if (!container.canManage) {
+				return {
+					result: { ok: false, error: `${container.name} cannot be changed from here right now.` },
+					gone: false
+				};
+			}
+
+			return {
+				result: await runContainerAction(data.hostId, data.containerId, data.action),
+				gone: false
+			};
+		}
+	)
+
+	/**
+	 * Remove one image, volume or network.
+	 *
+	 * Containers go through `containers:action` instead, because removing one is
+	 * part of its lifecycle and the confirmation has to know whether it is still
+	 * running. Everything else has no lifecycle — it exists or it does not.
+	 */
+	.http(
+		'containers:remove',
+		{
+			data: t.Object({
+				hostId: t.String({ minLength: 1 }),
+				kind: t.Union([t.Literal('image'), t.Literal('volume'), t.Literal('network')]),
+				id: t.String({ minLength: 1 }),
+				force: t.Optional(t.Boolean())
+			}),
+			response: t.Any()
+		},
+		async ({ data, conn }) => {
+			requireManageAccess(conn, data.hostId);
+			return { result: await removeResource(data.hostId, data.kind, data.id, data.force === true) };
+		}
+	)
+
+	/**
+	 * Clear up whatever is not in use.
+	 *
+	 * Takes a list rather than doing everything, because the kinds differ by what
+	 * they cost to get back: a stopped container is nothing, an unused image is a
+	 * pull or a build. The caller decides; each kind reports separately.
+	 *
+	 * Returns as soon as the sweep has started, not when it ends. A prune runs
+	 * for minutes and belongs to the host rather than to the dialog that asked
+	 * for it — the result arrives on `containers:prune-changed`.
+	 */
+	.http(
+		'containers:prune',
+		{
+			data: t.Object({
+				hostId: t.String({ minLength: 1 }),
+				kinds: t.Array(t.Union(PRUNE_KINDS), { minItems: 1, maxItems: 6 })
+			}),
+			response: t.Any()
+		},
+		async ({ data, conn }) => {
+			requireManageAccess(conn, data.hostId);
+			return { job: startPrune(data.hostId, data.kinds, ws.getUserId(conn)) };
+		}
+	)
+
+	/**
+	 * The host's current sweep, or the last one nobody has acknowledged.
+	 *
+	 * What a dialog reads when it opens, so a sweep started before a refresh —
+	 * or on another device — is still visible as the thing it is.
+	 */
+	.http(
+		'containers:prune-status',
+		{ data: t.Object({ hostId: t.String({ minLength: 1 }) }), response: t.Any() },
+		async ({ data, conn }) => {
+			requireHostAccess(conn, data.hostId);
+			return { job: pruneJobFor(data.hostId, ws.getUserId(conn)) };
+		}
+	)
+
+	/** Acknowledge a finished sweep, so its report stops being offered. */
+	.http(
+		'containers:prune-dismiss',
+		{ data: t.Object({ hostId: t.String({ minLength: 1 }) }), response: t.Any() },
+		async ({ data, conn }) => {
+			requireManageAccess(conn, data.hostId);
+			dismissPrune(data.hostId);
+			return { ok: true };
+		}
+	);

--- a/backend/ws/containers/index.ts
+++ b/backend/ws/containers/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Container manager WebSocket router.
+ *
+ * Reading the list, the detail and the logs is open to any signed-in user who
+ * can already reach the host; `containers:action` is registered in
+ * ADMIN_ONLY_ROUTES, and opening a shell is gated inside the PtyKit server's
+ * own `authorize`.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { containersListHandler } from './list';
+import { containersActionHandler } from './actions';
+import { containersLogsHandler } from './logs';
+import { containersTunnelHandler } from './tunnel';
+
+export const containersRouter = createRouter()
+	.merge(containersListHandler)
+	.merge(containersActionHandler)
+	.merge(containersLogsHandler)
+	.merge(containersTunnelHandler)
+	// Pushed only when a watched host's list actually changed.
+	.emit('containers:changed', t.Object({ result: t.Any() }))
+	// The sidebar count: containers running on this machine.
+	.emit('containers:badge', t.Object({ count: t.Number() }))
+	// A disk reading, pushed to whoever asked when it finally lands. It cannot
+	// be a response: `system df` takes as long as the host's disk is large.
+	.emit('containers:disk-usage-measured', t.Object({ hostId: t.String(), usage: t.Any() }))
+	// A cleanup sweep reaching its end, pushed to everyone attached to it — the
+	// dialog that started it may be long closed by then.
+	.emit('containers:prune-changed', t.Object({ job: t.Any() }))
+	// One coalesced push of container output while a log stream is followed.
+	.emit(
+		'containers:log-chunk',
+		t.Object({
+			streamId: t.String(),
+			hostId: t.String(),
+			containerId: t.String(),
+			data: t.String(),
+			done: t.Optional(t.Boolean()),
+			error: t.Optional(t.Union([t.String(), t.Null()]))
+		})
+	);

--- a/backend/ws/containers/list.ts
+++ b/backend/ws/containers/list.ts
@@ -1,0 +1,146 @@
+/**
+ * Containers — reading the list.
+ *
+ * Watching is per connection: a client asks for a host when it opens that panel
+ * and is pushed a fresh listing whenever the host's containers actually change.
+ * The watch is torn down when the socket closes, so a browser tab that vanishes
+ * cannot leave a host being polled forever.
+ *
+ * Reading is open to any signed-in user who can already reach the host. Acting
+ * on a container is not, and lives in actions.ts.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { LOCAL_HOST_ID } from '$shared/types/host';
+import { containerMonitor } from '../../containers/monitor';
+import { inspectContainer, readStats } from '../../containers/actions';
+import { requestDiskUsage } from '../../containers/disk-usage';
+import { stopLogStreamsForUser } from '../../containers/logs';
+import { sshConnectionQueries } from '../../database/queries';
+import { ws } from '../../utils/ws';
+
+/**
+ * A member may only watch an SSH host they can already reach. The local machine
+ * is watchable by anyone signed in — it is the machine they are already using
+ * Clopen on.
+ */
+export function requireHostAccess(conn: Parameters<typeof ws.getUserId>[0], hostId: string): void {
+	if (hostId === LOCAL_HOST_ID) return;
+	const userId = ws.getUserId(conn);
+	const isAdmin = ws.getRole(conn) === 'admin';
+	sshConnectionQueries.ensureAccess(hostId, userId, isAdmin);
+}
+
+const hostSchema = t.Object({ hostId: t.String({ minLength: 1 }) });
+
+export const containersListHandler = createRouter()
+	.http('containers:watch', { data: hostSchema, response: t.Any() }, async ({ data, conn }) => {
+		requireHostAccess(conn, data.hostId);
+		const userId = ws.getUserId(conn);
+
+		const result = await containerMonitor.watch(data.hostId, userId);
+		// The watch belongs to this socket; a reload must not leave it running,
+		// and neither must the log streams opened from the same panel.
+		ws.addCleanup(conn, () => {
+			containerMonitor.unwatch(data.hostId, userId);
+			stopLogStreamsForUser(userId);
+		});
+		return { result };
+	})
+
+	.http('containers:unwatch', { data: hostSchema, response: t.Any() }, async ({ data, conn }) => {
+		containerMonitor.unwatch(data.hostId, ws.getUserId(conn));
+		return { ok: true };
+	})
+
+	/**
+	 * The sidebar count, on demand.
+	 *
+	 * Pushes only carry changes, so a client that has just loaded — or just
+	 * reconnected — has no way to learn a count that has been steady. Asking for
+	 * it is how the badge survives a page refresh instead of reading zero until
+	 * something happens to move it.
+	 */
+	.http('containers:summary', { data: t.Object({}), response: t.Any() }, async () => ({
+		count: await containerMonitor.refreshBadge()
+	}))
+
+	/**
+	 * Everything `inspect` knows, read only when a detail pane opens.
+	 *
+	 * Environment values are stripped for anyone but an admin. A container's env
+	 * is where its database password lives, and this panel is reachable by every
+	 * member and through a shared Remote Access link — so the keys are shown,
+	 * which is what makes the pane useful, and the values are not.
+	 */
+	.http(
+		'containers:inspect',
+		{
+			data: t.Object({
+				hostId: t.String({ minLength: 1 }),
+				containerId: t.String({ minLength: 12 })
+			}),
+			response: t.Any()
+		},
+		async ({ data, conn }) => {
+			requireHostAccess(conn, data.hostId);
+			const detail = await inspectContainer(data.hostId, data.containerId);
+			if (!detail || ws.getRole(conn) === 'admin') return { detail, envRedacted: false };
+
+			return {
+				detail: {
+					...detail,
+					env: detail.env.map((line) => {
+						const split = line.indexOf('=');
+						return split <= 0 ? line : `${line.slice(0, split)}=`;
+					})
+				},
+				envRedacted: true
+			};
+		}
+	)
+
+	/**
+	 * What the host is holding and how much of it is reclaimable.
+	 *
+	 * Read-only, so any member may ask — it is the same `system df` they would
+	 * run in a terminal, and knowing the disk is full is not a privilege.
+	 *
+	 * Returns whatever was last measured, immediately, and reports whether a
+	 * fresh reading is on its way; that one arrives as
+	 * `containers:disk-usage-measured`. The measurement cannot be awaited here
+	 * because its duration is set by how much disk the host holds — see
+	 * `backend/containers/disk-usage.ts`.
+	 */
+	.http(
+		'containers:disk-usage',
+		{
+			data: t.Object({
+				hostId: t.String({ minLength: 1 }),
+				/** The Re-check button: measure again even if the cache is fresh. */
+				force: t.Optional(t.Boolean())
+			}),
+			response: t.Any()
+		},
+		async ({ data, conn }) => {
+			requireHostAccess(conn, data.hostId);
+			return requestDiskUsage(data.hostId, ws.getUserId(conn), data.force ?? false);
+		}
+	)
+
+	/** One live sample of what a container is consuming, when a pane asks. */
+	.http(
+		'containers:stats',
+		{
+			data: t.Object({
+				hostId: t.String({ minLength: 1 }),
+				containerId: t.String({ minLength: 12 })
+			}),
+			response: t.Any()
+		},
+		async ({ data, conn }) => {
+			requireHostAccess(conn, data.hostId);
+			return { stats: await readStats(data.hostId, data.containerId) };
+		}
+	);

--- a/backend/ws/containers/logs.ts
+++ b/backend/ws/containers/logs.ts
@@ -1,0 +1,43 @@
+/**
+ * Containers — following a container's output.
+ *
+ * Open to any member who can reach the host: reading a log changes nothing.
+ * The stream belongs to the socket that asked for it, so closing the tab stops
+ * the `docker logs -f` behind it rather than leaving a process running on
+ * someone's machine with nothing listening.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { startLogStream, stopLogStream } from '../../containers/logs';
+import { requireHostAccess } from './list';
+import { ws } from '../../utils/ws';
+
+export const containersLogsHandler = createRouter()
+	.http(
+		'containers:logs-start',
+		{
+			data: t.Object({
+				hostId: t.String({ minLength: 1 }),
+				containerId: t.String({ minLength: 12 })
+			}),
+			response: t.Any()
+		},
+		async ({ data, conn }) => {
+			requireHostAccess(conn, data.hostId);
+			const userId = ws.getUserId(conn);
+
+			const started = await startLogStream(data.hostId, data.containerId, userId);
+			ws.addCleanup(conn, () => stopLogStream(started.streamId, userId));
+			return started;
+		}
+	)
+
+	.http(
+		'containers:logs-stop',
+		{ data: t.Object({ streamId: t.String({ minLength: 1 }) }), response: t.Any() },
+		async ({ data, conn }) => {
+			stopLogStream(data.streamId, ws.getUserId(conn));
+			return { ok: true };
+		}
+	);

--- a/backend/ws/containers/tunnel.ts
+++ b/backend/ws/containers/tunnel.ts
@@ -1,0 +1,101 @@
+/**
+ * Containers — the shell tunnel.
+ *
+ * Mirrors backend/ws/ssh/tunnel.ts: PtyKit's wire protocol rides Clopen's
+ * app-wide socket on `containers:pty` / `containers:pty-out`, with one embedded
+ * PtyKit connection per Clopen connection.
+ *
+ * As with the SSH tunnel, the spawn target is stamped here rather than taken
+ * from the client. The namespace is the only thing the client says about what
+ * it wants, `authorize` has already checked that it may have it, and the target
+ * is derived from that same namespace — so naming one container in the
+ * namespace and another in the payload cannot open a shell anywhere.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import type { WSConnection } from '$shared/utils/ws-server';
+import type { PtyKitConnection } from '@myrialabs/ptykit/server';
+import type { WireFrame } from '@myrialabs/ptykit';
+import { ws } from '$backend/utils/ws';
+import { encodeContainerTarget } from '../../containers/pty-backend';
+import { containerPtyKitServer, rememberNamespace, targetFromNamespace } from '../../containers/pty';
+import { debug } from '$shared/utils/logger';
+
+/** One embedded PtyKit connection per Clopen ws connection (by stable id). */
+const containerPtyConnections = new Map<string, PtyKitConnection>();
+
+function getContainerPtyConnection(conn: WSConnection): PtyKitConnection {
+	const connId = ws.getConnectionId(conn);
+	if (!connId) {
+		throw new Error('Connection not registered');
+	}
+
+	const existing = containerPtyConnections.get(connId);
+	if (existing) return existing;
+
+	const userId = ws.getUserId(conn);
+	const isAdmin = ws.getRole(conn) === 'admin';
+	const ptyConn = containerPtyKitServer.createConnection({
+		data: { userId, isAdmin, connId },
+		send: (frame) => {
+			ws.sendToConnectionId(connId, JSON.stringify({ action: 'containers:pty-out', payload: frame }));
+		}
+	});
+	containerPtyKitServer.handleOpen(ptyConn);
+	containerPtyConnections.set(connId, ptyConn);
+
+	ws.addCleanup(conn, () => {
+		containerPtyKitServer.handleClose(ptyConn);
+		containerPtyConnections.delete(connId);
+	});
+
+	debug.log('containers', `PtyKit connection opened for ${connId}`);
+	return ptyConn;
+}
+
+/**
+ * Replace whatever `shell` the client sent with the target derived from the
+ * frame's own namespace. Frames that are not `create-session` pass through.
+ */
+function stampSpawnTarget(frame: WireFrame): WireFrame {
+	if (frame.action !== 'create-session') return frame;
+
+	const payload = frame.payload as { requestId?: string; data?: Record<string, unknown> } | null;
+	const request = payload?.data;
+	if (!request || typeof request.namespace !== 'string') return frame;
+
+	const target = targetFromNamespace(request.namespace);
+	if (!target) return frame;
+	rememberNamespace(request.namespace);
+
+	return {
+		action: frame.action,
+		payload: { ...payload, data: { ...request, shell: encodeContainerTarget(target) } }
+	};
+}
+
+export const containersTunnelHandler = createRouter()
+	// Client → server: one PtyKit wire frame for a container shell.
+	.on(
+		'containers:pty',
+		{
+			data: t.Object({
+				action: t.String(),
+				payload: t.Any()
+			})
+		},
+		({ conn, data }) => {
+			const ptyConn = getContainerPtyConnection(conn);
+			void containerPtyKitServer.handleFrame(ptyConn, stampSpawnTarget(data as WireFrame));
+		}
+	)
+	// Server → client: PtyKit wire frames. Declared for the typed WSAPI; actually
+	// sent via ws.sendToConnectionId above.
+	.emit(
+		'containers:pty-out',
+		t.Object({
+			action: t.String(),
+			payload: t.Any()
+		})
+	);

--- a/backend/ws/index.ts
+++ b/backend/ws/index.ts
@@ -33,6 +33,7 @@ import { stackRouter } from './stack';
 import { dbClientRouter } from './db-client';
 import { sshRouter } from './ssh';
 import { portsRouter } from './ports';
+import { containersRouter } from './containers';
 import { mcpRouter } from './mcp';
 import { skillsRouter } from './skills';
 import { commandsRouter } from './commands';
@@ -89,6 +90,7 @@ export const wsRouter = createRouter()
 	// SSH client (terminal, SFTP, port forwarding)
 	.merge(sshRouter)
 	.merge(portsRouter)
+	.merge(containersRouter)
 
 	// External MCP server management (install from the official registry)
 	.merge(mcpRouter)

--- a/backend/ws/ssh/connections.ts
+++ b/backend/ws/ssh/connections.ts
@@ -11,6 +11,8 @@ import { sshForwardManager } from '../../ssh/forwards';
 import { sshHealthService } from '../../ssh/health';
 import { knownHosts } from '../../ssh/known-hosts';
 import { killSessionsForConnection } from '../../ssh/ptykit';
+import { killContainerSessionsForHost } from '../../containers/pty';
+import { stopLogStreamsForHost } from '../../containers/logs';
 import type { SshConnectionInput } from '$shared/types/ssh';
 import { debug } from '$shared/utils/logger';
 import { getSshPrincipal, requireSshConnection } from './access';
@@ -78,9 +80,13 @@ function isInput(value: unknown): value is SshConnectionInput {
 /**
  * Changing where or how a host is reached invalidates everything riding the old
  * transport, so shells, forwards and the pooled client all go before the write.
+ * That includes the two things this host's containers hold open: shells running
+ * inside them, and any log stream being followed.
  */
 async function tearDownConnection(connectionId: string): Promise<void> {
 	killSessionsForConnection(connectionId);
+	killContainerSessionsForHost(connectionId);
+	stopLogStreamsForHost(connectionId);
 	await sshForwardManager.stopForConnection(connectionId);
 	sshClientPool.release(connectionId);
 	// Editing or deleting is not "disconnect" — a host suspended earlier should
@@ -187,6 +193,8 @@ export const sshConnectionsHandler = createRouter()
 	}, async ({ data, conn }) => {
 		requireSshConnection(conn, data.id);
 		killSessionsForConnection(data.id);
+		killContainerSessionsForHost(data.id);
+		stopLogStreamsForHost(data.id);
 		await sshForwardManager.stopForConnection(data.id);
 		sshClientPool.suspend(data.id);
 		return sshHealthService.testSaved(data.id);

--- a/frontend/App.svelte
+++ b/frontend/App.svelte
@@ -19,6 +19,7 @@
 	import { tunnelStore } from '$frontend/stores/features/tunnel.svelte';
 	import { remoteAccessStore } from '$frontend/stores/features/remote-access.svelte';
 	import { portsStore } from '$frontend/stores/features/ports.svelte';
+	import { containersStore } from '$frontend/stores/features/containers.svelte';
 	import { startUpdateChecker, stopUpdateChecker } from '$frontend/stores/ui/update.svelte';
 	import ws from '$frontend/utils/ws';
 	import { showNotificationWithActions } from '$frontend/stores/ui/notification.svelte';
@@ -60,6 +61,10 @@
 			// Keep the Ports count in sync. The server only scans when a terminal
 			// session is actually running, so an idle workspace costs nothing.
 			portsStore.initRealtimeListener();
+
+			// Same for the container count. A machine with no runtime costs nothing:
+			// the server remembers that answer and skips the command entirely.
+			containersStore.initRealtimeListener();
 
 			// Nudge admins to set project access when a new member joins via an invite,
 			// so the "invite → join → grant access" flow doesn't dead-end.

--- a/frontend/components/common/overlay/CommandPalette.svelte
+++ b/frontend/components/common/overlay/CommandPalette.svelte
@@ -422,9 +422,11 @@
 <svelte:window onkeydowncapture={handleGlobalKeydown} />
 
 {#if commandPaletteState.isOpen}
+	<!-- Above Dialog's z-10000: the palette is reachable from anywhere, including
+	     from behind an open dialog. -->
 	<div
 		use:portal
-		class="fixed inset-0 z-[200] bg-black/50 dark:bg-slate-950/70 backdrop-blur-sm flex items-start justify-center pt-[12vh] px-4"
+		class="fixed inset-0 z-[10100] bg-black/50 dark:bg-slate-950/70 backdrop-blur-sm flex items-start justify-center pt-[12vh] px-4"
 		role="dialog"
 		aria-modal="true"
 		aria-label="Command palette"

--- a/frontend/components/common/overlay/Dialog.svelte
+++ b/frontend/components/common/overlay/Dialog.svelte
@@ -21,6 +21,13 @@
 		closable?: boolean;
 		confirmDisabled?: boolean;
 		onConfirm?: (value?: string) => void;
+		/**
+		 * Whether confirming also closes the dialog. Default true, which is right
+		 * for a decision that is over the moment it is made. Set false when the
+		 * confirm starts something the dialog then reports on — the caller closes
+		 * it when there is something to close.
+		 */
+		closeOnConfirm?: boolean;
 		extraText?: string;
 		onExtra?: () => void;
 		/** Tailwind max-width class for the dialog box. Default 'max-w-md'; use a wider class for content-heavy dialogs (lists, changelogs). */
@@ -43,6 +50,7 @@
 		closable = true,
 		confirmDisabled = false,
 		onConfirm,
+		closeOnConfirm = true,
 		extraText,
 		onExtra,
 		maxWidth = 'max-w-md',
@@ -135,7 +143,7 @@
 		if (onConfirm) {
 			onConfirm(inputValue !== undefined ? inputValue : undefined);
 		}
-		onClose();
+		if (closeOnConfirm) onClose();
 	}
 
 	function handleCancel() {

--- a/frontend/components/containers/CleanupDialog.svelte
+++ b/frontend/components/containers/CleanupDialog.svelte
@@ -1,0 +1,344 @@
+<!--
+	Containers — reclaiming disk, with the numbers in front of the button.
+
+	A single "clean up" button would be the wrong shape here: the six kinds of
+	sweep differ enormously in what they cost to undo. A stopped container is
+	nothing to lose; every unused image is a pull or a build to get back, and on
+	a slow connection that is an afternoon. So each is its own choice, each says
+	what it would reclaim, and the two that hurt are off until they are asked
+	for.
+
+	The figures come from `system df` on the host, not from anything computed
+	here — the runtime is the authority on its own disk, and a number invented in
+	the browser is exactly the one nobody could trust.
+-->
+<script lang="ts">
+	import Dialog from '$frontend/components/common/overlay/Dialog.svelte';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { containersStore } from '$frontend/stores/features/containers.svelte';
+	import { SvelteSet } from 'svelte/reactivity';
+	import type { PruneKind } from '$shared/types/containers';
+
+	interface Props {
+		isOpen: boolean;
+		onClose: () => void;
+	}
+
+	let { isOpen = $bindable(), onClose }: Props = $props();
+
+	interface Sweep {
+		kind: PruneKind;
+		label: string;
+		blurb: string;
+		/** Which `system df` row speaks for it, when one does. */
+		usage: 'containers' | 'images' | 'volumes' | 'build-cache' | null;
+		/** True for the two that cost real time to undo. */
+		heavy: boolean;
+	}
+
+	const SWEEPS: Sweep[] = [
+		{
+			kind: 'containers',
+			label: 'Stopped containers',
+			blurb: 'Containers that have exited. Their volumes are kept.',
+			usage: 'containers',
+			heavy: false
+		},
+		{
+			kind: 'dangling-images',
+			label: 'Dangling images',
+			blurb: 'Untagged layers left behind by rebuilds.',
+			usage: null,
+			heavy: false
+		},
+		{
+			kind: 'networks',
+			label: 'Unused networks',
+			blurb: 'Networks with nothing attached. The built-in ones are left alone.',
+			usage: null,
+			heavy: false
+		},
+		{
+			kind: 'build-cache',
+			label: 'Build cache',
+			blurb: 'Cached layers. The next build is slower, and correct.',
+			usage: 'build-cache',
+			heavy: false
+		},
+		{
+			kind: 'images',
+			label: 'All unused images',
+			blurb: 'Every image no container uses — not just the untagged ones.',
+			usage: 'images',
+			heavy: true
+		},
+		{
+			kind: 'volumes',
+			label: 'Unused volumes',
+			blurb: 'Every volume no container mounts, named ones included. Their contents go with them.',
+			usage: 'volumes',
+			heavy: true
+		}
+	];
+
+	const selected = new SvelteSet<PruneKind>(['containers', 'dangling-images']);
+
+	const usage = $derived(containersStore.diskUsage);
+	const measuring = $derived(containersStore.diskUsageMeasuring);
+	// The sweep belongs to the host, so all three of these come from the server:
+	// this dialog is often not the one that started it, and sometimes not even
+	// the same browser.
+	const job = $derived(containersStore.pruneJob);
+	const running = $derived(containersStore.pruning);
+	const outcomes = $derived(job?.outcomes ?? null);
+
+	/**
+	 * How old the figures are, in the roughest terms that are still true.
+	 *
+	 * Worth saying at all because the reading is cached: walking the disk takes
+	 * as long as the disk is large, so a dialog that re-measured on every open
+	 * would spend a minute of the host's time redrawing numbers that had not
+	 * moved. Anything under a minute is close enough to now to say so.
+	 */
+	function ageOf(measuredAt: string | null): string | null {
+		if (!measuredAt) return null;
+		const then = Date.parse(measuredAt);
+		if (Number.isNaN(then)) return null;
+		const minutes = Math.floor((now - then) / 60_000);
+		if (minutes < 1) return 'just now';
+		if (minutes === 1) return '1 minute ago';
+		if (minutes < 60) return `${minutes} minutes ago`;
+		const hours = Math.floor(minutes / 60);
+		return hours === 1 ? '1 hour ago' : `${hours} hours ago`;
+	}
+
+	// Ticks only while the dialog is open, so the age does not go stale on screen.
+	let now = $state(Date.now());
+	$effect(() => {
+		if (!isOpen) return;
+		const timer = setInterval(() => (now = Date.now()), 30_000);
+		return () => clearInterval(timer);
+	});
+	const anyHeavy = $derived(SWEEPS.some((sweep) => sweep.heavy && selected.has(sweep.kind)));
+
+	function reclaimableFor(sweep: Sweep): string | null {
+		if (!sweep.usage) return null;
+		return usage?.rows.find((row) => row.kind === sweep.usage)?.reclaimable ?? null;
+	}
+
+	function toggle(kind: PruneKind): void {
+		if (selected.has(kind)) selected.delete(kind);
+		else selected.add(kind);
+	}
+
+	function labelFor(kind: PruneKind): string {
+		return SWEEPS.find((sweep) => sweep.kind === kind)?.label ?? kind;
+	}
+
+	/** How long the running sweep has been going, in the terms `ageOf` uses. */
+	const runningFor = $derived(job && !job.finishedAt ? ageOf(job.startedAt) : null);
+
+	$effect(() => {
+		if (!isOpen) return;
+		now = Date.now();
+		// Both are server-owned and both may already be in progress: a sweep
+		// started before this dialog existed has to be found, not assumed absent.
+		void containersStore.loadDiskUsage();
+		void containersStore.loadPruneStatus();
+	});
+
+	// While a sweep runs, the checkboxes show what it is actually sweeping rather
+	// than whatever this dialog happened to be left on.
+	$effect(() => {
+		const kinds = job && !job.finishedAt ? job.kinds : null;
+		if (!kinds) return;
+		selected.clear();
+		for (const kind of kinds) selected.add(kind);
+	});
+
+	/**
+	 * Start the sweep and stop there.
+	 *
+	 * Nothing is awaited: the sweep runs on the host for as long as it takes, and
+	 * how it went is reported by the store — which is still there whether or not
+	 * this dialog is.
+	 */
+	function run(): void {
+		if (running) return;
+		const kinds = SWEEPS.filter((sweep) => selected.has(sweep.kind)).map((sweep) => sweep.kind);
+		if (kinds.length === 0) return;
+		void containersStore.prune(kinds);
+	}
+
+	/** Closing after a sweep is the acknowledgement that its report was read. */
+	function close(): void {
+		if (outcomes) void containersStore.dismissPrune();
+		onClose();
+	}
+</script>
+
+<Dialog
+	bind:isOpen
+	onClose={close}
+	type="warning"
+	title="Clean up this host"
+	maxWidth="max-w-xl"
+	confirmText={running ? 'Cleaning…' : 'Clean up'}
+	confirmDisabled={running || selected.size === 0}
+	cancelText={outcomes ? 'Done' : 'Close'}
+	onConfirm={run}
+	closeOnConfirm={false}
+>
+	{#snippet children()}
+		<div class="flex flex-col gap-3">
+			<p class="m-0 text-xs text-slate-600 dark:text-slate-400">
+				Only things nothing is using are removed — a running container keeps its image, its
+				volumes and its network. Everything else is gone for good.
+			</p>
+
+			<!-- Said plainly because the sweep genuinely does not need this dialog:
+			     it runs on the host, and closing this changes nothing about it. -->
+			{#if running}
+				<div
+					class="flex items-start gap-2 p-2.5 rounded-lg bg-blue-500/10 text-xs text-blue-800 dark:text-blue-300"
+				>
+					<Icon name="lucide:loader-circle" class="w-4 h-4 shrink-0 mt-px animate-spin" />
+					<span>
+						Sweeping {job?.kinds.map(labelFor).join(', ').toLowerCase()}{runningFor &&
+						runningFor !== 'just now'
+							? `, started ${runningFor}`
+							: ''}. Runs on the host — closing this will not stop it.
+					</span>
+				</div>
+			{/if}
+
+			{#if usage && usage.rows.length > 0}
+				<div class="flex flex-col gap-1.5">
+					<div class="grid grid-cols-2 sm:grid-cols-4 gap-1.5">
+						{#each usage.rows as row (row.kind)}
+							<div class="flex flex-col p-2 rounded-lg bg-slate-100 dark:bg-slate-950">
+								<span
+									class="text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-500"
+								>
+									{row.kind === 'build-cache' ? 'build cache' : row.kind}
+								</span>
+								<span class="text-sm font-semibold text-slate-800 dark:text-slate-200">
+									{row.size}
+								</span>
+								<span class="text-[11px] text-emerald-600 dark:text-emerald-400">
+									{row.reclaimable} free
+								</span>
+							</div>
+						{/each}
+					</div>
+
+					<!-- The figures are cached, so how old they are is part of reading
+					     them. Measuring again is a deliberate act, not something the
+					     dialog does behind the user on every open. -->
+					<div class="flex items-center gap-2 text-[11px] text-slate-400 dark:text-slate-500">
+						{#if measuring}
+							<Icon name="lucide:loader-circle" class="w-3 h-3 animate-spin" />
+							<span>Measuring again — can take a minute.</span>
+						{:else}
+							{@const age = ageOf(usage.measuredAt)}
+							<span>Measured {age ?? 'at an unknown time'}.</span>
+							<button
+								type="button"
+								class="underline underline-offset-2 hover:text-slate-600 dark:hover:text-slate-300
+									transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-default"
+								disabled={running}
+								onclick={() => containersStore.loadDiskUsage(true)}
+							>
+								Re-check
+							</button>
+						{/if}
+					</div>
+				</div>
+			{:else if measuring}
+				<div class="flex items-center gap-2 text-xs text-slate-400">
+					<Icon name="lucide:loader-circle" class="flex-none w-3.5 h-3.5 animate-spin" />
+					<span>Measuring what this host holds — can take a minute. Sweeps work meanwhile.</span>
+				</div>
+			{:else if usage?.error}
+				<p class="m-0 text-xs text-amber-600 dark:text-amber-400">
+					This host would not report its disk usage: {usage.error}
+				</p>
+			{/if}
+
+			<div class="flex flex-col gap-1">
+				{#each SWEEPS as sweep (sweep.kind)}
+					{@const reclaimable = reclaimableFor(sweep)}
+					<label
+						class="flex items-start gap-2.5 p-2 rounded-lg cursor-pointer transition-colors hover:bg-slate-100 dark:hover:bg-slate-800/60"
+					>
+						<input
+							type="checkbox"
+							class="mt-0.5 w-4 h-4 shrink-0 accent-violet-600 cursor-pointer"
+							checked={selected.has(sweep.kind)}
+							disabled={running}
+							onchange={() => toggle(sweep.kind)}
+						/>
+						<span class="flex flex-col min-w-0 flex-1">
+							<span class="flex items-center gap-1.5">
+								<span class="text-sm font-medium text-slate-800 dark:text-slate-200">
+									{sweep.label}
+								</span>
+								{#if sweep.heavy}
+									<span
+										class="shrink-0 px-1 py-px rounded text-[9px] font-semibold uppercase tracking-wide bg-amber-500/15 text-amber-700 dark:text-amber-400"
+										title="Slow or impossible to undo"
+									>
+										costly
+									</span>
+								{/if}
+								{#if reclaimable}
+									<span class="shrink-0 text-[11px] text-emerald-600 dark:text-emerald-400">
+										up to {reclaimable}
+									</span>
+								{/if}
+							</span>
+							<span class="text-xs text-slate-500 dark:text-slate-500">{sweep.blurb}</span>
+						</span>
+					</label>
+				{/each}
+			</div>
+
+			{#if anyHeavy && !outcomes}
+				<p
+					class="m-0 flex items-start gap-2 p-2.5 rounded-lg bg-amber-500/10 text-xs text-amber-800 dark:text-amber-300"
+				>
+					<Icon name="lucide:triangle-alert" class="w-4 h-4 shrink-0 mt-px" />
+					<span>
+						Unused images have to be pulled or built again, and a deleted volume's contents are
+						not recoverable. Nothing on this host keeps a copy.
+					</span>
+				</p>
+			{/if}
+
+			{#if outcomes}
+				<div class="flex flex-col gap-1 pt-1 border-t border-slate-200 dark:border-slate-800">
+					{#each outcomes as outcome (outcome.kind)}
+						<div class="flex items-center gap-2 text-xs">
+							<Icon
+								name={outcome.ok ? 'lucide:circle-check' : 'lucide:circle-x'}
+								class="w-3.5 h-3.5 shrink-0 {outcome.ok
+									? 'text-emerald-600 dark:text-emerald-400'
+									: 'text-red-600 dark:text-red-400'}"
+							/>
+							<span class="text-slate-700 dark:text-slate-300">{labelFor(outcome.kind)}</span>
+							<span class="text-slate-500 dark:text-slate-500 truncate">
+								{#if !outcome.ok}
+									{outcome.error}
+								{:else if outcome.removed === 0}
+									nothing to remove
+								{:else}
+									{outcome.removed} removed{outcome.reclaimed ? ` · ${outcome.reclaimed} freed` : ''}
+								{/if}
+							</span>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	{/snippet}
+</Dialog>

--- a/frontend/components/containers/ContainerActionDialog.svelte
+++ b/frontend/components/containers/ContainerActionDialog.svelte
@@ -1,0 +1,84 @@
+<!--
+	Containers — the confirmation before stopping or restarting one.
+
+	Lives in one place because both entry points need it to say exactly the same
+	thing: what goes down, and for whom. Starting, pausing and resuming need no
+	confirmation — nothing is lost by any of them — so only the three that take
+	something away come through here.
+-->
+<script lang="ts">
+	import Dialog from '$frontend/components/common/overlay/Dialog.svelte';
+	import { containersStore } from '$frontend/stores/features/containers.svelte';
+	import { showError, showSuccess } from '$frontend/stores/ui/notification.svelte';
+	import type { ContainerAction, ContainerEntry } from '$shared/types/containers';
+	import { debug } from '$shared/utils/logger';
+
+	interface Props {
+		/** The container and action awaiting confirmation, cleared once decided. */
+		pending: { entry: ContainerEntry; action: ContainerAction } | null;
+	}
+
+	let { pending = $bindable() }: Props = $props();
+
+	const title = $derived(
+		pending?.action === 'restart'
+			? 'Restart this container?'
+			: pending?.action === 'remove' || pending?.action === 'force-remove'
+				? 'Remove this container?'
+				: 'Stop this container?'
+	);
+
+	const message = $derived.by(() => {
+		if (!pending) return '';
+		const name = pending.entry.name;
+		switch (pending.action) {
+			case 'restart':
+				return `${name} will be stopped and started again. Anything it serves is unavailable while it comes back.`;
+			case 'remove':
+				return `${name} will be deleted. Its image and its volumes stay, so an identical container can be created again — anything written inside the container itself and not into a volume is lost.`;
+			case 'force-remove':
+				// Worth its own sentence: this one stops a running container first.
+				return `${name} is still running. It will be stopped and then deleted, taking down whatever it serves for everyone. Its volumes are kept.`;
+			default:
+				return `${name} will be asked to stop. Anything it serves — for every member, not just you — goes down with it.`;
+		}
+	});
+
+	const confirmText = $derived(
+		pending?.action === 'restart'
+			? 'Restart it'
+			: pending?.action === 'remove' || pending?.action === 'force-remove'
+				? 'Remove it'
+				: 'Stop it'
+	);
+
+	async function run(): Promise<void> {
+		const target = pending;
+		pending = null;
+		if (!target) return;
+
+		const outcome = await containersStore.act(target.entry, target.action);
+		if (outcome.ok) {
+			const what =
+				target.action === 'restart'
+					? 'is coming back up'
+					: target.action === 'remove' || target.action === 'force-remove'
+						? 'has been removed'
+						: 'has been stopped';
+			showSuccess('Done', `${target.entry.name} ${what}.`);
+			return;
+		}
+		debug.warn('containers', `could not ${target.action} ${target.entry.name}:`, outcome.error);
+		showError('Could not do that', outcome.error ?? 'The host refused.');
+	}
+</script>
+
+<Dialog
+	isOpen={pending !== null}
+	onClose={() => (pending = null)}
+	type="warning"
+	{title}
+	{message}
+	{confirmText}
+	onConfirm={run}
+/>

--- a/frontend/components/containers/ContainerDetailLayer.svelte
+++ b/frontend/components/containers/ContainerDetailLayer.svelte
@@ -1,0 +1,69 @@
+<!--
+	Containers — how the details for a row appear.
+
+	Alongside the list on a wide screen, over it from below on a narrow one. Both
+	entry points render this rather than deciding for themselves, so a row
+	behaves the same wherever it was tapped.
+
+	`|global` on the transitions is what makes them run: a transition is local by
+	default and only plays when its own block is created, and these sit inside a
+	block an ancestor creates.
+-->
+<script lang="ts">
+	import { fade, fly } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
+	import ContainerDetail from './main/ContainerDetail.svelte';
+	import type { ContainerAction, ContainerEntry } from '$shared/types/containers';
+
+	interface Props {
+		entry: ContainerEntry;
+		canManage: boolean;
+		onClose: () => void;
+		onAction: (entry: ContainerEntry, action: ContainerAction) => void;
+	}
+
+	const { entry, canManage, onClose, onAction }: Props = $props();
+
+	/** Space left above the sheet so the list behind it stays visible. */
+	const SHEET_TOP_GAP = 56;
+	/** The side panel's own width, so it slides exactly its own length. */
+	const PANEL_TRAVEL = 320;
+
+	let windowWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 1024);
+	let windowHeight = $state(typeof window !== 'undefined' ? window.innerHeight : 768);
+
+	const isMobile = $derived(windowWidth < 768);
+	/**
+	 * How far the sheet travels. Derived from the viewport rather than measured
+	 * after mount, so the first open slides the same distance as every one after.
+	 */
+	const sheetTravel = $derived(Math.max(240, Math.round(windowHeight * 0.85) - SHEET_TOP_GAP));
+</script>
+
+<svelte:window bind:innerWidth={windowWidth} bind:innerHeight={windowHeight} />
+
+{#if isMobile}
+	<button
+		type="button"
+		class="absolute inset-0 z-20 bg-black/40 border-none p-0 cursor-default"
+		transition:fade|global={{ duration: 200 }}
+		onclick={onClose}
+		aria-label="Close details"
+	></button>
+	<!-- Stops short of the top on purpose: the strip of list left showing is
+	     what says this is a layer over the list, not a page you navigated to. -->
+	<div
+		class="absolute inset-x-0 bottom-0 z-30 flex shadow-[0_-8px_30px_rgba(0,0,0,0.25)]"
+		style="top: {SHEET_TOP_GAP}px"
+		transition:fly|global={{ y: sheetTravel, duration: 280, easing: cubicOut, opacity: 1 }}
+	>
+		<ContainerDetail sheet {entry} {canManage} {onClose} {onAction} />
+	</div>
+{:else}
+	<div
+		class="shrink-0 flex w-80"
+		transition:fly|global={{ x: PANEL_TRAVEL, duration: 240, easing: cubicOut, opacity: 1 }}
+	>
+		<ContainerDetail {entry} {canManage} {onClose} {onAction} />
+	</div>
+{/if}

--- a/frontend/components/containers/ContainersModal.svelte
+++ b/frontend/components/containers/ContainersModal.svelte
@@ -1,0 +1,75 @@
+<!--
+	Containers — what is running on this machine.
+
+	Scoped to the machine Clopen runs on. A saved SSH host's containers live in
+	the SSH Client, on the host they belong to, rather than behind a second host
+	picker here — one place per machine, no ambiguity about which is canonical.
+	The implementation underneath is shared: the same store, the same listing and
+	the same pane serve both.
+-->
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import Modal from '$frontend/components/common/overlay/Modal.svelte';
+	import ContainersPane from './ContainersPane.svelte';
+	import { LOCAL_CONTAINER_HOST } from '$shared/types/containers';
+
+	interface Props {
+		isOpen: boolean;
+		onClose: () => void;
+	}
+
+	let { isOpen = $bindable(), onClose }: Props = $props();
+
+	/**
+	 * The pane mounts only after the open transition has finished. It starts a
+	 * watch and can mount an xterm, and doing either in the same flush makes the
+	 * modal jump into place instead of scaling in.
+	 */
+	let contentReady = $state(false);
+
+	$effect(() => {
+		if (!isOpen) contentReady = false;
+	});
+</script>
+
+<Modal
+	bind:isOpen
+	{onClose}
+	bare
+	mobileFullscreen
+	onOpened={() => (contentReady = true)}
+	ariaLabelledBy="containers-title"
+	className="flex flex-col w-full max-w-5xl h-[85dvh] max-h-[900px] bg-slate-50 dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-2xl overflow-hidden shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)] dark:shadow-[0_25px_50px_-12px_rgba(0,0,0,0.5)]"
+>
+	{#snippet children()}
+		<header
+			class="flex items-center justify-between gap-3 px-4 py-2.5 shrink-0 border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900"
+		>
+			<div class="flex items-center gap-2.5 min-w-0">
+				<Icon name="lucide:container" class="w-4 h-4 shrink-0 text-blue-600 dark:text-blue-400" />
+				<span id="containers-title" class="text-md font-bold text-slate-900 dark:text-slate-100">
+					Containers
+				</span>
+				<span class="hidden sm:block text-xs text-slate-500 dark:text-slate-500 truncate">
+					on this machine
+				</span>
+			</div>
+			<button
+				type="button"
+				class="flex items-center justify-center w-9 h-9 shrink-0 bg-transparent border-none rounded-lg text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10"
+				onclick={onClose}
+				aria-label="Close"
+			>
+				<Icon name="lucide:x" class="w-5 h-5" />
+			</button>
+		</header>
+
+		{#if contentReady}
+			<ContainersPane hostId={LOCAL_CONTAINER_HOST} />
+		{:else}
+			<div class="flex-1 flex items-center justify-center">
+				<Icon name="lucide:loader-circle" class="w-5 h-5 animate-spin text-slate-400" />
+			</div>
+		{/if}
+	{/snippet}
+</Modal>

--- a/frontend/components/containers/ContainersPane.svelte
+++ b/frontend/components/containers/ContainersPane.svelte
@@ -1,0 +1,239 @@
+<!--
+	Containers — the whole view, for whichever host it is pointed at.
+
+	This is the feature. The Containers panel renders it for `local` and the SSH
+	Client renders it for a saved host, and neither knows anything the other does
+	not: same store, same lists, same detail pane, same logs and same shell. That
+	is what keeps the two surfaces from drifting into two features.
+
+	The pane has three faces — the lists, one container's logs, one container's
+	shell — because a terminal squeezed into a 320px detail panel is unusable and
+	a log squeezed in beside it is worse. Logs and the shell take the whole pane
+	and hand it back.
+
+	Every removal on this screen goes through a dialog that says what cannot be
+	undone. The runtime refuses to remove anything in use and that refusal is
+	shown as it came, so the destructive paths fail safe by default rather than
+	by our own bookkeeping.
+-->
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import ContainerTable from './main/ContainerTable.svelte';
+	import ImageList from './main/ImageList.svelte';
+	import VolumeList from './main/VolumeList.svelte';
+	import NetworkList from './main/NetworkList.svelte';
+	import ContainerLogsPane from './main/ContainerLogsPane.svelte';
+	import ContainerShellPane from './main/ContainerShellPane.svelte';
+	import ContainerDetailLayer from './ContainerDetailLayer.svelte';
+	import ContainerActionDialog from './ContainerActionDialog.svelte';
+	import ResourceRemoveDialog, { type PendingRemoval } from './ResourceRemoveDialog.svelte';
+	import CleanupDialog from './CleanupDialog.svelte';
+	import { containersStore, type ContainerTab } from '$frontend/stores/features/containers.svelte';
+	import { authStore } from '$frontend/stores/features/auth.svelte';
+	import type { ContainerAction, ContainerEntry } from '$shared/types/containers';
+	import type { IconName } from '$shared/types/ui/icons';
+
+	interface Props {
+		hostId: string;
+	}
+
+	const { hostId }: Props = $props();
+
+	let pending = $state<{ entry: ContainerEntry; action: ContainerAction } | null>(null);
+	let pendingRemoval = $state<PendingRemoval | null>(null);
+	let cleanupOpen = $state(false);
+
+	const result = $derived(containersStore.result);
+	const selected = $derived(containersStore.selected);
+	const view = $derived(containersStore.view);
+	const shellContainer = $derived(containersStore.shellContainer);
+	/** Reading is open to every member; starting, stopping and shells are not. */
+	const canManage = $derived(authStore.isAdmin);
+
+	const TABS: Array<{ id: ContainerTab; label: string; icon: IconName }> = [
+		{ id: 'containers', label: 'Containers', icon: 'lucide:container' },
+		{ id: 'images', label: 'Images', icon: 'lucide:layers' },
+		{ id: 'volumes', label: 'Volumes', icon: 'lucide:hard-drive' },
+		{ id: 'networks', label: 'Networks', icon: 'lucide:network' }
+	];
+
+	const counts = $derived({
+		containers: result?.entries.length ?? 0,
+		images: result?.images.length ?? 0,
+		volumes: result?.volumes.length ?? 0,
+		networks: result?.networks.length ?? 0
+	});
+
+	$effect(() => {
+		const id = hostId;
+		// `untrack` because starting a watch writes the store state it also reads
+		// — tracked, that is an effect that invalidates itself, and each re-run
+		// costs another round of watch/unwatch on the host.
+		untrack(() => void containersStore.watch(id));
+		// Leaving the panel must stop the polling behind it, not just hide it.
+		return () => {
+			void containersStore.unwatch(id);
+			void containersStore.stopLogs();
+		};
+	});
+
+	/**
+	 * Anything that takes something away asks first. Starting, pausing and
+	 * resuming do not: each is reversible by the button next to it.
+	 */
+	function requestAction(entry: ContainerEntry, action: ContainerAction): void {
+		if (action === 'start' || action === 'pause' || action === 'unpause') {
+			void containersStore.act(entry, action);
+			return;
+		}
+		pending = { entry, action };
+	}
+</script>
+
+<div class="flex flex-col flex-1 min-h-0">
+	{#if view === 'logs'}
+		<ContainerLogsPane onBack={() => containersStore.closeView()} />
+	{:else if view === 'shell' && shellContainer}
+		<ContainerShellPane
+			{hostId}
+			entry={shellContainer}
+			onBack={() => containersStore.showList()}
+			onClose={() => containersStore.closeShell()}
+		/>
+	{:else}
+		<div
+			class="flex items-center gap-2 px-2.5 sm:px-3 py-2 shrink-0 border-b border-slate-200 dark:border-slate-800"
+		>
+			<div
+				class="flex items-center gap-0.5 shrink-0 p-0.5 rounded-lg bg-slate-100 dark:bg-slate-950 border border-slate-200 dark:border-slate-800"
+			>
+				{#each TABS as tab (tab.id)}
+					<button
+						type="button"
+						title={tab.label}
+						class="flex items-center gap-1.5 px-2 h-7 rounded-md text-xs font-semibold transition-colors cursor-pointer
+							{containersStore.tab === tab.id
+							? 'bg-white dark:bg-slate-800 text-violet-700 dark:text-violet-300'
+							: 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'}"
+						onclick={() => (containersStore.tab = tab.id)}
+					>
+						<Icon name={tab.icon} class="w-3.5 h-3.5" />
+						<span class="hidden md:inline">{tab.label}</span>
+						{#if counts[tab.id] > 0}
+							<span class="text-[10px] text-slate-400 dark:text-slate-600">{counts[tab.id]}</span>
+						{/if}
+					</button>
+				{/each}
+			</div>
+
+			<div
+				class="flex items-center gap-2 flex-1 min-w-0 px-2.5 h-8 rounded-lg bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800"
+			>
+				<Icon name="lucide:search" class="w-3.5 h-3.5 shrink-0 text-slate-400" />
+				<input
+					type="text"
+					class="flex-1 min-w-0 bg-transparent border-none outline-none text-xs text-slate-800 dark:text-slate-200 placeholder:text-slate-400"
+					placeholder="Search name, image, port…"
+					bind:value={containersStore.search}
+				/>
+			</div>
+
+			{#if canManage}
+				<!-- Sits beside the search rather than in a row's menu: cleaning up is
+				     a question about the host, not about any one thing on it. -->
+				<button
+					type="button"
+					class="flex items-center gap-1.5 shrink-0 px-2 h-8 rounded-lg bg-transparent border-none text-slate-500 dark:text-slate-400 text-xs cursor-pointer hover:bg-violet-500/10 hover:text-violet-700 dark:hover:text-violet-300"
+					onclick={() => (cleanupOpen = true)}
+					title="Reclaim disk from what nothing is using"
+				>
+					<Icon name="lucide:brush-cleaning" class="w-3.5 h-3.5" />
+					<span class="hidden lg:inline">Clean up</span>
+				</button>
+			{/if}
+
+			{#if containersStore.shellId && view === 'list'}
+				<!-- A shell left running is easy to forget about; this is the way back
+				     to it, and it disappears with the session. -->
+				<button
+					type="button"
+					class="hidden sm:flex items-center gap-1.5 shrink-0 px-2 h-8 rounded-lg bg-transparent border-none text-violet-600 dark:text-violet-400 text-xs cursor-pointer hover:bg-violet-500/10"
+					onclick={() => containersStore.reopenShell()}
+				>
+					<Icon name="lucide:terminal" class="w-3.5 h-3.5" />
+					Shell
+				</button>
+			{/if}
+
+			{#if result?.runtime}
+				<span
+					class="hidden lg:flex items-center gap-1.5 shrink-0 text-[11px] text-slate-400 dark:text-slate-600"
+					title="This list refreshes every couple of seconds while the panel is open"
+				>
+					<span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
+					live
+				</span>
+			{/if}
+		</div>
+
+		{#if containersStore.isLoading && !result}
+			<div class="flex-1 flex items-center justify-center">
+				<Icon name="lucide:loader-circle" class="w-5 h-5 animate-spin text-slate-400" />
+			</div>
+		{:else}
+			<div class="flex flex-1 min-h-0 relative">
+				{#if containersStore.tab === 'containers'}
+					<ContainerTable {canManage} onToggle={(entry) =>
+						requestAction(entry, entry.state === 'running' || entry.state === 'paused' ? 'stop' : 'start')} />
+				{:else if containersStore.tab === 'images'}
+					<ImageList
+						{canManage}
+						onRemove={(image) =>
+							(pendingRemoval = {
+								kind: 'image',
+								id: image.id,
+								label: `${image.repository}:${image.tag}`,
+								usedBy: image.usedBy
+							})}
+					/>
+				{:else if containersStore.tab === 'volumes'}
+					<VolumeList
+						{canManage}
+						onRemove={(volume) =>
+							(pendingRemoval = {
+								kind: 'volume',
+								id: volume.name,
+								label: volume.name,
+								usedBy: volume.usedBy
+							})}
+					/>
+				{:else}
+					<NetworkList
+						{canManage}
+						onRemove={(network) =>
+							(pendingRemoval = {
+								kind: 'network',
+								id: network.name,
+								label: network.name,
+								usedBy: network.usedBy
+							})}
+					/>
+				{/if}
+
+				{#if selected && containersStore.tab === 'containers'}
+					<ContainerDetailLayer
+						entry={selected}
+						{canManage}
+						onClose={() => containersStore.select(null)}
+						onAction={requestAction}
+					/>
+				{/if}
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<ContainerActionDialog bind:pending />
+<ResourceRemoveDialog bind:pending={pendingRemoval} />
+<CleanupDialog bind:isOpen={cleanupOpen} onClose={() => (cleanupOpen = false)} />

--- a/frontend/components/containers/ResourceRemoveDialog.svelte
+++ b/frontend/components/containers/ResourceRemoveDialog.svelte
@@ -1,0 +1,84 @@
+<!--
+	Containers — the confirmation before removing an image, a volume or a network.
+
+	Each one is worth a different sentence. An image comes back with a pull or a
+	build; a volume does not come back at all, and its contents are the reason
+	anyone would be nervous here. Whether anything is currently using it decides
+	the tone, because the runtime will refuse in that case and the dialog should
+	say so before the user finds out from an error.
+-->
+<script lang="ts">
+	import Dialog from '$frontend/components/common/overlay/Dialog.svelte';
+	import { containersStore } from '$frontend/stores/features/containers.svelte';
+	import { showError, showSuccess } from '$frontend/stores/ui/notification.svelte';
+	import type { RemovableResourceKind } from '$shared/types/containers';
+	import { debug } from '$shared/utils/logger';
+
+	export interface PendingRemoval {
+		kind: RemovableResourceKind;
+		/** What the command takes: an id for an image, a name for the rest. */
+		id: string;
+		label: string;
+		usedBy: string[];
+	}
+
+	interface Props {
+		/** The resource awaiting confirmation, cleared once the user decides. */
+		pending: PendingRemoval | null;
+	}
+
+	let { pending = $bindable() }: Props = $props();
+
+	const inUse = $derived((pending?.usedBy.length ?? 0) > 0);
+
+	const title = $derived(
+		pending?.kind === 'image'
+			? 'Remove this image?'
+			: pending?.kind === 'volume'
+				? 'Remove this volume?'
+				: 'Remove this network?'
+	);
+
+	const message = $derived.by(() => {
+		if (!pending) return '';
+		const used = `${pending.label} is in use by ${pending.usedBy.slice(0, 3).join(', ')}${
+			pending.usedBy.length > 3 ? ` and ${pending.usedBy.length - 3} more` : ''
+		}, so the runtime will refuse to remove it. Remove or stop those first.`;
+		if (inUse) return used;
+
+		switch (pending.kind) {
+			case 'image':
+				return `${pending.label} will be deleted from this host. Getting it back means pulling or building it again.`;
+			case 'volume':
+				// The one deletion here with no way back at all.
+				return `${pending.label} and everything stored in it will be deleted. There is no undo, and nothing else on this host holds a copy.`;
+			default:
+				return `${pending.label} will be deleted. Any container later configured to use it will recreate it empty.`;
+		}
+	});
+
+	async function run(): Promise<void> {
+		const target = pending;
+		pending = null;
+		if (!target) return;
+
+		const outcome = await containersStore.removeResource(target.kind, target.id);
+		if (outcome.ok) {
+			showSuccess('Removed', `${target.label} is gone.`);
+			return;
+		}
+		debug.warn('containers', `could not remove ${target.kind} ${target.id}:`, outcome.error);
+		showError('Could not remove it', outcome.error ?? 'The host refused.');
+	}
+</script>
+
+<Dialog
+	isOpen={pending !== null}
+	onClose={() => (pending = null)}
+	type={inUse ? 'info' : 'warning'}
+	{title}
+	{message}
+	confirmText="Remove it"
+	confirmDisabled={inUse}
+	onConfirm={run}
+/>

--- a/frontend/components/containers/main/ContainerDetail.svelte
+++ b/frontend/components/containers/main/ContainerDetail.svelte
@@ -1,0 +1,385 @@
+<!--
+	Containers — everything known about one container.
+
+	The list answers "is it up"; this answers "what is it, where does it write,
+	what can reach it, and how do I get inside". It is also where the actions
+	live, because a stop that can be reached without opening anything is a stop
+	that will eventually be hit by accident.
+
+	Environment values are shown only to an admin, and only after asking: a
+	container's env is where its database password lives, and this pane is
+	reachable through a shared Remote Access link.
+-->
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { containersStore } from '$frontend/stores/features/containers.svelte';
+	import { portsStore } from '$frontend/stores/features/ports.svelte';
+	import { sshClientStore } from '$frontend/stores/features/ssh-client.svelte';
+	import { closeContainersDialog, openPortsDialog } from '$frontend/stores/ui/quick-panels.svelte';
+	import type { ContainerAction, ContainerEntry, ContainerPortBinding } from '$shared/types/containers';
+	import { LOCAL_HOST_ID } from '$shared/types/host';
+
+	interface Props {
+		entry: ContainerEntry;
+		canManage: boolean;
+		onClose: () => void;
+		onAction: (entry: ContainerEntry, action: ContainerAction) => void;
+		/** Rendered as a bottom sheet on small screens rather than a side panel. */
+		sheet?: boolean;
+	}
+
+	const { entry, canManage, onClose, onAction, sheet = false }: Props = $props();
+
+	let showEnv = $state(false);
+
+	const detail = $derived(containersStore.detailFor(entry.id));
+	const stats = $derived(containersStore.statsFor(entry.id));
+	const statsLoading = $derived(containersStore.statsLoading === entry.id);
+	const busy = $derived(containersStore.actingId === entry.id);
+	const isUp = $derived(entry.state === 'running' || entry.state === 'paused');
+	const isPaused = $derived(entry.state === 'paused');
+	const created = $derived(entry.createdAt ? new Date(entry.createdAt).toLocaleString() : null);
+	const started = $derived(
+		detail?.startedAt ? new Date(detail.startedAt).toLocaleString() : null
+	);
+
+	/**
+	 * Jump to the port table, at the row this mapping produced.
+	 *
+	 * The mirror of the Ports panel's link to here, and it opens the same way:
+	 * the panel and the SSH Client tab are one view, so which of the two to show
+	 * follows from the host. Only a published port has a row to jump to.
+	 */
+	function openPort(port: ContainerPortBinding): void {
+		if (port.hostPort === null) return;
+		const hostId = containersStore.activeHostId;
+		portsStore.focusPort(hostId, port.protocol, port.hostPort);
+		if (hostId === LOCAL_HOST_ID) {
+			closeContainersDialog();
+			openPortsDialog();
+			return;
+		}
+		sshClientStore.setView(hostId, 'ports');
+	}
+</script>
+
+<aside
+	class="flex flex-col w-full min-h-0 bg-white dark:bg-slate-900
+		{sheet
+		? 'rounded-t-2xl border-t border-slate-200 dark:border-slate-800'
+		: 'border-l border-slate-200 dark:border-slate-800'}"
+>
+	{#if sheet}
+		<div class="flex justify-center pt-2 pb-1 shrink-0">
+			<span class="w-9 h-1 rounded-full bg-slate-300 dark:bg-slate-700"></span>
+		</div>
+	{/if}
+
+	<header
+		class="flex items-center justify-between gap-2 px-4 py-3 border-b border-slate-200 dark:border-slate-800 shrink-0"
+	>
+		<div class="min-w-0">
+			<p class="m-0 text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">
+				{entry.name}
+			</p>
+			<p class="m-0 text-xs text-slate-500 dark:text-slate-500 truncate">{entry.statusText}</p>
+		</div>
+		<button
+			type="button"
+			class="shrink-0 flex items-center justify-center w-7 h-7 rounded-md border-none bg-transparent text-slate-400 cursor-pointer hover:bg-violet-500/10"
+			onclick={onClose}
+			aria-label="Close details"
+		>
+			<Icon name="lucide:x" class="w-4 h-4" />
+		</button>
+	</header>
+
+	<div class="flex flex-wrap items-center gap-1.5 px-4 py-2.5 shrink-0 border-b border-slate-200 dark:border-slate-800">
+		<button
+			type="button"
+			class="flex items-center gap-1.5 px-2.5 h-7 rounded-md text-xs font-semibold cursor-pointer transition-colors bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-violet-500/10 hover:text-violet-700 dark:hover:text-violet-300"
+			onclick={() => void containersStore.startLogs(entry)}
+		>
+			<Icon name="lucide:scroll-text" class="w-3.5 h-3.5" />
+			Logs
+		</button>
+
+		{#if canManage}
+			<button
+				type="button"
+				class="flex items-center gap-1.5 px-2.5 h-7 rounded-md text-xs font-semibold cursor-pointer transition-colors bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-violet-500/10 hover:text-violet-700 dark:hover:text-violet-300 disabled:opacity-40 disabled:cursor-not-allowed"
+				onclick={() => containersStore.openShell(entry)}
+				disabled={entry.state !== 'running'}
+				title={entry.state === 'running'
+					? 'Open a shell inside this container'
+					: 'A stopped container has nothing to attach to'}
+			>
+				<Icon name="lucide:terminal" class="w-3.5 h-3.5" />
+				Shell
+			</button>
+
+			{#if entry.canManage}
+				<button
+					type="button"
+					class="flex items-center gap-1.5 px-2.5 h-7 rounded-md text-xs font-semibold cursor-pointer transition-colors bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-violet-500/10 disabled:opacity-40 disabled:cursor-wait"
+					onclick={() => onAction(entry, isUp ? 'stop' : 'start')}
+					disabled={busy}
+				>
+					<Icon
+						name={busy ? 'lucide:loader-circle' : isUp ? 'lucide:square' : 'lucide:play'}
+						class="w-3.5 h-3.5 {busy ? 'animate-spin' : ''}"
+					/>
+					{isUp ? 'Stop' : 'Start'}
+				</button>
+				<button
+					type="button"
+					class="flex items-center gap-1.5 px-2.5 h-7 rounded-md text-xs font-semibold cursor-pointer transition-colors bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-violet-500/10 disabled:opacity-40 disabled:cursor-wait"
+					onclick={() => onAction(entry, 'restart')}
+					disabled={busy}
+				>
+					<Icon name="lucide:rotate-cw" class="w-3.5 h-3.5" />
+					Restart
+				</button>
+
+				{#if isUp}
+					<!-- Pause freezes the processes without unbinding the ports, which
+					     is the one way to stop something eating CPU and keep its port. -->
+					<button
+						type="button"
+						class="flex items-center gap-1.5 px-2.5 h-7 rounded-md text-xs font-semibold cursor-pointer transition-colors bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-violet-500/10 disabled:opacity-40 disabled:cursor-wait"
+						onclick={() => onAction(entry, isPaused ? 'unpause' : 'pause')}
+						disabled={busy}
+					>
+						<Icon name={isPaused ? 'lucide:play' : 'lucide:pause'} class="w-3.5 h-3.5" />
+						{isPaused ? 'Resume' : 'Pause'}
+					</button>
+				{/if}
+
+				<button
+					type="button"
+					class="flex items-center gap-1.5 px-2.5 h-7 rounded-md text-xs font-semibold cursor-pointer transition-colors bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-40 disabled:cursor-wait"
+					onclick={() => onAction(entry, isUp ? 'force-remove' : 'remove')}
+					disabled={busy}
+				>
+					<Icon name="lucide:trash-2" class="w-3.5 h-3.5" />
+					Remove
+				</button>
+			{/if}
+		{/if}
+	</div>
+
+	<div class="flex-1 min-h-0 overflow-y-auto p-4 flex flex-col gap-4">
+		<section class="flex flex-col gap-1.5">
+			<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-slate-500">Container</h4>
+			<dl class="m-0 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+				<dt class="text-slate-500 dark:text-slate-500">Image</dt>
+				<dd class="m-0 text-slate-700 dark:text-slate-300 break-all">{entry.image}</dd>
+
+				<dt class="text-slate-500 dark:text-slate-500">ID</dt>
+				<dd class="m-0 font-mono text-slate-700 dark:text-slate-300">{entry.shortId}</dd>
+
+				<dt class="text-slate-500 dark:text-slate-500">State</dt>
+				<dd class="m-0 text-slate-700 dark:text-slate-300">
+					{entry.state}{entry.health !== 'none' ? ` · ${entry.health}` : ''}
+				</dd>
+
+				<dt class="text-slate-500 dark:text-slate-500">Created</dt>
+				<dd class="m-0 text-slate-700 dark:text-slate-300">{created ?? 'unknown'}</dd>
+
+				<dt class="text-slate-500 dark:text-slate-500">Started</dt>
+				<dd class="m-0 text-slate-700 dark:text-slate-300">{started ?? (isUp ? '…' : 'not running')}</dd>
+
+				{#if entry.composeProject}
+					<dt class="text-slate-500 dark:text-slate-500">Compose</dt>
+					<dd class="m-0 text-slate-700 dark:text-slate-300">
+						{entry.composeProject}{entry.composeService ? ` · ${entry.composeService}` : ''}
+					</dd>
+				{/if}
+
+				{#if detail?.restartPolicy}
+					<dt class="text-slate-500 dark:text-slate-500">Restart</dt>
+					<dd class="m-0 text-slate-700 dark:text-slate-300">
+						{detail.restartPolicy}{detail.restartCount ? ` · ${detail.restartCount} restarts` : ''}
+					</dd>
+				{/if}
+
+				{#if detail?.pid}
+					<dt class="text-slate-500 dark:text-slate-500">Host PID</dt>
+					<dd class="m-0 font-mono text-slate-700 dark:text-slate-300">{detail.pid}</dd>
+				{/if}
+			</dl>
+
+			{#if entry.command}
+				<p
+					class="m-0 mt-1 p-2 rounded-md bg-slate-100 dark:bg-slate-950 font-mono text-[11px] text-slate-600 dark:text-slate-400 break-all"
+				>
+					{entry.command}
+				</p>
+			{/if}
+		</section>
+
+		<section class="flex flex-col gap-1.5">
+			<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-slate-500">Ports</h4>
+			{#if entry.ports.length === 0}
+				<p class="m-0 text-xs text-slate-500 dark:text-slate-500">
+					This container publishes nothing to the host.
+				</p>
+			{:else}
+				<ul class="m-0 p-0 list-none flex flex-col gap-1">
+					{#each entry.ports as port, index (`${port.protocol}:${port.hostPort}:${port.containerPort}:${index}`)}
+						<li class="font-mono text-[11px] text-slate-600 dark:text-slate-400 break-all">
+							{#if port.hostPort === null}
+								<!-- Exposed but not published: reachable from the container
+								     network and nowhere else, which is worth saying. And with
+								     no host port there is no row in the port table to open. -->
+								{port.containerPort}/{port.protocol} · inside the container network only
+							{:else}
+								<button
+									type="button"
+									class="inline-flex items-center gap-1 text-left rounded px-1 -mx-1 py-0.5
+										hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-slate-900
+										dark:hover:text-slate-200 transition-colors cursor-pointer"
+									title="Show {port.hostAddress ?? '*'}:{port.hostPort} in the port table"
+									onclick={() => openPort(port)}
+								>
+									{port.hostAddress ?? '*'}:{port.hostPort} → {port.containerPort}/{port.protocol}
+									<Icon name="lucide:arrow-up-right" class="w-3 h-3 shrink-0 opacity-60" />
+								</button>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</section>
+
+		{#if isUp}
+			<section class="flex flex-col gap-1.5">
+				<div class="flex items-center justify-between gap-2">
+					<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+						Resource use
+					</h4>
+					<button
+						type="button"
+						class="flex items-center gap-1 text-[11px] text-violet-600 dark:text-violet-400 bg-transparent border-none cursor-pointer p-0 disabled:opacity-40"
+						onclick={() => void containersStore.loadStats(entry.id)}
+						disabled={statsLoading}
+					>
+						<Icon
+							name={statsLoading ? 'lucide:loader-circle' : 'lucide:refresh-cw'}
+							class="w-3 h-3 {statsLoading ? 'animate-spin' : ''}"
+						/>
+						{stats ? 'Refresh' : 'Measure'}
+					</button>
+				</div>
+				{#if stats}
+					<dl class="m-0 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+						<dt class="text-slate-500 dark:text-slate-500">CPU</dt>
+						<dd class="m-0 text-slate-700 dark:text-slate-300">
+							{stats.cpuPercent === null ? 'unknown' : `${stats.cpuPercent}%`}
+						</dd>
+						<dt class="text-slate-500 dark:text-slate-500">Memory</dt>
+						<dd class="m-0 text-slate-700 dark:text-slate-300">
+							{stats.memoryUsage ?? 'unknown'}{stats.memoryPercent === null
+								? ''
+								: ` · ${stats.memoryPercent}%`}
+						</dd>
+						<dt class="text-slate-500 dark:text-slate-500">Network</dt>
+						<dd class="m-0 text-slate-700 dark:text-slate-300">{stats.networkIO ?? 'unknown'}</dd>
+						<dt class="text-slate-500 dark:text-slate-500">Disk</dt>
+						<dd class="m-0 text-slate-700 dark:text-slate-300">{stats.blockIO ?? 'unknown'}</dd>
+						<dt class="text-slate-500 dark:text-slate-500">Processes</dt>
+						<dd class="m-0 text-slate-700 dark:text-slate-300">{stats.pids ?? 'unknown'}</dd>
+					</dl>
+				{:else}
+					<!-- Sampled on request rather than polled: `stats` measures over a
+					     window and takes a second, which a live table cannot afford. -->
+					<p class="m-0 text-xs text-slate-500 dark:text-slate-500">
+						One sample, taken when you ask for it — it costs the host about a second.
+					</p>
+				{/if}
+			</section>
+		{/if}
+
+		{#if detail}
+			{#if detail.networks.length > 0}
+				<section class="flex flex-col gap-1.5">
+					<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+						Networks
+					</h4>
+					<ul class="m-0 p-0 list-none flex flex-col gap-1">
+						{#each detail.networks as network (network.name)}
+							<li class="text-[11px] text-slate-600 dark:text-slate-400 break-all">
+								{network.name}
+								<span class="font-mono text-slate-400 dark:text-slate-600">
+									{network.ipAddress ?? 'no address'}
+								</span>
+							</li>
+						{/each}
+					</ul>
+				</section>
+			{/if}
+
+			{#if detail.mounts.length > 0}
+				<section class="flex flex-col gap-1.5">
+					<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+						Mounts
+					</h4>
+					<ul class="m-0 p-0 list-none flex flex-col gap-1.5">
+						{#each detail.mounts as mount (mount.destination)}
+							<li class="flex flex-col">
+								<span class="font-mono text-[11px] text-slate-600 dark:text-slate-400 break-all">
+									{mount.destination}{mount.readOnly ? ' (read-only)' : ''}
+								</span>
+								<span class="font-mono text-[11px] text-slate-400 dark:text-slate-600 break-all">
+									{mount.kind} · {mount.source}
+								</span>
+							</li>
+						{/each}
+					</ul>
+				</section>
+			{/if}
+
+			{#if detail.env.length > 0}
+				<section class="flex flex-col gap-1.5">
+					<div class="flex items-center justify-between gap-2">
+						<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+							Environment ({detail.env.length})
+						</h4>
+						{#if !containersStore.envRedacted}
+							<button
+								type="button"
+								class="text-[11px] text-violet-600 dark:text-violet-400 bg-transparent border-none cursor-pointer p-0"
+								onclick={() => (showEnv = !showEnv)}
+							>
+								{showEnv ? 'Hide values' : 'Show values'}
+							</button>
+						{/if}
+					</div>
+					{#if containersStore.envRedacted}
+						<p class="m-0 text-xs text-slate-500 dark:text-slate-500">
+							Values are hidden. A container's environment is where its credentials live, so only
+							an admin can read them.
+						</p>
+					{/if}
+					<ul class="m-0 p-0 list-none flex flex-col gap-0.5">
+						{#each detail.env as line, index (`${line}:${index}`)}
+							{@const split = line.indexOf('=')}
+							{@const key = split > 0 ? line.slice(0, split) : line}
+							{@const value = split > 0 ? line.slice(split + 1) : ''}
+							<li class="font-mono text-[11px] text-slate-600 dark:text-slate-400 break-all">
+								{key}<span class="text-slate-400 dark:text-slate-600">
+									= {showEnv && value ? value : value ? '••••••' : ''}
+								</span>
+							</li>
+						{/each}
+					</ul>
+				</section>
+			{/if}
+		{:else if containersStore.detailLoading}
+			<div class="flex items-center gap-2 text-xs text-slate-400">
+				<Icon name="lucide:loader-circle" class="flex-none w-3.5 h-3.5 animate-spin" />
+				Reading the container…
+			</div>
+		{/if}
+	</div>
+</aside>

--- a/frontend/components/containers/main/ContainerLogsPane.svelte
+++ b/frontend/components/containers/main/ContainerLogsPane.svelte
@@ -1,0 +1,198 @@
+<!--
+	Containers — following one container's output.
+
+	Plain text rather than a terminal, on purpose: this is something to read,
+	search and copy out of, and an xterm is none of those. Following means
+	sticking to the bottom, and it stops the moment the reader scrolls up — an
+	auto-scroll that fights the person reading is worse than none.
+
+	The buffer is bounded on both ends. The server keeps the last N lines and so
+	does this, so a container writing continuously cannot grow either side.
+-->
+<script lang="ts">
+	import { tick } from 'svelte';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { containersStore } from '$frontend/stores/features/containers.svelte';
+	import { showSuccess } from '$frontend/stores/ui/notification.svelte';
+
+	interface Props {
+		onBack: () => void;
+	}
+
+	const { onBack }: Props = $props();
+
+	let viewport = $state<HTMLDivElement | null>(null);
+	let filter = $state('');
+	/** Whether the view is stuck to the bottom, decided by where the reader is. */
+	let following = $state(true);
+
+	const logs = $derived(containersStore.logs);
+	const lines = $derived(logs?.lines ?? []);
+	const needle = $derived(filter.trim().toLowerCase());
+	const visible = $derived(
+		needle ? lines.filter((line) => line.toLowerCase().includes(needle)) : lines
+	);
+
+	/** Level colouring, from the shapes almost every logger prints. */
+	function levelClass(line: string): string {
+		if (/\b(error|err|fatal|panic|exception)\b/i.test(line)) return 'text-red-600 dark:text-red-400';
+		if (/\bwarn(ing)?\b/i.test(line)) return 'text-amber-600 dark:text-amber-400';
+		if (/\b(debug|trace)\b/i.test(line)) return 'text-slate-400 dark:text-slate-600';
+		return 'text-slate-700 dark:text-slate-300';
+	}
+
+	function onScroll(): void {
+		if (!viewport) return;
+		const distance = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+		// A small tolerance: a browser's fractional scroll heights would otherwise
+		// unstick the view on its own the first time anything is appended.
+		following = distance < 24;
+	}
+
+	// Re-runs whenever a chunk arrives, because it reads `visible.length`.
+	$effect(() => {
+		const count = visible.length;
+		if (!following || logs?.paused || count === 0) return;
+		void tick().then(() => {
+			if (viewport) viewport.scrollTop = viewport.scrollHeight;
+		});
+	});
+
+	async function copyAll(): Promise<void> {
+		await navigator.clipboard.writeText(visible.join('\n'));
+		showSuccess('Copied', `${visible.length} lines copied to the clipboard.`);
+	}
+</script>
+
+<div class="flex flex-col flex-1 min-h-0">
+	<header
+		class="flex items-center gap-2 px-2.5 sm:px-3 py-2 shrink-0 border-b border-slate-200 dark:border-slate-800"
+	>
+		<button
+			type="button"
+			class="flex items-center gap-1.5 shrink-0 px-2 h-8 rounded-lg bg-transparent border-none text-slate-500 dark:text-slate-400 text-xs cursor-pointer hover:bg-violet-500/10"
+			onclick={onBack}
+		>
+			<Icon name="lucide:arrow-left" class="w-4 h-4" />
+			<span class="hidden sm:inline">Back</span>
+		</button>
+
+		<div class="flex flex-col min-w-0 flex-1">
+			<span class="truncate text-sm font-semibold text-slate-800 dark:text-slate-200">
+				{logs?.containerName ?? 'Logs'}
+			</span>
+			<span class="text-[11px] text-slate-400 dark:text-slate-600">
+				{#if logs?.starting}
+					opening the stream…
+				{:else if logs?.ended}
+					stream ended
+				{:else if logs?.paused}
+					paused · still buffering on the server
+				{:else}
+					following
+				{/if}
+			</span>
+		</div>
+
+		<div
+			class="hidden sm:flex items-center gap-2 min-w-0 max-w-56 px-2.5 h-8 rounded-lg bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800"
+		>
+			<Icon name="lucide:search" class="w-3.5 h-3.5 shrink-0 text-slate-400" />
+			<input
+				type="text"
+				class="flex-1 min-w-0 bg-transparent border-none outline-none text-xs text-slate-800 dark:text-slate-200 placeholder:text-slate-400"
+				placeholder="Filter these lines…"
+				bind:value={filter}
+			/>
+		</div>
+
+		<button
+			type="button"
+			class="flex items-center justify-center w-8 h-8 shrink-0 rounded-lg bg-transparent border-none text-slate-500 cursor-pointer hover:bg-violet-500/10"
+			onclick={() => containersStore.togglePause()}
+			title={logs?.paused ? 'Resume following' : 'Pause following'}
+			aria-label={logs?.paused ? 'Resume following' : 'Pause following'}
+		>
+			<Icon name={logs?.paused ? 'lucide:play' : 'lucide:pause'} class="w-4 h-4" />
+		</button>
+		<button
+			type="button"
+			class="flex items-center justify-center w-8 h-8 shrink-0 rounded-lg bg-transparent border-none text-slate-500 cursor-pointer hover:bg-violet-500/10"
+			onclick={copyAll}
+			title="Copy what is on screen"
+			aria-label="Copy log"
+		>
+			<Icon name="lucide:copy" class="w-4 h-4" />
+		</button>
+		<button
+			type="button"
+			class="flex items-center justify-center w-8 h-8 shrink-0 rounded-lg bg-transparent border-none text-slate-500 cursor-pointer hover:bg-violet-500/10"
+			onclick={() => containersStore.clearLogs()}
+			title="Clear the view"
+			aria-label="Clear the view"
+		>
+			<Icon name="lucide:eraser" class="w-4 h-4" />
+		</button>
+	</header>
+
+	<!-- The filter has nowhere to sit in the header on a phone, so it gets its
+	     own row rather than being dropped. -->
+	<div class="sm:hidden flex items-center gap-2 px-2.5 py-2 shrink-0 border-b border-slate-200 dark:border-slate-800">
+		<div
+			class="flex items-center gap-2 flex-1 min-w-0 px-2.5 h-8 rounded-lg bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800"
+		>
+			<Icon name="lucide:search" class="w-3.5 h-3.5 shrink-0 text-slate-400" />
+			<input
+				type="text"
+				class="flex-1 min-w-0 bg-transparent border-none outline-none text-xs text-slate-800 dark:text-slate-200 placeholder:text-slate-400"
+				placeholder="Filter these lines…"
+				bind:value={filter}
+			/>
+		</div>
+	</div>
+
+	{#if logs?.error}
+		<div class="flex items-start gap-2.5 m-3 p-3 rounded-lg bg-red-500/10 text-red-700 dark:text-red-400">
+			<Icon name="lucide:circle-alert" class="w-4 h-4 shrink-0 mt-0.5" />
+			<p class="m-0 text-xs">{logs.error}</p>
+		</div>
+	{/if}
+
+	<div
+		bind:this={viewport}
+		onscroll={onScroll}
+		class="flex-1 min-h-0 overflow-auto bg-slate-50 dark:bg-slate-950 px-3 py-2 font-mono text-[11px] leading-relaxed"
+	>
+		{#if logs?.starting}
+			<p class="m-0 text-slate-400">Opening the stream…</p>
+		{:else if visible.length === 0}
+			<p class="m-0 text-slate-400">
+				{needle ? 'No line matches that filter.' : 'This container has written nothing yet.'}
+			</p>
+		{:else}
+			{#each visible as line, index (index)}
+				<div class="whitespace-pre-wrap wrap-anywhere {levelClass(line)}">{line || ' '}</div>
+			{/each}
+		{/if}
+
+		{#if logs?.ended}
+			<p class="m-0 mt-2 text-slate-400 dark:text-slate-600">— {logs.ended}</p>
+		{/if}
+	</div>
+
+	{#if !following}
+		<!-- Scrolling up stops the view following; this is how to get back, and
+		     it only exists while it is needed. -->
+		<button
+			type="button"
+			class="flex items-center justify-center gap-1.5 shrink-0 py-1.5 border-t border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 text-[11px] text-violet-600 dark:text-violet-400 cursor-pointer"
+			onclick={() => {
+				following = true;
+				if (viewport) viewport.scrollTop = viewport.scrollHeight;
+			}}
+		>
+			<Icon name="lucide:arrow-down" class="w-3.5 h-3.5" />
+			Follow the newest output
+		</button>
+	{/if}
+</div>

--- a/frontend/components/containers/main/ContainerRow.svelte
+++ b/frontend/components/containers/main/ContainerRow.svelte
@@ -1,0 +1,157 @@
+<!--
+	Containers — one container.
+
+	The row answers the three questions a list is opened for: is it up, what is
+	it, and where can I reach it. Everything else — the mounts, the networks, the
+	environment, the full command — lives in the detail pane, so the row stays
+	readable on a phone where only the first two columns survive.
+-->
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import type { ContainerEntry } from '$shared/types/containers';
+
+	interface Props {
+		entry: ContainerEntry;
+		selected: boolean;
+		busy: boolean;
+		/** Admin: starting and stopping is theirs alone. */
+		canManage: boolean;
+		onSelect: () => void;
+		onToggle: () => void;
+		onLogs: () => void;
+	}
+
+	const { entry, selected, busy, canManage, onSelect, onToggle, onLogs }: Props = $props();
+
+	const isUp = $derived(entry.state === 'running' || entry.state === 'paused');
+
+	const accent = $derived(
+		entry.health === 'unhealthy'
+			? 'text-red-600 dark:text-red-400'
+			: entry.state === 'running'
+				? 'text-emerald-600 dark:text-emerald-400'
+				: entry.state === 'paused'
+					? 'text-amber-600 dark:text-amber-400'
+					: entry.state === 'restarting'
+						? 'text-sky-600 dark:text-sky-400'
+						: entry.state === 'dead'
+							? 'text-red-600 dark:text-red-400'
+							: 'text-slate-400 dark:text-slate-500'
+	);
+
+	/** Published ports, shortest useful form: the host port is what is reachable. */
+	const published = $derived(entry.ports.filter((port) => port.hostPort !== null));
+</script>
+
+<div
+	class="group flex items-center gap-2.5 sm:gap-3 px-2.5 sm:px-3 py-2 rounded-lg border transition-colors
+		{selected
+		? 'bg-violet-500/10 border-violet-500/30'
+		: 'bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800 hover:border-violet-500/30'}"
+>
+	<button
+		type="button"
+		class="flex items-center gap-2.5 sm:gap-3 flex-1 min-w-0 bg-transparent border-none p-0 text-left cursor-pointer"
+		onclick={onSelect}
+	>
+		<Icon name="lucide:container" class="w-4 h-4 shrink-0 {accent}" />
+
+		<span class="flex flex-col min-w-0 flex-1">
+			<span class="flex items-center gap-1.5 min-w-0">
+				<span class="truncate text-sm font-medium text-slate-800 dark:text-slate-200">
+					{entry.name}
+				</span>
+				{#if entry.health === 'unhealthy'}
+					<span
+						class="shrink-0 px-1 py-px rounded text-[9px] font-semibold uppercase tracking-wide bg-red-500/15 text-red-700 dark:text-red-400"
+						title="This container's own healthcheck is failing"
+					>
+						unhealthy
+					</span>
+				{:else if entry.health === 'healthy'}
+					<span
+						class="shrink-0 w-1.5 h-1.5 rounded-full bg-emerald-500"
+						title="This container's healthcheck is passing"
+					></span>
+				{:else if entry.health === 'starting'}
+					<span
+						class="shrink-0 px-1 py-px rounded text-[9px] font-semibold uppercase tracking-wide bg-amber-500/15 text-amber-700 dark:text-amber-400"
+						title="The healthcheck has not passed yet"
+					>
+						starting
+					</span>
+				{/if}
+				{#if entry.composeProject}
+					<span
+						class="hidden sm:inline shrink-0 px-1 py-px rounded text-[9px] font-semibold uppercase tracking-wide bg-slate-200 dark:bg-slate-800 text-slate-500 dark:text-slate-400"
+						title="Part of the {entry.composeProject} compose project"
+					>
+						{entry.composeProject}
+					</span>
+				{/if}
+			</span>
+			<span class="truncate text-xs text-slate-500 dark:text-slate-500">
+				{entry.image}
+			</span>
+		</span>
+
+		<span class="hidden md:flex flex-col items-end shrink-0 w-40 lg:w-52">
+			<span class="text-[11px] text-slate-500 dark:text-slate-500 truncate max-w-full">
+				{entry.statusText}
+			</span>
+			<span class="font-mono text-[11px] text-slate-400 dark:text-slate-600 truncate max-w-full">
+				{#if published.length > 0}
+					{published
+						.slice(0, 2)
+						.map((port) => `${port.hostPort}→${port.containerPort}`)
+						.join(' ')}{#if published.length > 2}
+						+{published.length - 2}{/if}
+				{:else}
+					{entry.shortId}
+				{/if}
+			</span>
+		</span>
+	</button>
+
+	<!-- On a phone the status has nowhere to live in the row, so it rides here
+	     instead of vanishing: it is the one fact the list exists to show. -->
+	<span class="md:hidden shrink-0 text-[11px] text-slate-400 dark:text-slate-600 max-w-24 truncate">
+		{entry.statusText}
+	</span>
+
+	<button
+		type="button"
+		class="hidden sm:flex shrink-0 items-center justify-center w-7 h-7 rounded-md border-none bg-transparent text-slate-400 cursor-pointer transition-colors hover:bg-violet-500/10 hover:text-violet-600 dark:hover:text-violet-400"
+		onclick={onLogs}
+		title="Follow this container's logs"
+		aria-label="Follow logs for {entry.name}"
+	>
+		<Icon name="lucide:scroll-text" class="w-3.5 h-3.5" />
+	</button>
+
+	{#if canManage && entry.canManage}
+		<button
+			type="button"
+			class="shrink-0 flex items-center justify-center w-7 h-7 rounded-md border-none bg-transparent cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-wait
+				{isUp
+				? 'text-slate-400 hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400'
+				: 'text-slate-400 hover:bg-emerald-500/10 hover:text-emerald-600 dark:hover:text-emerald-400'}"
+			onclick={onToggle}
+			disabled={busy}
+			title={isUp ? 'Stop this container' : 'Start this container'}
+			aria-label={isUp ? `Stop ${entry.name}` : `Start ${entry.name}`}
+		>
+			<Icon
+				name={busy ? 'lucide:loader-circle' : isUp ? 'lucide:square' : 'lucide:play'}
+				class="w-3.5 h-3.5 {busy ? 'animate-spin' : ''}"
+			/>
+		</button>
+	{:else if !canManage}
+		<span
+			class="shrink-0 flex items-center justify-center w-7 h-7 text-slate-300 dark:text-slate-700"
+			title="Only an admin can start or stop a container"
+		>
+			<Icon name="lucide:lock" class="w-3.5 h-3.5" />
+		</span>
+	{/if}
+</div>

--- a/frontend/components/containers/main/ContainerShellPane.svelte
+++ b/frontend/components/containers/main/ContainerShellPane.svelte
@@ -1,0 +1,127 @@
+<!--
+	Containers — a shell inside one container.
+
+	The same `<PtyTerminal>` the local and SSH terminals use, on its own PtyKit
+	client. The session id is derived from the container rather than generated,
+	so going back to the list and returning reattaches to the shell that is
+	already running instead of leaving it orphaned and starting a second.
+
+	The namespace carries the host and the container, and it is the only thing
+	the client gets to say about what it wants: the server checks it, derives the
+	spawn target from it, and refuses anything a non-admin asks for.
+-->
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { PtyTerminal } from '@myrialabs/ptykit/svelte';
+	import type { ComponentProps } from 'svelte';
+	import {
+		containerNamespace,
+		containerPtyClient,
+		containerSessionId
+	} from '$frontend/services/containers/container-pty-client';
+	import { settings } from '$frontend/stores/features/settings.svelte';
+	import type { ContainerEntry } from '$shared/types/containers';
+
+	interface Props {
+		hostId: string;
+		entry: ContainerEntry;
+		/** Back to the lists, leaving the shell running. */
+		onBack: () => void;
+		/** Close the shell for good, killing the session. */
+		onClose: () => void;
+	}
+
+	const { hostId, entry, onBack, onClose }: Props = $props();
+
+	// The shared client is a dist PtyKitClient; <PtyTerminal> (shipped as source)
+	// types its `client` prop against the source build. They are structurally the
+	// same class, so bridge the identities here rather than in every usage.
+	const sharedClient = containerPtyClient as unknown as ComponentProps<
+		typeof PtyTerminal
+	>['client'];
+
+	const namespace = $derived(containerNamespace(hostId, entry.id));
+	const sessionId = $derived(containerSessionId(hostId, entry.id));
+	const fontSize = $derived(Math.round(settings.fontSize * 0.9));
+
+	let session = $state<{ kill(): Promise<void> } | null>(null);
+
+	// Follow the app's dark/light class with PtyKit's matching built-in preset.
+	function computeThemeName(): 'dark' | 'light' {
+		const isDark =
+			typeof document !== 'undefined' && document.documentElement.classList.contains('dark');
+		return isDark ? 'dark' : 'light';
+	}
+	let theme = $state<'dark' | 'light'>(computeThemeName());
+
+	$effect(() => {
+		if (typeof document === 'undefined') return;
+		const observer = new MutationObserver(() => {
+			theme = computeThemeName();
+		});
+		observer.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ['class', 'data-theme']
+		});
+		return () => observer.disconnect();
+	});
+
+	async function endSession(): Promise<void> {
+		try {
+			await session?.kill();
+		} catch {
+			// Already gone — closing the view is still the right outcome.
+		}
+		onClose();
+	}
+</script>
+
+<div class="flex flex-col flex-1 min-h-0">
+	<header
+		class="flex items-center gap-2 px-2.5 sm:px-3 py-2 shrink-0 border-b border-slate-200 dark:border-slate-800"
+	>
+		<button
+			type="button"
+			class="flex items-center gap-1.5 shrink-0 px-2 h-8 rounded-lg bg-transparent border-none text-slate-500 dark:text-slate-400 text-xs cursor-pointer hover:bg-violet-500/10"
+			onclick={onBack}
+		>
+			<Icon name="lucide:arrow-left" class="w-4 h-4" />
+			<span class="hidden sm:inline">Back</span>
+		</button>
+
+		<div class="flex flex-col min-w-0 flex-1">
+			<span class="truncate text-sm font-semibold text-slate-800 dark:text-slate-200">
+				{entry.name}
+			</span>
+			<span class="truncate text-[11px] text-slate-400 dark:text-slate-600">
+				a shell inside the container · {entry.image}
+			</span>
+		</div>
+
+		<button
+			type="button"
+			class="flex items-center gap-1.5 shrink-0 px-2 h-8 rounded-lg bg-transparent border-none text-slate-400 text-xs cursor-pointer hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400"
+			onclick={endSession}
+			title="End this shell"
+		>
+			<Icon name="lucide:x" class="w-4 h-4" />
+			<span class="hidden sm:inline">End shell</span>
+		</button>
+	</header>
+
+	<div class="flex-1 relative min-h-0 overflow-hidden font-mono bg-slate-50 dark:bg-slate-950">
+		{#key sessionId}
+			<PtyTerminal
+				client={sharedClient}
+				{namespace}
+				{sessionId}
+				create={true}
+				showStatus={false}
+				{fontSize}
+				{theme}
+				padding={12}
+				onready={(context) => (session = context.session as { kill(): Promise<void> })}
+			/>
+		{/key}
+	</div>
+</div>

--- a/frontend/components/containers/main/ContainerTable.svelte
+++ b/frontend/components/containers/main/ContainerTable.svelte
@@ -1,0 +1,115 @@
+<!--
+	Containers — the list, split into what is running and what is not.
+
+	Both groups are always present, so a host with nothing up still shows where
+	its stopped containers would appear. The footer states how the host was read
+	and what it could not answer, for the same reason the port table does: an
+	empty list should never be ambiguous between "nothing is running" and "this
+	host would not say".
+-->
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import ContainerRow from './ContainerRow.svelte';
+	import { containersStore } from '$frontend/stores/features/containers.svelte';
+	import type { ContainerEntry } from '$shared/types/containers';
+
+	interface Props {
+		canManage: boolean;
+		onToggle: (entry: ContainerEntry) => void;
+	}
+
+	const { canManage, onToggle }: Props = $props();
+
+	const groups = $derived(containersStore.groups);
+	const result = $derived(containersStore.result);
+	const total = $derived(result?.entries.length ?? 0);
+	const shown = $derived(containersStore.entries.length);
+</script>
+
+<div class="flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 p-3">
+	{#if result?.error}
+		<div class="flex items-start gap-2.5 p-3 rounded-lg bg-red-500/10 text-red-700 dark:text-red-400">
+			<Icon name="lucide:circle-alert" class="w-4 h-4 shrink-0 mt-0.5" />
+			<p class="m-0 text-xs">{result.error}</p>
+		</div>
+	{/if}
+
+	{#each result?.limitations ?? [] as limitation (limitation.code)}
+		<!-- A host with no runtime is not an error, it is an answer. It is shown
+		     where the list would be, because that is the question being asked. -->
+		<div
+			class="flex items-start gap-2.5 p-3 rounded-lg bg-slate-100 dark:bg-slate-900/60 text-slate-600 dark:text-slate-400"
+		>
+			<Icon
+				name={limitation.code === 'no-runtime' ? 'lucide:info' : 'lucide:triangle-alert'}
+				class="w-4 h-4 shrink-0 mt-0.5"
+			/>
+			<p class="m-0 text-xs">{limitation.message}</p>
+		</div>
+	{/each}
+
+	{#if result?.runtime}
+		{#each groups as group (group.id)}
+			{@const collapsed = containersStore.isCollapsed(group.id)}
+			<section class="flex flex-col gap-1.5">
+				<button
+					type="button"
+					class="flex items-center gap-2 w-full px-1 py-1 bg-transparent border-none cursor-pointer text-left"
+					onclick={() => containersStore.toggleGroup(group.id)}
+				>
+					<Icon
+						name={collapsed ? 'lucide:chevron-right' : 'lucide:chevron-down'}
+						class="w-3.5 h-3.5 shrink-0 text-slate-400"
+					/>
+					<span
+						class="text-[11px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-400"
+					>
+						{group.title}
+					</span>
+					<span class="text-[11px] text-slate-400 dark:text-slate-600">{group.entries.length}</span>
+					<span class="hidden sm:block flex-1 text-[11px] text-slate-400 dark:text-slate-600 truncate">
+						{group.blurb}
+					</span>
+				</button>
+
+				{#if !collapsed}
+					{#if group.entries.length === 0}
+						<p class="m-0 px-3 py-2 text-xs text-slate-400 dark:text-slate-600">
+							Nothing here right now.
+						</p>
+					{:else}
+						<div class="flex flex-col gap-1">
+							{#each group.entries as entry (entry.key)}
+								<ContainerRow
+									{entry}
+									{canManage}
+									selected={containersStore.selectedId === entry.id}
+									busy={containersStore.actingId === entry.id}
+									onSelect={() => containersStore.select(entry.id)}
+									onToggle={() => onToggle(entry)}
+									onLogs={() => void containersStore.startLogs(entry)}
+								/>
+							{/each}
+						</div>
+					{/if}
+				{/if}
+			</section>
+		{/each}
+
+		{#if total > 0 && shown === 0}
+			<p class="m-0 px-3 py-6 text-center text-xs text-slate-500 dark:text-slate-500">
+				No container matches that search.
+			</p>
+		{/if}
+
+		<section class="flex flex-col gap-1.5 mt-2 p-3 rounded-lg bg-slate-100 dark:bg-slate-900/60">
+			<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+				How this host was read
+			</h4>
+			<p class="m-0 text-xs text-slate-500 dark:text-slate-500">
+				{result.runtime}{result.runtimeVersion ? ` ${result.runtimeVersion}` : ''} · detected, not
+				configured
+			</p>
+		</section>
+	{/if}
+</div>

--- a/frontend/components/containers/main/ImageList.svelte
+++ b/frontend/components/containers/main/ImageList.svelte
@@ -1,0 +1,100 @@
+<!--
+	Containers — the images on this host.
+
+	The question this answers is "what is this container actually running, and
+	what is eating the disk" — so the one action here is removal, of a single
+	image or, through Clean up, of everything nothing is using. Pulling and
+	building stay where they belong, in a terminal.
+-->
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { containersStore } from '$frontend/stores/features/containers.svelte';
+	import type { ContainerImageEntry } from '$shared/types/containers';
+
+	interface Props {
+		canManage: boolean;
+		onRemove: (image: ContainerImageEntry) => void;
+	}
+
+	const { canManage, onRemove }: Props = $props();
+
+	const images = $derived(containersStore.images);
+	const total = $derived(containersStore.result?.images.length ?? 0);
+	const unused = $derived(images.filter((image) => image.usedBy.length === 0).length);
+</script>
+
+<div class="flex-1 min-h-0 overflow-y-auto flex flex-col gap-1 p-3">
+	{#if total === 0}
+		<p class="m-0 px-3 py-6 text-center text-xs text-slate-500 dark:text-slate-500">
+			This host has no images.
+		</p>
+	{:else if images.length === 0}
+		<p class="m-0 px-3 py-6 text-center text-xs text-slate-500 dark:text-slate-500">
+			No image matches that search.
+		</p>
+	{:else}
+		<p class="m-0 px-1 pb-1 text-[11px] text-slate-400 dark:text-slate-600">
+			{images.length} shown · {unused} used by nothing on this host
+		</p>
+	{/if}
+
+	{#each images as image (image.key)}
+		<div
+			class="group flex items-center gap-3 px-3 py-2 rounded-lg border bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800"
+		>
+			<Icon
+				name="lucide:layers"
+				class="w-4 h-4 shrink-0 {image.dangling
+					? 'text-slate-300 dark:text-slate-700'
+					: 'text-sky-600 dark:text-sky-400'}"
+			/>
+
+			<div class="flex flex-col min-w-0 flex-1">
+				<span class="flex items-center gap-1.5 min-w-0">
+					<span class="truncate text-sm font-medium text-slate-800 dark:text-slate-200">
+						{image.repository}<span class="text-slate-400 dark:text-slate-600">:{image.tag}</span>
+					</span>
+					{#if image.dangling}
+						<span
+							class="shrink-0 px-1 py-px rounded text-[9px] font-semibold uppercase tracking-wide bg-slate-200 dark:bg-slate-800 text-slate-500 dark:text-slate-400"
+							title="An untagged layer left behind by a rebuild"
+						>
+							dangling
+						</span>
+					{/if}
+				</span>
+				<span class="truncate text-xs text-slate-500 dark:text-slate-500">
+					{#if image.usedBy.length > 0}
+						Used by {image.usedBy.slice(0, 3).join(', ')}{image.usedBy.length > 3
+							? ` +${image.usedBy.length - 3}`
+							: ''}
+					{:else}
+						Not used by any container here
+					{/if}
+				</span>
+			</div>
+
+			<span class="shrink-0 text-[11px] text-slate-500 dark:text-slate-500 tabular-nums">
+				{image.size}
+			</span>
+
+			{#if canManage}
+				<button
+					type="button"
+					class="shrink-0 flex items-center justify-center w-7 h-7 rounded-md border-none bg-transparent text-slate-400 cursor-pointer transition-colors hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50 disabled:cursor-wait"
+					onclick={() => onRemove(image)}
+					disabled={containersStore.actingId === image.id}
+					title={image.usedBy.length > 0
+						? 'In use — the runtime will refuse unless it is forced'
+						: 'Remove this image'}
+					aria-label="Remove image {image.repository}:{image.tag}"
+				>
+					<Icon
+						name={containersStore.actingId === image.id ? 'lucide:loader-circle' : 'lucide:trash-2'}
+						class="w-3.5 h-3.5 {containersStore.actingId === image.id ? 'animate-spin' : ''}"
+					/>
+				</button>
+			{/if}
+		</div>
+	{/each}
+</div>

--- a/frontend/components/containers/main/NetworkList.svelte
+++ b/frontend/components/containers/main/NetworkList.svelte
@@ -1,0 +1,109 @@
+<!--
+	Containers — the networks on this host.
+
+	The networks a compose project creates outlive `compose down` and accumulate
+	quietly, so the useful signal is the same one the volume list carries: which
+	of these is nothing attached to. The runtime's own networks are shown and
+	never offered for removal — `network rm bridge` fails on every host, and an
+	action that can only fail should not be on screen.
+-->
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { containersStore } from '$frontend/stores/features/containers.svelte';
+	import type { ContainerNetworkEntry } from '$shared/types/containers';
+
+	interface Props {
+		canManage: boolean;
+		onRemove: (network: ContainerNetworkEntry) => void;
+	}
+
+	const { canManage, onRemove }: Props = $props();
+
+	const networks = $derived(containersStore.networks);
+	const total = $derived(containersStore.result?.networks.length ?? 0);
+	const unused = $derived(
+		networks.filter((network) => !network.predefined && network.usedBy.length === 0).length
+	);
+</script>
+
+<div class="flex-1 min-h-0 overflow-y-auto flex flex-col gap-1 p-3">
+	{#if total === 0}
+		<p class="m-0 px-3 py-6 text-center text-xs text-slate-500 dark:text-slate-500">
+			This host has no networks.
+		</p>
+	{:else if networks.length === 0}
+		<p class="m-0 px-3 py-6 text-center text-xs text-slate-500 dark:text-slate-500">
+			No network matches that search.
+		</p>
+	{:else}
+		<p class="m-0 px-1 pb-1 text-[11px] text-slate-400 dark:text-slate-600">
+			{networks.length} shown · {unused} with nothing attached
+		</p>
+	{/if}
+
+	{#each networks as network (network.key)}
+		<div
+			class="group flex items-center gap-3 px-3 py-2 rounded-lg border bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800"
+		>
+			<Icon
+				name="lucide:network"
+				class="w-4 h-4 shrink-0 {network.usedBy.length > 0
+					? 'text-violet-600 dark:text-violet-400'
+					: 'text-slate-300 dark:text-slate-700'}"
+			/>
+
+			<div class="flex flex-col min-w-0 flex-1">
+				<span class="flex items-center gap-1.5 min-w-0">
+					<span class="truncate text-sm font-medium text-slate-800 dark:text-slate-200">
+						{network.name}
+					</span>
+					{#if network.predefined}
+						<span
+							class="shrink-0 px-1 py-px rounded text-[9px] font-semibold uppercase tracking-wide bg-slate-200 dark:bg-slate-800 text-slate-500 dark:text-slate-400"
+							title="Created by the runtime itself and part of how it works"
+						>
+							built-in
+						</span>
+					{/if}
+					{#if network.internal}
+						<span
+							class="hidden sm:inline shrink-0 px-1 py-px rounded text-[9px] font-semibold uppercase tracking-wide bg-slate-200 dark:bg-slate-800 text-slate-500 dark:text-slate-400"
+							title="No route out of this network"
+						>
+							internal
+						</span>
+					{/if}
+				</span>
+				<span class="truncate text-xs text-slate-500 dark:text-slate-500">
+					{#if network.usedBy.length > 0}
+						{network.usedBy.slice(0, 3).join(', ')}{network.usedBy.length > 3
+							? ` +${network.usedBy.length - 3}`
+							: ''}
+					{:else}
+						Nothing is attached to this network
+					{/if}
+				</span>
+			</div>
+
+			<span class="hidden md:block shrink-0 text-[11px] text-slate-400 dark:text-slate-600">
+				{network.driver}
+			</span>
+
+			{#if canManage && !network.predefined}
+				<button
+					type="button"
+					class="shrink-0 flex items-center justify-center w-7 h-7 rounded-md border-none bg-transparent text-slate-400 cursor-pointer transition-colors hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50 disabled:cursor-wait"
+					onclick={() => onRemove(network)}
+					disabled={containersStore.actingId === network.id}
+					title="Remove this network"
+					aria-label="Remove network {network.name}"
+				>
+					<Icon
+						name={containersStore.actingId === network.id ? 'lucide:loader-circle' : 'lucide:trash-2'}
+						class="w-3.5 h-3.5 {containersStore.actingId === network.id ? 'animate-spin' : ''}"
+					/>
+				</button>
+			{/if}
+		</div>
+	{/each}
+</div>

--- a/frontend/components/containers/main/VolumeList.svelte
+++ b/frontend/components/containers/main/VolumeList.svelte
@@ -1,0 +1,109 @@
+<!--
+	Containers — the volumes on this host.
+
+	The useful signal here is which volumes nothing is using: a machine that has
+	been developing for a while accumulates hundreds of anonymous ones holding
+	tens of gigabytes, and the list says so plainly rather than pretending they
+	are all meaningful. Removing one, or all of the unused ones through Clean up,
+	is the point of saying it.
+-->
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { containersStore, isAnonymousVolume } from '$frontend/stores/features/containers.svelte';
+	import type { ContainerVolumeEntry } from '$shared/types/containers';
+
+	interface Props {
+		canManage: boolean;
+		onRemove: (volume: ContainerVolumeEntry) => void;
+	}
+
+	const { canManage, onRemove }: Props = $props();
+
+	const volumes = $derived(containersStore.volumes);
+	const total = $derived(containersStore.result?.volumes.length ?? 0);
+	const unused = $derived(volumes.filter((volume) => volume.usedBy.length === 0).length);
+</script>
+
+<div class="flex-1 min-h-0 overflow-y-auto flex flex-col gap-1 p-3">
+	{#if total === 0}
+		<p class="m-0 px-3 py-6 text-center text-xs text-slate-500 dark:text-slate-500">
+			This host has no volumes.
+		</p>
+	{:else if volumes.length === 0}
+		<p class="m-0 px-3 py-6 text-center text-xs text-slate-500 dark:text-slate-500">
+			No volume matches that search.
+		</p>
+	{:else}
+		<p class="m-0 px-1 pb-1 text-[11px] text-slate-400 dark:text-slate-600">
+			{volumes.length} shown · {unused} used by nothing on this host
+		</p>
+	{/if}
+
+	{#each volumes as volume (volume.key)}
+		{@const anonymous = isAnonymousVolume(volume)}
+		<div
+			class="group flex items-center gap-3 px-3 py-2 rounded-lg border bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800"
+		>
+			<Icon
+				name="lucide:hard-drive"
+				class="w-4 h-4 shrink-0 {volume.usedBy.length > 0
+					? 'text-emerald-600 dark:text-emerald-400'
+					: 'text-slate-300 dark:text-slate-700'}"
+			/>
+
+			<div class="flex flex-col min-w-0 flex-1">
+				<span class="flex items-center gap-1.5 min-w-0">
+					<span
+						class="truncate text-sm font-medium text-slate-800 dark:text-slate-200 {anonymous
+							? 'font-mono text-xs'
+							: ''}"
+						title={volume.name}
+					>
+						{anonymous ? `${volume.name.slice(0, 12)}…` : volume.name}
+					</span>
+					{#if anonymous}
+						<span
+							class="shrink-0 px-1 py-px rounded text-[9px] font-semibold uppercase tracking-wide bg-slate-200 dark:bg-slate-800 text-slate-500 dark:text-slate-400"
+							title="Created by the runtime rather than named by anyone"
+						>
+							anonymous
+						</span>
+					{/if}
+				</span>
+				<span class="truncate text-xs text-slate-500 dark:text-slate-500">
+					{#if volume.usedBy.length > 0}
+						Used by {volume.usedBy.slice(0, 3).join(', ')}{volume.usedBy.length > 3
+							? ` +${volume.usedBy.length - 3}`
+							: ''}
+					{:else}
+						Not used by any container here
+					{/if}
+				</span>
+			</div>
+
+			<span class="hidden lg:block shrink-0 max-w-64 truncate font-mono text-[11px] text-slate-400 dark:text-slate-600">
+				{volume.mountpoint ?? volume.driver}
+			</span>
+
+			{#if canManage}
+				<button
+					type="button"
+					class="shrink-0 flex items-center justify-center w-7 h-7 rounded-md border-none bg-transparent text-slate-400 cursor-pointer transition-colors hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50 disabled:cursor-wait"
+					onclick={() => onRemove(volume)}
+					disabled={containersStore.actingId === volume.name}
+					title={volume.usedBy.length > 0
+						? 'In use — the runtime will refuse while a container has it mounted'
+						: 'Remove this volume'}
+					aria-label="Remove volume {volume.name}"
+				>
+					<Icon
+						name={containersStore.actingId === volume.name
+							? 'lucide:loader-circle'
+							: 'lucide:trash-2'}
+						class="w-3.5 h-3.5 {containersStore.actingId === volume.name ? 'animate-spin' : ''}"
+					/>
+				</button>
+			{/if}
+		</div>
+	{/each}
+</div>

--- a/frontend/components/ports/main/PortDetail.svelte
+++ b/frontend/components/ports/main/PortDetail.svelte
@@ -8,7 +8,11 @@
 -->
 <script lang="ts">
 	import Icon from '$frontend/components/common/display/Icon.svelte';
-	import type { PortEntry } from '$shared/types/ports';
+	import { portsStore } from '$frontend/stores/features/ports.svelte';
+	import { containersStore } from '$frontend/stores/features/containers.svelte';
+	import { sshClientStore } from '$frontend/stores/features/ssh-client.svelte';
+	import { closePortsDialog, openContainersDialog } from '$frontend/stores/ui/quick-panels.svelte';
+	import { LOCAL_PORT_HOST, type PortEntry } from '$shared/types/ports';
 
 	interface Props {
 		entry: PortEntry;
@@ -28,8 +32,26 @@
 			? 'Clopen opened this listener, so this is exact.'
 			: entry.origin.kind === 'session'
 				? 'Traced through the process tree — the lineage is certain.'
-				: 'Inferred from the command line. Clopen did not start this, so treat the label as a guess.'
+				: entry.origin.kind === 'container'
+					? 'The container runtime publishes this port, so the owner is exact. Whatever holds the socket is the runtime’s own proxy, not the server you are looking for.'
+					: 'Inferred from the command line. Clopen did not start this, so treat the label as a guess.'
 	);
+
+	/**
+	 * Jump to this port's container. The panel and the SSH Client tab are the
+	 * same view, so which one to open follows from which host the row is on.
+	 */
+	function openContainer(): void {
+		if (!entry.container) return;
+		const hostId = portsStore.activeHostId;
+		containersStore.focus(hostId, entry.container.id);
+		if (hostId === LOCAL_PORT_HOST) {
+			closePortsDialog();
+			openContainersDialog();
+			return;
+		}
+		sshClientStore.setView(hostId, 'containers');
+	}
 </script>
 
 <aside
@@ -74,6 +96,26 @@
 			{/if}
 		</section>
 
+		{#if entry.container}
+			<section class="flex flex-col gap-1.5 p-2.5 rounded-lg bg-blue-500/10">
+				<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-blue-700 dark:text-blue-400">
+					Published by a container
+				</h4>
+				<p class="m-0 text-xs text-blue-800 dark:text-blue-300 break-all">
+					{entry.container.name} · {entry.container.image} · container port
+					{entry.container.containerPort}
+				</p>
+				<button
+					type="button"
+					class="flex items-center gap-1.5 self-start mt-0.5 px-2 h-7 rounded-md bg-blue-500/15 border-none text-[11px] font-semibold text-blue-800 dark:text-blue-300 cursor-pointer hover:bg-blue-500/25"
+					onclick={openContainer}
+				>
+					<Icon name="lucide:container" class="w-3.5 h-3.5" />
+					Open in Containers
+				</button>
+			</section>
+		{/if}
+
 		{#if entry.publicUrl}
 			<section class="flex flex-col gap-1 p-2.5 rounded-lg bg-amber-500/10">
 				<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-amber-700 dark:text-amber-400">
@@ -101,7 +143,13 @@
 
 		<section class="flex flex-col gap-1.5">
 			<h4 class="m-0 text-[11px] font-semibold uppercase tracking-wider text-slate-500">Process</h4>
-			{#if entry.pid === null}
+			{#if entry.pid === null && entry.container}
+				<p class="m-0 text-xs text-slate-500 dark:text-slate-500">
+					Nothing is listening on this port. The runtime forwards it into the
+					container through a firewall rule instead, which is why no process
+					holds it — the port is still reachable.
+				</p>
+			{:else if entry.pid === null}
 				<p class="m-0 text-xs text-slate-500 dark:text-slate-500">
 					This host did not name the owning process. On Linux the kernel only
 					reveals it for your own processes.

--- a/frontend/components/ports/main/PortRow.svelte
+++ b/frontend/components/ports/main/PortRow.svelte
@@ -26,7 +26,9 @@
 			? 'lucide:shield-check'
 			: entry.origin.kind === 'session'
 				? 'lucide:terminal'
-				: 'lucide:circle-question-mark'
+				: entry.origin.kind === 'container'
+					? 'lucide:container'
+					: 'lucide:circle-question-mark'
 	);
 
 	const accent = $derived(
@@ -34,7 +36,9 @@
 			? 'text-violet-600 dark:text-violet-400'
 			: entry.origin.kind === 'session'
 				? 'text-sky-600 dark:text-sky-400'
-				: 'text-slate-400 dark:text-slate-500'
+				: entry.origin.kind === 'container'
+					? 'text-blue-600 dark:text-blue-400'
+					: 'text-slate-400 dark:text-slate-500'
 	);
 
 	/** Why the stop button is absent, in the user's terms rather than a code. */
@@ -47,7 +51,9 @@
 					? `Owned by ${entry.process?.user ?? 'another user'}`
 					: entry.killBlockedReason === 'system-process'
 						? 'System process'
-						: null
+						: entry.killBlockedReason === 'managed-by-container'
+							? 'Published by a container — stop the container instead'
+							: null
 	);
 </script>
 
@@ -85,6 +91,14 @@
 						guess
 					</span>
 				{/if}
+				{#if entry.container}
+					<span
+						class="hidden sm:inline shrink-0 px-1 py-px rounded text-[9px] font-semibold uppercase tracking-wide bg-blue-500/15 text-blue-700 dark:text-blue-400"
+						title="Published by the {entry.container.name} container from its port {entry.container.containerPort}"
+					>
+						{entry.container.runtime}
+					</span>
+				{/if}
 				{#if entry.publicUrl}
 					<span
 						class="shrink-0 px-1 py-px rounded text-[9px] font-semibold uppercase tracking-wide bg-amber-500/15 text-amber-700 dark:text-amber-400"
@@ -106,7 +120,11 @@
 				{entry.addresses.join(', ')}
 			</span>
 			<span class="text-[11px] text-slate-400 dark:text-slate-600">
-				{#if entry.pid === null}
+				{#if entry.pid === null && entry.container}
+					<!-- No process to name: the runtime forwards this port through a
+					     firewall rule rather than a listening socket. -->
+					published by {entry.container.runtime}
+				{:else if entry.pid === null}
 					owner unknown
 				{:else}
 					pid {entry.pid}{#if entry.workerPids.length > 1}

--- a/frontend/components/ssh-client/SshClientModal.svelte
+++ b/frontend/components/ssh-client/SshClientModal.svelte
@@ -1,6 +1,7 @@
 <!--
 	SSH Client — saved hosts in the sidebar, and per host a remote shell, an SFTP
-	file browser, port forwarding, and the host's connection/key overview.
+	file browser, its listening ports, its containers, port forwarding, and the
+	host's connection/key overview.
 
 	Laid out like the DB Client modal so the two read as one family: sidebar list
 	on the left, a view switcher and the active view on the right, and the sidebar
@@ -14,6 +15,7 @@
 	import FileBrowser from './main/FileBrowser.svelte';
 	import ForwardsPanel from './main/ForwardsPanel.svelte';
 	import PortsPanel from './main/PortsPanel.svelte';
+	import ContainersPanel from './main/ContainersPanel.svelte';
 	import HostOverview from './main/HostOverview.svelte';
 	import { sshClientStore, type SshView } from '$frontend/stores/features/ssh-client.svelte';
 	import { debug } from '$shared/utils/logger';
@@ -41,11 +43,14 @@
 	const activeView = $derived(view?.activeView ?? 'terminal');
 	const connected = $derived(sshClientStore.isConnected(activeConnection?.id));
 	const health = $derived(activeConnection ? sshClientStore.health[activeConnection.id] : null);
-	// Terminal, Files and Ports all run against the host itself, so they need a
-	// live transport; Forwards and Host are settings pages and stay readable
-	// while the host is disconnected.
+	// Terminal, Files, Ports and Containers all run against the host itself, so
+	// they need a live transport; Forwards and Host are settings pages and stay
+	// readable while the host is disconnected.
 	const viewNeedsConnection = $derived(
-		activeView === 'terminal' || activeView === 'files' || activeView === 'ports'
+		activeView === 'terminal' ||
+			activeView === 'files' ||
+			activeView === 'ports' ||
+			activeView === 'containers'
 	);
 
 	let connecting = $state(false);
@@ -66,6 +71,7 @@
 		{ id: 'terminal', label: 'Terminal', icon: 'lucide:terminal' },
 		{ id: 'files', label: 'Files', icon: 'lucide:folder' },
 		{ id: 'ports', label: 'Ports', icon: 'lucide:cable' },
+		{ id: 'containers', label: 'Containers', icon: 'lucide:container' },
 		{ id: 'forwards', label: 'Forwards', icon: 'lucide:arrow-left-right' },
 		{ id: 'overview', label: 'Host', icon: 'lucide:info' }
 	];
@@ -274,6 +280,8 @@
 										<FileBrowser connectionId={activeConnection.id} />
 									{:else if activeView === 'ports'}
 										<PortsPanel connectionId={activeConnection.id} />
+									{:else if activeView === 'containers'}
+										<ContainersPanel connectionId={activeConnection.id} />
 									{:else if activeView === 'forwards'}
 										<ForwardsPanel connectionId={activeConnection.id} />
 									{:else}

--- a/frontend/components/ssh-client/main/ContainersPanel.svelte
+++ b/frontend/components/ssh-client/main/ContainersPanel.svelte
@@ -1,0 +1,23 @@
+<!--
+	ssh-client — what is running on this host.
+
+	The same pane the Containers tool shows for the local machine, scoped to the
+	host the SSH Client is already on. Nothing is reimplemented here: the store,
+	the listing, the detail pane, the log stream and the container shell are all
+	shared, and this only supplies the host id.
+-->
+<script lang="ts">
+	import ContainersPane from '$frontend/components/containers/ContainersPane.svelte';
+
+	interface Props {
+		connectionId: string;
+	}
+
+	const { connectionId }: Props = $props();
+</script>
+
+<div
+	class="flex flex-col flex-1 min-h-0 bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden"
+>
+	<ContainersPane hostId={connectionId} />
+</div>

--- a/frontend/components/workspace/DesktopNavigator.svelte
+++ b/frontend/components/workspace/DesktopNavigator.svelte
@@ -27,6 +27,7 @@
 	import DbClientModal from '$frontend/components/db-client/DbClientModal.svelte';
 	import SshClientModal from '$frontend/components/ssh-client/SshClientModal.svelte';
 	import PortsModal from '$frontend/components/ports/PortsModal.svelte';
+	import ContainersModal from '$frontend/components/containers/ContainersModal.svelte';
 	import MemoryModal from '$frontend/components/memory/MemoryModal.svelte';
 	import SettingButton from '$frontend/components/settings/SettingButton.svelte';
 	import ProjectUserAvatars from '$frontend/components/common/display/ProjectUserAvatars.svelte';
@@ -44,6 +45,8 @@
 		openSshClientDialog,
 		closeSshClientDialog,
 		openPortsDialog,
+		closeContainersDialog,
+		openContainersDialog,
 		closePortsDialog,
 		openMemoryDialog,
 		closeMemoryDialog
@@ -396,6 +399,7 @@
 					onDbClient={openDbClientDialog}
 					onSshClient={openSshClientDialog}
 					onPorts={openPortsDialog}
+					onContainers={openContainersDialog}
 					onMemory={openMemoryDialog}
 				/>
 				<QuickSearchButton />
@@ -465,6 +469,7 @@
 					onDbClient={openDbClientDialog}
 					onSshClient={openSshClientDialog}
 					onPorts={openPortsDialog}
+					onContainers={openContainersDialog}
 					onMemory={openMemoryDialog}
 				/>
 				<QuickSearchButton collapsed={true} />
@@ -557,4 +562,5 @@
 <DbClientModal bind:isOpen={quickPanelsState.dbClientOpen} onClose={closeDbClientDialog} />
 <SshClientModal bind:isOpen={quickPanelsState.sshClientOpen} onClose={closeSshClientDialog} />
 <PortsModal bind:isOpen={quickPanelsState.portsOpen} onClose={closePortsDialog} />
+<ContainersModal bind:isOpen={quickPanelsState.containersOpen} onClose={closeContainersDialog} />
 <MemoryModal bind:isOpen={quickPanelsState.memoryOpen} onClose={closeMemoryDialog} />

--- a/frontend/components/workspace/MobileNavigator.svelte
+++ b/frontend/components/workspace/MobileNavigator.svelte
@@ -12,6 +12,7 @@
 	import DbClientModal from '$frontend/components/db-client/DbClientModal.svelte';
 	import SshClientModal from '$frontend/components/ssh-client/SshClientModal.svelte';
 	import PortsModal from '$frontend/components/ports/PortsModal.svelte';
+	import ContainersModal from '$frontend/components/containers/ContainersModal.svelte';
 	import MemoryModal from '$frontend/components/memory/MemoryModal.svelte';
 	import SettingButton from '$frontend/components/settings/SettingButton.svelte';
 	import type { Project } from '$shared/types/database/schema';
@@ -33,6 +34,8 @@
 		openSshClientDialog,
 		closeSshClientDialog,
 		openPortsDialog,
+		closeContainersDialog,
+		openContainersDialog,
 		closePortsDialog,
 		openMemoryDialog,
 		closeMemoryDialog
@@ -182,6 +185,7 @@
 			onDbClient={openDbClientDialog}
 					onSshClient={openSshClientDialog}
 					onPorts={openPortsDialog}
+					onContainers={openContainersDialog}
 					onMemory={openMemoryDialog}
 		/>
 
@@ -428,4 +432,5 @@
 <DbClientModal bind:isOpen={quickPanelsState.dbClientOpen} onClose={closeDbClientDialog} />
 <SshClientModal bind:isOpen={quickPanelsState.sshClientOpen} onClose={closeSshClientDialog} />
 <PortsModal bind:isOpen={quickPanelsState.portsOpen} onClose={closePortsDialog} />
+<ContainersModal bind:isOpen={quickPanelsState.containersOpen} onClose={closeContainersDialog} />
 <MemoryModal bind:isOpen={quickPanelsState.memoryOpen} onClose={closeMemoryDialog} />

--- a/frontend/components/workspace/ToolsMenu.svelte
+++ b/frontend/components/workspace/ToolsMenu.svelte
@@ -8,6 +8,7 @@
 	import { dbClientStore } from '$frontend/stores/features/db-client.svelte';
 	import { sshClientStore } from '$frontend/stores/features/ssh-client.svelte';
 	import { portsStore } from '$frontend/stores/features/ports.svelte';
+	import { containersStore } from '$frontend/stores/features/containers.svelte';
 	import type { IconName } from '$shared/types/ui/icons';
 
 	interface Props {
@@ -18,6 +19,7 @@
 		onDbClient: () => void;
 		onSshClient: () => void;
 		onPorts: () => void;
+		onContainers: () => void;
 		onMemory: () => void;
 	}
 
@@ -29,6 +31,7 @@
 		onDbClient,
 		onSshClient,
 		onPorts,
+		onContainers,
 		onMemory
 	}: Props = $props();
 
@@ -39,9 +42,15 @@
 	const dbCount = $derived(dbClientStore.liveCount);
 	const sshCount = $derived(sshClientStore.liveCount);
 	const portsCount = $derived(portsStore.liveCount);
+	const containersCount = $derived(containersStore.liveCount);
 	// A single dot on the trigger signals "something under here is active".
 	const hasActivity = $derived(
-		remoteCount > 0 || tunnelCount > 0 || dbCount > 0 || sshCount > 0 || portsCount > 0
+		remoteCount > 0 ||
+			tunnelCount > 0 ||
+			dbCount > 0 ||
+			sshCount > 0 ||
+			portsCount > 0 ||
+			containersCount > 0
 	);
 
 	interface ToolItem {
@@ -95,6 +104,16 @@
 			// a machine's own listeners are a constant, not a sign of activity.
 			count: portsCount,
 			accent: 'text-amber-600 dark:text-amber-400'
+		},
+		{
+			label: 'Containers',
+			description: 'Docker and Podman on this machine',
+			icon: 'lucide:container',
+			onClick: onContainers,
+			// Containers running here. Unlike ports, every one of these is
+			// something someone chose to start, so all of them count.
+			count: containersCount,
+			accent: 'text-blue-600 dark:text-blue-400'
 		},
 		{
 			label: 'Memory',

--- a/frontend/components/workspace/WorkspaceLayout.svelte
+++ b/frontend/components/workspace/WorkspaceLayout.svelte
@@ -201,9 +201,10 @@
 <!-- File peek modal (opened when a file link fires while the Files panel is hidden) -->
 <FilePeekModal />
 
-<!-- Toast Notifications -->
+<!-- Toast Notifications. Above Dialog's z-10000, or a dialog hides the very
+     notification that reports what it started. -->
 {#if notificationStore.notifications.length > 0}
-	<div class="fixed top-4 right-4 z-[200] flex flex-col gap-2">
+	<div class="fixed top-4 right-4 z-[10200] flex flex-col gap-2">
 		{#each notificationStore.notifications as notification (notification.id)}
 			<NotificationToast {notification} />
 		{/each}

--- a/frontend/config/command-registry.ts
+++ b/frontend/config/command-registry.ts
@@ -17,7 +17,8 @@ import {
 	openTunnelDialog,
 	openDbClientDialog,
 	openSshClientDialog,
-	openPortsDialog
+	openPortsDialog,
+	openContainersDialog
 } from '$frontend/stores/ui/quick-panels.svelte';
 import { addNotification } from '$frontend/stores/ui/notification.svelte';
 
@@ -202,6 +203,15 @@ export function getCommandActions(): CommandAction[] {
 		icon: 'lucide:cable',
 		keywords: ['port', 'listening', 'process', 'kill', 'netstat', 'lsof', 'in use', 'occupied'],
 		run: openPortsDialog
+	});
+
+	actions.push({
+		id: 'containers',
+		label: 'Containers',
+		description: 'Docker and Podman on this machine — logs, shell, start and stop',
+		icon: 'lucide:container',
+		keywords: ['docker', 'podman', 'container', 'compose', 'image', 'volume', 'logs', 'exec'],
+		run: openContainersDialog
 	});
 
 	actions.push({

--- a/frontend/services/containers/container-pty-client.ts
+++ b/frontend/services/containers/container-pty-client.ts
@@ -1,0 +1,39 @@
+/**
+ * Frontend PtyKit client for shells inside containers, riding Clopen's app-wide
+ * WebSocket.
+ *
+ * A sibling of frontend/services/ssh/ssh-pty-client.ts, tunneled on
+ * `containers:pty` / `containers:pty-out`. Three clients rather than one
+ * because each is bound to a backend manager, and the three managers spawn
+ * three different things: a local shell, a remote shell, and a shell inside a
+ * container on either of those.
+ */
+
+import { PtyKitClient, hostSocket } from '@myrialabs/ptykit/client';
+import ws, { onWsStatus } from '$frontend/utils/ws';
+
+/** One PtyKit client shared by every container shell (one socket, N sessions). */
+export const containerPtyClient = new PtyKitClient({
+	// `url` is unused — this rides the host socket below.
+	WebSocketImpl: hostSocket({
+		send: (frame) => ws.emit('containers:pty', frame),
+		subscribe: (onFrame) => ws.on('containers:pty-out', (frame) => onFrame(frame)),
+		isOpen: () => ws.connected(),
+		onStatusChange: (cb) => onWsStatus(cb)
+	})
+});
+
+/**
+ * The session a container's shell lives in.
+ *
+ * Derived from the container rather than generated, so reopening the shell —
+ * after a refresh, or after a trip back to the list — reattaches to the running
+ * one instead of leaving an orphan behind and starting a second.
+ */
+export function containerSessionId(hostId: string, containerId: string): string {
+	return `container-${hostId}-${containerId.slice(0, 12)}`;
+}
+
+export function containerNamespace(hostId: string, containerId: string): string {
+	return `container:${hostId}:${containerId}`;
+}

--- a/frontend/stores/features/containers.svelte.ts
+++ b/frontend/stores/features/containers.svelte.ts
@@ -1,0 +1,789 @@
+/**
+ * Container manager store — what is running, on whichever host is selected.
+ *
+ * The server owns the list and pushes it; this owns which host is being looked
+ * at, which of the three lists is on screen, what is selected, and the sidebar
+ * count. Watching is explicit on both ends: opening a host asks the server to
+ * watch it, and leaving stops it, so no host is polled for a view nobody has
+ * open.
+ *
+ * One store serves both places containers are shown — the Containers panel for
+ * this machine and the SSH Client's Containers tab for a saved host. `local` is
+ * not a special case here; it is just the host whose id happens to be `local`.
+ */
+
+import { debug } from '$shared/utils/logger';
+import ws, { onWsReconnect } from '$frontend/utils/ws';
+import { showError, showSuccess } from '$frontend/stores/ui/notification.svelte';
+import { SvelteSet } from 'svelte/reactivity';
+import type {
+	ContainerAction,
+	ContainerDetail,
+	ContainerDiskUsage,
+	ContainerEntry,
+	ContainerImageEntry,
+	ContainerLogChunk,
+	ContainerNetworkEntry,
+	RemovableResourceKind,
+	ContainerScanResult,
+	ContainerState,
+	ContainerStats,
+	ContainerVolumeEntry,
+	PruneKind,
+	PruneJob
+} from '$shared/types/containers';
+import {
+	CONTAINER_LOG_BUFFER_LINES,
+	CONTAINER_TIMEOUTS,
+	LOCAL_CONTAINER_HOST,
+	TRANSPORT_GRACE_MS
+} from '$shared/types/containers';
+
+/** The four lists a host offers. Containers is the point; the rest is context. */
+export type ContainerTab = 'containers' | 'images' | 'volumes' | 'networks';
+
+/** What fills the pane: the lists, or one container's logs or shell. */
+export type ContainerView = 'list' | 'logs' | 'shell';
+
+/**
+ * Rows are grouped by whether they are doing anything. It is the split every
+ * other question follows from — what is up, and what could be brought up.
+ */
+export const STATE_GROUPS: Array<{
+	id: 'running' | 'stopped';
+	title: string;
+	blurb: string;
+	states: ContainerState[];
+}> = [
+	{
+		id: 'running',
+		title: 'Running',
+		blurb: 'Containers doing something right now',
+		states: ['running', 'paused', 'restarting']
+	},
+	{
+		id: 'stopped',
+		title: 'Not running',
+		blurb: 'Stopped, created, or gone wrong',
+		states: ['created', 'exited', 'dead', 'removing', 'unknown']
+	}
+];
+
+interface LogState {
+	streamId: string | null;
+	hostId: string;
+	containerId: string;
+	containerName: string;
+	lines: string[];
+	/** Set when the stream ended on its own — the container stopped, or an error. */
+	ended: string | null;
+	starting: boolean;
+	error: string | null;
+	/** Paused only stops the view from following; the stream keeps buffering. */
+	paused: boolean;
+}
+
+interface ContainersState {
+	/** The host being watched: `local`, or an SSH connection id. */
+	activeHostId: string;
+	/** Latest listing per host, so switching back is instant. */
+	results: Record<string, ContainerScanResult>;
+	/** Hosts this client has asked the server to watch. */
+	watching: SvelteSet<string>;
+	search: string;
+	tab: ContainerTab;
+	view: ContainerView;
+	/** Groups the user has collapsed, remembered while the panel is open. */
+	collapsed: SvelteSet<string>;
+	selectedId: string | null;
+	/** Detail from `inspect`, per container, fetched when a pane opens. */
+	details: Record<string, ContainerDetail>;
+	detailLoading: boolean;
+	/** True when the server withheld environment values from this member. */
+	envRedacted: boolean;
+	badge: number;
+	isLoading: boolean;
+	error: string | null;
+	/** Container or resource currently being acted on, so its row can show it. */
+	actingId: string | null;
+	/** One live sample per container, read on demand rather than polled. */
+	stats: Record<string, ContainerStats>;
+	statsLoading: string | null;
+	/** The last reading the server had for the active host, however old. */
+	diskUsage: ContainerDiskUsage | null;
+	/** Set while the server is walking the disk for a fresh reading. */
+	diskUsageMeasuring: boolean;
+	/**
+	 * The host's clean-up sweep, as the server reports it. Server-owned so that
+	 * closing the dialog, refreshing, or opening the panel on a second device
+	 * cannot lose track of a sweep that is still deleting.
+	 */
+	pruneJob: PruneJob | null;
+	logs: LogState | null;
+	/** The container whose shell is open, kept so the tab can be returned to. */
+	shellId: string | null;
+}
+
+const state = $state<ContainersState>({
+	activeHostId: LOCAL_CONTAINER_HOST,
+	results: {},
+	watching: new SvelteSet(),
+	search: '',
+	tab: 'containers',
+	view: 'list',
+	collapsed: new SvelteSet(),
+	selectedId: null,
+	details: {},
+	detailLoading: false,
+	envRedacted: false,
+	badge: 0,
+	isLoading: false,
+	error: null,
+	actingId: null,
+	stats: {},
+	statsLoading: null,
+	diskUsage: null,
+	diskUsageMeasuring: false,
+	pruneJob: null,
+	logs: null,
+	shellId: null
+});
+
+/**
+ * How long to wait on a request, given what the command behind it may take.
+ *
+ * The command's own budget plus a margin, so the command is always the thing
+ * that gives up first. A transport that times out earlier does not cancel
+ * anything — the daemon keeps stopping the container, keeps deleting the
+ * volumes — it just guarantees nobody is told how it went. That is how a prune
+ * that worked comes back as six failures.
+ */
+function requestBudget(kind: keyof typeof CONTAINER_TIMEOUTS): number {
+	return CONTAINER_TIMEOUTS[kind] + TRANSPORT_GRACE_MS;
+}
+
+function matchesContainer(entry: ContainerEntry, needle: string): boolean {
+	if (!needle) return true;
+	return [
+		entry.name,
+		entry.image,
+		entry.shortId,
+		entry.state,
+		entry.statusText,
+		entry.composeProject ?? '',
+		entry.composeService ?? '',
+		entry.command ?? '',
+		...entry.ports.map((port) => `${port.hostPort ?? ''}:${port.containerPort}`)
+	]
+		.join(' ')
+		.toLowerCase()
+		.includes(needle);
+}
+
+/** A name that is 64 hex characters is one the runtime invented, not a user. */
+export function isAnonymousVolume(volume: ContainerVolumeEntry): boolean {
+	return /^[a-f0-9]{64}$/i.test(volume.name);
+}
+
+export const containersStore = {
+	get activeHostId(): string {
+		return state.activeHostId;
+	},
+	get result(): ContainerScanResult | null {
+		return state.results[state.activeHostId] ?? null;
+	},
+	get search(): string {
+		return state.search;
+	},
+	set search(value: string) {
+		state.search = value;
+	},
+	get tab(): ContainerTab {
+		return state.tab;
+	},
+	set tab(value: ContainerTab) {
+		state.tab = value;
+	},
+	get view(): ContainerView {
+		return state.view;
+	},
+	get isLoading(): boolean {
+		return state.isLoading;
+	},
+	get error(): string | null {
+		return state.error;
+	},
+	get actingId(): string | null {
+		return state.actingId;
+	},
+	get selectedId(): string | null {
+		return state.selectedId;
+	},
+	get detailLoading(): boolean {
+		return state.detailLoading;
+	},
+	get envRedacted(): boolean {
+		return state.envRedacted;
+	},
+	get logs(): LogState | null {
+		return state.logs;
+	},
+	get shellId(): string | null {
+		return state.shellId;
+	},
+
+	/** The sidebar count: containers running on this machine. */
+	get liveCount(): number {
+		return state.badge;
+	},
+
+	get entries(): ContainerEntry[] {
+		const needle = state.search.trim().toLowerCase();
+		return (this.result?.entries ?? []).filter((entry) => matchesContainer(entry, needle));
+	},
+
+	/** Rows in display order, split into running and everything else. */
+	get groups(): Array<{ id: string; title: string; blurb: string; entries: ContainerEntry[] }> {
+		const entries = this.entries;
+		return STATE_GROUPS.map((group) => ({
+			id: group.id,
+			title: group.title,
+			blurb: group.blurb,
+			entries: entries.filter((entry) => group.states.includes(entry.state))
+		}));
+	},
+
+	get images(): ContainerImageEntry[] {
+		const needle = state.search.trim().toLowerCase();
+		return (this.result?.images ?? []).filter((image) =>
+			`${image.repository}:${image.tag} ${image.id} ${image.usedBy.join(' ')}`
+				.toLowerCase()
+				.includes(needle)
+		);
+	},
+
+	get volumes(): ContainerVolumeEntry[] {
+		const needle = state.search.trim().toLowerCase();
+		return (this.result?.volumes ?? []).filter((volume) =>
+			`${volume.name} ${volume.driver} ${volume.mountpoint ?? ''} ${volume.usedBy.join(' ')}`
+				.toLowerCase()
+				.includes(needle)
+		);
+	},
+
+	get networks(): ContainerNetworkEntry[] {
+		const needle = state.search.trim().toLowerCase();
+		return (this.result?.networks ?? []).filter((network) =>
+			`${network.name} ${network.driver} ${network.scope} ${network.usedBy.join(' ')}`
+				.toLowerCase()
+				.includes(needle)
+		);
+	},
+
+	get diskUsage(): ContainerDiskUsage | null {
+		return state.diskUsage;
+	},
+	get diskUsageMeasuring(): boolean {
+		return state.diskUsageMeasuring;
+	},
+	get pruneJob(): PruneJob | null {
+		return state.pruneJob;
+	},
+
+	/** True while this host's sweep is still running. */
+	get pruning(): boolean {
+		return state.pruneJob !== null && state.pruneJob.finishedAt === null;
+	},
+	get statsLoading(): string | null {
+		return state.statsLoading;
+	},
+
+	statsFor(containerId: string): ContainerStats | null {
+		return state.stats[containerId] ?? null;
+	},
+
+	get selected(): ContainerEntry | null {
+		if (!state.selectedId) return null;
+		return (this.result?.entries ?? []).find((entry) => entry.id === state.selectedId) ?? null;
+	},
+
+	/** The container whose shell is open, as long as it is still on this host. */
+	get shellContainer(): ContainerEntry | null {
+		if (!state.shellId) return null;
+		return (this.result?.entries ?? []).find((entry) => entry.id === state.shellId) ?? null;
+	},
+
+	detailFor(containerId: string): ContainerDetail | null {
+		return state.details[containerId] ?? null;
+	},
+
+	isCollapsed(groupId: string): boolean {
+		return state.collapsed.has(groupId);
+	},
+
+	toggleGroup(groupId: string): void {
+		if (state.collapsed.has(groupId)) state.collapsed.delete(groupId);
+		else state.collapsed.add(groupId);
+	},
+
+	select(containerId: string | null): void {
+		state.selectedId = state.selectedId === containerId ? null : containerId;
+		if (state.selectedId) void this.loadDetail(state.selectedId);
+	},
+
+	/**
+	 * Open a host: start the server watching it and show its first listing.
+	 *
+	 * Only one host is watched at a time. Leaving a host stops its polling —
+	 * an SSH host in particular should not keep costing a listing every few
+	 * seconds for a tab that is no longer on screen — while its last result
+	 * stays cached, so coming back renders immediately and then refreshes.
+	 */
+	async watch(hostId: string): Promise<void> {
+		const previous = state.activeHostId;
+		state.activeHostId = hostId;
+		state.error = null;
+		if (previous !== hostId) {
+			state.selectedId = null;
+			state.view = 'list';
+			state.shellId = null;
+			await this.stopLogs();
+			await this.unwatch(previous);
+		}
+		if (state.watching.has(hostId)) return;
+
+		state.isLoading = !state.results[hostId];
+		try {
+			const response = (await ws.http('containers:watch', { hostId }, requestBudget('scan'))) as {
+				result: ContainerScanResult;
+			};
+			state.watching.add(hostId);
+			state.results[hostId] = response.result;
+			state.error = response.result.error;
+		} catch (error) {
+			debug.warn('containers', `Could not watch ${hostId}:`, error);
+			state.error = error instanceof Error ? error.message : String(error);
+		} finally {
+			state.isLoading = false;
+		}
+	},
+
+	/** Stop watching one host, leaving its last listing cached for a quick return. */
+	async unwatch(hostId: string): Promise<void> {
+		if (!state.watching.has(hostId)) return;
+		state.watching.delete(hostId);
+		try {
+			await ws.http('containers:unwatch', { hostId });
+		} catch (error) {
+			debug.warn('containers', `Could not unwatch ${hostId}:`, error);
+		}
+	},
+
+	/** Everything `inspect` knows, fetched once per container per open. */
+	async loadDetail(containerId: string): Promise<void> {
+		state.detailLoading = true;
+		try {
+			const response = (await ws.http(
+				'containers:inspect',
+				{ hostId: state.activeHostId, containerId },
+				requestBudget('inspect')
+			)) as { detail: ContainerDetail | null; envRedacted: boolean };
+			if (response.detail) state.details[containerId] = response.detail;
+			state.envRedacted = response.envRedacted === true;
+		} catch (error) {
+			debug.warn('containers', `Could not inspect ${containerId}:`, error);
+		} finally {
+			state.detailLoading = false;
+		}
+	},
+
+	/**
+	 * Start, stop or restart a container. The server re-reads the host before
+	 * acting, so the row only has to name itself.
+	 */
+	async act(
+		entry: ContainerEntry,
+		action: ContainerAction
+	): Promise<{ ok: boolean; error: string | null }> {
+		state.actingId = entry.id;
+		try {
+			const response = (await ws.http(
+				'containers:action',
+				{ hostId: state.activeHostId, containerId: entry.id, action },
+				requestBudget('action')
+			)) as { result: { ok: boolean; error: string | null }; gone: boolean };
+
+			if (response.gone) return { ok: false, error: 'That container is no longer on this host.' };
+			return response.result;
+		} catch (error) {
+			return { ok: false, error: error instanceof Error ? error.message : String(error) };
+		} finally {
+			state.actingId = null;
+		}
+	},
+
+	/**
+	 * Remove an image, a volume or a network. The runtime refuses anything still
+	 * in use and that refusal is passed straight back, so a volume a running
+	 * container has mounted survives a mis-click.
+	 */
+	async removeResource(
+		kind: RemovableResourceKind,
+		id: string,
+		force = false
+	): Promise<{ ok: boolean; error: string | null }> {
+		state.actingId = id;
+		try {
+			const response = (await ws.http(
+				'containers:remove',
+				{ hostId: state.activeHostId, kind, id, force },
+				requestBudget('action')
+			)) as { result: { ok: boolean; error: string | null } };
+			return response.result;
+		} catch (error) {
+			return { ok: false, error: error instanceof Error ? error.message : String(error) };
+		} finally {
+			state.actingId = null;
+		}
+	},
+
+	/**
+	 * Start a sweep, and stop caring whether this dialog is still open.
+	 *
+	 * Returns once the server has the job, not once the sweep is done — a prune
+	 * runs for minutes. The result arrives on `containers:prune-changed`, which
+	 * is handled in the store rather than in the dialog precisely because the
+	 * dialog may be gone by then.
+	 */
+	async prune(kinds: PruneKind[]): Promise<void> {
+		const hostId = state.activeHostId;
+		try {
+			const response = (await ws.http('containers:prune', { hostId, kinds })) as {
+				job: PruneJob;
+			};
+			if (hostId === state.activeHostId) state.pruneJob = response.job;
+		} catch (error) {
+			debug.warn('containers', 'Could not start the clean-up:', error);
+			showError(
+				'Could not start the clean-up',
+				error instanceof Error ? error.message : String(error)
+			);
+		}
+	},
+
+	/**
+	 * Attach to whatever sweep this host has, running or just finished.
+	 *
+	 * Read whenever the panel opens: the sweep belongs to the host, so one
+	 * started before a refresh — or from another device — has to be found rather
+	 * than assumed absent.
+	 */
+	async loadPruneStatus(): Promise<void> {
+		const hostId = state.activeHostId;
+		try {
+			const response = (await ws.http('containers:prune-status', { hostId })) as {
+				job: PruneJob | null;
+			};
+			if (hostId === state.activeHostId) state.pruneJob = response.job;
+		} catch (error) {
+			debug.warn('containers', 'Could not read the clean-up status:', error);
+		}
+	},
+
+	/** Acknowledge a finished sweep, so its report stops being offered. */
+	async dismissPrune(): Promise<void> {
+		if (this.pruning) return;
+		const hostId = state.activeHostId;
+		state.pruneJob = null;
+		try {
+			await ws.http('containers:prune-dismiss', { hostId });
+		} catch (error) {
+			debug.warn('containers', 'Could not dismiss the clean-up report:', error);
+		}
+	},
+
+	/**
+	 * What this host is holding, and how much of it it could give back.
+	 *
+	 * Returns as soon as the server has answered with whatever it last measured,
+	 * which is usually instant and may be nothing at all on a first open. The
+	 * measurement itself is not awaited — `system df` takes as long as the host's
+	 * disk is large, over a minute on a machine with a few hundred volumes — so
+	 * it arrives later on `containers:disk-usage-measured`.
+	 */
+	async loadDiskUsage(force = false): Promise<void> {
+		const hostId = state.activeHostId;
+		try {
+			const response = (await ws.http('containers:disk-usage', { hostId, force })) as {
+				usage: ContainerDiskUsage | null;
+				measuring: boolean;
+			};
+			// The dialog can be closed and another host opened while this is in
+			// flight; a reading belongs to the host it was asked for.
+			if (hostId !== state.activeHostId) return;
+			state.diskUsage = response.usage;
+			state.diskUsageMeasuring = response.measuring;
+		} catch (error) {
+			debug.warn('containers', 'Could not read disk usage:', error);
+			if (hostId !== state.activeHostId) return;
+			state.diskUsage = {
+				rows: [],
+				error: error instanceof Error ? error.message : String(error),
+				measuredAt: null
+			};
+			state.diskUsageMeasuring = false;
+		}
+	},
+
+	/** One sample of what a container is consuming, when the pane asks for it. */
+	async loadStats(containerId: string): Promise<void> {
+		state.statsLoading = containerId;
+		try {
+			const response = (await ws.http(
+				'containers:stats',
+				{
+					hostId: state.activeHostId,
+					containerId
+				},
+				requestBudget('stats')
+			)) as { stats: ContainerStats | null };
+			if (response.stats) state.stats[containerId] = response.stats;
+		} catch (error) {
+			debug.warn('containers', `Could not read stats for ${containerId}:`, error);
+		} finally {
+			state.statsLoading = null;
+		}
+	},
+
+	// -- logs ----------------------------------------------------------------
+
+	/** Follow a container's output, replacing whatever was being followed. */
+	async startLogs(entry: ContainerEntry): Promise<void> {
+		await this.stopLogs();
+
+		state.logs = {
+			streamId: null,
+			hostId: state.activeHostId,
+			containerId: entry.id,
+			containerName: entry.name,
+			lines: [],
+			ended: null,
+			starting: true,
+			error: null,
+			paused: false
+		};
+		state.view = 'logs';
+
+		try {
+			const response = (await ws.http('containers:logs-start', {
+				hostId: state.activeHostId,
+				containerId: entry.id
+			})) as { streamId: string; backlog: string };
+
+			if (!state.logs || state.logs.containerId !== entry.id) return;
+			state.logs.streamId = response.streamId;
+			state.logs.starting = false;
+			if (response.backlog) appendLogText(state.logs, response.backlog);
+		} catch (error) {
+			if (!state.logs) return;
+			state.logs.starting = false;
+			state.logs.error = error instanceof Error ? error.message : String(error);
+		}
+	},
+
+	async stopLogs(): Promise<void> {
+		const logs = state.logs;
+		state.logs = null;
+		if (!logs?.streamId) return;
+		try {
+			await ws.http('containers:logs-stop', { streamId: logs.streamId });
+		} catch (error) {
+			debug.warn('containers', 'Could not stop the log stream:', error);
+		}
+	},
+
+	togglePause(): void {
+		if (state.logs) state.logs.paused = !state.logs.paused;
+	},
+
+	clearLogs(): void {
+		if (state.logs) state.logs.lines = [];
+	},
+
+	// -- views ---------------------------------------------------------------
+
+	/** Open the shell for a container, which is the pane's other full view. */
+	openShell(entry: ContainerEntry): void {
+		state.shellId = entry.id;
+		state.view = 'shell';
+	},
+
+	/** Back to the lists. The shell keeps running; the log stream does not. */
+	closeView(): void {
+		if (state.view === 'logs') void this.stopLogs();
+		state.view = 'list';
+	},
+
+	/** Leave the shell open but go back to the lists, keeping the session alive. */
+	showList(): void {
+		state.view = 'list';
+	},
+
+	reopenShell(): void {
+		if (state.shellId) state.view = 'shell';
+	},
+
+	closeShell(): void {
+		state.shellId = null;
+		state.view = 'list';
+	},
+
+	/**
+	 * Point the panel at one container, used by the cross-link from Ports.
+	 *
+	 * Goes through `watch` rather than setting the host directly: the panel this
+	 * opens will ask to watch the host anyway, and assigning it here would make
+	 * that call believe the host had not changed — leaving the previous one
+	 * polling on the server with nothing on screen.
+	 */
+	focus(hostId: string, containerId: string): void {
+		void (async () => {
+			// A leftover search would filter the row out of the list the moment
+			// it is selected, which reads as the jump having done nothing.
+			state.search = '';
+			await this.watch(hostId);
+			state.tab = 'containers';
+			state.view = 'list';
+			state.selectedId = containerId;
+			await this.loadDetail(containerId);
+		})();
+	},
+
+	// -- realtime ------------------------------------------------------------
+
+	/** Ask for the current count, which pushes alone cannot deliver on load. */
+	async loadBadge(): Promise<void> {
+		try {
+			const response = (await ws.http('containers:summary', {})) as { count: number };
+			state.badge = typeof response?.count === 'number' ? response.count : 0;
+		} catch (error) {
+			debug.warn('containers', 'Could not read the container count:', error);
+		}
+	},
+
+	/**
+	 * Subscribe to pushed listings, log output and the sidebar count. Call once
+	 * on app mount: the badge arrives whether or not the panel has ever been
+	 * opened.
+	 */
+	initRealtimeListener(): () => void {
+		const cleanupChanged = ws.on('containers:changed', (data: { result: ContainerScanResult }) => {
+			if (!data?.result) return;
+			state.results[data.result.hostId] = data.result;
+			if (data.result.hostId === state.activeHostId) state.error = data.result.error;
+		});
+
+		const cleanupBadge = ws.on('containers:badge', (data: { count: number }) => {
+			state.badge = typeof data?.count === 'number' ? data.count : 0;
+		});
+
+		/**
+		 * A sweep reaching its end.
+		 *
+		 * Reported here rather than in the dialog because the dialog is exactly
+		 * what may not exist any more: a sweep runs for minutes and the modal that
+		 * started it is often long closed. The toast is how someone who walked
+		 * away finds out, and the figures are re-read because a sweep is the one
+		 * thing that certainly moved them.
+		 */
+		const cleanupPrune = ws.on('containers:prune-changed', (data: { job: PruneJob }) => {
+			const job = data?.job;
+			if (!job) return;
+			// The store mirrors one host, so only that host's job is held here — but
+			// being told a sweep finished is not state, and a sweep on the host you
+			// are not currently looking at is exactly the one you would otherwise
+			// never hear about.
+			if (job.hostId === state.activeHostId) {
+				state.pruneJob = job;
+				void containersStore.loadDiskUsage(true);
+			}
+
+			const outcomes = job.outcomes ?? [];
+			const failed = outcomes.filter((outcome) => !outcome.ok);
+			if (failed.length > 0) {
+				showError(
+					'Some sweeps failed',
+					failed.map((outcome) => `${outcome.kind}: ${outcome.error}`).join('\n')
+				);
+				return;
+			}
+			const reclaimed = outcomes
+				.map((outcome) => outcome.reclaimed)
+				.filter((value): value is string => value !== null);
+			showSuccess(
+				'Cleaned up',
+				reclaimed.length > 0 ? `Reclaimed ${reclaimed.join(' + ')}.` : 'The host is tidy.'
+			);
+		});
+
+		// The disk reading, whenever the server finishes walking the disk for it.
+		const cleanupDiskUsage = ws.on(
+			'containers:disk-usage-measured',
+			(data: { hostId: string; usage: ContainerDiskUsage }) => {
+				if (!data?.usage || data.hostId !== state.activeHostId) return;
+				state.diskUsage = data.usage;
+				state.diskUsageMeasuring = false;
+			}
+		);
+
+		const cleanupLogs = ws.on('containers:log-chunk', (chunk: ContainerLogChunk) => {
+			const logs = state.logs;
+			if (!logs || !chunk || chunk.streamId !== logs.streamId) return;
+			if (chunk.data) appendLogText(logs, chunk.data);
+			if (chunk.done) {
+				logs.ended = chunk.error ?? 'The stream ended.';
+				logs.streamId = null;
+			}
+		});
+
+		// A watch lives on the socket that asked for it, so a reconnect leaves the
+		// server watching nothing while this side still believes it is. Without
+		// re-asking, the list would sit there looking live and never change again.
+		const cleanupReconnect = onWsReconnect(() => {
+			const wasWatching = state.watching.size > 0;
+			state.watching.clear();
+			void containersStore.loadBadge();
+			if (!wasWatching) return;
+			void containersStore.watch(state.activeHostId);
+		});
+
+		// The count is state, not an event, so it is read on load rather than
+		// waited for — a refreshed page must not sit at zero until it changes.
+		void containersStore.loadBadge();
+
+		return () => {
+			cleanupChanged();
+			cleanupBadge();
+			cleanupPrune();
+			cleanupDiskUsage();
+			cleanupLogs();
+			cleanupReconnect();
+		};
+	}
+};
+
+/**
+ * Append output, keeping the view's buffer bounded the same way the server's
+ * is. A container writing a megabyte a second would otherwise turn a log view
+ * into an out-of-memory crash in the browser rather than on the host.
+ */
+function appendLogText(logs: LogState, text: string): void {
+	const pieces = text.split('\n');
+	const last = logs.lines.length - 1;
+	// The first piece continues whatever line the previous chunk left open.
+	if (last >= 0) logs.lines[last] += pieces.shift() ?? '';
+	for (const piece of pieces) logs.lines.push(piece);
+	if (logs.lines.length > CONTAINER_LOG_BUFFER_LINES) {
+		logs.lines.splice(0, logs.lines.length - CONTAINER_LOG_BUFFER_LINES);
+	}
+}

--- a/frontend/stores/features/ports.svelte.ts
+++ b/frontend/stores/features/ports.svelte.ts
@@ -14,13 +14,18 @@
 import { debug } from '$shared/utils/logger';
 import ws, { onWsReconnect } from '$frontend/utils/ws';
 import { SvelteSet } from 'svelte/reactivity';
-import type { PortEntry, PortOriginKind, PortScanResult } from '$shared/types/ports';
+import type { PortEntry, PortOriginKind, PortProtocol, PortScanResult } from '$shared/types/ports';
 import { LOCAL_PORT_HOST } from '$shared/types/ports';
 
 /** Rows are grouped by where they came from, most explicable first. */
 export const ORIGIN_GROUPS: Array<{ kind: PortOriginKind; title: string; blurb: string }> = [
 	{ kind: 'clopen', title: 'Opened by Clopen', blurb: 'Listeners Clopen is responsible for' },
 	{ kind: 'session', title: 'Started from Clopen', blurb: 'Terminals, engines, and anything they launched' },
+	{
+		kind: 'container',
+		title: 'Published by containers',
+		blurb: 'Ports a container runtime forwards into a container'
+	},
 	{ kind: 'external', title: 'Outside Clopen', blurb: 'Everything else on this host' }
 ];
 
@@ -66,6 +71,8 @@ function matches(entry: PortEntry, needle: string): boolean {
 		entry.process?.user ?? '',
 		entry.process?.cwd ?? '',
 		entry.pid === null ? '' : String(entry.pid),
+		entry.container?.name ?? '',
+		entry.container?.image ?? '',
 		...entry.addresses
 	]
 		.join(' ')
@@ -134,6 +141,28 @@ export const portsStore = {
 
 	select(key: string | null): void {
 		state.selectedKey = state.selectedKey === key ? null : key;
+	},
+
+	/**
+	 * Point the table at one host port, used by the cross-link from Containers.
+	 *
+	 * Matched on protocol and port rather than on a row key, because the
+	 * container side knows the mapping and not which pid ended up holding the
+	 * socket — and where the userland proxy is off, no pid ever will. The search
+	 * and the row's group are cleared on the way in: selecting a row that a
+	 * filter or a collapsed group is hiding looks exactly like the jump failing.
+	 */
+	focusPort(hostId: string, protocol: PortProtocol, port: number): void {
+		void (async () => {
+			state.search = '';
+			await this.watch(hostId);
+			const entry = (state.results[hostId]?.entries ?? []).find(
+				(candidate) => candidate.protocol === protocol && candidate.port === port
+			);
+			if (!entry) return;
+			state.collapsed.delete(entry.origin.kind);
+			state.selectedKey = entry.key;
+		})();
 	},
 
 	/**

--- a/frontend/stores/features/ssh-client.svelte.ts
+++ b/frontend/stores/features/ssh-client.svelte.ts
@@ -32,7 +32,7 @@ import type {
 	SshKnownHost
 } from '$shared/types/ssh';
 
-export type SshView = 'terminal' | 'files' | 'ports' | 'forwards' | 'overview';
+export type SshView = 'terminal' | 'files' | 'ports' | 'containers' | 'forwards' | 'overview';
 
 /** One terminal tab. `sessionId` is the PtyKit session it renders. */
 export interface SshTerminalTab {

--- a/frontend/stores/ui/quick-panels.svelte.ts
+++ b/frontend/stores/ui/quick-panels.svelte.ts
@@ -13,6 +13,7 @@ interface QuickPanelsState {
 	dbClientOpen: boolean;
 	sshClientOpen: boolean;
 	portsOpen: boolean;
+	containersOpen: boolean;
 	memoryOpen: boolean;
 }
 
@@ -23,6 +24,7 @@ export const quickPanelsState = $state<QuickPanelsState>({
 	dbClientOpen: false,
 	sshClientOpen: false,
 	portsOpen: false,
+	containersOpen: false,
 	memoryOpen: false
 });
 
@@ -72,6 +74,14 @@ export function openPortsDialog() {
 
 export function closePortsDialog() {
 	quickPanelsState.portsOpen = false;
+}
+
+export function openContainersDialog() {
+	quickPanelsState.containersOpen = true;
+}
+
+export function closeContainersDialog() {
+	quickPanelsState.containersOpen = false;
 }
 
 export function openMemoryDialog() {

--- a/shared/types/containers/container.ts
+++ b/shared/types/containers/container.ts
@@ -1,0 +1,366 @@
+/**
+ * Containers — the shape of "what is running on this host, and how to reach it".
+ *
+ * One model serves the machine Clopen runs on and any saved SSH host, so the
+ * same table, detail pane, log view and shell render either. Docker and Podman
+ * answer the same questions in slightly different words; the differences are
+ * flattened here rather than pushed into the UI, and anything a runtime cannot
+ * report is `null` with the reason carried in `limitations` — never a guess
+ * dressed as a fact.
+ */
+
+import { LOCAL_HOST_ID, type HostId } from '../host';
+
+/** The runtimes Clopen knows how to drive. Detected, never configured. */
+export type ContainerRuntime = 'docker' | 'podman';
+
+/**
+ * Lifecycle states, normalised across both runtimes. `unknown` is kept rather
+ * than folded into `exited`: a state Clopen does not recognise must not be
+ * rendered as one it does.
+ */
+export type ContainerState =
+	| 'running'
+	| 'paused'
+	| 'restarting'
+	| 'created'
+	| 'exited'
+	| 'dead'
+	| 'removing'
+	| 'unknown';
+
+/** A healthcheck verdict. `none` means the image declares no healthcheck. */
+export type ContainerHealth = 'healthy' | 'unhealthy' | 'starting' | 'none';
+
+/**
+ * One published port. `hostPort` is null when the port is exposed by the image
+ * but not published to the host — the container can be reached from its own
+ * network and nowhere else, which is worth showing rather than hiding.
+ */
+export interface ContainerPortBinding {
+	/** The address on the host the port is bound to, e.g. `0.0.0.0`. */
+	hostAddress: string | null;
+	hostPort: number | null;
+	containerPort: number;
+	protocol: 'tcp' | 'udp';
+}
+
+/** One row in the container table. */
+export interface ContainerEntry {
+	/** Stable across scans, so the UI can diff without rebuilding the table. */
+	key: string;
+	/** Full id, used for every action so a name collision cannot misfire. */
+	id: string;
+	/** Twelve characters of the id, which is how the runtime prints it. */
+	shortId: string;
+	name: string;
+	image: string;
+	state: ContainerState;
+	/** The runtime's own words, e.g. `Up 3 hours (healthy)`. */
+	statusText: string;
+	health: ContainerHealth;
+	/** ISO timestamp, or null when the runtime printed a date nothing can parse. */
+	createdAt: string | null;
+	/** ISO timestamp of the current run; null unless the container is running. */
+	startedAt: string | null;
+	ports: ContainerPortBinding[];
+	/** Set from the compose labels, so a stack reads as a stack. */
+	composeProject: string | null;
+	composeService: string | null;
+	/** The entrypoint command, as the runtime reports it. */
+	command: string | null;
+	/**
+	 * False when this host would refuse the action anyway — a container the
+	 * account cannot touch is shown, but not offered as something to stop.
+	 */
+	canManage: boolean;
+}
+
+/** An image on the host. Read-only: building and pulling are out of scope. */
+export interface ContainerImageEntry {
+	key: string;
+	id: string;
+	repository: string;
+	tag: string;
+	/** Human size exactly as the runtime printed it. */
+	size: string;
+	createdAt: string | null;
+	/** True for `<none>:<none>` layers left behind by a rebuild. */
+	dangling: boolean;
+	/** Names of containers currently using it, so deleting is never a surprise. */
+	usedBy: string[];
+}
+
+/** A network on the host. */
+export interface ContainerNetworkEntry {
+	key: string;
+	id: string;
+	name: string;
+	driver: string;
+	scope: string;
+	internal: boolean;
+	createdAt: string | null;
+	usedBy: string[];
+	/**
+	 * True for the networks the runtime creates itself — `bridge`, `host`,
+	 * `none`, `podman`. They cannot be removed, and offering to would only
+	 * produce an error the user cannot act on.
+	 */
+	predefined: boolean;
+}
+
+/** A volume on the host. */
+export interface ContainerVolumeEntry {
+	key: string;
+	name: string;
+	driver: string;
+	mountpoint: string | null;
+	createdAt: string | null;
+	usedBy: string[];
+}
+
+/**
+ * A capability this host could not deliver. Surfaced in the UI so an empty
+ * table reads as "this host cannot tell us" rather than "nothing is running".
+ */
+export type ContainerLimitationCode =
+	| 'no-runtime'
+	| 'daemon-unreachable'
+	| 'permission-denied'
+	| 'images-unavailable'
+	| 'volumes-unavailable'
+	| 'networks-unavailable'
+	| 'no-start-times';
+
+export interface ContainerLimitation {
+	code: ContainerLimitationCode;
+	message: string;
+}
+
+/** How the host answered when asked what runtime it has. */
+export interface ContainerRuntimeInfo {
+	runtime: ContainerRuntime | null;
+	version: string | null;
+	/**
+	 * Why there is no usable runtime. Split out because the three causes need
+	 * three different things from the user, and "no containers" is the wrong
+	 * answer to all of them.
+	 */
+	problem: 'none' | 'not-installed' | 'daemon-unreachable' | 'permission-denied';
+	/** The runtime's own error, when it gave one. */
+	detail: string | null;
+}
+
+export interface ContainerScanResult {
+	hostId: HostId;
+	/** ISO timestamp of the scan that produced this. */
+	scannedAt: string;
+	runtime: ContainerRuntime | null;
+	runtimeVersion: string | null;
+	runtimeProblem: ContainerRuntimeInfo['problem'];
+	entries: ContainerEntry[];
+	images: ContainerImageEntry[];
+	volumes: ContainerVolumeEntry[];
+	networks: ContainerNetworkEntry[];
+	limitations: ContainerLimitation[];
+	/** Set when the scan failed outright; the lists are then empty. */
+	error: string | null;
+}
+
+/** What a row offers to do. All of these are admin-only on the server. */
+export type ContainerAction =
+	| 'start'
+	| 'stop'
+	| 'restart'
+	| 'pause'
+	| 'unpause'
+	| 'remove'
+	/** `remove` on something still running: it is stopped first, by the runtime. */
+	| 'force-remove';
+
+export interface ContainerActionResult {
+	ok: boolean;
+	error: string | null;
+}
+
+/** The four things a host holds that this feature can remove. */
+export type ContainerResourceKind = 'container' | 'image' | 'volume' | 'network';
+
+/**
+ * The three that are removed as themselves. A container is removed through its
+ * own lifecycle instead, because whether it is still running changes both the
+ * command and what the confirmation has to say.
+ */
+export type RemovableResourceKind = Exclude<ContainerResourceKind, 'container'>;
+
+/**
+ * What a clean-up sweep can reclaim.
+ *
+ * Split by what each one costs to get back rather than lumped into one button.
+ * Removing a stopped container is nothing; removing an unused image means
+ * pulling or building it again, which on a slow connection is an afternoon.
+ */
+export type PruneKind =
+	| 'containers'
+	| 'dangling-images'
+	| 'images'
+	| 'volumes'
+	| 'networks'
+	| 'build-cache';
+
+export interface PruneOutcome {
+	kind: PruneKind;
+	ok: boolean;
+	/** Entries the runtime listed as removed. Zero is a normal answer. */
+	removed: number;
+	/** Space the runtime says it freed, in its own words. Null if it did not say. */
+	reclaimed: string | null;
+	error: string | null;
+}
+
+/**
+ * A cleanup sweep, as the server remembers it.
+ *
+ * The sweep belongs to the host, not to the dialog that started it. Closing the
+ * dialog — or refreshing the browser, or opening the panel on another device —
+ * must not lose track of a `prune` that is still deleting, and must not invite
+ * a second one on top of it. So the server owns the job and the dialog attaches
+ * to whatever it finds.
+ */
+export interface PruneJob {
+	hostId: string;
+	kinds: PruneKind[];
+	startedAt: string;
+	/** Null while the sweep is still running. */
+	finishedAt: string | null;
+	/** One line per kind, filled in when the sweep ends. */
+	outcomes: PruneOutcome[] | null;
+}
+
+/** One line of `system df`: how much of a resource is in use, and how much is not. */
+export interface ContainerDiskUsageRow {
+	kind: 'images' | 'containers' | 'volumes' | 'build-cache';
+	total: number | null;
+	active: number | null;
+	/** Sizes stay as the runtime printed them — it is the authority on its own units. */
+	size: string;
+	reclaimable: string;
+}
+
+export interface ContainerDiskUsage {
+	rows: ContainerDiskUsageRow[];
+	error: string | null;
+	/**
+	 * When this reading was taken, so the dialog can say how old it is.
+	 *
+	 * A reading is shown from cache rather than re-measured on every open,
+	 * because `system df` is the one container command whose cost is set by how
+	 * much disk the host holds rather than by how many containers it runs: the
+	 * daemon walks every image layer and every volume to answer it. On a host
+	 * with a few hundred volumes on a virtualised filesystem that is over a
+	 * minute, and almost all of it is the volumes.
+	 */
+	measuredAt: string | null;
+}
+
+/**
+ * How long each container command may run, and therefore how long a caller has
+ * to be prepared to wait for it.
+ *
+ * Both ends read these. The backend hands them to the runtime as the command
+ * budget; the frontend hands them to `ws.http` as the request budget, plus
+ * `TRANSPORT_GRACE_MS`. They have to come from one place, because a transport
+ * that gives up before the command does turns every slow-but-successful run
+ * into a reported failure — a prune that is still deleting, a container that is
+ * still stopping — and the caller then has no way to find out it worked.
+ */
+export const CONTAINER_TIMEOUTS = {
+	/** `stop` waits out the container's grace period, which can be long. */
+	action: 120_000,
+	/** A prune walks and unlinks everything it removes. */
+	prune: 300_000,
+	/** One `ps`, `images`, `volume ls` or `network ls`. */
+	list: 20_000,
+	/** A full listing: the four above, plus detecting the runtime. */
+	scan: 90_000,
+	/** `stats` samples over a window before it prints. */
+	stats: 30_000,
+	inspect: 20_000
+} as const;
+
+/**
+ * The extra the transport allows on top of the command's own budget.
+ *
+ * Enough to cover the round trip and the runtime's own teardown, so the command
+ * is always the thing that gives up first and the caller always hears why.
+ */
+export const TRANSPORT_GRACE_MS = 15_000;
+
+/**
+ * How long a disk reading stays good before the dialog measures again.
+ *
+ * The figures only move when something is created or removed, and a prune
+ * invalidates them outright, so re-measuring on every open would spend a minute
+ * of the daemon's time to redraw numbers that had not changed.
+ */
+export const DISK_USAGE_STALE_MS = 300_000;
+
+/**
+ * How long the measurement itself may run before it is abandoned.
+ *
+ * Nothing waits on this — it is pushed when it lands — so the budget is here to
+ * stop a wedged daemon holding a slot forever, not to bound anyone's spinner.
+ */
+export const DISK_USAGE_TIMEOUT_MS = 600_000;
+
+/** A single sample of what one container is consuming, read on demand. */
+export interface ContainerStats {
+	cpuPercent: number | null;
+	memoryUsage: string | null;
+	memoryPercent: number | null;
+	networkIO: string | null;
+	blockIO: string | null;
+	pids: number | null;
+}
+
+/** Everything `inspect` adds to a row, fetched only when a detail pane opens. */
+export interface ContainerDetail {
+	id: string;
+	name: string;
+	image: string;
+	imageId: string | null;
+	command: string | null;
+	createdAt: string | null;
+	startedAt: string | null;
+	finishedAt: string | null;
+	state: ContainerState;
+	health: ContainerHealth;
+	exitCode: number | null;
+	restartCount: number | null;
+	restartPolicy: string | null;
+	pid: number | null;
+	workingDir: string | null;
+	user: string | null;
+	networks: Array<{ name: string; ipAddress: string | null }>;
+	mounts: Array<{ source: string; destination: string; readOnly: boolean; kind: string }>;
+	ports: ContainerPortBinding[];
+	env: string[];
+	labels: Array<{ key: string; value: string }>;
+}
+
+/** One push of container output while a log stream is being followed. */
+export interface ContainerLogChunk {
+	streamId: string;
+	hostId: HostId;
+	containerId: string;
+	/** Newline-terminated text exactly as the container wrote it. */
+	data: string;
+	/** Set once when the stream ends, with the reason if it was not asked for. */
+	done?: boolean;
+	error?: string | null;
+}
+
+export const LOCAL_CONTAINER_HOST: HostId = LOCAL_HOST_ID;
+
+/** Lines kept per stream. A chatty container must not grow without limit. */
+export const CONTAINER_LOG_BUFFER_LINES = 2000;

--- a/shared/types/containers/index.ts
+++ b/shared/types/containers/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Container manager types barrel export.
+ */
+
+export * from './container';

--- a/shared/types/host/index.ts
+++ b/shared/types/host/index.ts
@@ -1,0 +1,18 @@
+/**
+ * The identity of a machine Clopen can act on.
+ *
+ * Ports, containers and everything host-scoped that follows them address a
+ * machine the same way: `local` is the machine Clopen itself runs on, and any
+ * other id is a saved SSH connection. `local` is not a special case — it is
+ * simply the host whose id happens to be `local`, which is what lets one store
+ * and one scan serve both the More Tools panel and the SSH Client tab.
+ */
+
+export type HostId = string;
+
+export const LOCAL_HOST_ID: HostId = 'local';
+
+/** True when this id names the machine Clopen is running on. */
+export function isLocalHost(hostId: HostId): boolean {
+	return hostId === LOCAL_HOST_ID;
+}

--- a/shared/types/ports/port.ts
+++ b/shared/types/ports/port.ts
@@ -8,6 +8,8 @@
  * than guessing.
  */
 
+import { LOCAL_HOST_ID, type HostId } from '../host';
+
 export type PortProtocol = 'tcp' | 'udp';
 
 export type PortIpVersion = 'v4' | 'v6';
@@ -60,12 +62,13 @@ export interface PortProcess {
 export type PortOriginConfidence = 'certain' | 'guess';
 
 /**
- * The three tiers the UI groups by:
- * - `clopen`   — a listener Clopen opened, registered by the feature that owns it
- * - `session`  — a process descended from a Clopen terminal session
- * - `external` — everything else on the machine
+ * The four tiers the UI groups by:
+ * - `clopen`    — a listener Clopen opened, registered by the feature that owns it
+ * - `session`   — a process descended from a Clopen terminal session
+ * - `container` — a port a container runtime publishes on this host
+ * - `external`  — everything else on the machine
  */
-export type PortOriginKind = 'clopen' | 'session' | 'external';
+export type PortOriginKind = 'clopen' | 'session' | 'container' | 'external';
 
 /** Which Clopen feature owns a `clopen` port, so it can be stopped properly. */
 export type PortOwnerFeature =
@@ -94,6 +97,29 @@ export interface PortOrigin {
 	projectId?: string;
 	/** Set when the lineage ends at an sshd session rather than a Clopen one. */
 	remoteSessionUser?: string;
+	/** Set when `kind` is `container` — the container publishing this port. */
+	containerId?: string;
+}
+
+/**
+ * The container publishing a port, when one does.
+ *
+ * A published port is a fact the runtime states outright, so this is never a
+ * guess. It is also the only owner worth naming: the listening process is
+ * `docker-proxy` or the daemon itself, and with the userland proxy disabled
+ * there is no listening socket at all — the port is reached through a firewall
+ * rule. Either way the thing to act on is the container.
+ */
+export interface PortContainerRef {
+	runtime: 'docker' | 'podman';
+	/** Full container id, so an action can address it unambiguously. */
+	id: string;
+	/** Twelve-character id, which is how the runtime's own output reads. */
+	shortId: string;
+	name: string;
+	image: string;
+	/** The port inside the container this host port is mapped to. */
+	containerPort: number;
 }
 
 /** A peer currently connected to a listening port. */
@@ -109,7 +135,8 @@ export type PortKillBlockedReason =
 	| 'is-clopen-itself'
 	| 'unknown-pid'
 	| 'not-permitted'
-	| 'system-process';
+	| 'system-process'
+	| 'managed-by-container';
 
 /** One row in the table: a port, its owner, and what is connected to it. */
 export interface PortEntry {
@@ -138,6 +165,13 @@ export interface PortEntry {
 	 * reachable from the public internet.
 	 */
 	publicUrl: string | null;
+	/**
+	 * Set when a container runtime publishes this port. Like `publicUrl` this
+	 * describes how the port is reached rather than replacing whoever holds it,
+	 * and it is what lets the row point at the container instead of offering to
+	 * signal a proxy process that would only come back.
+	 */
+	container: PortContainerRef | null;
 	canKill: boolean;
 	killBlockedReason: PortKillBlockedReason | null;
 }
@@ -158,10 +192,14 @@ export interface PortLimitation {
 	message: string;
 }
 
-/** `local` is the machine running Clopen; any other id is an SSH connection. */
-export type PortHostId = string;
+/**
+ * `local` is the machine running Clopen; any other id is an SSH connection.
+ * Both names point at the same value: host identity is shared by every
+ * host-scoped feature, and ports keep their own spelling only for readability.
+ */
+export type PortHostId = HostId;
 
-export const LOCAL_PORT_HOST: PortHostId = 'local';
+export const LOCAL_PORT_HOST: PortHostId = LOCAL_HOST_ID;
 
 export interface PortScanResult {
 	hostId: PortHostId;

--- a/shared/utils/logger.ts
+++ b/shared/utils/logger.ts
@@ -48,6 +48,8 @@ export type LogLabel =
 	| 'db-client'
 	| 'ssh'
 	| 'ports'
+	| 'containers'
+	| 'host'
 	
 	// User
 	| 'user'


### PR DESCRIPTION
## Summary
Adds a container manager for Docker and Podman that works identically on the
local machine and on any saved SSH host, and teaches the port table which
container publishes each port.

## Why
The port manager could say a port was open but not what was behind it. On a
host running a container runtime that answer is almost always a container, and
reaching it meant leaving Clopen for a terminal.

Published ports are also the one case where the process holding the socket is
not what the user means: on Linux it is `docker-proxy`, and with the userland
proxy disabled there is no listening socket at all. Only the runtime can
answer, so the port scan has to ask it.

## Changes
- Container manager backend: runtime detection, scan, logs, PTY, actions, and
  a port index the port scan reads. Docker and Podman parsers for each.
- WS routes for listing, actions, logs and tunnelling. Removal, prune and
  prune-dismiss are admin-only.
- Panel, detail pane, image/volume/network tables, and the cleanup and removal
  dialogs — served by one store in both the Containers panel and the SSH
  Client's Containers tab.
- Disk measurement and cleanup sweeps are server-owned jobs, read on open and
  pushed on completion, so they survive closing the modal or refreshing.
- Command timeouts moved to one shared constant read by both ends, so the
  transport always outlasts the command it is waiting on.
- The CommandRunner moved from `backend/ports` to `backend/host`.
- Quick Search and toasts now sit above dialogs.

## Test plan
- `bun run check` — 0 errors, 0 warnings across 4576 files
- `bun run lint` — clean
- `bun run test` — 791 pass, 17 skip, 0 fail
- 84 tests across the containers and ports modules: Docker and Podman output
  for every command used, the disk-reading cache policy, the timeout
  invariants, and the sweep registry's single-job guard
- Verified against a live Docker 29.2.0 host: runtime detection, `system df`,
  network listing and `usedBy`, per-container stats, and every `prune` flag
  the code passes

## Security impact
Listings and logs are readable by anyone who can already reach the host.
Environment variables are not: admin-only, and revealed only on an explicit
click, because a container's env holds its database password and this pane is
reachable through a shared Remote Access link. Removal and prune are admin-only.
Nothing runs under `sudo`, and a force flag is only passed when the dialog
said so.

## Notes
Read paths are verified against Docker. Prune is covered by fixtures and unit
tests only — it was not run against a live daemon, being destructive by
definition. Podman parsing is written against its documented JSON output and
exercised by fixtures, but has not been run against a live Podman host.

## Follow-ups
- `WorkflowTranscriptTailer > replays each appended child tool call and result
  exactly once` sits on its 5s timeout and fails intermittently. Unrelated to
  this change; worth raising separately.