### PR TITLE
fix(chat): drop per-message copy and debug in compact mode

### DIFF
--- a/frontend/components/chat/message/ChatMessage.svelte
+++ b/frontend/components/chat/message/ChatMessage.svelte
@@ -417,7 +417,6 @@
 			onCopy={copyToClipboard}
 			onRestore={handleRestore}
 			onEdit={handleEdit}
-			onShowDebug={openDebugInfoModal}
 		/>
 	</div>
 {:else}

--- a/frontend/components/chat/message/variants/compact/MessageBubble.svelte
+++ b/frontend/components/chat/message/variants/compact/MessageBubble.svelte
@@ -27,7 +27,6 @@
 		onCopy,
 		onRestore,
 		onEdit,
-		onShowDebug,
 	}: {
 		message: FrontendMessage;
 		messageTimestamp: string;
@@ -40,7 +39,6 @@
 		onCopy: () => void;
 		onRestore: () => void;
 		onEdit: () => void;
-		onShowDebug: () => void;
 	} = $props();
 
 	let scrollContainer: HTMLDivElement | undefined = $state();
@@ -249,53 +247,26 @@
 	</div>
 
 {:else}
-	<!-- Assistant / reasoning / system -->
-	<!-- The actions sit outside the scroll container on purpose: for `system` the inner
-	     div scrolls, and an absolutely positioned child of a scroll container travels
-	     with its content instead of staying pinned to the row. -->
-	<div class="relative">
-		<!-- Copy + Debug — always visible, subtle by colour rather than opacity -->
-		<div class="absolute top-1 right-1 z-10 flex items-center gap-0.5">
-			{#if roleCategory === 'assistant'}
-				<button
-					type="button"
-					onclick={(e) => { e.stopPropagation(); handleCopy(); }}
-					class="inline-flex p-1 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
-					aria-label={isCopied ? 'Copied' : 'Copy message'}
-					title={isCopied ? 'Copied!' : 'Copy message'}
-				>
-					<Icon name={isCopied ? 'lucide:check' : 'lucide:copy'} class="w-3.5 h-3.5" />
-				</button>
-			{/if}
-			<button
-				type="button"
-				onclick={(e) => { e.stopPropagation(); onShowDebug(); }}
-				class="inline-flex p-1 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
-				aria-label="Show debug info"
-				title="Debug info"
-			>
-				<Icon name="lucide:bug" class="w-3.5 h-3.5" />
-			</button>
-		</div>
-		<div
-			bind:this={scrollContainer}
-			onscroll={handleScroll}
-			class="text-slate-900 dark:text-slate-100 {roleCategory === 'system' ? 'max-h-48 overflow-y-auto' : ''} {roleCategory === 'assistant' ? 'pr-14' : 'pr-8'} py-1"
-		>
-			{#if roleCategory === 'reasoning'}
-				<!-- Reasoning row — same icon, indent, color and font as the tool rows -->
-				<div class="flex items-start gap-2 py-[2px] min-w-0">
-					<span class="relative shrink-0 w-[14px] mt-[1px] flex items-center justify-center text-slate-500 dark:text-slate-400 z-10">
-						<span class="absolute inset-0 -m-[3px] rounded bg-slate-50 dark:bg-slate-900"></span>
-						<Icon name="lucide:sparkles" class="relative w-[13px] h-[13px]" />
-					</span>
-					<span class="text-[12px] text-slate-500 dark:text-slate-400">
-						{#if isThinkingInProgress}Thinking{thinkingDots}{:else}Thought for a moment{/if}
-					</span>
-				</div>
-			{:else}
-				<MessageFormatter {message} />
-			{/if}
-		</div>
+	<!-- Assistant / reasoning / system — no per-message actions: compact mode keeps
+	     the transcript clean, only the user row carries copy/undo/edit. -->
+	<div
+		bind:this={scrollContainer}
+		onscroll={handleScroll}
+		class="text-slate-900 dark:text-slate-100 {roleCategory === 'system' ? 'max-h-48 overflow-y-auto pr-2' : ''} py-1"
+	>
+		{#if roleCategory === 'reasoning'}
+			<!-- Reasoning row — same icon, indent, color and font as the tool rows -->
+			<div class="flex items-start gap-2 py-[2px] min-w-0">
+				<span class="relative shrink-0 w-[14px] mt-[1px] flex items-center justify-center text-slate-500 dark:text-slate-400 z-10">
+					<span class="absolute inset-0 -m-[3px] rounded bg-slate-50 dark:bg-slate-900"></span>
+					<Icon name="lucide:sparkles" class="relative w-[13px] h-[13px]" />
+				</span>
+				<span class="text-[12px] text-slate-500 dark:text-slate-400">
+					{#if isThinkingInProgress}Thinking{thinkingDots}{:else}Thought for a moment{/if}
+				</span>
+			</div>
+		{:else}
+			<MessageFormatter {message} />
+		{/if}
 	</div>
 {/if}


### PR DESCRIPTION
## Summary
Remove the per-message copy and debug buttons from assistant, reasoning and
system rows in compact chat mode. Only the user row keeps its actions.

## Why
Compact mode is a dense timeline, and a floating icon pair on every row worked
against that. The buttons also reserved `pr-14`/`pr-8` of horizontal space,
narrowing assistant text on every message for controls that are rarely used
there. Copy and edit still belong on the user row, so those stay.

## Changes
- `frontend/components/chat/message/variants/compact/MessageBubble.svelte` —
  drop the absolute copy/debug cluster from the assistant/reasoning/system
  branch, along with the `relative` wrapper it required and the `pr-14`/`pr-8`
  padding reserved for it; `system` keeps a small `pr-2` for its scrollbar
- same file — remove the now-unused `onShowDebug` prop
- `frontend/components/chat/message/ChatMessage.svelte` — stop passing
  `onShowDebug` to the compact bubble
- user row is unchanged: copy, undo-to-checkpoint, edit

## Notes
The debug modal is now reachable only from classic mode — no compact-mode entry
point remains. If compact needs one, it should be a separate affordance (context
menu or an appearance setting) rather than a per-row button.

## Test plan
- `bun run check` — 0 errors
- `bun run lint` — clean (one pre-existing warning in `AboutDeviceSettings.svelte`)