### PR TITLE
feat(projects): add per-project resource monitoring with info modal

### DIFF
--- a/backend/host/metrics.test.ts
+++ b/backend/host/metrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { collectProcessTree, cpuCapacityFactor } from './info';
+import { collectProcessTree, cpuCapacityFactor, getHostFacts, withTimeout } from './metrics';
 
 function proc(pid: number, parentPid: number) {
 	return { pid, parentPid };
@@ -70,5 +70,41 @@ describe('cpuCapacityFactor', () => {
 
 	it('refuses to divide by a missing core count', () => {
 		expect(cpuCapacityFactor('darwin', 0, null, true)).toBeNull();
+	});
+});
+
+describe('withTimeout', () => {
+	it('passes a value through when it beats the deadline', async () => {
+		expect(await withTimeout(Promise.resolve(7), 1000)).toBe(7);
+	});
+
+	it('resolves null on timeout when no fallback is given', async () => {
+		expect(await withTimeout(new Promise(() => {}), 10)).toBeNull();
+	});
+
+	it('resolves the fallback on timeout when one is given', async () => {
+		expect(await withTimeout(new Promise<number>(() => {}), 10, -1)).toBe(-1);
+	});
+
+	it('treats a rejection like a timeout rather than propagating it', async () => {
+		expect(await withTimeout(Promise.reject(new Error('nope')), 1000)).toBeNull();
+	});
+});
+
+describe('getHostFacts', () => {
+	it('probes once and hands every caller the same object', async () => {
+		const [a, b] = await Promise.all([getHostFacts(), getHostFacts()]);
+		expect(a).toBe(b);
+	});
+
+	it('always answers with a usable core count and installed RAM', async () => {
+		// Both are denominators: the core count normalises per-process CPU on
+		// macOS/BSD, and the RAM total is what "percent of host memory" divides
+		// by in Project Info. A zero from a failed probe would poison both.
+		const facts = await getHostFacts();
+		expect(facts.logicalCores).toBeGreaterThan(0);
+		expect(facts.totalMemBytes).toBeGreaterThan(0);
+		expect(facts.platform).toBeTruthy();
+		expect(facts.arch).toBeTruthy();
 	});
 });

--- a/backend/host/metrics.ts
+++ b/backend/host/metrics.ts
@@ -1,46 +1,11 @@
 /**
- * Host metrics — what this machine is, and what is running on it.
+ * Host metrics — hardware identity and the live process table.
  *
- * `runner.ts` next door answers host questions by running commands, local or
- * remote. This answers the ones `systeminformation` is better at: hardware
- * identity, and the live process table with per-process CPU and memory.
- *
- * It is one module because two panels already ask these questions and their
- * answers have to line up. Settings → Device reports the whole machine; Project
- * Info reports one project's slice of it. "This project is at 12% and the
- * machine is at 40%" is only a sentence worth printing if both numbers were
- * measured against the same thing — and that is not a promise two independent
- * copies of this code can keep.
- *
- * ## Reading per-process CPU across platforms
- *
- * `si.processes()` reports per-process CPU against a different basis on every
- * platform, so the raw values cannot be summed and labelled the same way:
- *
- * - Linux — a delta over `/proc` jiffies against every core, i.e. already a
- *   share of total machine capacity.
- * - macOS/BSD/SunOS — `ps pcpu`, a decaying recent average in which 100% means
- *   one saturated core, so it has to be divided by the logical core count.
- * - Windows — a delta against the CPU *consumed by processes* during the
- *   interval, not against capacity: one busy process reads close to 100% on an
- *   otherwise idle 8-core box. Scaling it by the machine's busy fraction, taken
- *   from `os.cpus()` tick deltas over the same interval, converts it to a share
- *   of capacity.
- *
- * Everything is therefore normalised to percent of total machine capacity,
- * which is the basis `si.currentLoad()` already reports the host on, so the two
- * panels agree by construction rather than by coincidence.
- *
- * The busy fraction is read here rather than taken from `si.currentLoad()`
- * deliberately: `currentLoad` measures the interval between its own successive
- * calls, and the conversion is only sound over the interval `si.processes()`
- * itself measured. Sampling the ticks at the same instant as the probe is what
- * keeps those two intervals identical.
- *
- * Linux and Windows both need a previous sample before they can produce a
- * delta, so the first probe has no honest answer and the factor is `null` —
- * callers report unknown rather than a zero a panel would render as "idle",
- * the same choice `system:device-info` makes for GPU utilisation.
+ * One module because Settings → Device and Project Info both ask, and their
+ * numbers only compare if measured the same way. `si.processes()` reports CPU
+ * against a different basis per platform (total capacity on Linux, one core on
+ * macOS/BSD, consumed CPU on Windows), so everything is normalised here to
+ * percent of machine capacity — the basis `si.currentLoad()` already uses.
  */
 
 import os from 'node:os';
@@ -48,10 +13,7 @@ import si from 'systeminformation';
 import type { Systeminformation } from 'systeminformation';
 import { debug } from '$shared/utils/logger';
 
-/**
- * Race a promise against a deadline. Without a `fallback` the timeout resolves
- * `null`, which keeps the union in the return type and spares callers a cast.
- */
+/** Race a promise against a deadline. Without a fallback, a timeout gives null. */
 export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null>;
 export function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T>;
 export function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T | null = null): Promise<T | null> {
@@ -85,8 +47,7 @@ export interface HostFacts {
 	physicalCores: number;
 	logicalCores: number;
 	cpuSpeedGhz: number | null;
-	/** Installed RAM. Static for the life of the process, and the single
-	 *  denominator behind every "percent of host memory" figure. */
+	/** The single denominator behind every "percent of host memory" figure. */
 	totalMemBytes: number;
 	gpus: Array<{ model: string; vendor: string; vramMb: number | null }>;
 }
@@ -96,17 +57,17 @@ let hostFactsPromise: Promise<HostFacts> | null = null;
 /** Hardware identity, probed once per process. */
 export function getHostFacts(): Promise<HostFacts> {
 	if (!hostFactsPromise) {
-		hostFactsPromise = probeHostFacts().catch((err) => {
-			// Don't cache a failed probe — allow the next request to retry.
+		hostFactsPromise = probeHostFacts().catch((error) => {
+			// Don't cache a failed probe — let the next request retry.
 			hostFactsPromise = null;
-			throw err;
+			throw error;
 		});
 	}
 	return hostFactsPromise;
 }
 
 async function probeHostFacts(): Promise<HostFacts> {
-	const [osInfo, cpu, system, graphics, mem] = await Promise.all([
+	const [osInfo, cpu, system, graphics, memory] = await Promise.all([
 		withTimeout(si.osInfo(), 4000),
 		withTimeout(si.cpu(), 4000),
 		withTimeout(si.system(), 4000),
@@ -127,22 +88,19 @@ async function probeHostFacts(): Promise<HostFacts> {
 		physicalCores: cpu?.physicalCores || cpu?.cores || os.cpus().length,
 		logicalCores: cpu?.cores || os.cpus().length,
 		cpuSpeedGhz: typeof cpu?.speed === 'number' && cpu.speed > 0 ? cpu.speed : null,
-		totalMemBytes: typeof mem?.total === 'number' && mem.total > 0 ? mem.total : os.totalmem(),
-		gpus: (graphics?.controllers ?? []).map((c) => ({
-			model: c.model || 'Unknown GPU',
-			vendor: c.vendor || 'Unknown',
-			vramMb: typeof c.vram === 'number' && c.vram > 0 ? c.vram : null
+		totalMemBytes: typeof memory?.total === 'number' && memory.total > 0 ? memory.total : os.totalmem(),
+		gpus: (graphics?.controllers ?? []).map((controller) => ({
+			model: controller.model || 'Unknown GPU',
+			vendor: controller.vendor || 'Unknown',
+			vramMb: typeof controller.vram === 'number' && controller.vram > 0 ? controller.vram : null
 		}))
 	};
 }
 
 // ── Process table ────────────────────────────────────────────────────────────
 
-/**
- * Longer than the 500ms window `si` caches its own process table for, so a
- * cache hit here can never hand back a table whose CPU delta spans a different
- * interval than the `os.cpus()` snapshot it is paired with.
- */
+/** Longer than the 500ms window `si` caches its own table for, so a hit here
+ *  can never pair a stale table with a fresh `os.cpus()` snapshot. */
 const PROCESS_CACHE_TTL_MS = 2_000;
 /** `si.processes()` shells out — to PowerShell on Windows, which can hang. */
 const PROCESS_PROBE_TIMEOUT_MS = 10_000;
@@ -151,8 +109,7 @@ export interface ProbedProcess {
 	pid: number;
 	parentPid: number;
 	name: string;
-	/** Raw `si` percentage. Multiply by `ProcessTable.cpuFactor` to get a share
-	 *  of machine capacity; the raw value means something different per OS. */
+	/** Raw `si` percentage — multiply by `cpuFactor` for a share of capacity. */
 	cpu: number;
 	/** `si` reports RSS in KB on every platform. */
 	memRss: number;
@@ -161,7 +118,7 @@ export interface ProbedProcess {
 
 export interface ProcessTable {
 	list: ProbedProcess[];
-	/** `null` when no honest conversion to capacity share exists yet. */
+	/** null when no honest conversion to a capacity share exists yet. */
 	cpuFactor: number | null;
 }
 
@@ -173,18 +130,18 @@ let probeCount = 0;
 function readCpuTicks(): { busy: number; total: number } {
 	let busy = 0;
 	let total = 0;
-	for (const cpu of os.cpus()) {
-		const times = cpu.times;
-		const active = times.user + times.nice + times.sys + times.irq;
+	for (const core of os.cpus()) {
+		const active = core.times.user + core.times.nice + core.times.sys + core.times.irq;
 		busy += active;
-		total += active + times.idle;
+		total += active + core.times.idle;
 	}
 	return { busy, total };
 }
 
 /**
- * The multiplier that turns one `si` CPU percentage into a share of total
- * machine capacity. See the module header for why each platform needs its own.
+ * Multiplier turning one `si` CPU percentage into a share of machine capacity.
+ * Linux is already capacity-relative; macOS/BSD count one core as 100%; Windows
+ * is relative to CPU the processes consumed, so it scales by the busy fraction.
  */
 export function cpuCapacityFactor(
 	platform: NodeJS.Platform,
@@ -194,29 +151,23 @@ export function cpuCapacityFactor(
 ): number | null {
 	if (platform === 'linux') return hasDelta ? 1 : null;
 	if (platform === 'win32') return hasDelta && busyFraction !== null ? busyFraction : null;
-	// macOS, the BSDs and SunOS all read `ps pcpu`, where one core is 100%.
 	return logicalCores > 0 ? 1 / logicalCores : null;
 }
 
 /**
- * Every descendant of `roots`, by walking a parent → children index once.
- *
- * The index makes this exact at any tree depth. Matching by repeated passes
- * over a flat list instead would silently stop at whatever pass limit bounds
- * the loop, dropping the deep end of a `shell → npm → node → esbuild → …`
- * chain. `seen` doubles as the cycle guard for a process table that reports a
- * parent pid which is itself a descendant (recycled pids on Windows).
+ * Every descendant of `roots`, via a parent → children index walked once.
+ * Exact at any depth, and `seen` guards the pid cycles Windows can report.
  */
 export function collectProcessTree(
 	list: Array<{ pid: number; parentPid: number }>,
 	roots: number[]
 ): Set<number> {
 	const children = new Map<number, number[]>();
-	for (const proc of list) {
-		if (proc.parentPid === proc.pid) continue;
-		const bucket = children.get(proc.parentPid);
-		if (bucket) bucket.push(proc.pid);
-		else children.set(proc.parentPid, [proc.pid]);
+	for (const entry of list) {
+		if (entry.parentPid === entry.pid) continue;
+		const siblings = children.get(entry.parentPid);
+		if (siblings) siblings.push(entry.pid);
+		else children.set(entry.parentPid, [entry.pid]);
 	}
 
 	const seen = new Set<number>(roots);
@@ -233,8 +184,8 @@ export function collectProcessTree(
 }
 
 async function probeProcessTable(): Promise<ProcessTable | null> {
-	// Snapshotted at the same instant `si` takes its own sample, so both deltas
-	// span the same interval and the Windows conversion stays sound.
+	// Sampled at the instant `si` takes its own sample, so both deltas span the
+	// same interval and the Windows conversion stays sound.
 	const ticks = readCpuTicks();
 	const previous = lastCpuTicks;
 	lastCpuTicks = ticks;
@@ -244,9 +195,8 @@ async function probeProcessTable(): Promise<ProcessTable | null> {
 
 	const result = await withTimeout(si.processes(), PROCESS_PROBE_TIMEOUT_MS);
 	if (!result) {
-		// A timed-out probe still lands eventually and advances `si`'s internal
-		// delta base at a moment we no longer know, so drop our own base too
-		// rather than pair it with a mismatched interval next tick.
+		// A timed-out probe still lands later and moves `si`'s delta base at a
+		// moment we no longer know, so drop our base rather than mismatch it.
 		debug.warn('host', 'si.processes() unavailable — reporting process metrics as unknown');
 		lastCpuTicks = null;
 		probeCount = 0;
@@ -256,23 +206,20 @@ async function probeProcessTable(): Promise<ProcessTable | null> {
 	probeCount++;
 
 	return {
-		list: (result.list ?? []).map((p: Systeminformation.ProcessesProcessData) => ({
-			pid: p.pid,
-			parentPid: p.parentPid,
-			name: p.name,
-			cpu: typeof p.cpu === 'number' && Number.isFinite(p.cpu) ? p.cpu : 0,
-			memRss: typeof p.memRss === 'number' && Number.isFinite(p.memRss) ? p.memRss : 0,
-			command: p.command
+		list: (result.list ?? []).map((entry: Systeminformation.ProcessesProcessData) => ({
+			pid: entry.pid,
+			parentPid: entry.parentPid,
+			name: entry.name,
+			cpu: typeof entry.cpu === 'number' && Number.isFinite(entry.cpu) ? entry.cpu : 0,
+			memRss: typeof entry.memRss === 'number' && Number.isFinite(entry.memRss) ? entry.memRss : 0,
+			command: entry.command
 		})),
+		// Linux and Windows need a second sample before a delta exists.
 		cpuFactor: cpuCapacityFactor(process.platform, os.cpus().length, busyFraction, probeCount >= 2)
 	};
 }
 
-/**
- * The host process table, cached and single-flighted: N panels polling in step
- * cost one probe per interval rather than one each. `null` when the host could
- * not be asked.
- */
+/** Cached and single-flighted: N panels polling in step cost one probe. */
 export function getProcessTable(): Promise<ProcessTable | null> {
 	if (cachedTable && Date.now() - cachedTable.at < PROCESS_CACHE_TTL_MS) {
 		return Promise.resolve(cachedTable.table);

--- a/backend/host/metrics.ts
+++ b/backend/host/metrics.ts
@@ -1,0 +1,288 @@
+/**
+ * Host metrics — what this machine is, and what is running on it.
+ *
+ * `runner.ts` next door answers host questions by running commands, local or
+ * remote. This answers the ones `systeminformation` is better at: hardware
+ * identity, and the live process table with per-process CPU and memory.
+ *
+ * It is one module because two panels already ask these questions and their
+ * answers have to line up. Settings → Device reports the whole machine; Project
+ * Info reports one project's slice of it. "This project is at 12% and the
+ * machine is at 40%" is only a sentence worth printing if both numbers were
+ * measured against the same thing — and that is not a promise two independent
+ * copies of this code can keep.
+ *
+ * ## Reading per-process CPU across platforms
+ *
+ * `si.processes()` reports per-process CPU against a different basis on every
+ * platform, so the raw values cannot be summed and labelled the same way:
+ *
+ * - Linux — a delta over `/proc` jiffies against every core, i.e. already a
+ *   share of total machine capacity.
+ * - macOS/BSD/SunOS — `ps pcpu`, a decaying recent average in which 100% means
+ *   one saturated core, so it has to be divided by the logical core count.
+ * - Windows — a delta against the CPU *consumed by processes* during the
+ *   interval, not against capacity: one busy process reads close to 100% on an
+ *   otherwise idle 8-core box. Scaling it by the machine's busy fraction, taken
+ *   from `os.cpus()` tick deltas over the same interval, converts it to a share
+ *   of capacity.
+ *
+ * Everything is therefore normalised to percent of total machine capacity,
+ * which is the basis `si.currentLoad()` already reports the host on, so the two
+ * panels agree by construction rather than by coincidence.
+ *
+ * The busy fraction is read here rather than taken from `si.currentLoad()`
+ * deliberately: `currentLoad` measures the interval between its own successive
+ * calls, and the conversion is only sound over the interval `si.processes()`
+ * itself measured. Sampling the ticks at the same instant as the probe is what
+ * keeps those two intervals identical.
+ *
+ * Linux and Windows both need a previous sample before they can produce a
+ * delta, so the first probe has no honest answer and the factor is `null` —
+ * callers report unknown rather than a zero a panel would render as "idle",
+ * the same choice `system:device-info` makes for GPU utilisation.
+ */
+
+import os from 'node:os';
+import si from 'systeminformation';
+import type { Systeminformation } from 'systeminformation';
+import { debug } from '$shared/utils/logger';
+
+/**
+ * Race a promise against a deadline. Without a `fallback` the timeout resolves
+ * `null`, which keeps the union in the return type and spares callers a cast.
+ */
+export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null>;
+export function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T>;
+export function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T | null = null): Promise<T | null> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new Error(`timeout after ${ms}ms`)), ms);
+	});
+	return Promise.race([promise, timeout])
+		.then((value) => {
+			clearTimeout(timer);
+			return value;
+		})
+		.catch(() => {
+			clearTimeout(timer);
+			return fallback;
+		});
+}
+
+// ── Static facts ─────────────────────────────────────────────────────────────
+
+export interface HostFacts {
+	hostname: string;
+	platform: string;
+	distro: string;
+	release: string;
+	kernel: string;
+	arch: string;
+	isVirtual: boolean;
+	cpuBrand: string;
+	cpuManufacturer: string;
+	physicalCores: number;
+	logicalCores: number;
+	cpuSpeedGhz: number | null;
+	/** Installed RAM. Static for the life of the process, and the single
+	 *  denominator behind every "percent of host memory" figure. */
+	totalMemBytes: number;
+	gpus: Array<{ model: string; vendor: string; vramMb: number | null }>;
+}
+
+let hostFactsPromise: Promise<HostFacts> | null = null;
+
+/** Hardware identity, probed once per process. */
+export function getHostFacts(): Promise<HostFacts> {
+	if (!hostFactsPromise) {
+		hostFactsPromise = probeHostFacts().catch((err) => {
+			// Don't cache a failed probe — allow the next request to retry.
+			hostFactsPromise = null;
+			throw err;
+		});
+	}
+	return hostFactsPromise;
+}
+
+async function probeHostFacts(): Promise<HostFacts> {
+	const [osInfo, cpu, system, graphics, mem] = await Promise.all([
+		withTimeout(si.osInfo(), 4000),
+		withTimeout(si.cpu(), 4000),
+		withTimeout(si.system(), 4000),
+		withTimeout(si.graphics(), 4000),
+		withTimeout(si.mem(), 4000)
+	]);
+
+	return {
+		hostname: osInfo?.hostname || os.hostname(),
+		platform: osInfo?.platform || os.platform(),
+		distro: osInfo?.distro || '',
+		release: osInfo?.release || os.release(),
+		kernel: osInfo?.kernel || os.version(),
+		arch: osInfo?.arch || os.arch(),
+		isVirtual: Boolean(system?.virtual),
+		cpuBrand: cpu?.brand || '',
+		cpuManufacturer: cpu?.manufacturer || '',
+		physicalCores: cpu?.physicalCores || cpu?.cores || os.cpus().length,
+		logicalCores: cpu?.cores || os.cpus().length,
+		cpuSpeedGhz: typeof cpu?.speed === 'number' && cpu.speed > 0 ? cpu.speed : null,
+		totalMemBytes: typeof mem?.total === 'number' && mem.total > 0 ? mem.total : os.totalmem(),
+		gpus: (graphics?.controllers ?? []).map((c) => ({
+			model: c.model || 'Unknown GPU',
+			vendor: c.vendor || 'Unknown',
+			vramMb: typeof c.vram === 'number' && c.vram > 0 ? c.vram : null
+		}))
+	};
+}
+
+// ── Process table ────────────────────────────────────────────────────────────
+
+/**
+ * Longer than the 500ms window `si` caches its own process table for, so a
+ * cache hit here can never hand back a table whose CPU delta spans a different
+ * interval than the `os.cpus()` snapshot it is paired with.
+ */
+const PROCESS_CACHE_TTL_MS = 2_000;
+/** `si.processes()` shells out — to PowerShell on Windows, which can hang. */
+const PROCESS_PROBE_TIMEOUT_MS = 10_000;
+
+export interface ProbedProcess {
+	pid: number;
+	parentPid: number;
+	name: string;
+	/** Raw `si` percentage. Multiply by `ProcessTable.cpuFactor` to get a share
+	 *  of machine capacity; the raw value means something different per OS. */
+	cpu: number;
+	/** `si` reports RSS in KB on every platform. */
+	memRss: number;
+	command: string;
+}
+
+export interface ProcessTable {
+	list: ProbedProcess[];
+	/** `null` when no honest conversion to capacity share exists yet. */
+	cpuFactor: number | null;
+}
+
+let cachedTable: { table: ProcessTable | null; at: number } | null = null;
+let inFlightTable: Promise<ProcessTable | null> | null = null;
+let lastCpuTicks: { busy: number; total: number } | null = null;
+let probeCount = 0;
+
+function readCpuTicks(): { busy: number; total: number } {
+	let busy = 0;
+	let total = 0;
+	for (const cpu of os.cpus()) {
+		const times = cpu.times;
+		const active = times.user + times.nice + times.sys + times.irq;
+		busy += active;
+		total += active + times.idle;
+	}
+	return { busy, total };
+}
+
+/**
+ * The multiplier that turns one `si` CPU percentage into a share of total
+ * machine capacity. See the module header for why each platform needs its own.
+ */
+export function cpuCapacityFactor(
+	platform: NodeJS.Platform,
+	logicalCores: number,
+	busyFraction: number | null,
+	hasDelta: boolean
+): number | null {
+	if (platform === 'linux') return hasDelta ? 1 : null;
+	if (platform === 'win32') return hasDelta && busyFraction !== null ? busyFraction : null;
+	// macOS, the BSDs and SunOS all read `ps pcpu`, where one core is 100%.
+	return logicalCores > 0 ? 1 / logicalCores : null;
+}
+
+/**
+ * Every descendant of `roots`, by walking a parent → children index once.
+ *
+ * The index makes this exact at any tree depth. Matching by repeated passes
+ * over a flat list instead would silently stop at whatever pass limit bounds
+ * the loop, dropping the deep end of a `shell → npm → node → esbuild → …`
+ * chain. `seen` doubles as the cycle guard for a process table that reports a
+ * parent pid which is itself a descendant (recycled pids on Windows).
+ */
+export function collectProcessTree(
+	list: Array<{ pid: number; parentPid: number }>,
+	roots: number[]
+): Set<number> {
+	const children = new Map<number, number[]>();
+	for (const proc of list) {
+		if (proc.parentPid === proc.pid) continue;
+		const bucket = children.get(proc.parentPid);
+		if (bucket) bucket.push(proc.pid);
+		else children.set(proc.parentPid, [proc.pid]);
+	}
+
+	const seen = new Set<number>(roots);
+	const queue = [...roots];
+	for (let head = 0; head < queue.length; head++) {
+		for (const child of children.get(queue[head]) ?? []) {
+			if (seen.has(child)) continue;
+			seen.add(child);
+			queue.push(child);
+		}
+	}
+
+	return seen;
+}
+
+async function probeProcessTable(): Promise<ProcessTable | null> {
+	// Snapshotted at the same instant `si` takes its own sample, so both deltas
+	// span the same interval and the Windows conversion stays sound.
+	const ticks = readCpuTicks();
+	const previous = lastCpuTicks;
+	lastCpuTicks = ticks;
+
+	const totalDelta = previous ? ticks.total - previous.total : 0;
+	const busyFraction = previous && totalDelta > 0 ? (ticks.busy - previous.busy) / totalDelta : null;
+
+	const result = await withTimeout(si.processes(), PROCESS_PROBE_TIMEOUT_MS);
+	if (!result) {
+		// A timed-out probe still lands eventually and advances `si`'s internal
+		// delta base at a moment we no longer know, so drop our own base too
+		// rather than pair it with a mismatched interval next tick.
+		debug.warn('host', 'si.processes() unavailable — reporting process metrics as unknown');
+		lastCpuTicks = null;
+		probeCount = 0;
+		return null;
+	}
+
+	probeCount++;
+
+	return {
+		list: (result.list ?? []).map((p: Systeminformation.ProcessesProcessData) => ({
+			pid: p.pid,
+			parentPid: p.parentPid,
+			name: p.name,
+			cpu: typeof p.cpu === 'number' && Number.isFinite(p.cpu) ? p.cpu : 0,
+			memRss: typeof p.memRss === 'number' && Number.isFinite(p.memRss) ? p.memRss : 0,
+			command: p.command
+		})),
+		cpuFactor: cpuCapacityFactor(process.platform, os.cpus().length, busyFraction, probeCount >= 2)
+	};
+}
+
+/**
+ * The host process table, cached and single-flighted: N panels polling in step
+ * cost one probe per interval rather than one each. `null` when the host could
+ * not be asked.
+ */
+export function getProcessTable(): Promise<ProcessTable | null> {
+	if (cachedTable && Date.now() - cachedTable.at < PROCESS_CACHE_TTL_MS) {
+		return Promise.resolve(cachedTable.table);
+	}
+	if (inFlightTable) return inFlightTable;
+
+	inFlightTable = probeProcessTable().then((table) => {
+		cachedTable = { table, at: Date.now() };
+		inFlightTable = null;
+		return table;
+	});
+	return inFlightTable;
+}

--- a/backend/ports/attribute.test.ts
+++ b/backend/ports/attribute.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { PortProcess, PortSocket } from '$shared/types/ports';
-import { findClopenPids, groupListenerPids, traceAncestry, type SessionPid } from './attribute';
+import { findClopenPids, groupListenerPids, traceAncestry } from './attribute';
+import type { ProjectShell } from '../projects/shell-ownership';
 import { findConnectionSshd, parseEnvironProbe, sameConnection } from './ssh-lineage';
 
 function proc(pid: number, parentPid: number | null, command: string): PortProcess {
@@ -75,7 +76,7 @@ describe('groupListenerPids', () => {
 });
 
 describe('traceAncestry', () => {
-	const sessions = new Map<number, SessionPid>([
+	const sessions = new Map<number, ProjectShell>([
 		[400, { pid: 400, sessionId: 'sess-1', projectId: 'proj-1', projectName: 'shop', cwd: '/srv/shop' }]
 	]);
 

--- a/backend/ports/attribute.ts
+++ b/backend/ports/attribute.ts
@@ -23,47 +23,8 @@
 
 import type { PortOrigin, PortProcess, PortSocket } from '$shared/types/ports';
 import type { ProbePlatform } from '../host/runner';
-import { ptyKitManager } from '../terminal/ptykit';
-import { projectQueries } from '../database/queries';
+import { collectSessionPids, type ProjectShell } from '../projects/shell-ownership';
 import { collectOwnedPorts, ownedPortKey, type OwnedPort } from './registry';
-import { debug } from '$shared/utils/logger';
-
-/** A live Clopen terminal session, keyed by the pid of its shell. */
-export interface SessionPid {
-	pid: number;
-	sessionId: string;
-	projectId: string;
-	projectName: string | null;
-	cwd: string;
-}
-
-/**
- * Shell pids of every active PTY session. The manager lists per namespace and
- * a namespace is a project, so every project is asked in turn.
- */
-export function collectSessionPids(): Map<number, SessionPid> {
-	const sessions = new Map<number, SessionPid>();
-
-	try {
-		for (const project of projectQueries.getAll()) {
-			for (const session of ptyKitManager.list(project.id)) {
-				const info = session.info();
-				if (info.status !== 'active' || !info.pid) continue;
-				sessions.set(info.pid, {
-					pid: info.pid,
-					sessionId: info.sessionId,
-					projectId: project.id,
-					projectName: project.name ?? null,
-					cwd: info.cwd
-				});
-			}
-		}
-	} catch (error) {
-		debug.log('ports', 'could not read terminal sessions:', error);
-	}
-
-	return sessions;
-}
 
 /** Guard against a malformed parent chain looping forever. */
 const MAX_ANCESTRY_DEPTH = 40;
@@ -118,7 +79,7 @@ export interface Ancestry {
 	/** The chain from the process itself up to init, self first. */
 	chain: PortProcess[];
 	/** The Clopen terminal session it descends from, if any. */
-	session: SessionPid | null;
+	session: ProjectShell | null;
 	/**
 	 * True when the chain reaches a process Clopen is: one of its own instances
 	 * locally, or the sshd session it is using on a remote host.
@@ -137,13 +98,13 @@ function sshdUserOf(command: string): string | null {
 export function traceAncestry(
 	pid: number,
 	processes: Map<number, PortProcess>,
-	sessions: Map<number, SessionPid>,
+	sessions: Map<number, ProjectShell>,
 	clopenRootPids: ReadonlySet<number> = new Set()
 ): Ancestry {
 	const chain: PortProcess[] = [];
 	const seen = new Set<number>();
 
-	let session: SessionPid | null = null;
+	let session: ProjectShell | null = null;
 	let sshdUser: string | null = null;
 	let fromClopen = false;
 	let current: number | null = pid;
@@ -218,7 +179,7 @@ export interface AttributionContext {
 	/** Ports Clopen opened on this host, whichever host it is. */
 	owned: Map<string, OwnedPort>;
 	/** Shell pids of local terminal sessions; empty on an SSH host. */
-	sessions: Map<number, SessionPid>;
+	sessions: Map<number, ProjectShell>;
 	/**
 	 * The processes that count as "Clopen" on this host: its own instances
 	 * locally, and remotely everything found to belong to Clopen's own SSH

--- a/backend/projects/shell-ownership.ts
+++ b/backend/projects/shell-ownership.ts
@@ -1,0 +1,65 @@
+/**
+ * Which processes belong to a project.
+ *
+ * A PtyKit namespace is a project id, so an active PTY session's shell pid is
+ * the root of everything that project spawned. Two features ask this and walk
+ * it in opposite directions — Ports climbs from a listening socket's pid to
+ * find the owning session, Project Info descends from the project to total its
+ * usage — so the roots themselves are defined once, here.
+ */
+
+import { projectQueries } from '$backend/database/queries';
+import { ptyKitManager } from '../terminal/ptykit';
+import { debug } from '$shared/utils/logger';
+
+/** An active terminal shell, and the project it belongs to. */
+export interface ProjectShell {
+	pid: number;
+	sessionId: string;
+	projectId: string;
+	projectName: string | null;
+	cwd: string;
+}
+
+function shellsOf(projectId: string, projectName: string | null): ProjectShell[] {
+	const shells: ProjectShell[] = [];
+	for (const session of ptyKitManager.list(projectId)) {
+		const info = session.info();
+		if (info.status !== 'active' || !Number.isFinite(info.pid) || info.pid <= 0) continue;
+		shells.push({
+			pid: info.pid,
+			sessionId: info.sessionId,
+			projectId,
+			projectName,
+			cwd: info.cwd
+		});
+	}
+	return shells;
+}
+
+/** Every active shell on this host, keyed by pid. */
+export function collectSessionPids(): Map<number, ProjectShell> {
+	const sessions = new Map<number, ProjectShell>();
+
+	try {
+		for (const project of projectQueries.getAll()) {
+			for (const shell of shellsOf(project.id, project.name ?? null)) {
+				sessions.set(shell.pid, shell);
+			}
+		}
+	} catch (error) {
+		debug.log('project', 'could not read terminal sessions:', error);
+	}
+
+	return sessions;
+}
+
+/** Root pids to descend from when totalling one project's usage. */
+export function projectShellPids(projectId: string): number[] {
+	try {
+		return shellsOf(projectId, null).map((shell) => shell.pid);
+	} catch (error) {
+		debug.log('project', 'could not read terminal sessions:', error);
+		return [];
+	}
+}

--- a/backend/ws/projects/index.ts
+++ b/backend/ws/projects/index.ts
@@ -13,6 +13,7 @@ import { createRouter } from '$shared/utils/ws-server';
 import { crudHandler } from './crud';
 import { statusHandler } from './status';
 import { presenceHandler } from './presence';
+import { infoHandler } from './info';
 
 export const projectsRouter = createRouter()
 	// CRUD Operations (HTTP)
@@ -22,4 +23,7 @@ export const projectsRouter = createRouter()
 	.merge(statusHandler)
 
 	// Presence Management (HTTP + Broadcast)
-	.merge(presenceHandler);
+	.merge(presenceHandler)
+
+	// Per-project resource info (storage + process-isolated CPU/RAM)
+	.merge(infoHandler);

--- a/backend/ws/projects/info.test.ts
+++ b/backend/ws/projects/info.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test';
+import type { PortEntry, PortOriginKind } from '$shared/types/ports';
+import { groupPortsByProject } from './info';
+
+function entry(port: number, kind: PortOriginKind, projectId?: string, publicUrl: string | null = null): PortEntry {
+	return {
+		key: `tcp:${port}`,
+		protocol: 'tcp',
+		port,
+		addresses: ['127.0.0.1'],
+		ipVersions: ['v4'],
+		pid: 1000 + port,
+		process: null,
+		workerPids: [],
+		origin: { kind, confidence: 'certain', label: 'Vite dev server', detail: null, projectId },
+		peers: [],
+		peerCount: 0,
+		publicUrl,
+		container: null,
+		canKill: true,
+		killBlockedReason: null
+	};
+}
+
+describe('groupPortsByProject', () => {
+	it('keeps only ports a terminal session owns', () => {
+		const grouped = groupPortsByProject([
+			entry(5173, 'session', 'project-a'),
+			entry(8080, 'external'),
+			entry(6379, 'container', 'project-a')
+		]);
+		expect([...grouped.keys()]).toEqual(['project-a']);
+		expect(grouped.get('project-a')?.map((port) => port.port)).toEqual([5173]);
+	});
+
+	it('drops a session port that names no project', () => {
+		expect(groupPortsByProject([entry(3000, 'session')]).size).toBe(0);
+	});
+
+	it('separates ports belonging to different projects', () => {
+		const grouped = groupPortsByProject([
+			entry(5173, 'session', 'project-a'),
+			entry(3000, 'session', 'project-b'),
+			entry(4000, 'session', 'project-a')
+		]);
+		expect(grouped.get('project-a')?.map((port) => port.port)).toEqual([5173, 4000]);
+		expect(grouped.get('project-b')?.map((port) => port.port)).toEqual([3000]);
+	});
+
+	it('carries the public URL through so a tunnelled port stays reachable', () => {
+		const grouped = groupPortsByProject([entry(5173, 'session', 'project-a', 'https://demo.trycloudflare.com')]);
+		expect(grouped.get('project-a')?.[0].publicUrl).toBe('https://demo.trycloudflare.com');
+	});
+});

--- a/backend/ws/projects/info.test.ts
+++ b/backend/ws/projects/info.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test';
+import { collectProcessTree, cpuCapacityFactor } from './info';
+
+function proc(pid: number, parentPid: number) {
+	return { pid, parentPid };
+}
+
+describe('collectProcessTree', () => {
+	it('keeps the roots even when the table does not list them', () => {
+		expect([...collectProcessTree([], [42])]).toEqual([42]);
+	});
+
+	it('excludes processes outside the roots', () => {
+		const tree = collectProcessTree([proc(100, 1), proc(200, 1), proc(201, 200)], [200]);
+		expect([...tree].sort((a, b) => a - b)).toEqual([200, 201]);
+	});
+
+	it('reaches past the depth a bounded pass count would stop at', () => {
+		// shell → 15 nested children, listed child-before-parent so a
+		// repeated-pass matcher would only pick up one level per pass.
+		const list = [];
+		for (let depth = 15; depth >= 1; depth--) list.push(proc(1000 + depth, 1000 + depth - 1));
+		const tree = collectProcessTree(list, [1000]);
+		expect(tree.size).toBe(16);
+		expect(tree.has(1015)).toBe(true);
+	});
+
+	it('collects several roots at once', () => {
+		const list = [proc(11, 10), proc(21, 20), proc(31, 30)];
+		const tree = collectProcessTree(list, [10, 20]);
+		expect([...tree].sort((a, b) => a - b)).toEqual([10, 11, 20, 21]);
+	});
+
+	it('terminates on a parent cycle', () => {
+		const tree = collectProcessTree([proc(2, 1), proc(1, 2)], [1]);
+		expect([...tree].sort((a, b) => a - b)).toEqual([1, 2]);
+	});
+
+	it('ignores a process that claims to be its own parent', () => {
+		const tree = collectProcessTree([proc(5, 5), proc(6, 5)], [5]);
+		expect([...tree].sort((a, b) => a - b)).toEqual([5, 6]);
+	});
+});
+
+describe('cpuCapacityFactor', () => {
+	it('passes Linux through once a delta exists', () => {
+		expect(cpuCapacityFactor('linux', 8, 0.5, true)).toBe(1);
+	});
+
+	it('has no answer for Linux before the second sample', () => {
+		expect(cpuCapacityFactor('linux', 8, 0.5, false)).toBeNull();
+	});
+
+	it('divides the per-core macOS reading by the core count', () => {
+		expect(cpuCapacityFactor('darwin', 8, null, false)).toBe(1 / 8);
+	});
+
+	it('treats the BSDs like macOS', () => {
+		expect(cpuCapacityFactor('freebsd', 4, null, true)).toBe(1 / 4);
+	});
+
+	it('scales Windows by the machine busy fraction', () => {
+		expect(cpuCapacityFactor('win32', 8, 0.25, true)).toBe(0.25);
+	});
+
+	it('has no answer for Windows without a busy fraction', () => {
+		expect(cpuCapacityFactor('win32', 8, null, true)).toBeNull();
+		expect(cpuCapacityFactor('win32', 8, 0.25, false)).toBeNull();
+	});
+
+	it('refuses to divide by a missing core count', () => {
+		expect(cpuCapacityFactor('darwin', 0, null, true)).toBeNull();
+	});
+});

--- a/backend/ws/projects/info.ts
+++ b/backend/ws/projects/info.ts
@@ -1,31 +1,81 @@
 /**
- * Projects Info — per-project resource monitoring
+ * Projects Info — what one project costs on this machine.
  *
- * Returns storage (folder size) and CPU/RAM computed ONLY from processes
- * belonging to the project. CPU/RAM are NOT host totals.
+ * Two independent probes, both bounded, both shared between concurrent callers
+ * so that N open panels polling every few seconds cost one probe per interval
+ * rather than N:
  *
- * - Storage: recursive walk of project.path (includes .git), capped at 300k entries
- * - CPU/RAM: sum of all processes whose pid is a PTY session pid for this
- *            project (namespace = projectId) OR a descendant via parentPid chain.
- *            If no active PTY sessions, status = not_running and cpu/ram = 0.
+ * - Storage: a recursive walk of `project.path`. Nothing is excluded — `.git`
+ *   and `node_modules` are part of what the folder actually occupies — so the
+ *   walk is stopped by whichever of `MAX_ENTRIES` or `WALK_DEADLINE_MS` comes
+ *   first and reports `truncated` when it was.
+ * - CPU/RAM: the PTY shells Clopen opened for this project plus every live
+ *   descendant of them. Nothing else on the host is counted, so this is the
+ *   project's own footprint and not the server's. Engine processes that Clopen
+ *   runs outside a terminal are not shells and do not appear here.
  *
- * Poll-safe: storage walk and process list are done in parallel, both are
- * bounded and non-blocking for other requests.
+ * ## Why the CPU number is not `si`'s CPU number
+ *
+ * `si.processes()` reports per-process CPU against a different basis on every
+ * platform, so the raw values cannot be summed and labelled the same way:
+ *
+ * - Linux — a delta over `/proc` jiffies against every core, i.e. already a
+ *   share of total machine capacity.
+ * - macOS/BSD/SunOS — `ps pcpu`, a decaying recent average in which 100% means
+ *   one saturated core, so it has to be divided by the logical core count.
+ * - Windows — a delta against the CPU *consumed by processes* during the
+ *   interval, not against capacity: one busy process reads close to 100% on an
+ *   otherwise idle 8-core box. Scaling it by the machine's busy fraction, taken
+ *   from `os.cpus()` tick deltas over the same interval, converts it to a share
+ *   of capacity.
+ *
+ * Everything is therefore normalised to "percent of total machine capacity",
+ * which is the only reading of "this project is using X% CPU" that means the
+ * same thing on a laptop and on a 32-core VPS.
+ *
+ * Linux and Windows both need a previous sample before they can produce a
+ * delta, so the first probe has no honest answer and `cpuPercent` is `null`
+ * there rather than a zero the panel would render as "idle" — the same choice
+ * `system:device-info` makes for GPU utilisation.
  */
 
 import { t } from 'elysia';
+import os from 'node:os';
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
 import { createRouter } from '$shared/utils/ws-server';
 import { projectQueries } from '../../database/queries';
 import { requireProjectAccess } from '../access';
 import { ptyKitManager } from '../../terminal/ptykit';
 import si from 'systeminformation';
 import { debug } from '$shared/utils/logger';
-import { readdir, stat } from 'node:fs/promises';
-import { join } from 'node:path';
 
+/** Ceiling on entries visited by one walk, so a monorepo cannot pin a core. */
 const MAX_ENTRIES = 300_000;
+/** Wall-clock ceiling on one walk — the backstop for slow disks and network mounts. */
+const WALK_DEADLINE_MS = 15_000;
+/** How many `stat` calls are in flight at once while walking one directory. */
+const STAT_BATCH = 64;
+/** A folder's size changes slowly; a poll should not re-walk it every tick. */
 const STORAGE_CACHE_TTL_MS = 15_000;
-const storageCache = new Map<string, { stats: FolderStats; at: number }>();
+/**
+ * An expensive walk earns a proportionally longer rest: a tree that takes ten
+ * seconds to measure would otherwise be re-walked the moment its answer went
+ * stale, leaving one core busy for as long as the panel stays open.
+ */
+const STORAGE_TTL_PER_MS_SPENT = 4;
+const STORAGE_CACHE_MAX_TTL_MS = 5 * 60_000;
+
+/**
+ * Longer than the 500ms window `si` caches its own process table for, so a
+ * cache hit here can never make `si` return a stale table whose CPU delta
+ * spans a different interval than our `os.cpus()` snapshot.
+ */
+const PROCESS_CACHE_TTL_MS = 2_000;
+/** `si.processes()` shells out — to PowerShell on Windows, which can hang. */
+const PROCESS_PROBE_TIMEOUT_MS = 10_000;
+
+// ── Storage ──────────────────────────────────────────────────────────────────
 
 interface FolderStats {
 	sizeBytes: number;
@@ -35,23 +85,51 @@ interface FolderStats {
 	error?: string;
 }
 
-async function getFolderStatsCached(root: string): Promise<FolderStats> {
+const storageCache = new Map<string, { stats: FolderStats; at: number; ttl: number }>();
+const storageInFlight = new Map<string, Promise<FolderStats>>();
+
+/**
+ * Cached *and* single-flighted.
+ *
+ * Single-flight is the load-bearing half: a walk of a large project takes far
+ * longer than the panel's poll interval, and a result-only cache is still empty
+ * while the first walk runs, so every poll would start another full walk and
+ * they would pile up faster than they finish.
+ */
+function getFolderStats(root: string): Promise<FolderStats> {
 	const cached = storageCache.get(root);
-	if (cached && Date.now() - cached.at < STORAGE_CACHE_TTL_MS) {
-		return cached.stats;
+	if (cached && Date.now() - cached.at < cached.ttl) {
+		return Promise.resolve(cached.stats);
 	}
-	const stats = await getFolderStatsUncached(root);
-	storageCache.set(root, { stats, at: Date.now() });
-	return stats;
+
+	const inFlight = storageInFlight.get(root);
+	if (inFlight) return inFlight;
+
+	const startedAt = Date.now();
+	const walk = walkFolder(root)
+		.catch((e): FolderStats => ({
+			sizeBytes: 0,
+			fileCount: 0,
+			dirCount: 0,
+			truncated: false,
+			error: e instanceof Error ? e.message : String(e)
+		}))
+		.then((stats) => {
+			const spent = Date.now() - startedAt;
+			const ttl = Math.min(
+				STORAGE_CACHE_MAX_TTL_MS,
+				Math.max(STORAGE_CACHE_TTL_MS, spent * STORAGE_TTL_PER_MS_SPENT)
+			);
+			storageCache.set(root, { stats, at: Date.now(), ttl });
+			storageInFlight.delete(root);
+			return stats;
+		});
+
+	storageInFlight.set(root, walk);
+	return walk;
 }
 
-async function getFolderStatsUncached(root: string): Promise<FolderStats> {
-	let sizeBytes = 0;
-	let fileCount = 0;
-	let dirCount = 0;
-	let truncated = false;
-
-	// Verify root exists
+async function walkFolder(root: string): Promise<FolderStats> {
 	try {
 		const rootStat = await stat(root);
 		if (!rootStat.isDirectory()) {
@@ -62,163 +140,300 @@ async function getFolderStatsUncached(root: string): Promise<FolderStats> {
 		return { sizeBytes: 0, fileCount: 0, dirCount: 0, truncated: false, error: msg };
 	}
 
+	const deadline = Date.now() + WALK_DEADLINE_MS;
 	const stack: string[] = [root];
+	let sizeBytes = 0;
+	let fileCount = 0;
+	let dirCount = 0;
+	let truncated = false;
 
 	while (stack.length > 0) {
-		if (fileCount + dirCount > MAX_ENTRIES) {
+		if (fileCount + dirCount >= MAX_ENTRIES || Date.now() > deadline) {
 			truncated = true;
 			break;
 		}
+
 		const dir = stack.pop()!;
 		let entries: import('node:fs').Dirent[];
 		try {
 			entries = await readdir(dir, { withFileTypes: true });
 		} catch {
+			// Unreadable directory (permissions, vanished mid-walk) — skip it.
 			continue;
 		}
 
+		const files: string[] = [];
 		for (const entry of entries) {
-			if (fileCount + dirCount > MAX_ENTRIES) {
+			if (fileCount + dirCount >= MAX_ENTRIES) {
 				truncated = true;
 				break;
 			}
-			const fullPath = join(dir, entry.name);
-			try {
-				// Symbolic links: do not follow to avoid cycles
-				if (entry.isSymbolicLink()) continue;
+			// Symlinks and Windows junctions are not followed: they would double
+			// count their target at best and loop forever at worst.
+			if (entry.isSymbolicLink()) continue;
 
-				if (entry.isDirectory()) {
-					dirCount++;
-					stack.push(fullPath);
-				} else if (entry.isFile()) {
-					fileCount++;
-					try {
-						const st = await stat(fullPath);
-						sizeBytes += st.size;
-					} catch {
-						// ignore unreadable files
-					}
-				}
-			} catch {
-				// ignore
+			if (entry.isDirectory()) {
+				dirCount++;
+				stack.push(join(dir, entry.name));
+			} else if (entry.isFile()) {
+				fileCount++;
+				files.push(join(dir, entry.name));
 			}
+		}
+
+		// One `stat` per file is unavoidable — no platform reports sizes from a
+		// directory read — but they need not be serialised.
+		for (let i = 0; i < files.length; i += STAT_BATCH) {
+			const sizes = await Promise.all(
+				files.slice(i, i + STAT_BATCH).map((file) => stat(file).then((s) => s.size, () => 0))
+			);
+			for (const size of sizes) sizeBytes += size;
 		}
 	}
 
 	return { sizeBytes, fileCount, dirCount, truncated };
 }
 
-interface ProcessStats {
-	status: 'running' | 'not_running';
-	cpuPercent: number;
-	memRssBytes: number;
-	memPercent: number;
-	processCount: number;
-	processes: Array<{
-		pid: number;
-		parentPid: number;
-		name: string;
-		cpu: number;
-		mem: number;
-		memRss: number;
-		command: string;
-	}>;
-	rootPids: number[];
+// ── Process table ────────────────────────────────────────────────────────────
+
+export interface ProbedProcess {
+	pid: number;
+	parentPid: number;
+	name: string;
+	cpu: number;
+	memRss: number;
+	command: string;
 }
 
-async function getProjectProcessStats(projectId: string): Promise<ProcessStats> {
-	const sessions = ptyKitManager.list(projectId);
-	const active = sessions.filter((s) => s.status === 'active');
-	const rootPids = active.map((s) => s.pid).filter((pid) => Number.isFinite(pid) && pid > 0);
-
-	if (rootPids.length === 0) {
-		return {
-			status: 'not_running',
-			cpuPercent: 0,
-			memRssBytes: 0,
-			memPercent: 0,
-			processCount: 0,
-			processes: [],
-			rootPids: []
-		};
+/**
+ * Every descendant of `roots`, by walking a parent → children index once.
+ *
+ * The index makes this exact at any tree depth. Matching by repeated passes
+ * over a flat list instead would silently stop at whatever pass limit bounds
+ * the loop, dropping the deep end of a `shell → npm → node → esbuild → …`
+ * chain. `seen` doubles as the cycle guard for a process table that reports a
+ * parent pid which is itself a descendant (recycled pids on Windows).
+ */
+export function collectProcessTree(
+	list: Array<{ pid: number; parentPid: number }>,
+	roots: number[]
+): Set<number> {
+	const children = new Map<number, number[]>();
+	for (const proc of list) {
+		if (proc.parentPid === proc.pid) continue;
+		const bucket = children.get(proc.parentPid);
+		if (bucket) bucket.push(proc.pid);
+		else children.set(proc.parentPid, [proc.pid]);
 	}
 
-	let allList: Array<{
-		pid: number;
-		parentPid: number;
-		name: string;
-		cpu: number;
-		mem: number;
-		memRss: number;
-		command: string;
-	}> = [];
-
-	try {
-		const result = await si.processes();
-		// systeminformation returns { all, list:[...] }
-		allList = (result.list as typeof allList) ?? [];
-	} catch (e) {
-		debug.warn('project', 'si.processes failed:', e);
-		return {
-			status: 'running',
-			cpuPercent: 0,
-			memRssBytes: 0,
-			memPercent: 0,
-			processCount: rootPids.length,
-			processes: [],
-			rootPids
-		};
-	}
-
-	// Build project pid set via BFS through parentPid chain
-	const pidSet = new Set<number>(rootPids);
-	let added = true;
-	// Prevent infinite loop: at most one full pass per new pid, limited rounds
-	let rounds = 0;
-	while (added && rounds < 10) {
-		added = false;
-		rounds++;
-		for (const proc of allList) {
-			if (!pidSet.has(proc.pid) && pidSet.has(proc.parentPid)) {
-				pidSet.add(proc.pid);
-				added = true;
-			}
+	const seen = new Set<number>(roots);
+	const queue = [...roots];
+	for (let head = 0; head < queue.length; head++) {
+		for (const child of children.get(queue[head]) ?? []) {
+			if (seen.has(child)) continue;
+			seen.add(child);
+			queue.push(child);
 		}
 	}
 
-	const matched = allList.filter((p) => pidSet.has(p.pid));
+	return seen;
+}
 
-	let cpuPercent = 0;
-	let memPercent = 0;
-	let memRssKb = 0;
-	for (const p of matched) {
-		cpuPercent += typeof p.cpu === 'number' ? p.cpu : 0;
-		memPercent += typeof p.mem === 'number' ? p.mem : 0;
-		memRssKb += typeof p.memRss === 'number' ? p.memRss : 0;
+/**
+ * The multiplier that turns one `si` CPU percentage into a share of total
+ * machine capacity. `null` when no honest conversion exists yet — see the
+ * module header for why each platform needs a different one.
+ */
+export function cpuCapacityFactor(
+	platform: NodeJS.Platform,
+	logicalCores: number,
+	busyFraction: number | null,
+	hasDelta: boolean
+): number | null {
+	if (platform === 'linux') return hasDelta ? 1 : null;
+	if (platform === 'win32') return hasDelta && busyFraction !== null ? busyFraction : null;
+	// macOS, the BSDs and SunOS all read `ps pcpu`, where one core is 100%.
+	return logicalCores > 0 ? 1 / logicalCores : null;
+}
+
+function readCpuTicks(): { busy: number; total: number } {
+	let busy = 0;
+	let total = 0;
+	for (const cpu of os.cpus()) {
+		const times = cpu.times;
+		const active = times.user + times.nice + times.sys + times.irq;
+		busy += active;
+		total += active + times.idle;
+	}
+	return { busy, total };
+}
+
+interface ProcessProbe {
+	list: ProbedProcess[];
+	factor: number | null;
+}
+
+let cachedProbe: { probe: ProcessProbe | null; at: number } | null = null;
+let inFlightProbe: Promise<ProcessProbe | null> | null = null;
+let lastCpuTicks: { busy: number; total: number } | null = null;
+let probeCount = 0;
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<null>((resolve) => {
+		timer = setTimeout(() => resolve(null), ms);
+	});
+	return Promise.race([promise, timeout])
+		.then((value) => {
+			clearTimeout(timer);
+			return value;
+		})
+		.catch(() => {
+			clearTimeout(timer);
+			return null;
+		});
+}
+
+async function probeProcesses(): Promise<ProcessProbe | null> {
+	// Snapshotted at the same instant `si` takes its own sample, so both deltas
+	// span the same interval and the Windows conversion stays sound.
+	const ticks = readCpuTicks();
+	const previous = lastCpuTicks;
+	lastCpuTicks = ticks;
+
+	const totalDelta = previous ? ticks.total - previous.total : 0;
+	const busyFraction = previous && totalDelta > 0 ? (ticks.busy - previous.busy) / totalDelta : null;
+
+	const result = await withTimeout(si.processes(), PROCESS_PROBE_TIMEOUT_MS);
+	if (!result) {
+		// A timed-out probe still lands eventually and advances `si`'s internal
+		// delta base at a moment we no longer know, so drop our own base too
+		// rather than pair it with a mismatched interval next tick.
+		debug.warn('project', 'si.processes() unavailable — reporting resources as unknown');
+		lastCpuTicks = null;
+		probeCount = 0;
+		return null;
 	}
 
-	// memRss from si is in KB, convert to bytes
-	const memRssBytes = memRssKb * 1024;
+	probeCount++;
+	const factor = cpuCapacityFactor(process.platform, os.cpus().length, busyFraction, probeCount >= 2);
 
-	// If none of the root pids were found in the OS process list (e.g. just spawned
-	// and not yet visible), still report running with the count of sessions.
-	if (matched.length === 0) {
+	const list: ProbedProcess[] = (result.list ?? []).map((p) => ({
+		pid: p.pid,
+		parentPid: p.parentPid,
+		name: p.name,
+		cpu: typeof p.cpu === 'number' && Number.isFinite(p.cpu) ? p.cpu : 0,
+		// `si` reports RSS in KB on every platform.
+		memRss: typeof p.memRss === 'number' && Number.isFinite(p.memRss) ? p.memRss : 0,
+		command: p.command
+	}));
+
+	return { list, factor };
+}
+
+/** Cached and single-flighted: N panels polling in step cost one probe. */
+function getProcessProbe(): Promise<ProcessProbe | null> {
+	if (cachedProbe && Date.now() - cachedProbe.at < PROCESS_CACHE_TTL_MS) {
+		return Promise.resolve(cachedProbe.probe);
+	}
+	if (inFlightProbe) return inFlightProbe;
+
+	inFlightProbe = probeProcesses().then((probe) => {
+		cachedProbe = { probe, at: Date.now() };
+		inFlightProbe = null;
+		return probe;
+	});
+	return inFlightProbe;
+}
+
+interface ProjectProcess {
+	pid: number;
+	parentPid: number;
+	name: string;
+	cpuPercent: number | null;
+	memRssBytes: number;
+	command: string;
+}
+
+interface ProcessStats {
+	status: 'running' | 'not_running';
+	cpuPercent: number | null;
+	memRssBytes: number | null;
+	memPercent: number | null;
+	processCount: number;
+	processes: ProjectProcess[];
+	rootPids: number[];
+}
+
+const IDLE: ProcessStats = {
+	status: 'not_running',
+	cpuPercent: 0,
+	memRssBytes: 0,
+	memPercent: 0,
+	processCount: 0,
+	processes: [],
+	rootPids: []
+};
+
+async function getProjectProcessStats(projectId: string): Promise<ProcessStats> {
+	const rootPids = ptyKitManager
+		.list(projectId)
+		.filter((session) => session.status === 'active')
+		.map((session) => session.pid)
+		.filter((pid) => Number.isFinite(pid) && pid > 0);
+
+	// No shells means nothing of this project is running, and zero is the truth
+	// rather than a stand-in for a number we failed to read.
+	if (rootPids.length === 0) return IDLE;
+
+	const probe = await getProcessProbe();
+
+	// Shells are alive but the host's process table is unreadable, or none of
+	// them are visible in it yet. Either way the usage is unknown, not zero.
+	if (!probe || probe.list.length === 0) {
 		return {
 			status: 'running',
-			cpuPercent: 0,
-			memRssBytes: 0,
-			memPercent: 0,
+			cpuPercent: null,
+			memRssBytes: null,
+			memPercent: null,
 			processCount: 0,
 			processes: [],
 			rootPids
 		};
 	}
+
+	const tree = collectProcessTree(probe.list, rootPids);
+	const matched = probe.list.filter((p) => tree.has(p.pid));
+
+	if (matched.length === 0) {
+		return {
+			status: 'running',
+			cpuPercent: null,
+			memRssBytes: null,
+			memPercent: null,
+			processCount: 0,
+			processes: [],
+			rootPids
+		};
+	}
+
+	const factor = probe.factor;
+	let cpuPercent = factor === null ? null : 0;
+	let memRssBytes = 0;
+	for (const proc of matched) {
+		if (cpuPercent !== null && factor !== null) cpuPercent += proc.cpu * factor;
+		memRssBytes += proc.memRss * 1024;
+	}
+	if (cpuPercent !== null) cpuPercent = Math.min(100, Math.max(0, cpuPercent));
+
+	const totalMem = os.totalmem();
 
 	return {
 		status: 'running',
 		cpuPercent,
 		memRssBytes,
-		memPercent,
+		// Derived from the bytes above so the two figures can never disagree.
+		memPercent: totalMem > 0 ? (memRssBytes / totalMem) * 100 : null,
 		processCount: matched.length,
 		processes: matched
 			.slice()
@@ -228,14 +443,17 @@ async function getProjectProcessStats(projectId: string): Promise<ProcessStats> 
 				pid: p.pid,
 				parentPid: p.parentPid,
 				name: p.name,
-				cpu: p.cpu,
-				mem: p.mem,
-				memRss: p.memRss,
+				cpuPercent: factor === null ? null : Math.min(100, Math.max(0, p.cpu * factor)),
+				memRssBytes: p.memRss * 1024,
 				command: p.command
 			})),
 		rootPids
 	};
 }
+
+// ── Handler ──────────────────────────────────────────────────────────────────
+
+const nullableNumber = t.Union([t.Number(), t.Null()]);
 
 export const infoHandler = createRouter().http(
 	'projects:info',
@@ -254,9 +472,9 @@ export const infoHandler = createRouter().http(
 			}),
 			resources: t.Object({
 				status: t.Union([t.Literal('running'), t.Literal('not_running')]),
-				cpuPercent: t.Number(),
-				memRssBytes: t.Number(),
-				memPercent: t.Number(),
+				cpuPercent: nullableNumber,
+				memRssBytes: nullableNumber,
+				memPercent: nullableNumber,
 				processCount: t.Number(),
 				rootPids: t.Array(t.Number()),
 				processes: t.Array(
@@ -264,16 +482,16 @@ export const infoHandler = createRouter().http(
 						pid: t.Number(),
 						parentPid: t.Number(),
 						name: t.String(),
-						cpu: t.Number(),
-						mem: t.Number(),
-						memRss: t.Number(),
+						cpuPercent: nullableNumber,
+						memRssBytes: t.Number(),
 						command: t.String()
 					})
 				)
 			}),
 			meta: t.Object({
 				platform: t.String(),
-				arch: t.String()
+				arch: t.String(),
+				logicalCores: t.Number()
 			})
 		})
 	},
@@ -285,7 +503,7 @@ export const infoHandler = createRouter().http(
 		}
 
 		const [storage, resources] = await Promise.all([
-			getFolderStatsCached(project.path),
+			getFolderStats(project.path),
 			getProjectProcessStats(data.id)
 		]);
 
@@ -295,7 +513,8 @@ export const infoHandler = createRouter().http(
 			resources,
 			meta: {
 				platform: process.platform,
-				arch: process.arch
+				arch: process.arch,
+				logicalCores: os.cpus().length
 			}
 		};
 	}

--- a/backend/ws/projects/info.ts
+++ b/backend/ws/projects/info.ts
@@ -1,0 +1,302 @@
+/**
+ * Projects Info — per-project resource monitoring
+ *
+ * Returns storage (folder size) and CPU/RAM computed ONLY from processes
+ * belonging to the project. CPU/RAM are NOT host totals.
+ *
+ * - Storage: recursive walk of project.path (includes .git), capped at 300k entries
+ * - CPU/RAM: sum of all processes whose pid is a PTY session pid for this
+ *            project (namespace = projectId) OR a descendant via parentPid chain.
+ *            If no active PTY sessions, status = not_running and cpu/ram = 0.
+ *
+ * Poll-safe: storage walk and process list are done in parallel, both are
+ * bounded and non-blocking for other requests.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { projectQueries } from '../../database/queries';
+import { requireProjectAccess } from '../access';
+import { ptyKitManager } from '../../terminal/ptykit';
+import si from 'systeminformation';
+import { debug } from '$shared/utils/logger';
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const MAX_ENTRIES = 300_000;
+const STORAGE_CACHE_TTL_MS = 15_000;
+const storageCache = new Map<string, { stats: FolderStats; at: number }>();
+
+interface FolderStats {
+	sizeBytes: number;
+	fileCount: number;
+	dirCount: number;
+	truncated: boolean;
+	error?: string;
+}
+
+async function getFolderStatsCached(root: string): Promise<FolderStats> {
+	const cached = storageCache.get(root);
+	if (cached && Date.now() - cached.at < STORAGE_CACHE_TTL_MS) {
+		return cached.stats;
+	}
+	const stats = await getFolderStatsUncached(root);
+	storageCache.set(root, { stats, at: Date.now() });
+	return stats;
+}
+
+async function getFolderStatsUncached(root: string): Promise<FolderStats> {
+	let sizeBytes = 0;
+	let fileCount = 0;
+	let dirCount = 0;
+	let truncated = false;
+
+	// Verify root exists
+	try {
+		const rootStat = await stat(root);
+		if (!rootStat.isDirectory()) {
+			return { sizeBytes: rootStat.size, fileCount: 1, dirCount: 0, truncated: false };
+		}
+	} catch (e) {
+		const msg = e instanceof Error ? e.message : String(e);
+		return { sizeBytes: 0, fileCount: 0, dirCount: 0, truncated: false, error: msg };
+	}
+
+	const stack: string[] = [root];
+
+	while (stack.length > 0) {
+		if (fileCount + dirCount > MAX_ENTRIES) {
+			truncated = true;
+			break;
+		}
+		const dir = stack.pop()!;
+		let entries: import('node:fs').Dirent[];
+		try {
+			entries = await readdir(dir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+
+		for (const entry of entries) {
+			if (fileCount + dirCount > MAX_ENTRIES) {
+				truncated = true;
+				break;
+			}
+			const fullPath = join(dir, entry.name);
+			try {
+				// Symbolic links: do not follow to avoid cycles
+				if (entry.isSymbolicLink()) continue;
+
+				if (entry.isDirectory()) {
+					dirCount++;
+					stack.push(fullPath);
+				} else if (entry.isFile()) {
+					fileCount++;
+					try {
+						const st = await stat(fullPath);
+						sizeBytes += st.size;
+					} catch {
+						// ignore unreadable files
+					}
+				}
+			} catch {
+				// ignore
+			}
+		}
+	}
+
+	return { sizeBytes, fileCount, dirCount, truncated };
+}
+
+interface ProcessStats {
+	status: 'running' | 'not_running';
+	cpuPercent: number;
+	memRssBytes: number;
+	memPercent: number;
+	processCount: number;
+	processes: Array<{
+		pid: number;
+		parentPid: number;
+		name: string;
+		cpu: number;
+		mem: number;
+		memRss: number;
+		command: string;
+	}>;
+	rootPids: number[];
+}
+
+async function getProjectProcessStats(projectId: string): Promise<ProcessStats> {
+	const sessions = ptyKitManager.list(projectId);
+	const active = sessions.filter((s) => s.status === 'active');
+	const rootPids = active.map((s) => s.pid).filter((pid) => Number.isFinite(pid) && pid > 0);
+
+	if (rootPids.length === 0) {
+		return {
+			status: 'not_running',
+			cpuPercent: 0,
+			memRssBytes: 0,
+			memPercent: 0,
+			processCount: 0,
+			processes: [],
+			rootPids: []
+		};
+	}
+
+	let allList: Array<{
+		pid: number;
+		parentPid: number;
+		name: string;
+		cpu: number;
+		mem: number;
+		memRss: number;
+		command: string;
+	}> = [];
+
+	try {
+		const result = await si.processes();
+		// systeminformation returns { all, list:[...] }
+		allList = (result.list as typeof allList) ?? [];
+	} catch (e) {
+		debug.warn('project', 'si.processes failed:', e);
+		return {
+			status: 'running',
+			cpuPercent: 0,
+			memRssBytes: 0,
+			memPercent: 0,
+			processCount: rootPids.length,
+			processes: [],
+			rootPids
+		};
+	}
+
+	// Build project pid set via BFS through parentPid chain
+	const pidSet = new Set<number>(rootPids);
+	let added = true;
+	// Prevent infinite loop: at most one full pass per new pid, limited rounds
+	let rounds = 0;
+	while (added && rounds < 10) {
+		added = false;
+		rounds++;
+		for (const proc of allList) {
+			if (!pidSet.has(proc.pid) && pidSet.has(proc.parentPid)) {
+				pidSet.add(proc.pid);
+				added = true;
+			}
+		}
+	}
+
+	const matched = allList.filter((p) => pidSet.has(p.pid));
+
+	let cpuPercent = 0;
+	let memPercent = 0;
+	let memRssKb = 0;
+	for (const p of matched) {
+		cpuPercent += typeof p.cpu === 'number' ? p.cpu : 0;
+		memPercent += typeof p.mem === 'number' ? p.mem : 0;
+		memRssKb += typeof p.memRss === 'number' ? p.memRss : 0;
+	}
+
+	// memRss from si is in KB, convert to bytes
+	const memRssBytes = memRssKb * 1024;
+
+	// If none of the root pids were found in the OS process list (e.g. just spawned
+	// and not yet visible), still report running with the count of sessions.
+	if (matched.length === 0) {
+		return {
+			status: 'running',
+			cpuPercent: 0,
+			memRssBytes: 0,
+			memPercent: 0,
+			processCount: 0,
+			processes: [],
+			rootPids
+		};
+	}
+
+	return {
+		status: 'running',
+		cpuPercent,
+		memRssBytes,
+		memPercent,
+		processCount: matched.length,
+		processes: matched
+			.slice()
+			.sort((a, b) => b.cpu - a.cpu)
+			.slice(0, 20)
+			.map((p) => ({
+				pid: p.pid,
+				parentPid: p.parentPid,
+				name: p.name,
+				cpu: p.cpu,
+				mem: p.mem,
+				memRss: p.memRss,
+				command: p.command
+			})),
+		rootPids
+	};
+}
+
+export const infoHandler = createRouter().http(
+	'projects:info',
+	{
+		data: t.Object({
+			id: t.String({ minLength: 1 })
+		}),
+		response: t.Object({
+			project: t.Any(),
+			storage: t.Object({
+				sizeBytes: t.Number(),
+				fileCount: t.Number(),
+				dirCount: t.Number(),
+				truncated: t.Boolean(),
+				error: t.Optional(t.String())
+			}),
+			resources: t.Object({
+				status: t.Union([t.Literal('running'), t.Literal('not_running')]),
+				cpuPercent: t.Number(),
+				memRssBytes: t.Number(),
+				memPercent: t.Number(),
+				processCount: t.Number(),
+				rootPids: t.Array(t.Number()),
+				processes: t.Array(
+					t.Object({
+						pid: t.Number(),
+						parentPid: t.Number(),
+						name: t.String(),
+						cpu: t.Number(),
+						mem: t.Number(),
+						memRss: t.Number(),
+						command: t.String()
+					})
+				)
+			}),
+			meta: t.Object({
+				platform: t.String(),
+				arch: t.String()
+			})
+		})
+	},
+	async ({ data, conn }) => {
+		requireProjectAccess(conn, data.id);
+		const project = projectQueries.getById(data.id);
+		if (!project) {
+			throw new Error('Project not found');
+		}
+
+		const [storage, resources] = await Promise.all([
+			getFolderStatsCached(project.path),
+			getProjectProcessStats(data.id)
+		]);
+
+		return {
+			project,
+			storage,
+			resources,
+			meta: {
+				platform: process.platform,
+				arch: process.arch
+			}
+		};
+	}
+);

--- a/backend/ws/projects/info.ts
+++ b/backend/ws/projects/info.ts
@@ -1,20 +1,11 @@
 /**
  * Projects Info — what one project costs on this machine.
  *
- * Storage is measured here; CPU and RAM are read from the shared host probe in
- * `backend/host/metrics.ts` and then narrowed to this project, so the figures
- * sit on the same basis as the ones Settings → Device reports for the whole
- * machine.
- *
- * - Storage: a recursive walk of `project.path`. Nothing is excluded — `.git`
- *   and `node_modules` are part of what the folder actually occupies — so the
- *   walk is stopped by whichever of `MAX_ENTRIES` or `WALK_DEADLINE_MS` comes
- *   first and reports `truncated` when it was. Both bounds are shared between
- *   concurrent callers, so N open panels cost one walk rather than N.
- * - CPU/RAM: the PTY shells Clopen opened for this project plus every live
- *   descendant of them. Nothing else on the host is counted, so this is the
- *   project's own footprint and not the server's. Engine processes that Clopen
- *   runs outside a terminal are not shells and do not appear here.
+ * Storage is a bounded walk of the project folder, nothing excluded. CPU and
+ * RAM come from the shared host probe in `backend/host/metrics.ts`, narrowed to
+ * the project's PTY shells and their descendants, so they sit on the same basis
+ * Settings → Device reports for the whole machine. Engine processes Clopen runs
+ * outside a terminal are not shells and do not appear here.
  */
 
 import { t } from 'elysia';
@@ -28,17 +19,14 @@ import { collectProcessTree, getHostFacts, getProcessTable } from '../../host/me
 
 /** Ceiling on entries visited by one walk, so a monorepo cannot pin a core. */
 const MAX_ENTRIES = 300_000;
-/** Wall-clock ceiling on one walk — the backstop for slow disks and network mounts. */
+/** Wall-clock ceiling — the backstop for slow disks and network mounts. */
 const WALK_DEADLINE_MS = 15_000;
 /** How many `stat` calls are in flight at once while walking one directory. */
 const STAT_BATCH = 64;
 /** A folder's size changes slowly; a poll should not re-walk it every tick. */
 const STORAGE_CACHE_TTL_MS = 15_000;
-/**
- * An expensive walk earns a proportionally longer rest: a tree that takes ten
- * seconds to measure would otherwise be re-walked the moment its answer went
- * stale, leaving one core busy for as long as the panel stays open.
- */
+/** An expensive walk earns a longer rest, so it is not repeated the moment its
+ *  answer goes stale — otherwise one core stays busy while the panel is open. */
 const STORAGE_TTL_PER_MS_SPENT = 4;
 const STORAGE_CACHE_MAX_TTL_MS = 5 * 60_000;
 
@@ -55,14 +43,8 @@ interface FolderStats {
 const storageCache = new Map<string, { stats: FolderStats; at: number; ttl: number }>();
 const storageInFlight = new Map<string, Promise<FolderStats>>();
 
-/**
- * Cached *and* single-flighted.
- *
- * Single-flight is the load-bearing half: a walk of a large project takes far
- * longer than the panel's poll interval, and a result-only cache is still empty
- * while the first walk runs, so every poll would start another full walk and
- * they would pile up faster than they finish.
- */
+/** Cached and single-flighted: a big walk outlives the poll interval, so a
+ *  result-only cache would let every tick start another one. */
 function getFolderStats(root: string): Promise<FolderStats> {
 	const cached = storageCache.get(root);
 	if (cached && Date.now() - cached.at < cached.ttl) {
@@ -74,12 +56,12 @@ function getFolderStats(root: string): Promise<FolderStats> {
 
 	const startedAt = Date.now();
 	const walk = walkFolder(root)
-		.catch((e): FolderStats => ({
+		.catch((error): FolderStats => ({
 			sizeBytes: 0,
 			fileCount: 0,
 			dirCount: 0,
 			truncated: false,
-			error: e instanceof Error ? e.message : String(e)
+			error: error instanceof Error ? error.message : String(error)
 		}))
 		.then((stats) => {
 			const spent = Date.now() - startedAt;
@@ -102,9 +84,9 @@ async function walkFolder(root: string): Promise<FolderStats> {
 		if (!rootStat.isDirectory()) {
 			return { sizeBytes: rootStat.size, fileCount: 1, dirCount: 0, truncated: false };
 		}
-	} catch (e) {
-		const msg = e instanceof Error ? e.message : String(e);
-		return { sizeBytes: 0, fileCount: 0, dirCount: 0, truncated: false, error: msg };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return { sizeBytes: 0, fileCount: 0, dirCount: 0, truncated: false, error: message };
 	}
 
 	const deadline = Date.now() + WALK_DEADLINE_MS;
@@ -135,8 +117,7 @@ async function walkFolder(root: string): Promise<FolderStats> {
 				truncated = true;
 				break;
 			}
-			// Symlinks and Windows junctions are not followed: they would double
-			// count their target at best and loop forever at worst.
+			// Symlinks and Windows junctions: double-counted at best, a loop at worst.
 			if (entry.isSymbolicLink()) continue;
 
 			if (entry.isDirectory()) {
@@ -148,11 +129,11 @@ async function walkFolder(root: string): Promise<FolderStats> {
 			}
 		}
 
-		// One `stat` per file is unavoidable — no platform reports sizes from a
-		// directory read — but they need not be serialised.
-		for (let i = 0; i < files.length; i += STAT_BATCH) {
+		// No platform reports sizes from a directory read, so one `stat` per file
+		// is unavoidable — but they need not be serialised.
+		for (let offset = 0; offset < files.length; offset += STAT_BATCH) {
 			const sizes = await Promise.all(
-				files.slice(i, i + STAT_BATCH).map((file) => stat(file).then((s) => s.size, () => 0))
+				files.slice(offset, offset + STAT_BATCH).map((file) => stat(file).then((info) => info.size, () => 0))
 			);
 			for (const size of sizes) sizeBytes += size;
 		}
@@ -199,14 +180,12 @@ async function getProjectProcessStats(projectId: string, totalMemBytes: number):
 		.map((session) => session.pid)
 		.filter((pid) => Number.isFinite(pid) && pid > 0);
 
-	// No shells means nothing of this project is running, and zero is the truth
-	// rather than a stand-in for a number we failed to read.
+	// No shells means nothing is running, so zero is the truth here.
 	if (rootPids.length === 0) return IDLE;
 
 	const probe = await getProcessTable();
 
-	// Shells are alive but the host's process table is unreadable, or none of
-	// them are visible in it yet. Either way the usage is unknown, not zero.
+	// Shells are alive but the host table is unreadable — unknown, not zero.
 	if (!probe || probe.list.length === 0) {
 		return {
 			status: 'running',
@@ -220,7 +199,7 @@ async function getProjectProcessStats(projectId: string, totalMemBytes: number):
 	}
 
 	const tree = collectProcessTree(probe.list, rootPids);
-	const matched = probe.list.filter((p) => tree.has(p.pid));
+	const matched = probe.list.filter((entry) => tree.has(entry.pid));
 
 	if (matched.length === 0) {
 		return {
@@ -237,9 +216,9 @@ async function getProjectProcessStats(projectId: string, totalMemBytes: number):
 	const factor = probe.cpuFactor;
 	let cpuPercent = factor === null ? null : 0;
 	let memRssBytes = 0;
-	for (const proc of matched) {
-		if (cpuPercent !== null && factor !== null) cpuPercent += proc.cpu * factor;
-		memRssBytes += proc.memRss * 1024;
+	for (const entry of matched) {
+		if (cpuPercent !== null && factor !== null) cpuPercent += entry.cpu * factor;
+		memRssBytes += entry.memRss * 1024;
 	}
 	if (cpuPercent !== null) cpuPercent = Math.min(100, Math.max(0, cpuPercent));
 
@@ -247,21 +226,20 @@ async function getProjectProcessStats(projectId: string, totalMemBytes: number):
 		status: 'running',
 		cpuPercent,
 		memRssBytes,
-		// Derived from the bytes above, against the same installed-RAM figure
-		// Settings -> Device reports, so no two panels can disagree on the total.
+		// Same installed-RAM figure Settings -> Device divides by.
 		memPercent: totalMemBytes > 0 ? (memRssBytes / totalMemBytes) * 100 : null,
 		processCount: matched.length,
 		processes: matched
 			.slice()
 			.sort((a, b) => b.cpu - a.cpu)
 			.slice(0, 20)
-			.map((p) => ({
-				pid: p.pid,
-				parentPid: p.parentPid,
-				name: p.name,
-				cpuPercent: factor === null ? null : Math.min(100, Math.max(0, p.cpu * factor)),
-				memRssBytes: p.memRss * 1024,
-				command: p.command
+			.map((entry) => ({
+				pid: entry.pid,
+				parentPid: entry.parentPid,
+				name: entry.name,
+				cpuPercent: factor === null ? null : Math.min(100, Math.max(0, entry.cpu * factor)),
+				memRssBytes: entry.memRss * 1024,
+				command: entry.command
 			})),
 		rootPids
 	};
@@ -318,8 +296,7 @@ export const infoHandler = createRouter().http(
 			throw new Error('Project not found');
 		}
 
-		// Host facts are probed once per process and cached, so only the first
-		// caller pays for them; every panel then reads the same numbers.
+		// Probed once per process, so only the first caller pays.
 		const facts = await getHostFacts();
 
 		const [storage, resources] = await Promise.all([

--- a/backend/ws/projects/info.ts
+++ b/backend/ws/projects/info.ts
@@ -14,7 +14,10 @@ import { join } from 'node:path';
 import { createRouter } from '$shared/utils/ws-server';
 import { projectQueries } from '../../database/queries';
 import { requireProjectAccess } from '../access';
-import { ptyKitManager } from '../../terminal/ptykit';
+import { projectShellPids } from '../../projects/shell-ownership';
+import { portMonitor } from '../../ports/monitor';
+import { LOCAL_PORT_HOST, type PortEntry } from '$shared/types/ports';
+import { debug } from '$shared/utils/logger';
 import { collectProcessTree, getHostFacts, getProcessTable } from '../../host/metrics';
 
 /** Ceiling on entries visited by one walk, so a monorepo cannot pin a core. */
@@ -29,6 +32,8 @@ const STORAGE_CACHE_TTL_MS = 15_000;
  *  answer goes stale — otherwise one core stays busy while the panel is open. */
 const STORAGE_TTL_PER_MS_SPENT = 4;
 const STORAGE_CACHE_MAX_TTL_MS = 5 * 60_000;
+/** A scan reads the socket table and the process list; the panel polls faster. */
+const PORTS_CACHE_TTL_MS = 5_000;
 
 // ── Storage ──────────────────────────────────────────────────────────────────
 
@@ -174,11 +179,7 @@ const IDLE: ProcessStats = {
 };
 
 async function getProjectProcessStats(projectId: string, totalMemBytes: number): Promise<ProcessStats> {
-	const rootPids = ptyKitManager
-		.list(projectId)
-		.filter((session) => session.status === 'active')
-		.map((session) => session.pid)
-		.filter((pid) => Number.isFinite(pid) && pid > 0);
+	const rootPids = projectShellPids(projectId);
 
 	// No shells means nothing is running, so zero is the truth here.
 	if (rootPids.length === 0) return IDLE;
@@ -245,6 +246,75 @@ async function getProjectProcessStats(projectId: string, totalMemBytes: number):
 	};
 }
 
+// ── Ports ────────────────────────────────────────────────────────────────────
+
+export interface ProjectPort {
+	port: number;
+	protocol: string;
+	label: string;
+	publicUrl: string | null;
+}
+
+let cachedPorts: { entries: Map<string, ProjectPort[]>; at: number } | null = null;
+let inFlightPorts: Promise<Map<string, ProjectPort[]>> | null = null;
+
+/**
+ * Ports the local scan already attributed to a project, grouped by project id.
+ *
+ * The attribution is the port manager's, not a second guess: it climbs from the
+ * listening pid to a terminal session using the same shell roots this handler
+ * descends from. Ports a container publishes are the runtime's, not a shell's,
+ * so they carry no project and do not appear here.
+ */
+export function groupPortsByProject(entries: PortEntry[]): Map<string, ProjectPort[]> {
+	const byProject = new Map<string, ProjectPort[]>();
+
+	for (const entry of entries) {
+		const projectId = entry.origin.projectId;
+		// A container's published port belongs to the runtime, not to a shell.
+		if (entry.origin.kind !== 'session' || !projectId) continue;
+		const list = byProject.get(projectId) ?? [];
+		list.push({
+			port: entry.port,
+			protocol: entry.protocol,
+			label: entry.origin.label,
+			publicUrl: entry.publicUrl
+		});
+		byProject.set(projectId, list);
+	}
+
+	return byProject;
+}
+
+async function scanProjectPorts(): Promise<Map<string, ProjectPort[]>> {
+	try {
+		const scan = await portMonitor.scanOnce(LOCAL_PORT_HOST);
+		return groupPortsByProject(scan.entries);
+	} catch (error) {
+		// A panel that cannot list ports still reports storage and usage.
+		debug.warn('project', 'port scan failed for project info:', error);
+		return new Map();
+	}
+}
+
+/** Cached and single-flighted — one scan serves every open panel. */
+function getProjectPorts(projectId: string): Promise<ProjectPort[]> {
+	const pick = (entries: Map<string, ProjectPort[]>) =>
+		(entries.get(projectId) ?? []).sort((left, right) => left.port - right.port);
+
+	if (cachedPorts && Date.now() - cachedPorts.at < PORTS_CACHE_TTL_MS) {
+		return Promise.resolve(pick(cachedPorts.entries));
+	}
+	if (inFlightPorts) return inFlightPorts.then(pick);
+
+	inFlightPorts = scanProjectPorts().then((entries) => {
+		cachedPorts = { entries, at: Date.now() };
+		inFlightPorts = null;
+		return entries;
+	});
+	return inFlightPorts.then(pick);
+}
+
 // ── Handler ──────────────────────────────────────────────────────────────────
 
 const nullableNumber = t.Union([t.Number(), t.Null()]);
@@ -282,6 +352,14 @@ export const infoHandler = createRouter().http(
 					})
 				)
 			}),
+			ports: t.Array(
+				t.Object({
+					port: t.Number(),
+					protocol: t.String(),
+					label: t.String(),
+					publicUrl: t.Union([t.String(), t.Null()])
+				})
+			),
 			meta: t.Object({
 				platform: t.String(),
 				arch: t.String(),
@@ -299,15 +377,17 @@ export const infoHandler = createRouter().http(
 		// Probed once per process, so only the first caller pays.
 		const facts = await getHostFacts();
 
-		const [storage, resources] = await Promise.all([
+		const [storage, resources, ports] = await Promise.all([
 			getFolderStats(project.path),
-			getProjectProcessStats(data.id, facts.totalMemBytes)
+			getProjectProcessStats(data.id, facts.totalMemBytes),
+			getProjectPorts(data.id)
 		]);
 
 		return {
 			project,
 			storage,
 			resources,
+			ports,
 			meta: {
 				platform: facts.platform,
 				arch: facts.arch,

--- a/backend/ws/projects/info.ts
+++ b/backend/ws/projects/info.ts
@@ -1,54 +1,30 @@
 /**
  * Projects Info — what one project costs on this machine.
  *
- * Two independent probes, both bounded, both shared between concurrent callers
- * so that N open panels polling every few seconds cost one probe per interval
- * rather than N:
+ * Storage is measured here; CPU and RAM are read from the shared host probe in
+ * `backend/host/metrics.ts` and then narrowed to this project, so the figures
+ * sit on the same basis as the ones Settings → Device reports for the whole
+ * machine.
  *
  * - Storage: a recursive walk of `project.path`. Nothing is excluded — `.git`
  *   and `node_modules` are part of what the folder actually occupies — so the
  *   walk is stopped by whichever of `MAX_ENTRIES` or `WALK_DEADLINE_MS` comes
- *   first and reports `truncated` when it was.
+ *   first and reports `truncated` when it was. Both bounds are shared between
+ *   concurrent callers, so N open panels cost one walk rather than N.
  * - CPU/RAM: the PTY shells Clopen opened for this project plus every live
  *   descendant of them. Nothing else on the host is counted, so this is the
  *   project's own footprint and not the server's. Engine processes that Clopen
  *   runs outside a terminal are not shells and do not appear here.
- *
- * ## Why the CPU number is not `si`'s CPU number
- *
- * `si.processes()` reports per-process CPU against a different basis on every
- * platform, so the raw values cannot be summed and labelled the same way:
- *
- * - Linux — a delta over `/proc` jiffies against every core, i.e. already a
- *   share of total machine capacity.
- * - macOS/BSD/SunOS — `ps pcpu`, a decaying recent average in which 100% means
- *   one saturated core, so it has to be divided by the logical core count.
- * - Windows — a delta against the CPU *consumed by processes* during the
- *   interval, not against capacity: one busy process reads close to 100% on an
- *   otherwise idle 8-core box. Scaling it by the machine's busy fraction, taken
- *   from `os.cpus()` tick deltas over the same interval, converts it to a share
- *   of capacity.
- *
- * Everything is therefore normalised to "percent of total machine capacity",
- * which is the only reading of "this project is using X% CPU" that means the
- * same thing on a laptop and on a 32-core VPS.
- *
- * Linux and Windows both need a previous sample before they can produce a
- * delta, so the first probe has no honest answer and `cpuPercent` is `null`
- * there rather than a zero the panel would render as "idle" — the same choice
- * `system:device-info` makes for GPU utilisation.
  */
 
 import { t } from 'elysia';
-import os from 'node:os';
 import { readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createRouter } from '$shared/utils/ws-server';
 import { projectQueries } from '../../database/queries';
 import { requireProjectAccess } from '../access';
 import { ptyKitManager } from '../../terminal/ptykit';
-import si from 'systeminformation';
-import { debug } from '$shared/utils/logger';
+import { collectProcessTree, getHostFacts, getProcessTable } from '../../host/metrics';
 
 /** Ceiling on entries visited by one walk, so a monorepo cannot pin a core. */
 const MAX_ENTRIES = 300_000;
@@ -65,15 +41,6 @@ const STORAGE_CACHE_TTL_MS = 15_000;
  */
 const STORAGE_TTL_PER_MS_SPENT = 4;
 const STORAGE_CACHE_MAX_TTL_MS = 5 * 60_000;
-
-/**
- * Longer than the 500ms window `si` caches its own process table for, so a
- * cache hit here can never make `si` return a stale table whose CPU delta
- * spans a different interval than our `os.cpus()` snapshot.
- */
-const PROCESS_CACHE_TTL_MS = 2_000;
-/** `si.processes()` shells out — to PowerShell on Windows, which can hang. */
-const PROCESS_PROBE_TIMEOUT_MS = 10_000;
 
 // ── Storage ──────────────────────────────────────────────────────────────────
 
@@ -194,157 +161,7 @@ async function walkFolder(root: string): Promise<FolderStats> {
 	return { sizeBytes, fileCount, dirCount, truncated };
 }
 
-// ── Process table ────────────────────────────────────────────────────────────
-
-export interface ProbedProcess {
-	pid: number;
-	parentPid: number;
-	name: string;
-	cpu: number;
-	memRss: number;
-	command: string;
-}
-
-/**
- * Every descendant of `roots`, by walking a parent → children index once.
- *
- * The index makes this exact at any tree depth. Matching by repeated passes
- * over a flat list instead would silently stop at whatever pass limit bounds
- * the loop, dropping the deep end of a `shell → npm → node → esbuild → …`
- * chain. `seen` doubles as the cycle guard for a process table that reports a
- * parent pid which is itself a descendant (recycled pids on Windows).
- */
-export function collectProcessTree(
-	list: Array<{ pid: number; parentPid: number }>,
-	roots: number[]
-): Set<number> {
-	const children = new Map<number, number[]>();
-	for (const proc of list) {
-		if (proc.parentPid === proc.pid) continue;
-		const bucket = children.get(proc.parentPid);
-		if (bucket) bucket.push(proc.pid);
-		else children.set(proc.parentPid, [proc.pid]);
-	}
-
-	const seen = new Set<number>(roots);
-	const queue = [...roots];
-	for (let head = 0; head < queue.length; head++) {
-		for (const child of children.get(queue[head]) ?? []) {
-			if (seen.has(child)) continue;
-			seen.add(child);
-			queue.push(child);
-		}
-	}
-
-	return seen;
-}
-
-/**
- * The multiplier that turns one `si` CPU percentage into a share of total
- * machine capacity. `null` when no honest conversion exists yet — see the
- * module header for why each platform needs a different one.
- */
-export function cpuCapacityFactor(
-	platform: NodeJS.Platform,
-	logicalCores: number,
-	busyFraction: number | null,
-	hasDelta: boolean
-): number | null {
-	if (platform === 'linux') return hasDelta ? 1 : null;
-	if (platform === 'win32') return hasDelta && busyFraction !== null ? busyFraction : null;
-	// macOS, the BSDs and SunOS all read `ps pcpu`, where one core is 100%.
-	return logicalCores > 0 ? 1 / logicalCores : null;
-}
-
-function readCpuTicks(): { busy: number; total: number } {
-	let busy = 0;
-	let total = 0;
-	for (const cpu of os.cpus()) {
-		const times = cpu.times;
-		const active = times.user + times.nice + times.sys + times.irq;
-		busy += active;
-		total += active + times.idle;
-	}
-	return { busy, total };
-}
-
-interface ProcessProbe {
-	list: ProbedProcess[];
-	factor: number | null;
-}
-
-let cachedProbe: { probe: ProcessProbe | null; at: number } | null = null;
-let inFlightProbe: Promise<ProcessProbe | null> | null = null;
-let lastCpuTicks: { busy: number; total: number } | null = null;
-let probeCount = 0;
-
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
-	let timer: ReturnType<typeof setTimeout> | undefined;
-	const timeout = new Promise<null>((resolve) => {
-		timer = setTimeout(() => resolve(null), ms);
-	});
-	return Promise.race([promise, timeout])
-		.then((value) => {
-			clearTimeout(timer);
-			return value;
-		})
-		.catch(() => {
-			clearTimeout(timer);
-			return null;
-		});
-}
-
-async function probeProcesses(): Promise<ProcessProbe | null> {
-	// Snapshotted at the same instant `si` takes its own sample, so both deltas
-	// span the same interval and the Windows conversion stays sound.
-	const ticks = readCpuTicks();
-	const previous = lastCpuTicks;
-	lastCpuTicks = ticks;
-
-	const totalDelta = previous ? ticks.total - previous.total : 0;
-	const busyFraction = previous && totalDelta > 0 ? (ticks.busy - previous.busy) / totalDelta : null;
-
-	const result = await withTimeout(si.processes(), PROCESS_PROBE_TIMEOUT_MS);
-	if (!result) {
-		// A timed-out probe still lands eventually and advances `si`'s internal
-		// delta base at a moment we no longer know, so drop our own base too
-		// rather than pair it with a mismatched interval next tick.
-		debug.warn('project', 'si.processes() unavailable — reporting resources as unknown');
-		lastCpuTicks = null;
-		probeCount = 0;
-		return null;
-	}
-
-	probeCount++;
-	const factor = cpuCapacityFactor(process.platform, os.cpus().length, busyFraction, probeCount >= 2);
-
-	const list: ProbedProcess[] = (result.list ?? []).map((p) => ({
-		pid: p.pid,
-		parentPid: p.parentPid,
-		name: p.name,
-		cpu: typeof p.cpu === 'number' && Number.isFinite(p.cpu) ? p.cpu : 0,
-		// `si` reports RSS in KB on every platform.
-		memRss: typeof p.memRss === 'number' && Number.isFinite(p.memRss) ? p.memRss : 0,
-		command: p.command
-	}));
-
-	return { list, factor };
-}
-
-/** Cached and single-flighted: N panels polling in step cost one probe. */
-function getProcessProbe(): Promise<ProcessProbe | null> {
-	if (cachedProbe && Date.now() - cachedProbe.at < PROCESS_CACHE_TTL_MS) {
-		return Promise.resolve(cachedProbe.probe);
-	}
-	if (inFlightProbe) return inFlightProbe;
-
-	inFlightProbe = probeProcesses().then((probe) => {
-		cachedProbe = { probe, at: Date.now() };
-		inFlightProbe = null;
-		return probe;
-	});
-	return inFlightProbe;
-}
+// ── Per-project slice of the host process table ──────────────────────────────
 
 interface ProjectProcess {
 	pid: number;
@@ -375,7 +192,7 @@ const IDLE: ProcessStats = {
 	rootPids: []
 };
 
-async function getProjectProcessStats(projectId: string): Promise<ProcessStats> {
+async function getProjectProcessStats(projectId: string, totalMemBytes: number): Promise<ProcessStats> {
 	const rootPids = ptyKitManager
 		.list(projectId)
 		.filter((session) => session.status === 'active')
@@ -386,7 +203,7 @@ async function getProjectProcessStats(projectId: string): Promise<ProcessStats> 
 	// rather than a stand-in for a number we failed to read.
 	if (rootPids.length === 0) return IDLE;
 
-	const probe = await getProcessProbe();
+	const probe = await getProcessTable();
 
 	// Shells are alive but the host's process table is unreadable, or none of
 	// them are visible in it yet. Either way the usage is unknown, not zero.
@@ -417,7 +234,7 @@ async function getProjectProcessStats(projectId: string): Promise<ProcessStats> 
 		};
 	}
 
-	const factor = probe.factor;
+	const factor = probe.cpuFactor;
 	let cpuPercent = factor === null ? null : 0;
 	let memRssBytes = 0;
 	for (const proc of matched) {
@@ -426,14 +243,13 @@ async function getProjectProcessStats(projectId: string): Promise<ProcessStats> 
 	}
 	if (cpuPercent !== null) cpuPercent = Math.min(100, Math.max(0, cpuPercent));
 
-	const totalMem = os.totalmem();
-
 	return {
 		status: 'running',
 		cpuPercent,
 		memRssBytes,
-		// Derived from the bytes above so the two figures can never disagree.
-		memPercent: totalMem > 0 ? (memRssBytes / totalMem) * 100 : null,
+		// Derived from the bytes above, against the same installed-RAM figure
+		// Settings -> Device reports, so no two panels can disagree on the total.
+		memPercent: totalMemBytes > 0 ? (memRssBytes / totalMemBytes) * 100 : null,
 		processCount: matched.length,
 		processes: matched
 			.slice()
@@ -502,9 +318,13 @@ export const infoHandler = createRouter().http(
 			throw new Error('Project not found');
 		}
 
+		// Host facts are probed once per process and cached, so only the first
+		// caller pays for them; every panel then reads the same numbers.
+		const facts = await getHostFacts();
+
 		const [storage, resources] = await Promise.all([
 			getFolderStats(project.path),
-			getProjectProcessStats(data.id)
+			getProjectProcessStats(data.id, facts.totalMemBytes)
 		]);
 
 		return {
@@ -512,9 +332,9 @@ export const infoHandler = createRouter().http(
 			storage,
 			resources,
 			meta: {
-				platform: process.platform,
-				arch: process.arch,
-				logicalCores: os.cpus().length
+				platform: facts.platform,
+				arch: facts.arch,
+				logicalCores: facts.logicalCores
 			}
 		};
 	}

--- a/backend/ws/system/device-info.ts
+++ b/backend/ws/system/device-info.ts
@@ -11,9 +11,12 @@
  *   not expose it (only NVIDIA via nvidia-smi typically does), so util fields
  *   are `null` when unavailable rather than a misleading `0`.
  *
- * Static facts (OS, CPU model, core count, GPU model, virtualization) are
- * captured once per process; dynamic metrics (load, memory, battery, disk,
- * GPU utilization) are recomputed on every request so the panel can poll live.
+ * Static facts (OS, CPU model, core count, installed RAM, GPU model,
+ * virtualization) come from `backend/host/metrics.ts`, which probes them once
+ * per process and is also what Project Info reads, so the two panels cannot
+ * disagree about the machine they are describing. Dynamic metrics (load,
+ * memory in use, battery, disk, GPU utilization) are recomputed on every
+ * request so the panel can poll live.
  */
 
 import { t } from 'elysia';
@@ -21,42 +24,7 @@ import os from 'node:os';
 import si from 'systeminformation';
 import type { Systeminformation } from 'systeminformation';
 import { createRouter } from '$shared/utils/ws-server';
-
-interface StaticInfo {
-	hostname: string;
-	platform: string;
-	distro: string;
-	release: string;
-	kernel: string;
-	arch: string;
-	isVirtual: boolean;
-	cpuBrand: string;
-	cpuManufacturer: string;
-	physicalCores: number;
-	logicalCores: number;
-	cpuSpeedGhz: number | null;
-	gpus: Array<{ model: string; vendor: string; vramMb: number | null }>;
-}
-
-/** Timeout helper: race a promise against a deadline, return fallback on timeout. */
-function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
-	let timer: ReturnType<typeof setTimeout> | undefined;
-	const timeout = new Promise<T>((_, reject) => {
-		timer = setTimeout(() => reject(new Error(`timeout after ${ms}ms`)), ms);
-	});
-	return Promise.race([promise, timeout])
-		.then((v) => {
-			clearTimeout(timer);
-			return v;
-		})
-		.catch(() => {
-			clearTimeout(timer);
-			return fallback;
-		});
-}
-
-/** Static facts don't change while the process runs — resolve them once. */
-let staticInfoPromise: Promise<StaticInfo> | null = null;
+import { getHostFacts, withTimeout } from '../../host/metrics';
 
 /** Last-good caches for dynamic probes: prevents transient WMI timeouts from
  *  flickering the UI between "This Device" <-> "Server" or dropping Storage cards. */
@@ -66,60 +34,6 @@ let lastFsSizeCache: Systeminformation.FsSizeData[] | null = null;
 let lastLoadCache: Systeminformation.CurrentLoadData | null = null;
 let lastGraphicsCache: Systeminformation.GraphicsData | null = null;
 let lastNetCache: Systeminformation.NetworkInterfacesData | null = null;
-
-async function getStaticInfo(): Promise<StaticInfo> {
-	if (!staticInfoPromise) {
-		staticInfoPromise = (async () => {
-			const fallbackOs = {
-				hostname: os.hostname(),
-				platform: os.platform(),
-				distro: '',
-				release: os.release(),
-				kernel: os.version(),
-				arch: os.arch()
-			} as unknown as Systeminformation.OsData;
-			const fallbackCpu = {
-				brand: '',
-				manufacturer: '',
-				physicalCores: os.cpus().length,
-				cores: os.cpus().length,
-				speed: 0
-			} as unknown as Systeminformation.CpuData;
-			const fallbackSystem = { virtual: false } as unknown as Systeminformation.SystemData;
-			const fallbackGraphics = { controllers: [] } as unknown as Systeminformation.GraphicsData;
-			const [osInfo, cpu, system, graphics] = await Promise.all([
-				withTimeout(si.osInfo(), 4000, fallbackOs),
-				withTimeout(si.cpu(), 4000, fallbackCpu),
-				withTimeout(si.system(), 4000, fallbackSystem),
-				withTimeout(si.graphics(), 4000, fallbackGraphics)
-			]);
-			return {
-				hostname: (osInfo?.hostname || os.hostname()) as string,
-				platform: (osInfo?.platform || os.platform()) as string,
-				distro: (osInfo?.distro || '') as string,
-				release: (osInfo?.release || os.release()) as string,
-				kernel: (osInfo?.kernel || os.version()) as string,
-				arch: (osInfo?.arch || os.arch()) as string,
-				isVirtual: Boolean(system?.virtual),
-				cpuBrand: (cpu?.brand || '') as string,
-				cpuManufacturer: (cpu?.manufacturer || '') as string,
-				physicalCores: (cpu?.physicalCores || cpu?.cores || os.cpus().length) as number,
-				logicalCores: (cpu?.cores || os.cpus().length) as number,
-				cpuSpeedGhz: typeof cpu?.speed === 'number' && cpu.speed > 0 ? cpu.speed : null,
-				gpus: graphics.controllers.map((c) => ({
-					model: c.model || 'Unknown GPU',
-					vendor: c.vendor || 'Unknown',
-					vramMb: typeof c.vram === 'number' && c.vram > 0 ? c.vram : null
-				}))
-			};
-		})().catch((err) => {
-			// Don't cache a failed probe — allow the next request to retry.
-			staticInfoPromise = null;
-			throw err;
-		});
-	}
-	return staticInfoPromise;
-}
 
 const GpuSchema = t.Object({
 	model: t.String(),
@@ -253,40 +167,40 @@ export const deviceInfoHandler = createRouter()
 			disks: t.Array(DiskSchema)
 		})
 	}, async () => {
-		const staticInfo = await getStaticInfo();
+		const facts = await getHostFacts();
 
 		const [load, mem, battery, graphics, fsSize, netDefault] = await Promise.all([
-			withTimeout(si.currentLoad(), 3500, null as unknown as Systeminformation.CurrentLoadData | null),
-			withTimeout(si.mem(), 3500, null as unknown as Systeminformation.MemData | null),
-			withTimeout(si.battery(), 3500, null as unknown as Systeminformation.BatteryData | null),
-			withTimeout(si.graphics(), 3500, null as unknown as Systeminformation.GraphicsData | null),
-			withTimeout(si.fsSize(), 3500, null as unknown as Systeminformation.FsSizeData[] | null),
-			withTimeout(si.networkInterfaces('default'), 3500, null as unknown as Systeminformation.NetworkInterfacesData | null)
+			withTimeout(si.currentLoad(), 3500),
+			withTimeout(si.mem(), 3500),
+			withTimeout(si.battery(), 3500),
+			withTimeout(si.graphics(), 3500),
+			withTimeout(si.fsSize(), 3500),
+			withTimeout(si.networkInterfaces('default'), 3500)
 		]);
 
 		// Update last-good caches; reuse them when a probe times out so the UI
 		// doesn't flicker between "This Device" <-> "Server" or drop Storage cards.
-		if (mem) lastMemCache = mem as unknown as Systeminformation.MemData;
-		if (battery) lastBatteryCache = battery as unknown as Systeminformation.BatteryData;
-		if (fsSize) lastFsSizeCache = fsSize as unknown as Systeminformation.FsSizeData[];
-		if (load) lastLoadCache = load as unknown as Systeminformation.CurrentLoadData;
-		if (graphics) lastGraphicsCache = graphics as unknown as Systeminformation.GraphicsData;
-		if (netDefault) lastNetCache = (Array.isArray(netDefault) ? netDefault[0] : netDefault) as unknown as Systeminformation.NetworkInterfacesData;
+		if (mem) lastMemCache = mem;
+		if (battery) lastBatteryCache = battery;
+		if (fsSize) lastFsSizeCache = fsSize;
+		if (load) lastLoadCache = load;
+		if (graphics) lastGraphicsCache = graphics;
+		if (netDefault) lastNetCache = Array.isArray(netDefault) ? netDefault[0] : netDefault;
 
-		const memEff = (mem as unknown as Systeminformation.MemData) ?? lastMemCache;
-		const batteryEff = (battery as unknown as Systeminformation.BatteryData) ?? lastBatteryCache;
-		const fsSizeEff = (fsSize as unknown as Systeminformation.FsSizeData[]) ?? lastFsSizeCache ?? [];
-		const loadEff = (load as unknown as Systeminformation.CurrentLoadData) ?? lastLoadCache;
-		const graphicsEff = (graphics as unknown as Systeminformation.GraphicsData) ?? lastGraphicsCache ?? { controllers: [] } as unknown as Systeminformation.GraphicsData;
-		const netRawEff = (netDefault as unknown as Systeminformation.NetworkInterfacesData | null) ?? lastNetCache;
-		const net = Array.isArray(netRawEff) ? netRawEff[0] : (netRawEff as unknown as Systeminformation.NetworkInterfacesData | null);
+		const memEff = mem ?? lastMemCache;
+		const batteryEff = battery ?? lastBatteryCache;
+		const fsSizeEff = fsSize ?? lastFsSizeCache ?? [];
+		const loadEff = load ?? lastLoadCache;
+		const graphicsEff = graphics ?? lastGraphicsCache;
+		const netRawEff = netDefault ?? lastNetCache;
+		const net = Array.isArray(netRawEff) ? netRawEff[0] : netRawEff;
 
 		// avgLoad is 0/undefined on platforms without load average (e.g. Windows).
-		const loadAvg1 = typeof (loadEff as unknown as { avgLoad?: number })?.avgLoad === 'number' && (loadEff as unknown as { avgLoad: number }).avgLoad > 0 ? (loadEff as unknown as { avgLoad: number }).avgLoad : null;
+		const loadAvg1 = typeof loadEff?.avgLoad === 'number' && loadEff.avgLoad > 0 ? loadEff.avgLoad : null;
 
 		// Pair live GPU utilization with the cached controller identity by index.
-		const gpus = staticInfo.gpus.map((g, i) => {
-			const live = (graphicsEff as Systeminformation.GraphicsData)?.controllers?.[i];
+		const gpus = facts.gpus.map((g, i) => {
+			const live = graphicsEff?.controllers?.[i];
 			return {
 				model: g.model,
 				vendor: g.vendor,
@@ -298,46 +212,50 @@ export const deviceInfoHandler = createRouter()
 		});
 
 		// Show only the primary disk(s); collapses macOS APFS synthetic volumes.
-		const disks = selectPrimaryDisks((fsSizeEff as Systeminformation.FsSizeData[]) || [], staticInfo.platform);
+		const disks = selectPrimaryDisks(fsSizeEff, facts.platform);
 
 		return {
-			hostname: staticInfo.hostname,
-			platform: staticInfo.platform,
-			distro: staticInfo.distro,
-			release: staticInfo.release,
-			kernel: staticInfo.kernel,
-			arch: staticInfo.arch,
-			isVirtual: staticInfo.isVirtual,
+			hostname: facts.hostname,
+			platform: facts.platform,
+			distro: facts.distro,
+			release: facts.release,
+			kernel: facts.kernel,
+			arch: facts.arch,
+			isVirtual: facts.isVirtual,
 			uptimeSec: os.uptime(),
 			cpu: {
-				brand: staticInfo.cpuBrand,
-				manufacturer: staticInfo.cpuManufacturer,
-				physicalCores: staticInfo.physicalCores,
-				logicalCores: staticInfo.logicalCores,
-				speedGhz: staticInfo.cpuSpeedGhz,
-				loadPercent: typeof (loadEff as unknown as { currentLoad?: number })?.currentLoad === 'number' ? (loadEff as unknown as { currentLoad: number }).currentLoad : 0,
+				brand: facts.cpuBrand,
+				manufacturer: facts.cpuManufacturer,
+				physicalCores: facts.physicalCores,
+				logicalCores: facts.logicalCores,
+				speedGhz: facts.cpuSpeedGhz,
+				// Percent of total machine capacity — the same basis Project Info
+				// normalises its per-project figure to, so the two are comparable.
+				loadPercent: typeof loadEff?.currentLoad === 'number' ? loadEff.currentLoad : 0,
 				loadAvg1
 			},
 			memory: {
-				totalBytes: (memEff as unknown as Systeminformation.MemData)?.total ?? os.totalmem(),
-				usedBytes: (memEff as unknown as Systeminformation.MemData)?.active ?? os.totalmem() - os.freemem(),
-				freeBytes: (memEff as unknown as Systeminformation.MemData)?.available ?? os.freemem(),
-				swapTotalBytes: (memEff as unknown as Systeminformation.MemData)?.swaptotal ?? 0,
-				swapUsedBytes: (memEff as unknown as Systeminformation.MemData)?.swapused ?? 0
+				// Installed RAM comes from the shared host facts so this total and
+				// the one Project Info divides by are always the same number.
+				totalBytes: facts.totalMemBytes,
+				usedBytes: memEff?.active ?? os.totalmem() - os.freemem(),
+				freeBytes: memEff?.available ?? os.freemem(),
+				swapTotalBytes: memEff?.swaptotal ?? 0,
+				swapUsedBytes: memEff?.swapused ?? 0
 			},
 			network: {
-				iface: (net as unknown as { iface?: string })?.iface || '',
-				ip4: (net as unknown as { ip4?: string })?.ip4 || '',
-				mac: (net as unknown as { mac?: string })?.mac || ''
+				iface: net?.iface || '',
+				ip4: net?.ip4 || '',
+				mac: net?.mac || ''
 			},
 			battery: {
-				hasBattery: Boolean((batteryEff as unknown as Systeminformation.BatteryData)?.hasBattery),
-				percent: typeof (batteryEff as unknown as Systeminformation.BatteryData)?.percent === 'number' && (batteryEff as unknown as Systeminformation.BatteryData)?.hasBattery ? (batteryEff as unknown as Systeminformation.BatteryData).percent : null,
-				isCharging: Boolean((batteryEff as unknown as Systeminformation.BatteryData)?.isCharging),
-				acConnected: Boolean((batteryEff as unknown as Systeminformation.BatteryData)?.acConnected),
+				hasBattery: Boolean(batteryEff?.hasBattery),
+				percent: typeof batteryEff?.percent === 'number' && batteryEff.hasBattery ? batteryEff.percent : null,
+				isCharging: Boolean(batteryEff?.isCharging),
+				acConnected: Boolean(batteryEff?.acConnected),
 				timeRemainingMinutes:
-					typeof (batteryEff as unknown as Systeminformation.BatteryData)?.timeRemaining === 'number' && (batteryEff as unknown as Systeminformation.BatteryData).timeRemaining > 0
-						? (batteryEff as unknown as Systeminformation.BatteryData).timeRemaining
+					typeof batteryEff?.timeRemaining === 'number' && batteryEff.timeRemaining > 0
+						? batteryEff.timeRemaining
 						: null
 			},
 			gpus,

--- a/frontend/components/common/overlay/CommandPalette.svelte
+++ b/frontend/components/common/overlay/CommandPalette.svelte
@@ -310,6 +310,12 @@
 		return all.filter((g) => g.items.length > 0);
 	});
 
+	// Reset cursor to first result whenever search query changes; keep navigation intact.
+	$effect(() => {
+		void query;
+		if (commandPaletteState.isOpen) selectedIndex = 0;
+	});
+
 	// Keep the selection valid as the result set shrinks/grows while typing.
 	$effect(() => {
 		if (selectedIndex >= items.length) selectedIndex = Math.max(0, items.length - 1);

--- a/frontend/components/common/overlay/CommandPalette.svelte
+++ b/frontend/components/common/overlay/CommandPalette.svelte
@@ -310,12 +310,6 @@
 		return all.filter((g) => g.items.length > 0);
 	});
 
-	// Reset cursor to first result whenever search query changes; keep navigation intact.
-	$effect(() => {
-		void query;
-		if (commandPaletteState.isOpen) selectedIndex = 0;
-	});
-
 	// Keep the selection valid as the result set shrinks/grows while typing.
 	$effect(() => {
 		if (selectedIndex >= items.length) selectedIndex = Math.max(0, items.length - 1);

--- a/frontend/components/workspace/DesktopNavigator.svelte
+++ b/frontend/components/workspace/DesktopNavigator.svelte
@@ -31,6 +31,7 @@
 	import MemoryModal from '$frontend/components/memory/MemoryModal.svelte';
 	import SettingButton from '$frontend/components/settings/SettingButton.svelte';
 	import ProjectUserAvatars from '$frontend/components/common/display/ProjectUserAvatars.svelte';
+	import ProjectInfoModal from '$frontend/components/workspace/ProjectInfoModal.svelte';
 	import ws from '$frontend/utils/ws';
 	import {
 		quickPanelsState,
@@ -55,6 +56,8 @@
 	// State
 	let showDeleteDialog = $state(false);
 	let projectToDelete = $state<Project | null>(null);
+	let showProjectInfo = $state(false);
+	let projectInfoProject = $state<Project | null>(null);
 	let searchQuery = $state('');
 	let hoveredProject = $state<Project | null>(null);
 	let tooltipY = $state(0);
@@ -167,6 +170,16 @@
 		event.stopPropagation();
 		projectToDelete = project;
 		showDeleteDialog = true;
+	}
+
+	function handleInfoClick(project: Project, event: MouseEvent) {
+		event.stopPropagation();
+		projectInfoProject = project;
+		showProjectInfo = true;
+	}
+
+	function closeProjectInfo() {
+		showProjectInfo = false;
 	}
 
 	// Get project initials (max 2 characters)
@@ -354,6 +367,15 @@
 								</div>
 								<div class="flex items-center gap-1 shrink-0">
 									<ProjectUserAvatars projectStatus={presenceState.statuses.get(project.id ?? '')} maxVisible={2} />
+									<button
+										type="button"
+										class="flex items-center justify-center w-6 h-6 bg-transparent border-none rounded-md text-slate-400 dark:text-slate-600 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-violet-600 shrink-0"
+										onclick={(e) => handleInfoClick(project, e)}
+										aria-label="Project info"
+										title="Info"
+									>
+										<Icon name="lucide:info" class="w-3.5 h-3.5" />
+									</button>
 									{#if canManageProjects}
 										<button
 											type="button"
@@ -564,3 +586,5 @@
 <PortsModal bind:isOpen={quickPanelsState.portsOpen} onClose={closePortsDialog} />
 <ContainersModal bind:isOpen={quickPanelsState.containersOpen} onClose={closeContainersDialog} />
 <MemoryModal bind:isOpen={quickPanelsState.memoryOpen} onClose={closeMemoryDialog} />
+
+<ProjectInfoModal bind:isOpen={showProjectInfo} onClose={closeProjectInfo} project={projectInfoProject} />

--- a/frontend/components/workspace/MobileNavigator.svelte
+++ b/frontend/components/workspace/MobileNavigator.svelte
@@ -18,6 +18,7 @@
 	import type { Project } from '$shared/types/database/schema';
 	import FolderBrowser from '$frontend/components/common/form/FolderBrowser.svelte';
 	import ProjectUserAvatars from '$frontend/components/common/display/ProjectUserAvatars.svelte';
+	import ProjectInfoModal from '$frontend/components/workspace/ProjectInfoModal.svelte';
 	import { authStore } from '$frontend/stores/features/auth.svelte';
 	import ws from '$frontend/utils/ws';
 	import { debug } from '$shared/utils/logger';
@@ -46,6 +47,8 @@
 	let showProjectMenu = $state(false);
 	let showDeleteDialog = $state(false);
 	let projectToDelete = $state<Project | null>(null);
+	let showProjectInfo = $state(false);
+	let projectInfoProject = $state<Project | null>(null);
 	let searchQuery = $state('');
 
 	const canManageProjects = $derived(authStore.isAdmin);
@@ -89,6 +92,16 @@
 		event.stopPropagation();
 		projectToDelete = project;
 		showDeleteDialog = true;
+	}
+
+	function handleInfoClick(project: Project, event: MouseEvent) {
+		event.stopPropagation();
+		projectInfoProject = project;
+		showProjectInfo = true;
+	}
+
+	function closeProjectInfo() {
+		showProjectInfo = false;
 	}
 
 	let deletingProject = $state(false);
@@ -330,6 +343,15 @@
 							</div>
 						</button>
 						<ProjectUserAvatars projectStatus={presenceState.statuses.get(project.id ?? '')} maxVisible={2} />
+						<button
+							type="button"
+							class="flex items-center justify-center w-8 h-8 bg-transparent border-none rounded-lg text-slate-400 dark:text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-violet-600 shrink-0"
+							onclick={(e) => handleInfoClick(project, e)}
+							aria-label="Project info"
+							title="Info"
+						>
+							<Icon name="lucide:info" class="w-4 h-4" />
+						</button>
 						{#if canManageProjects}
 							<button
 								type="button"
@@ -431,6 +453,8 @@
 <!-- DB Client Modal -->
 <DbClientModal bind:isOpen={quickPanelsState.dbClientOpen} onClose={closeDbClientDialog} />
 <SshClientModal bind:isOpen={quickPanelsState.sshClientOpen} onClose={closeSshClientDialog} />
-<PortsModal bind:isOpen={quickPanelsState.portsOpen} onClose={closePortsDialog} />
-<ContainersModal bind:isOpen={quickPanelsState.containersOpen} onClose={closeContainersDialog} />
-<MemoryModal bind:isOpen={quickPanelsState.memoryOpen} onClose={closeMemoryDialog} />
+	<PortsModal bind:isOpen={quickPanelsState.portsOpen} onClose={closePortsDialog} />
+	<ContainersModal bind:isOpen={quickPanelsState.containersOpen} onClose={closeContainersDialog} />
+	<MemoryModal bind:isOpen={quickPanelsState.memoryOpen} onClose={closeMemoryDialog} />
+
+	<ProjectInfoModal bind:isOpen={showProjectInfo} onClose={closeProjectInfo} project={projectInfoProject} />

--- a/frontend/components/workspace/MobileNavigator.svelte
+++ b/frontend/components/workspace/MobileNavigator.svelte
@@ -453,8 +453,8 @@
 <!-- DB Client Modal -->
 <DbClientModal bind:isOpen={quickPanelsState.dbClientOpen} onClose={closeDbClientDialog} />
 <SshClientModal bind:isOpen={quickPanelsState.sshClientOpen} onClose={closeSshClientDialog} />
-	<PortsModal bind:isOpen={quickPanelsState.portsOpen} onClose={closePortsDialog} />
-	<ContainersModal bind:isOpen={quickPanelsState.containersOpen} onClose={closeContainersDialog} />
-	<MemoryModal bind:isOpen={quickPanelsState.memoryOpen} onClose={closeMemoryDialog} />
+<PortsModal bind:isOpen={quickPanelsState.portsOpen} onClose={closePortsDialog} />
+<ContainersModal bind:isOpen={quickPanelsState.containersOpen} onClose={closeContainersDialog} />
+<MemoryModal bind:isOpen={quickPanelsState.memoryOpen} onClose={closeMemoryDialog} />
 
-	<ProjectInfoModal bind:isOpen={showProjectInfo} onClose={closeProjectInfo} project={projectInfoProject} />
+<ProjectInfoModal bind:isOpen={showProjectInfo} onClose={closeProjectInfo} project={projectInfoProject} />

--- a/frontend/components/workspace/ProjectInfoModal.svelte
+++ b/frontend/components/workspace/ProjectInfoModal.svelte
@@ -38,6 +38,12 @@
 				command: string;
 			}>;
 		};
+		ports: Array<{
+			port: number;
+			protocol: string;
+			label: string;
+			publicUrl: string | null;
+		}>;
 		meta: {
 			platform: string;
 			arch: string;
@@ -289,6 +295,36 @@
 						{/if}
 					</div>
 				</div>
+
+				<!-- Ports the port manager attributed to this project -->
+				{#if data.ports.length > 0}
+					<div class="flex flex-col gap-2">
+						<h3 class="text-xs font-semibold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+							<Icon name="lucide:radio-tower" class="w-3.5 h-3.5" />
+							Listening ({data.ports.length})
+						</h3>
+						<div class="flex flex-wrap gap-2">
+							{#each data.ports as entry (entry.protocol + entry.port)}
+								<div class="flex items-center gap-2 px-2.5 py-1.5 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg">
+									<span class="font-mono text-xs font-semibold text-slate-900 dark:text-slate-100">:{entry.port}</span>
+									<span class="text-2xs text-slate-500 dark:text-slate-400 truncate max-w-[160px]" title={entry.label}>{entry.label}</span>
+									{#if entry.publicUrl}
+										<a
+											href={entry.publicUrl}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="shrink-0 text-violet-500 hover:text-violet-400"
+											title={entry.publicUrl}
+											aria-label="Open public URL"
+										>
+											<Icon name="lucide:external-link" class="w-3 h-3" />
+										</a>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					</div>
+				{/if}
 
 				<!-- Process list (only when running) -->
 				{#if data.resources.status === 'running' && data.resources.processes.length > 0}

--- a/frontend/components/workspace/ProjectInfoModal.svelte
+++ b/frontend/components/workspace/ProjectInfoModal.svelte
@@ -1,0 +1,298 @@
+<script lang="ts">
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import Modal from '$frontend/components/common/overlay/Modal.svelte';
+	import type { Project } from '$shared/types/database/schema';
+	import ws from '$frontend/utils/ws';
+
+	interface Props {
+		isOpen: boolean;
+		onClose: () => void;
+		project: Project | null;
+	}
+
+	let { isOpen = $bindable(), onClose, project }: Props = $props();
+
+	interface InfoData {
+		project: Project;
+		storage: {
+			sizeBytes: number;
+			fileCount: number;
+			dirCount: number;
+			truncated: boolean;
+			error?: string;
+		};
+		resources: {
+			status: 'running' | 'not_running';
+			cpuPercent: number;
+			memRssBytes: number;
+			memPercent: number;
+			processCount: number;
+			rootPids: number[];
+			processes: Array<{
+				pid: number;
+				parentPid: number;
+				name: string;
+				cpu: number;
+				mem: number;
+				memRss: number;
+				command: string;
+			}>;
+		};
+		meta: {
+			platform: string;
+			arch: string;
+		};
+	}
+
+	let data = $state<InfoData | null>(null);
+	let loading = $state(false);
+	let error = $state<string | null>(null);
+	let copied = $state(false);
+	let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+	function formatBytes(bytes: number): string {
+		if (bytes === 0) return '0 B';
+		const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+		const k = 1024;
+		const i = Math.floor(Math.log(bytes) / Math.log(k));
+		const size = bytes / Math.pow(k, i);
+		return `${size >= 100 ? Math.round(size) : size >= 10 ? size.toFixed(1) : size.toFixed(2)} ${units[i]}`;
+	}
+
+	function formatCpu(cpu: number): string {
+		return `${cpu.toFixed(1)}%`;
+	}
+
+	function formatMem(bytes: number): string {
+		return formatBytes(bytes);
+	}
+
+	async function fetchInfo() {
+		if (!project?.id) return;
+		try {
+			const result = await ws.http('projects:info', { id: project.id });
+			data = result as InfoData;
+			error = null;
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		if (isOpen && project?.id) {
+			loading = true;
+			data = null;
+			error = null;
+			void fetchInfo();
+			// Poll every 3s while open for live CPU/RAM
+			if (pollTimer) clearInterval(pollTimer);
+			pollTimer = setInterval(() => {
+				void fetchInfo();
+			}, 3000);
+			return () => {
+				if (pollTimer) clearInterval(pollTimer);
+				pollTimer = null;
+			};
+		} else {
+			if (pollTimer) clearInterval(pollTimer);
+			pollTimer = null;
+			data = null;
+			error = null;
+			loading = false;
+		}
+	});
+
+	function copyPath() {
+		if (!project?.path) return;
+		navigator.clipboard.writeText(project.path).then(() => {
+			copied = true;
+			setTimeout(() => (copied = false), 1500);
+		});
+	}
+
+	function handleClose() {
+		if (pollTimer) clearInterval(pollTimer);
+		pollTimer = null;
+		onClose();
+	}
+</script>
+
+<Modal bind:isOpen={isOpen} onClose={handleClose} size="lg" title="Project Info">
+	{#snippet children()}
+		{#if !project}
+			<div class="flex items-center justify-center py-12 text-sm text-slate-500">No project selected</div>
+		{:else if loading && !data}
+			<div class="flex flex-col items-center justify-center py-12 gap-3">
+				<Icon name="lucide:loader-circle" class="w-6 h-6 animate-spin text-violet-500" />
+				<span class="text-sm text-slate-500 dark:text-slate-400">Loading project info...</span>
+			</div>
+		{:else if error && !data}
+			<div class="flex flex-col items-center gap-3 py-8">
+				<Icon name="lucide:circle-x" class="w-8 h-8 text-red-400" />
+				<p class="text-sm text-red-600 dark:text-red-400">{error}</p>
+				<button
+					type="button"
+					class="px-4 py-2 bg-violet-600 text-white rounded-lg text-sm font-medium hover:bg-violet-700"
+					onclick={() => {
+						loading = true;
+						error = null;
+						void fetchInfo();
+					}}
+				>
+					Retry
+				</button>
+			</div>
+		{:else if data}
+			<div class="flex flex-col gap-5">
+				<!-- Header: name + path -->
+				<div class="flex items-start gap-3 p-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl">
+					<div class="w-10 h-10 rounded-lg bg-violet-100 dark:bg-violet-900/30 flex items-center justify-center shrink-0">
+						<Icon name="lucide:folder" class="w-5 h-5 text-violet-600 dark:text-violet-400" />
+					</div>
+					<div class="flex-1 min-w-0">
+						<p class="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">{data.project.name}</p>
+						<div class="flex items-center gap-1.5 mt-0.5">
+							<p class="text-xs font-mono text-slate-500 dark:text-slate-400 truncate flex-1 min-w-0" title={data.project.path}>
+								{data.project.path}
+							</p>
+							<button
+								type="button"
+								class="shrink-0 w-6 h-6 flex items-center justify-center rounded-md text-slate-400 hover:text-violet-600 hover:bg-violet-500/10 transition-colors"
+								onclick={copyPath}
+								title={copied ? 'Copied!' : 'Copy path'}
+								aria-label="Copy path"
+							>
+								<Icon name={copied ? 'lucide:check' : 'lucide:copy'} class="w-3.5 h-3.5" />
+							</button>
+						</div>
+						<p class="text-3xs text-slate-400 dark:text-slate-500 mt-1">
+							Created {new Date(data.project.created_at).toLocaleDateString()} · Platform {data.meta.platform} {data.meta.arch}
+						</p>
+					</div>
+					<span
+						class="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium border
+							{data.resources.status === 'running'
+							? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300 border-green-200 dark:border-green-800'
+							: 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 border-slate-200 dark:border-slate-700'}"
+					>
+						<span class="w-2 h-2 rounded-full {data.resources.status === 'running' ? 'bg-green-500 animate-pulse' : 'bg-slate-400'}"></span>
+						{data.resources.status === 'running' ? 'Running' : 'Not Running'}
+					</span>
+				</div>
+
+				<!-- Resource cards: CPU / RAM / Storage (per-project only) -->
+				<div class="grid grid-cols-3 gap-3">
+					<!-- CPU -->
+					<div class="flex flex-col gap-2 p-3 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl">
+						<div class="flex items-center gap-2 text-xs font-semibold text-slate-600 dark:text-slate-400 uppercase tracking-wider">
+							<Icon name="lucide:cpu" class="w-3.5 h-3.5 text-violet-500" />
+							CPU
+							<span
+								class="ml-auto w-2 h-2 rounded-full {data.resources.status === 'running' ? 'bg-green-500 animate-pulse' : 'bg-slate-300 dark:bg-slate-600'}"
+								title={data.resources.status === 'running' ? 'Resource active — live process' : 'Inactive — no process'}
+							></span>
+						</div>
+						{#if data.resources.status === 'not_running'}
+							<p class="text-lg font-bold text-slate-400 dark:text-slate-500">0%</p>
+							<p class="text-2xs text-slate-400 dark:text-slate-500">No active process</p>
+						{:else}
+							<p class="text-lg font-bold text-slate-900 dark:text-slate-100">{formatCpu(data.resources.cpuPercent)}</p>
+							<p class="text-2xs text-slate-500 dark:text-slate-400">
+								{data.resources.processCount} process{data.resources.processCount !== 1 ? 'es' : ''} · {data.resources.rootPids.length} shell{data.resources.rootPids.length !== 1 ? 's' : ''}
+							</p>
+						{/if}
+					</div>
+
+					<!-- RAM -->
+					<div class="flex flex-col gap-2 p-3 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl">
+						<div class="flex items-center gap-2 text-xs font-semibold text-slate-600 dark:text-slate-400 uppercase tracking-wider">
+							<Icon name="lucide:memory-stick" class="w-3.5 h-3.5 text-blue-500" />
+							RAM
+							<span
+								class="ml-auto w-2 h-2 rounded-full {data.resources.status === 'running' ? 'bg-green-500 animate-pulse' : 'bg-slate-300 dark:bg-slate-600'}"
+								title={data.resources.status === 'running' ? 'Resource active — live process' : 'Inactive — no process'}
+							></span>
+						</div>
+						{#if data.resources.status === 'not_running'}
+							<p class="text-lg font-bold text-slate-400 dark:text-slate-500">0 B</p>
+							<p class="text-2xs text-slate-400 dark:text-slate-500">No active process</p>
+						{:else}
+							<p class="text-lg font-bold text-slate-900 dark:text-slate-100">{formatMem(data.resources.memRssBytes)}</p>
+							<p class="text-2xs text-slate-500 dark:text-slate-400">{data.resources.memPercent.toFixed(2)}% mem</p>
+						{/if}
+					</div>
+
+					<!-- Storage -->
+					<div class="flex flex-col gap-2 p-3 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl">
+						<div class="flex items-center gap-2 text-xs font-semibold text-slate-600 dark:text-slate-400 uppercase tracking-wider">
+							<Icon name="lucide:hard-drive" class="w-3.5 h-3.5 text-amber-500" />
+							Storage
+						</div>
+						{#if data.storage.error}
+							<p class="text-xs text-red-500 truncate" title={data.storage.error}>Unavailable</p>
+						{:else}
+							<p class="text-lg font-bold text-slate-900 dark:text-slate-100">{formatBytes(data.storage.sizeBytes)}</p>
+							<p class="text-2xs text-slate-500 dark:text-slate-400">
+								{data.storage.fileCount.toLocaleString()} files · {data.storage.dirCount.toLocaleString()} dirs
+								{#if data.storage.truncated}
+									<span class="text-amber-600 dark:text-amber-400"> (truncated)</span>
+								{/if}
+							</p>
+						{/if}
+					</div>
+				</div>
+
+				<!-- Process list (only when running) -->
+				{#if data.resources.status === 'running' && data.resources.processes.length > 0}
+					<div class="flex flex-col gap-2">
+						<h3 class="text-xs font-semibold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+							<Icon name="lucide:list-tree" class="w-3.5 h-3.5" />
+							Processes ({data.resources.processCount})
+						</h3>
+						<div class="border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden">
+							<div class="max-h-48 overflow-y-auto">
+								<table class="w-full text-xs">
+									<thead class="sticky top-0 bg-slate-50 dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700">
+										<tr class="text-left text-slate-500 dark:text-slate-400">
+											<th class="px-3 py-2 font-medium">PID</th>
+											<th class="px-3 py-2 font-medium">Name</th>
+											<th class="px-3 py-2 font-medium text-right">CPU</th>
+											<th class="px-3 py-2 font-medium text-right">RAM</th>
+										</tr>
+									</thead>
+									<tbody class="divide-y divide-slate-100 dark:divide-slate-800">
+										{#each data.resources.processes as proc (proc.pid)}
+											<tr class="hover:bg-slate-50 dark:hover:bg-slate-800/50">
+												<td class="px-3 py-1.5 font-mono text-slate-600 dark:text-slate-400">{proc.pid}</td>
+												<td class="px-3 py-1.5 max-w-[180px] truncate text-slate-900 dark:text-slate-100" title={proc.command || proc.name}>{proc.name}</td>
+												<td class="px-3 py-1.5 text-right font-mono text-slate-600 dark:text-slate-400">{proc.cpu.toFixed(1)}%</td>
+												<td class="px-3 py-1.5 text-right font-mono text-slate-600 dark:text-slate-400">{formatBytes(proc.memRss * 1024)}</td>
+											</tr>
+										{/each}
+									</tbody>
+								</table>
+							</div>
+						</div>
+						<p class="text-3xs text-slate-400 dark:text-slate-500">
+							CPU/RAM sum includes child processes (Node/Bun/npm) spawned from the project shells. Polls every 3s.
+						</p>
+					</div>
+				{:else if data.resources.status === 'running' && data.resources.processes.length === 0}
+					<div class="flex items-center gap-2 p-3 bg-amber-50 dark:bg-amber-900/10 border border-amber-200 dark:border-amber-800 rounded-lg text-xs text-amber-700 dark:text-amber-300">
+						<Icon name="lucide:info" class="w-4 h-4 shrink-0" />
+						Shell is running but no process details available yet.
+					</div>
+				{/if}
+
+				{#if data.storage.truncated}
+					<p class="text-3xs text-amber-600 dark:text-amber-400 text-center">
+						Storage scan capped at 300,000 entries. Size is partial.
+					</p>
+				{/if}
+			</div>
+		{/if}
+	{/snippet}
+</Modal>
+

--- a/frontend/components/workspace/ProjectInfoModal.svelte
+++ b/frontend/components/workspace/ProjectInfoModal.svelte
@@ -23,103 +23,137 @@
 		};
 		resources: {
 			status: 'running' | 'not_running';
-			cpuPercent: number;
-			memRssBytes: number;
-			memPercent: number;
+			/** null when the host process table could not be read — not zero. */
+			cpuPercent: number | null;
+			memRssBytes: number | null;
+			memPercent: number | null;
 			processCount: number;
 			rootPids: number[];
 			processes: Array<{
 				pid: number;
 				parentPid: number;
 				name: string;
-				cpu: number;
-				mem: number;
-				memRss: number;
+				cpuPercent: number | null;
+				memRssBytes: number;
 				command: string;
 			}>;
 		};
 		meta: {
 			platform: string;
 			arch: string;
+			logicalCores: number;
 		};
 	}
+
+	const POLL_INTERVAL_MS = 3000;
 
 	let data = $state<InfoData | null>(null);
 	let loading = $state(false);
 	let error = $state<string | null>(null);
 	let copied = $state(false);
-	let pollTimer: ReturnType<typeof setInterval> | null = null;
 
 	function formatBytes(bytes: number): string {
-		if (bytes === 0) return '0 B';
+		if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
 		const units = ['B', 'KB', 'MB', 'GB', 'TB'];
 		const k = 1024;
-		const i = Math.floor(Math.log(bytes) / Math.log(k));
+		const i = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(k)));
 		const size = bytes / Math.pow(k, i);
 		return `${size >= 100 ? Math.round(size) : size >= 10 ? size.toFixed(1) : size.toFixed(2)} ${units[i]}`;
 	}
 
-	function formatCpu(cpu: number): string {
-		return `${cpu.toFixed(1)}%`;
+	function formatPercent(value: number | null): string {
+		return value === null ? '—' : `${value.toFixed(1)}%`;
 	}
 
-	function formatMem(bytes: number): string {
-		return formatBytes(bytes);
-	}
+	/**
+	 * One poll at a time, chained after the previous answer instead of fired on a
+	 * fixed interval: the probe walks a folder and reads the host process table,
+	 * which on a large project or a Windows host outruns the interval and would
+	 * otherwise queue requests faster than the server answers them.
+	 *
+	 * `token` drops the answer to a request whose project is no longer the one on
+	 * screen, so switching projects quickly cannot paint stale numbers.
+	 */
+	let token = 0;
+	let pollTimer: ReturnType<typeof setTimeout> | null = null;
 
-	async function fetchInfo() {
-		if (!project?.id) return;
+	async function fetchInfo(projectId: string, requestToken: number, reschedule: boolean) {
 		try {
-			const result = await ws.http('projects:info', { id: project.id });
-			data = result as InfoData;
+			const result = (await ws.http('projects:info', { id: projectId })) as InfoData;
+			if (requestToken !== token) return;
+			data = result;
 			error = null;
 		} catch (e) {
+			if (requestToken !== token) return;
 			error = e instanceof Error ? e.message : String(e);
 		} finally {
-			loading = false;
+			if (requestToken === token) {
+				loading = false;
+				if (reschedule) {
+					pollTimer = setTimeout(() => void fetchInfo(projectId, requestToken, true), POLL_INTERVAL_MS);
+				}
+			}
 		}
 	}
 
 	$effect(() => {
-		if (isOpen && project?.id) {
-			loading = true;
-			data = null;
-			error = null;
-			void fetchInfo();
-			// Poll every 3s while open for live CPU/RAM
-			if (pollTimer) clearInterval(pollTimer);
-			pollTimer = setInterval(() => {
-				void fetchInfo();
-			}, 3000);
-			return () => {
-				if (pollTimer) clearInterval(pollTimer);
-				pollTimer = null;
-			};
-		} else {
-			if (pollTimer) clearInterval(pollTimer);
-			pollTimer = null;
+		const projectId = isOpen ? project?.id : undefined;
+
+		token++;
+		if (pollTimer) clearTimeout(pollTimer);
+		pollTimer = null;
+
+		if (!projectId) {
 			data = null;
 			error = null;
 			loading = false;
+			return;
 		}
+
+		const requestToken = token;
+		loading = true;
+		data = null;
+		error = null;
+		void fetchInfo(projectId, requestToken, true);
+
+		return () => {
+			token++;
+			if (pollTimer) clearTimeout(pollTimer);
+			pollTimer = null;
+		};
 	});
 
-	function copyPath() {
-		if (!project?.path) return;
-		navigator.clipboard.writeText(project.path).then(() => {
+	/**
+	 * `navigator.clipboard` only exists on a secure origin, and Clopen is
+	 * routinely reached over plain HTTP on a LAN address, so the async API cannot
+	 * be the only path — without the fallback the button throws and does nothing.
+	 */
+	async function copyPath() {
+		const path = project?.path;
+		if (!path) return;
+		try {
+			if (navigator.clipboard?.writeText) {
+				await navigator.clipboard.writeText(path);
+			} else {
+				const field = document.createElement('textarea');
+				field.value = path;
+				field.setAttribute('readonly', '');
+				field.style.position = 'fixed';
+				field.style.opacity = '0';
+				document.body.appendChild(field);
+				field.select();
+				document.execCommand('copy');
+				field.remove();
+			}
 			copied = true;
 			setTimeout(() => (copied = false), 1500);
-		});
-	}
-
-	function handleClose() {
-		if (pollTimer) clearInterval(pollTimer);
-		pollTimer = null;
-		onClose();
+		} catch {
+			// Clipboard denied by the browser — leave the icon unchanged.
+		}
 	}
 </script>
 
-<Modal bind:isOpen={isOpen} onClose={handleClose} size="lg" title="Project Info">
+<Modal bind:isOpen {onClose} size="lg" title="Project Info">
 	{#snippet children()}
 		{#if !project}
 			<div class="flex items-center justify-center py-12 text-sm text-slate-500">No project selected</div>
@@ -136,9 +170,11 @@
 					type="button"
 					class="px-4 py-2 bg-violet-600 text-white rounded-lg text-sm font-medium hover:bg-violet-700"
 					onclick={() => {
+						if (!project?.id) return;
+						token++;
 						loading = true;
 						error = null;
-						void fetchInfo();
+						void fetchInfo(project.id, token, true);
 					}}
 				>
 					Retry
@@ -168,7 +204,8 @@
 							</button>
 						</div>
 						<p class="text-3xs text-slate-400 dark:text-slate-500 mt-1">
-							Created {new Date(data.project.created_at).toLocaleDateString()} · Platform {data.meta.platform} {data.meta.arch}
+							Created {new Date(data.project.created_at).toLocaleDateString()} · {data.meta.platform}
+							{data.meta.arch} · {data.meta.logicalCores} cores
 						</p>
 					</div>
 					<span
@@ -198,9 +235,14 @@
 							<p class="text-lg font-bold text-slate-400 dark:text-slate-500">0%</p>
 							<p class="text-2xs text-slate-400 dark:text-slate-500">No active process</p>
 						{:else}
-							<p class="text-lg font-bold text-slate-900 dark:text-slate-100">{formatCpu(data.resources.cpuPercent)}</p>
+							<p class="text-lg font-bold text-slate-900 dark:text-slate-100">{formatPercent(data.resources.cpuPercent)}</p>
 							<p class="text-2xs text-slate-500 dark:text-slate-400">
-								{data.resources.processCount} process{data.resources.processCount !== 1 ? 'es' : ''} · {data.resources.rootPids.length} shell{data.resources.rootPids.length !== 1 ? 's' : ''}
+								{#if data.resources.cpuPercent === null}
+									Measuring…
+								{:else}
+									{data.resources.processCount} process{data.resources.processCount !== 1 ? 'es' : ''} · {data.resources.rootPids.length}
+									shell{data.resources.rootPids.length !== 1 ? 's' : ''}
+								{/if}
 							</p>
 						{/if}
 					</div>
@@ -218,9 +260,12 @@
 						{#if data.resources.status === 'not_running'}
 							<p class="text-lg font-bold text-slate-400 dark:text-slate-500">0 B</p>
 							<p class="text-2xs text-slate-400 dark:text-slate-500">No active process</p>
+						{:else if data.resources.memRssBytes === null}
+							<p class="text-lg font-bold text-slate-400 dark:text-slate-500">—</p>
+							<p class="text-2xs text-slate-400 dark:text-slate-500">Unavailable</p>
 						{:else}
-							<p class="text-lg font-bold text-slate-900 dark:text-slate-100">{formatMem(data.resources.memRssBytes)}</p>
-							<p class="text-2xs text-slate-500 dark:text-slate-400">{data.resources.memPercent.toFixed(2)}% mem</p>
+							<p class="text-lg font-bold text-slate-900 dark:text-slate-100">{formatBytes(data.resources.memRssBytes)}</p>
+							<p class="text-2xs text-slate-500 dark:text-slate-400">{formatPercent(data.resources.memPercent)} of host memory</p>
 						{/if}
 					</div>
 
@@ -237,7 +282,7 @@
 							<p class="text-2xs text-slate-500 dark:text-slate-400">
 								{data.storage.fileCount.toLocaleString()} files · {data.storage.dirCount.toLocaleString()} dirs
 								{#if data.storage.truncated}
-									<span class="text-amber-600 dark:text-amber-400"> (truncated)</span>
+									<span class="text-amber-600 dark:text-amber-400"> (partial)</span>
 								{/if}
 							</p>
 						{/if}
@@ -267,8 +312,8 @@
 											<tr class="hover:bg-slate-50 dark:hover:bg-slate-800/50">
 												<td class="px-3 py-1.5 font-mono text-slate-600 dark:text-slate-400">{proc.pid}</td>
 												<td class="px-3 py-1.5 max-w-[180px] truncate text-slate-900 dark:text-slate-100" title={proc.command || proc.name}>{proc.name}</td>
-												<td class="px-3 py-1.5 text-right font-mono text-slate-600 dark:text-slate-400">{proc.cpu.toFixed(1)}%</td>
-												<td class="px-3 py-1.5 text-right font-mono text-slate-600 dark:text-slate-400">{formatBytes(proc.memRss * 1024)}</td>
+												<td class="px-3 py-1.5 text-right font-mono text-slate-600 dark:text-slate-400">{formatPercent(proc.cpuPercent)}</td>
+												<td class="px-3 py-1.5 text-right font-mono text-slate-600 dark:text-slate-400">{formatBytes(proc.memRssBytes)}</td>
 											</tr>
 										{/each}
 									</tbody>
@@ -276,23 +321,27 @@
 							</div>
 						</div>
 						<p class="text-3xs text-slate-400 dark:text-slate-500">
-							CPU/RAM sum includes child processes (Node/Bun/npm) spawned from the project shells. Polls every 3s.
+							The terminal shells opened for this project and everything they spawned, as a share of the whole machine. Refreshes every {POLL_INTERVAL_MS /
+								1000}s.
 						</p>
 					</div>
 				{:else if data.resources.status === 'running' && data.resources.processes.length === 0}
 					<div class="flex items-center gap-2 p-3 bg-amber-50 dark:bg-amber-900/10 border border-amber-200 dark:border-amber-800 rounded-lg text-xs text-amber-700 dark:text-amber-300">
 						<Icon name="lucide:info" class="w-4 h-4 shrink-0" />
-						Shell is running but no process details available yet.
+						{data.resources.rootPids.length} shell{data.resources.rootPids.length !== 1 ? 's' : ''} running, but the host process table could not be read.
 					</div>
 				{/if}
 
 				{#if data.storage.truncated}
 					<p class="text-3xs text-amber-600 dark:text-amber-400 text-center">
-						Storage scan capped at 300,000 entries. Size is partial.
+						Storage scan stopped early — the folder is larger than one pass covers, so the size is a floor, not a total.
 					</p>
+				{/if}
+
+				{#if error}
+					<p class="text-3xs text-red-500 text-center">Last refresh failed: {error}</p>
 				{/if}
 			</div>
 		{/if}
 	{/snippet}
 </Modal>
-

--- a/frontend/components/workspace/ProjectInfoModal.svelte
+++ b/frontend/components/workspace/ProjectInfoModal.svelte
@@ -61,19 +61,25 @@
 		return `${size >= 100 ? Math.round(size) : size >= 10 ? size.toFixed(1) : size.toFixed(2)} ${units[i]}`;
 	}
 
+	// A share of an 8-core machine is 8x smaller than the per-core number `top`
+	// prints, so separate real-but-tiny from genuinely idle.
 	function formatPercent(value: number | null): string {
-		return value === null ? '—' : `${value.toFixed(1)}%`;
+		if (value === null) return '—';
+		if (value === 0) return '0%';
+		if (value < 0.1) return '<0.1%';
+		return `${value.toFixed(1)}%`;
 	}
 
-	/**
-	 * One poll at a time, chained after the previous answer instead of fired on a
-	 * fixed interval: the probe walks a folder and reads the host process table,
-	 * which on a large project or a Windows host outruns the interval and would
-	 * otherwise queue requests faster than the server answers them.
-	 *
-	 * `token` drops the answer to a request whose project is no longer the one on
-	 * screen, so switching projects quickly cannot paint stale numbers.
-	 */
+	/** The same figure in the unit developers reason about. */
+	function formatCores(percent: number, logicalCores: number): string {
+		const cores = (percent / 100) * logicalCores;
+		if (cores === 0) return `0 of ${logicalCores} cores`;
+		if (cores < 0.01) return `<0.01 of ${logicalCores} cores`;
+		return `${cores < 1 ? cores.toFixed(2) : cores.toFixed(1)} of ${logicalCores} cores`;
+	}
+
+	// One poll at a time, chained after the previous answer: the probe can outrun
+	// a fixed interval. `token` drops answers for a project no longer on screen.
 	let token = 0;
 	let pollTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -83,9 +89,9 @@
 			if (requestToken !== token) return;
 			data = result;
 			error = null;
-		} catch (e) {
+		} catch (requestError) {
 			if (requestToken !== token) return;
-			error = e instanceof Error ? e.message : String(e);
+			error = requestError instanceof Error ? requestError.message : String(requestError);
 		} finally {
 			if (requestToken === token) {
 				loading = false;
@@ -123,11 +129,8 @@
 		};
 	});
 
-	/**
-	 * `navigator.clipboard` only exists on a secure origin, and Clopen is
-	 * routinely reached over plain HTTP on a LAN address, so the async API cannot
-	 * be the only path — without the fallback the button throws and does nothing.
-	 */
+	// `navigator.clipboard` is absent on the plain-HTTP LAN origins Clopen is
+	// reached on, where the async API alone would throw and do nothing.
 	async function copyPath() {
 		const path = project?.path;
 		if (!path) return;
@@ -187,25 +190,24 @@
 					<div class="w-10 h-10 rounded-lg bg-violet-100 dark:bg-violet-900/30 flex items-center justify-center shrink-0">
 						<Icon name="lucide:folder" class="w-5 h-5 text-violet-600 dark:text-violet-400" />
 					</div>
-					<div class="flex-1 min-w-0">
+					<div class="flex-1 min-w-0 flex flex-col gap-0.5">
 						<p class="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">{data.project.name}</p>
-						<div class="flex items-center gap-1.5 mt-0.5">
-							<p class="text-xs font-mono text-slate-500 dark:text-slate-400 truncate flex-1 min-w-0" title={data.project.path}>
+						<div class="flex items-center gap-1 min-w-0">
+							<p class="text-xs font-mono text-slate-500 dark:text-slate-400 truncate" title={data.project.path}>
 								{data.project.path}
 							</p>
 							<button
 								type="button"
-								class="shrink-0 w-6 h-6 flex items-center justify-center rounded-md text-slate-400 hover:text-violet-600 hover:bg-violet-500/10 transition-colors"
+								class="shrink-0 w-5 h-5 flex items-center justify-center rounded text-slate-400 hover:text-violet-600 hover:bg-violet-500/10 transition-colors"
 								onclick={copyPath}
 								title={copied ? 'Copied!' : 'Copy path'}
 								aria-label="Copy path"
 							>
-								<Icon name={copied ? 'lucide:check' : 'lucide:copy'} class="w-3.5 h-3.5" />
+								<Icon name={copied ? 'lucide:check' : 'lucide:copy'} class="w-3 h-3" />
 							</button>
 						</div>
-						<p class="text-3xs text-slate-400 dark:text-slate-500 mt-1">
-							Created {new Date(data.project.created_at).toLocaleDateString()} · {data.meta.platform}
-							{data.meta.arch} · {data.meta.logicalCores} cores
+						<p class="text-3xs text-slate-400 dark:text-slate-500">
+							Created {new Date(data.project.created_at).toLocaleDateString()}
 						</p>
 					</div>
 					<span
@@ -240,8 +242,7 @@
 								{#if data.resources.cpuPercent === null}
 									Measuring…
 								{:else}
-									{data.resources.processCount} process{data.resources.processCount !== 1 ? 'es' : ''} · {data.resources.rootPids.length}
-									shell{data.resources.rootPids.length !== 1 ? 's' : ''}
+									{formatCores(data.resources.cpuPercent, data.meta.logicalCores)}
 								{/if}
 							</p>
 						{/if}
@@ -294,7 +295,7 @@
 					<div class="flex flex-col gap-2">
 						<h3 class="text-xs font-semibold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
 							<Icon name="lucide:list-tree" class="w-3.5 h-3.5" />
-							Processes ({data.resources.processCount})
+							Processes ({data.resources.processCount}) · {data.resources.rootPids.length} shell{data.resources.rootPids.length !== 1 ? 's' : ''}
 						</h3>
 						<div class="border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden">
 							<div class="max-h-48 overflow-y-auto">


### PR DESCRIPTION
## Summary
Adds a Project Info modal, opened from an Info button in both navigators, showing
what one project costs on the machine: folder size, CPU/RAM attributed to that
project alone, and the ports it is listening on. Consolidates the host-probing
and project-ownership logic that three features were each defining for themselves.

## Why
The only resource reading Clopen offered was Settings → Device, which reports the
server. On a box running several projects it attributes one shared Bun process to
all of them and answers nothing about any single project. Clopen already knows
which PTY shells belong to which project namespace, and every process a project
spawns descends from one of those shells — so walking down from them yields a
footprint that excludes the rest of the host by construction.

## Changes
- `backend/host/metrics.ts` — new. Timeout helper, hardware facts probed once per
  process, and the process table with its per-platform CPU normalisation.
- `backend/projects/shell-ownership.ts` — new. The one definition of which PTY
  shells belong to which project.
- `backend/ports/attribute.ts` — reads its session map from the shared module
  instead of building its own.
- `backend/ws/system/device-info.ts` — reads static facts and the timeout helper
  from the shared module (+62/−144); typing `withTimeout` as `Promise<T | null>`
  retires all 39 `as unknown as` casts.
- `backend/ws/projects/info.ts` — new `projects:info` handler: bounded folder
  walk, per-project CPU/RAM, and the ports the port manager already attributed.
- `backend/ws/projects/index.ts` — merge `infoHandler` into `projectsRouter`.
- `frontend/components/workspace/ProjectInfoModal.svelte` — CPU/RAM/Storage cards,
  running badge, listening ports, process table, path copy.
- `frontend/components/workspace/{Desktop,Mobile}Navigator.svelte` — Info button
  before Delete, modal wiring.

## Notes
**The panels agree by construction.** `si.processes()` reports per-process CPU
against a different basis on each platform: a share of total capacity on Linux, a
share of one core on macOS and the BSDs (verified — the raw sum across all
processes was 116% on 8 cores), a share of the CPU that processes consumed on
Windows. All three are normalised to percent of machine capacity, the basis
`si.currentLoad()` already reports the host on. Installed RAM and the core count
come from the same shared facts, so no two panels divide by different totals.

**Unknown is reported as unknown.** Linux and Windows need a second sample before
a delta exists, so the first reading — and any failed or timed-out probe — is
`null` rather than a zero the panel would draw as idle. Below one decimal the
panel prints `<0.1%`, so a near-idle project does not read as broken.

**Both probes are cached and single-flighted.** A walk of a large tree runs far
longer than the poll interval (12.5s for a 300k-entry tree on the dev machine),
so a result-only cache would leave every tick starting another walk. An expensive
walk earns a proportionally longer rest, capped at five minutes.

**Scope.** CPU/RAM cover terminal shells and their descendants; engine processes
Clopen runs outside a terminal are not shells and do not appear. Container-published
ports belong to the runtime rather than a shell and are left out — pid lineage
cannot reach them, so they would need a different attribution mechanism. Device
Info's dynamic probes stay where they are: one consumer, and moving them would
risk regressing the last-good caching from #511 for no shared benefit.

## Test plan
- `bun run check` — 0 errors, `bun run lint` — 0 errors
- `bun run test` — 844 pass, 0 fail (23 new across `metrics.test.ts` and `info.test.ts`)
- Measured a process pinned to one core end to end: 100 raw in, 12.5% of an
  8-core machine out, stable across five polls
- Storage walk benchmarked against a 300k-entry tree — bounded by the deadline
  and correctly flagged `truncated`