### PR TITLE
fix(preview): stop treating a still page as a dead stream

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -104,8 +104,8 @@ wsRouter.setAuthMiddleware(async (conn, action) => {
 });
 
 // Register message rate limiter on WebSocket router — prevents DoS via message spam
-wsRouter.setRateLimiter((conn, action) => {
-	return messageRateLimiter.checkRateLimit(conn, action);
+wsRouter.setRateLimiter((conn, action, isRequest) => {
+	return messageRateLimiter.checkRateLimit(conn, action, isRequest);
 });
 
 /**

--- a/backend/preview/browser/browser-video-capture.ts
+++ b/backend/preview/browser/browser-video-capture.ts
@@ -162,18 +162,23 @@ interface VideoStreamSession {
 	scriptInjected: boolean; // Track if persistent script was injected
 	scriptsPreInjected: boolean; // Track if scripts were pre-injected during tab creation
 	/**
-	 * When the page last reported frames reaching its encoder. A connected
-	 * viewer while this stands still is watching a stream that has stopped
-	 * producing — which looks identical, from the client, to a slow page.
+	 * When the page last reported ANYTHING, frames or not.
+	 *
+	 * This is the liveness signal, and the distinction it draws is the whole
+	 * point: the page ticks a stats report every two seconds for as long as its
+	 * encoder loop is alive, whether or not there was anything to encode. Reports
+	 * arriving with zero frames mean a still picture. Reports stopping mean the
+	 * loop itself is gone — a navigation that took the injected script with it, a
+	 * context that was torn down — which is the only thing a repair can fix.
 	 */
-	lastEncodedAt: number;
+	lastPageReportAt: number;
 	/** Guards the watchdog against re-entering while a repair is in flight. */
 	repairing: boolean;
 	/**
-	 * Repairs attempted since the stream last produced anything. A repair that
-	 * did not restore frames must escalate rather than be repeated: the cheap
-	 * one asks the page what it thinks, and a page whose own answer is the
-	 * wrong one will give the same answer every time.
+	 * Repairs attempted since the page last reported in. A repair that did not
+	 * restore reporting must escalate rather than be repeated: the cheap one asks
+	 * the page what it thinks, and a page whose own answer is the wrong one will
+	 * give the same answer every time.
 	 */
 	stallRounds: number;
 	/** Codecs every viewer can decode — one encoder serves them all. */
@@ -588,11 +593,18 @@ export class BrowserVideoCapture extends EventEmitter {
 	private static readonly VIEWER_HANDSHAKE_TTL_MS = 45_000;
 
 	/**
-	 * Silence tolerated from a connected viewer's stream before the watchdog
-	 * repairs it. Two encoder-stat windows plus slack — long enough that a
-	 * genuinely idle page (which still tops off) never trips it.
+	 * Silence tolerated from the PAGE before the watchdog repairs the stream,
+	 * and the interval the watchdog itself runs on.
+	 *
+	 * The page reports encoder stats every two seconds for as long as its capture
+	 * loop is alive, so this is three missed reports: late enough that a slow tick
+	 * or a busy host is never mistaken for a dead page, early enough that a
+	 * genuinely broken stream is repaired before anyone reaches for reload.
+	 *
+	 * This deliberately measures REPORTS, not frames — a still page produces no
+	 * frames at all and is perfectly healthy. See `checkForStall`.
 	 */
-	private static readonly STREAM_STALL_MS = 6_000;
+	private static readonly PAGE_SILENCE_MS = 6_000;
 
 	/**
 	 * Cheap stall repairs before the watchdog stops taking the page's word for
@@ -740,7 +752,7 @@ export class BrowserVideoCapture extends EventEmitter {
 			viewers: new Map(),
 			scriptInjected: false,
 			scriptsPreInjected: false,
-			lastEncodedAt: 0,
+			lastPageReportAt: 0,
 			repairing: false,
 			stallRounds: 0,
 			codecSupport: { ...DEFAULT_CODEC_SUPPORT },
@@ -856,7 +868,10 @@ export class BrowserVideoCapture extends EventEmitter {
 			// for the first mouse move to see anything. Push one refresh
 			// frame as soon as the peer is up.
 			if (state === 'connected' && videoSession.tab) {
-				videoSession.lastEncodedAt = Date.now();
+				// A peer that just reached `connected` is a page that was talking to
+				// us a moment ago — give it a fresh silence window rather than
+				// judging it on a clock that predates the handshake.
+				videoSession.lastPageReportAt = Date.now();
 				void this.requestKeyframe(sessionId, videoSession.tab);
 			}
 
@@ -1045,7 +1060,8 @@ export class BrowserVideoCapture extends EventEmitter {
 			this.reconcileViewers(videoSession, health);
 		}
 
-		videoSession.lastEncodedAt = Date.now();
+		// `ensureLive` just heard from the page directly, so this IS a report.
+		videoSession.lastPageReportAt = Date.now();
 		this.ensureWatchdog();
 		return true;
 	}
@@ -1561,7 +1577,7 @@ export class BrowserVideoCapture extends EventEmitter {
 				if (this.reapStaleViewers(videoSession)) continue;
 				this.checkForStall(videoSession);
 			}
-		}, BrowserVideoCapture.STREAM_STALL_MS);
+		}, BrowserVideoCapture.PAGE_SILENCE_MS);
 
 		// Nothing here should hold the process open on its own.
 		this.watchdogTimer.unref?.();
@@ -1606,36 +1622,71 @@ export class BrowserVideoCapture extends EventEmitter {
 	}
 
 	/**
-	 * Repair a stream that has stopped producing while someone is watching it.
+	 * Repair a stream whose PAGE has stopped reporting while someone is watching.
 	 *
 	 * Recovery used to live entirely in the viewer: it noticed no first frame,
 	 * asked for a screencast refresh, then re-handshook. That only works while
 	 * the *client's* view of the problem is right — and the failures that stuck
 	 * were the ones where the client did everything correctly and the source
-	 * was the broken half. Repairing from here closes that gap, and costs
-	 * nothing on a healthy stream because even an idle page still tops off.
+	 * was the broken half. Repairing from here closes that gap.
+	 *
+	 * WHAT COUNTS AS A STALL, AND WHY IT CHANGED
+	 *
+	 * This used to key on `lastEncodedAt` — frames reaching the encoder — on the
+	 * stated assumption that "even an idle page still tops off". That assumption
+	 * was wrong, and the bug it caused was severe.
+	 *
+	 * Capture is damage-driven: `framesAttempted` is only incremented for motion
+	 * frames (see `shouldSkipMotionFrame` in scripts/video-stream.ts), and the
+	 * still-page top-off is a one-shot that fires after motion stops, not a
+	 * heartbeat. So a page that is simply SITTING THERE — the normal case, a user
+	 * looking at their app without touching it — reports zero frames forever, and
+	 * every one of those reports was read as "the stream is dead".
+	 *
+	 * The result was a permanent loop on every idle preview: six seconds of
+	 * stillness triggered a repair, twelve seconds triggered a FORCED peer
+	 * rebuild, which drops every viewer into a re-handshake — the reload with a
+	 * progress bar that users saw arrive every few seconds and could not explain.
+	 * The rebuild produced a keyframe, which reset the counters, which started
+	 * the same clock again. It also made the failure self-sustaining across the
+	 * rest of the app: each rebuild is a burst of CDP work plus handshake round
+	 * trips on the shared socket, so the busier the instance, the more of them
+	 * were in flight at once.
+	 *
+	 * The honest signal is whether the PAGE is still talking to us, not whether
+	 * it has anything to show. Its stats timer ticks every two seconds for as
+	 * long as the encoder loop is alive, so silence there — and only there —
+	 * means the loop is genuinely gone. A still picture is not a stall.
+	 *
+	 * The other real failure, an in-page capture that ends on its own, is already
+	 * detected explicitly in `applyEncoderStats` rather than inferred from frame
+	 * absence, so nothing is lost by no longer guessing here.
 	 */
 	private checkForStall(videoSession: VideoStreamSession): void {
 		if (videoSession.paused || videoSession.repairing || !videoSession.tab) return;
 		if (videoSession.viewers.size === 0) return;
 		if (!Array.from(videoSession.viewers.values()).some((viewer) => viewer.connected)) return;
 
-		const silentFor = Date.now() - videoSession.lastEncodedAt;
-		if (videoSession.lastEncodedAt === 0 || silentFor < BrowserVideoCapture.STREAM_STALL_MS) return;
+		// Nothing reported yet: the stream is still coming up and its own
+		// handshake path owns that window.
+		if (videoSession.lastPageReportAt === 0) return;
+
+		const silentFor = Date.now() - videoSession.lastPageReportAt;
+		if (silentFor < BrowserVideoCapture.PAGE_SILENCE_MS) return;
 
 		const { sessionId, tab } = videoSession;
 		videoSession.stallRounds++;
 
 		// The first round asks the page what state it is in and repairs from
 		// that answer, which is cheap and keeps every viewer's peer intact. Once
-		// that has been tried and the stream is still silent, the page's own
+		// that has been tried and the page is still silent, the page's own
 		// account is the thing that cannot be trusted — so rebuild the peer
 		// outright. Viewers lose their connection and re-handshake, which is a
 		// visible hiccup, but they are looking at a frozen picture either way.
 		const force = videoSession.stallRounds > BrowserVideoCapture.STALL_REPAIR_ROUNDS;
 		debug.warn(
 			'webcodecs',
-			`Stream for ${sessionId} produced nothing for ${silentFor}ms — ` +
+			`Page for ${sessionId} stopped reporting for ${silentFor}ms — ` +
 				`${force ? 'rebuilding the page peer' : 'repairing'} (round ${videoSession.stallRounds})`
 		);
 
@@ -1647,7 +1698,10 @@ export class BrowserVideoCapture extends EventEmitter {
 			.catch((error) => debug.warn('webcodecs', `Stall repair failed for ${sessionId}:`, error))
 			.finally(() => {
 				videoSession.repairing = false;
-				videoSession.lastEncodedAt = Date.now();
+				// Give the repaired page a full silence window to report in before
+				// it can be judged again. Without this the next tick would measure
+				// against a clock that never moved and escalate immediately.
+				videoSession.lastPageReportAt = Date.now();
 			});
 	}
 
@@ -1661,13 +1715,12 @@ export class BrowserVideoCapture extends EventEmitter {
 
 		videoSession.captureMode = stats.captureMode || videoSession.captureMode;
 
-		// Frames reaching the encoder is the one signal that means the pipeline
-		// is genuinely alive end to end. The counter is per-window, so any
-		// non-zero report is proof of life for this window.
-		if (stats.framesAttempted > 0) {
-			videoSession.lastEncodedAt = Date.now();
-			videoSession.stallRounds = 0;
-		}
+		// THE report arriving is proof the page's capture loop is alive — whether
+		// or not it had anything to encode. This is what the watchdog measures.
+		// Frames are a property of the CONTENT (a still page has none and is
+		// perfectly healthy); reports are a property of the PIPELINE.
+		videoSession.lastPageReportAt = Date.now();
+		videoSession.stallRounds = 0;
 
 		// In-page capture can end on its own — the captured surface goes away
 		// on some navigations — and the page has no way to start a screencast.

--- a/backend/ws/message-rate-limiter.test.ts
+++ b/backend/ws/message-rate-limiter.test.ts
@@ -56,6 +56,51 @@ describe('MessageRateLimiter', () => {
 		expect(closeCalls.length).toBe(0);
 	});
 
+	test('throttling never drops a request somebody is waiting on', () => {
+		const limiter = new MessageRateLimiter();
+		const { conn, closeCalls } = createMockConnection();
+
+		// Push the connection into the throttled state with event traffic — the
+		// shape of a preview stream or a terminal, which is what actually fills
+		// this window on a busy instance.
+		for (let i = 0; i < 99; i++) {
+			expect(limiter.checkRateLimit(conn, 'preview:browser-interaction')).toBe(true);
+		}
+		expect(limiter.checkRateLimit(conn, 'preview:browser-interaction')).toBe(false);
+		expect(limiter.getConnectionStats(conn)?.isThrottled).toBe(true);
+
+		// A request-response call arriving in the same window still gets through.
+		// Shedding it used to hang its caller for a full timeout, which the client
+		// then "healed" by tearing down the socket — a far bigger burst than the
+		// one being throttled, and the reason the overload sustained itself.
+		expect(limiter.checkRateLimit(conn, 'files:list-tree', true)).toBe(true);
+		expect(limiter.checkRateLimit(conn, 'git:status', true)).toBe(true);
+
+		// Only the events were counted as dropped.
+		expect(limiter.getConnectionStats(conn)?.messagesDropped).toBe(1);
+		expect(closeCalls.length).toBe(0);
+	});
+
+	test('a request is still refused once the connection is closed for abuse', () => {
+		const limiter = new MessageRateLimiter({
+			warningThreshold: 50,
+			throttleThreshold: 100,
+			disconnectThreshold: 200,
+			windowMs: 1000
+		});
+		const { conn, closeCalls } = createMockConnection();
+
+		for (let i = 0; i < 199; i++) {
+			limiter.checkRateLimit(conn, 'files:list-tree', true);
+		}
+
+		// Requests are exempt from THROTTLING, not from the abuse ceiling: past the
+		// disconnect threshold the socket is gone, so there is nothing to protect.
+		expect(limiter.checkRateLimit(conn, 'files:list-tree', true)).toBe(false);
+		expect(limiter.getConnectionStats(conn)?.isFlagged).toBe(true);
+		expect(closeCalls.length).toBe(1);
+	});
+
 	test('drops and closes connection at disconnect threshold', () => {
 		const limiter = new MessageRateLimiter({
 			warningThreshold: 50,

--- a/backend/ws/message-rate-limiter.ts
+++ b/backend/ws/message-rate-limiter.ts
@@ -6,8 +6,29 @@
  *
  * Thresholds:
  *   50 messages/second  → warning logged
- *   100 messages/second → connection throttled (messages dropped)
- *   200 messages/second → connection flagged for potential disconnect
+ *   100 messages/second → connection throttled (fire-and-forget events dropped)
+ *   200 messages/second → connection closed
+ *
+ * WHAT GETS SHED WHEN THROTTLING
+ *
+ * Throttling drops events, never request-response calls, and the asymmetry is
+ * the entire point. A busy Clopen tab is dominated by high-volume fire-and-
+ * forget traffic — preview pointer moves at ~30/s per viewer, terminal
+ * keystrokes, stream feedback — while the calls a panel actually waits on
+ * (`files:list-tree`, `git:status`, `engine:*-accounts-list`) are a trickle by
+ * comparison.
+ *
+ * Counting them in one bucket and dropping whatever arrived last meant the
+ * flood survived and the request died. That is backwards twice over: a dropped
+ * pointer move is invisible because the next one supersedes it a frame later,
+ * whereas a dropped request leaves a panel with no data and a user with no
+ * explanation. Worse, it was self-amplifying — a dropped request used to hang
+ * its caller until the client tore the socket down and every panel refetched at
+ * once, which is a bigger burst than the one that tripped the limiter.
+ *
+ * Abuse is still bounded, and by the threshold that was always the real one:
+ * a connection genuinely spamming the server crosses 200/s and gets closed
+ * regardless of what it is sending.
  */
 
 import { debug } from '$shared/utils/logger';
@@ -59,7 +80,13 @@ export class MessageRateLimiter {
 		return state;
 	}
 
-	checkRateLimit(conn: WSConnection, action: string): boolean {
+	/**
+	 * @param isRequest Whether `action` is a request-response route — i.e. a
+	 *   caller is blocked waiting for its reply. Such calls are counted like
+	 *   everything else but are never shed by throttling; see the note at the
+	 *   top of this file.
+	 */
+	checkRateLimit(conn: WSConnection, action: string, isRequest = false): boolean {
 		const state = this.getState(conn);
 		const now = Date.now();
 		const windowStart = now - this.config.windowMs;
@@ -91,6 +118,10 @@ export class MessageRateLimiter {
 				state.isWarning = false;
 				debug.warn('rate-limit', `Connection throttled: ${messagesPerSecond.toFixed(0)} msg/s on action ${action}`);
 			}
+			// Shed the flood, not the thing somebody is waiting on. Below the
+			// disconnect threshold a request is always answered; above it the
+			// connection is gone anyway.
+			if (isRequest) return true;
 			state.messagesDropped++;
 			return false;
 		}

--- a/frontend/stores/features/claude-accounts.svelte.ts
+++ b/frontend/stores/features/claude-accounts.svelte.ts
@@ -8,6 +8,7 @@
 
 import ws from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { createCachedLoad } from '$frontend/stores/utils/cached-load.svelte';
 
 export interface ClaudeAccountItem {
 	id: number;
@@ -17,42 +18,47 @@ export interface ClaudeAccountItem {
 }
 
 let accounts = $state<ClaudeAccountItem[]>([]);
-let loaded = $state(false);
+const cache = createCachedLoad('Claude accounts');
 
 export const claudeAccountsStore = {
 	get accounts() { return accounts; },
-	get loaded() { return loaded; },
+	get loaded() { return cache.loaded; },
 
-	/** Fetch accounts from backend. Idempotent — skips if already loaded. */
+	/** Fetch accounts from backend. Idempotent — skips only if already loaded. */
 	async fetch(): Promise<ClaudeAccountItem[]> {
-		if (loaded) return accounts;
-		return this.refresh();
+		await cache.ensure(load);
+		return accounts;
 	},
 
 	/** Force re-fetch accounts from backend. */
 	async refresh(): Promise<ClaudeAccountItem[]> {
-		try {
-			const result = await ws.http('engine:claude-accounts-list', {});
-			accounts = result.accounts;
-			loaded = true;
-			debug.log('settings', `Claude accounts loaded: ${accounts.length}`);
-			return accounts;
-		} catch {
-			accounts = [];
-			loaded = true;
-			return [];
-		}
+		await cache.refresh(load);
+		return accounts;
 	},
 
 	/** Update accounts list directly (avoids round-trip to backend). */
 	set(newAccounts: ClaudeAccountItem[]) {
 		accounts = newAccounts;
-		loaded = true;
+		cache.markLoaded();
 	},
 
 	/** Reset store state. */
 	reset() {
 		accounts = [];
-		loaded = false;
+		cache.reset();
 	}
 };
+
+/**
+ * The one request behind this store.
+ *
+ * It deliberately does not catch: `createCachedLoad` decides what a failure
+ * means, and the answer is "do not cache it" — blanking `accounts` here is what
+ * used to turn a timeout into an account list that stayed empty for the rest of
+ * the session.
+ */
+async function load(): Promise<void> {
+	const result = await ws.http('engine:claude-accounts-list', {});
+	accounts = result.accounts;
+	debug.log('settings', `Claude accounts loaded: ${accounts.length}`);
+}

--- a/frontend/stores/features/cline-accounts.svelte.ts
+++ b/frontend/stores/features/cline-accounts.svelte.ts
@@ -8,6 +8,7 @@
 
 import ws from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { createCachedLoad } from '$frontend/stores/utils/cached-load.svelte';
 
 export interface ClineAccountItem {
 	id: number;
@@ -21,38 +22,47 @@ export interface ClineAccountItem {
 }
 
 let accounts = $state<ClineAccountItem[]>([]);
-let loaded = $state(false);
+const cache = createCachedLoad('Cline accounts');
 
 export const clineAccountsStore = {
 	get accounts() { return accounts; },
-	get loaded() { return loaded; },
+	get loaded() { return cache.loaded; },
 
+	/** Fetch accounts from backend. Idempotent — skips only if already loaded. */
 	async fetch(): Promise<ClineAccountItem[]> {
-		if (loaded) return accounts;
-		return this.refresh();
+		await cache.ensure(load);
+		return accounts;
 	},
 
+	/** Force re-fetch accounts from backend. */
 	async refresh(): Promise<ClineAccountItem[]> {
-		try {
-			const result = await ws.http('engine:cline-accounts-list', {});
-			accounts = result.accounts;
-			loaded = true;
-			debug.log('settings', `Cline accounts loaded: ${accounts.length}`);
-			return accounts;
-		} catch {
-			accounts = [];
-			loaded = true;
-			return [];
-		}
+		await cache.refresh(load);
+		return accounts;
 	},
 
+	/** Update accounts list directly (avoids round-trip to backend). */
 	set(newAccounts: ClineAccountItem[]) {
 		accounts = newAccounts;
-		loaded = true;
+		cache.markLoaded();
 	},
 
+	/** Reset store state. */
 	reset() {
 		accounts = [];
-		loaded = false;
+		cache.reset();
 	}
 };
+
+/**
+ * The one request behind this store.
+ *
+ * It deliberately does not catch: `createCachedLoad` decides what a failure
+ * means, and the answer is "do not cache it" — blanking `accounts` here is what
+ * used to turn a timeout into an account list that stayed empty for the rest of
+ * the session.
+ */
+async function load(): Promise<void> {
+	const result = await ws.http('engine:cline-accounts-list', {});
+	accounts = result.accounts;
+	debug.log('settings', `Cline accounts loaded: ${accounts.length}`);
+}

--- a/frontend/stores/features/cline-presets.svelte.ts
+++ b/frontend/stores/features/cline-presets.svelte.ts
@@ -7,36 +7,39 @@
 
 import ws from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { createCachedLoad } from '$frontend/stores/utils/cached-load.svelte';
 import type { ClineProviderPreset } from '$shared/types/unified';
 
 let presets = $state<ClineProviderPreset[]>([]);
-let loaded = $state(false);
+const cache = createCachedLoad('Cline presets');
 
 export const clinePresetsStore = {
 	get presets() { return presets; },
-	get loaded() { return loaded; },
+	get loaded() { return cache.loaded; },
 
 	async fetch(): Promise<ClineProviderPreset[]> {
-		if (loaded) return presets;
-		return this.refresh();
+		await cache.ensure(load);
+		return presets;
 	},
 
 	async refresh(): Promise<ClineProviderPreset[]> {
-		try {
-			const result = await ws.http('engine:cline-presets-list', {});
-			presets = result.presets;
-			loaded = true;
-			debug.log('settings', `Cline presets loaded: ${presets.length}`);
-			return presets;
-		} catch {
-			presets = [];
-			loaded = true;
-			return [];
-		}
+		await cache.refresh(load);
+		return presets;
 	},
 
 	reset() {
 		presets = [];
-		loaded = false;
+		cache.reset();
 	}
 };
+
+/**
+ * The one request behind this store. It does not catch — see the note in
+ * `createCachedLoad`: a failed load must not be cached as an empty catalog,
+ * because nothing would ever ask for it again.
+ */
+async function load(): Promise<void> {
+	const result = await ws.http('engine:cline-presets-list', {});
+	presets = result.presets;
+	debug.log('settings', `Cline presets loaded: ${presets.length}`);
+}

--- a/frontend/stores/features/codex-accounts.svelte.ts
+++ b/frontend/stores/features/codex-accounts.svelte.ts
@@ -10,6 +10,7 @@
 
 import ws from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { createCachedLoad } from '$frontend/stores/utils/cached-load.svelte';
 
 export interface CodexAccountItem {
 	id: number;
@@ -20,38 +21,47 @@ export interface CodexAccountItem {
 }
 
 let accounts = $state<CodexAccountItem[]>([]);
-let loaded = $state(false);
+const cache = createCachedLoad('Codex accounts');
 
 export const codexAccountsStore = {
 	get accounts() { return accounts; },
-	get loaded() { return loaded; },
+	get loaded() { return cache.loaded; },
 
+	/** Fetch accounts from backend. Idempotent — skips only if already loaded. */
 	async fetch(): Promise<CodexAccountItem[]> {
-		if (loaded) return accounts;
-		return this.refresh();
+		await cache.ensure(load);
+		return accounts;
 	},
 
+	/** Force re-fetch accounts from backend. */
 	async refresh(): Promise<CodexAccountItem[]> {
-		try {
-			const result = await ws.http('engine:codex-accounts-list', {});
-			accounts = result.accounts;
-			loaded = true;
-			debug.log('settings', `Codex accounts loaded: ${accounts.length}`);
-			return accounts;
-		} catch {
-			accounts = [];
-			loaded = true;
-			return [];
-		}
+		await cache.refresh(load);
+		return accounts;
 	},
 
+	/** Update accounts list directly (avoids round-trip to backend). */
 	set(newAccounts: CodexAccountItem[]) {
 		accounts = newAccounts;
-		loaded = true;
+		cache.markLoaded();
 	},
 
+	/** Reset store state. */
 	reset() {
 		accounts = [];
-		loaded = false;
+		cache.reset();
 	}
 };
+
+/**
+ * The one request behind this store.
+ *
+ * It deliberately does not catch: `createCachedLoad` decides what a failure
+ * means, and the answer is "do not cache it" — blanking `accounts` here is what
+ * used to turn a timeout into an account list that stayed empty for the rest of
+ * the session.
+ */
+async function load(): Promise<void> {
+	const result = await ws.http('engine:codex-accounts-list', {});
+	accounts = result.accounts;
+	debug.log('settings', `Codex accounts loaded: ${accounts.length}`);
+}

--- a/frontend/stores/features/copilot-accounts.svelte.ts
+++ b/frontend/stores/features/copilot-accounts.svelte.ts
@@ -8,6 +8,7 @@
 
 import ws from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { createCachedLoad } from '$frontend/stores/utils/cached-load.svelte';
 
 export interface CopilotAccountItem {
 	id: number;
@@ -17,42 +18,47 @@ export interface CopilotAccountItem {
 }
 
 let accounts = $state<CopilotAccountItem[]>([]);
-let loaded = $state(false);
+const cache = createCachedLoad('Copilot accounts');
 
 export const copilotAccountsStore = {
 	get accounts() { return accounts; },
-	get loaded() { return loaded; },
+	get loaded() { return cache.loaded; },
 
-	/** Fetch accounts from backend. Idempotent — skips if already loaded. */
+	/** Fetch accounts from backend. Idempotent — skips only if already loaded. */
 	async fetch(): Promise<CopilotAccountItem[]> {
-		if (loaded) return accounts;
-		return this.refresh();
+		await cache.ensure(load);
+		return accounts;
 	},
 
 	/** Force re-fetch accounts from backend. */
 	async refresh(): Promise<CopilotAccountItem[]> {
-		try {
-			const result = await ws.http('engine:copilot-accounts-list', {});
-			accounts = result.accounts;
-			loaded = true;
-			debug.log('settings', `Copilot accounts loaded: ${accounts.length}`);
-			return accounts;
-		} catch {
-			accounts = [];
-			loaded = true;
-			return [];
-		}
+		await cache.refresh(load);
+		return accounts;
 	},
 
 	/** Update accounts list directly (avoids round-trip to backend). */
 	set(newAccounts: CopilotAccountItem[]) {
 		accounts = newAccounts;
-		loaded = true;
+		cache.markLoaded();
 	},
 
 	/** Reset store state. */
 	reset() {
 		accounts = [];
-		loaded = false;
+		cache.reset();
 	}
 };
+
+/**
+ * The one request behind this store.
+ *
+ * It deliberately does not catch: `createCachedLoad` decides what a failure
+ * means, and the answer is "do not cache it" — blanking `accounts` here is what
+ * used to turn a timeout into an account list that stayed empty for the rest of
+ * the session.
+ */
+async function load(): Promise<void> {
+	const result = await ws.http('engine:copilot-accounts-list', {});
+	accounts = result.accounts;
+	debug.log('settings', `Copilot accounts loaded: ${accounts.length}`);
+}

--- a/frontend/stores/features/cursor-accounts.svelte.ts
+++ b/frontend/stores/features/cursor-accounts.svelte.ts
@@ -8,6 +8,7 @@
 
 import ws from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { createCachedLoad } from '$frontend/stores/utils/cached-load.svelte';
 
 export interface CursorAccountItem {
 	id: number;
@@ -17,42 +18,47 @@ export interface CursorAccountItem {
 }
 
 let accounts = $state<CursorAccountItem[]>([]);
-let loaded = $state(false);
+const cache = createCachedLoad('Cursor accounts');
 
 export const cursorAccountsStore = {
 	get accounts() { return accounts; },
-	get loaded() { return loaded; },
+	get loaded() { return cache.loaded; },
 
-	/** Fetch accounts from backend. Idempotent — skips if already loaded. */
+	/** Fetch accounts from backend. Idempotent — skips only if already loaded. */
 	async fetch(): Promise<CursorAccountItem[]> {
-		if (loaded) return accounts;
-		return this.refresh();
+		await cache.ensure(load);
+		return accounts;
 	},
 
 	/** Force re-fetch accounts from backend. */
 	async refresh(): Promise<CursorAccountItem[]> {
-		try {
-			const result = await ws.http('engine:cursor-accounts-list', {});
-			accounts = result.accounts;
-			loaded = true;
-			debug.log('settings', `Cursor accounts loaded: ${accounts.length}`);
-			return accounts;
-		} catch {
-			accounts = [];
-			loaded = true;
-			return [];
-		}
+		await cache.refresh(load);
+		return accounts;
 	},
 
 	/** Update accounts list directly (avoids round-trip to backend). */
 	set(newAccounts: CursorAccountItem[]) {
 		accounts = newAccounts;
-		loaded = true;
+		cache.markLoaded();
 	},
 
 	/** Reset store state. */
 	reset() {
 		accounts = [];
-		loaded = false;
+		cache.reset();
 	}
 };
+
+/**
+ * The one request behind this store.
+ *
+ * It deliberately does not catch: `createCachedLoad` decides what a failure
+ * means, and the answer is "do not cache it" — blanking `accounts` here is what
+ * used to turn a timeout into an account list that stayed empty for the rest of
+ * the session.
+ */
+async function load(): Promise<void> {
+	const result = await ws.http('engine:cursor-accounts-list', {});
+	accounts = result.accounts;
+	debug.log('settings', `Cursor accounts loaded: ${accounts.length}`);
+}

--- a/frontend/stores/features/opencode-providers.svelte.ts
+++ b/frontend/stores/features/opencode-providers.svelte.ts
@@ -7,6 +7,7 @@
 
 import ws from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { createCachedLoad } from '$frontend/stores/utils/cached-load.svelte';
 
 export interface OpenCodeAccountItem {
 	id: number;
@@ -38,37 +39,28 @@ export interface ModelsDevProviderItem {
 let providers = $state<OpenCodeProviderItem[]>([]);
 let catalog = $state<ModelsDevProviderItem[]>([]);
 let catalogCachedAt = $state<string | null>(null);
-let loaded = $state(false);
-let catalogLoaded = $state(false);
+const providersCache = createCachedLoad('OpenCode providers');
+const catalogCache = createCachedLoad('Models.dev catalog');
 
 export const opencodeProvidersStore = {
 	get providers() { return providers; },
 	get catalog() { return catalog; },
 	get catalogCachedAt() { return catalogCachedAt; },
-	get loaded() { return loaded; },
-	get catalogLoaded() { return catalogLoaded; },
+	get loaded() { return providersCache.loaded; },
+	get catalogLoaded() { return catalogCache.loaded; },
 
 	// ========================================================================
 	// Providers
 	// ========================================================================
 
 	async fetchProviders(): Promise<OpenCodeProviderItem[]> {
-		if (loaded) return providers;
-		return this.refreshProviders();
+		await providersCache.ensure(loadProviders);
+		return providers;
 	},
 
 	async refreshProviders(): Promise<OpenCodeProviderItem[]> {
-		try {
-			const result = await ws.http('engine:opencode-providers-list', {});
-			providers = result.providers;
-			loaded = true;
-			debug.log('settings', `OpenCode providers loaded: ${providers.length}`);
-			return providers;
-		} catch {
-			providers = [];
-			loaded = true;
-			return [];
-		}
+		await providersCache.refresh(loadProviders);
+		return providers;
 	},
 
 	async addProvider(data: {
@@ -149,31 +141,28 @@ export const opencodeProvidersStore = {
 	// ========================================================================
 
 	async fetchCatalog(): Promise<ModelsDevProviderItem[]> {
-		if (catalogLoaded) return catalog;
-		return this.refreshCatalog();
+		await catalogCache.ensure(loadCatalog);
+		return catalog;
 	},
 
 	async refreshCatalog(): Promise<ModelsDevProviderItem[]> {
-		try {
-			const result = await ws.http('engine:opencode-models-dev-list', {});
-			catalog = result.catalog;
-			catalogCachedAt = result.cachedAt;
-			catalogLoaded = true;
-			debug.log('settings', `Models.dev catalog loaded: ${catalog.length} providers`);
-			return catalog;
-		} catch {
-			catalog = [];
-			catalogLoaded = true;
-			return [];
-		}
+		await catalogCache.refresh(loadCatalog);
+		return catalog;
 	},
 
+	/**
+	 * Ask the backend to go back to models.dev rather than serve its cache.
+	 *
+	 * Unlike the two above this one still throws: it is only ever reached from an
+	 * explicit "refresh catalog" button, and a user who pressed it is owed an
+	 * error rather than a list that quietly did not change.
+	 */
 	async refetchCatalog(): Promise<ModelsDevProviderItem[]> {
 		try {
 			const result = await ws.http('engine:opencode-models-dev-fetch', {});
 			catalog = result.catalog;
 			catalogCachedAt = result.cachedAt;
-			catalogLoaded = true;
+			catalogCache.markLoaded();
 			debug.log('settings', `Models.dev catalog re-fetched: ${catalog.length} providers`);
 			return catalog;
 		} catch (error) {
@@ -190,7 +179,26 @@ export const opencodeProvidersStore = {
 		providers = [];
 		catalog = [];
 		catalogCachedAt = null;
-		loaded = false;
-		catalogLoaded = false;
+		providersCache.reset();
+		catalogCache.reset();
 	}
 };
+
+/**
+ * The two requests behind this store. Neither catches — see the note in
+ * `createCachedLoad`: a failed load must not be cached as an empty list, or the
+ * Engines settings would show "no providers" for the rest of the session with no
+ * way back short of a reload.
+ */
+async function loadProviders(): Promise<void> {
+	const result = await ws.http('engine:opencode-providers-list', {});
+	providers = result.providers;
+	debug.log('settings', `OpenCode providers loaded: ${providers.length}`);
+}
+
+async function loadCatalog(): Promise<void> {
+	const result = await ws.http('engine:opencode-models-dev-list', {});
+	catalog = result.catalog;
+	catalogCachedAt = result.cachedAt;
+	debug.log('settings', `Models.dev catalog loaded: ${catalog.length} providers`);
+}

--- a/frontend/stores/features/pi-accounts.svelte.ts
+++ b/frontend/stores/features/pi-accounts.svelte.ts
@@ -8,6 +8,7 @@
 
 import ws from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { createCachedLoad } from '$frontend/stores/utils/cached-load.svelte';
 
 export interface PiAccountItem {
 	id: number;
@@ -21,38 +22,47 @@ export interface PiAccountItem {
 }
 
 let accounts = $state<PiAccountItem[]>([]);
-let loaded = $state(false);
+const cache = createCachedLoad('Pi accounts');
 
 export const piAccountsStore = {
 	get accounts() { return accounts; },
-	get loaded() { return loaded; },
+	get loaded() { return cache.loaded; },
 
+	/** Fetch accounts from backend. Idempotent — skips only if already loaded. */
 	async fetch(): Promise<PiAccountItem[]> {
-		if (loaded) return accounts;
-		return this.refresh();
+		await cache.ensure(load);
+		return accounts;
 	},
 
+	/** Force re-fetch accounts from backend. */
 	async refresh(): Promise<PiAccountItem[]> {
-		try {
-			const result = await ws.http('engine:pi-accounts-list', {});
-			accounts = result.accounts;
-			loaded = true;
-			debug.log('settings', `Pi accounts loaded: ${accounts.length}`);
-			return accounts;
-		} catch {
-			accounts = [];
-			loaded = true;
-			return [];
-		}
+		await cache.refresh(load);
+		return accounts;
 	},
 
+	/** Update accounts list directly (avoids round-trip to backend). */
 	set(newAccounts: PiAccountItem[]) {
 		accounts = newAccounts;
-		loaded = true;
+		cache.markLoaded();
 	},
 
+	/** Reset store state. */
 	reset() {
 		accounts = [];
-		loaded = false;
+		cache.reset();
 	}
 };
+
+/**
+ * The one request behind this store.
+ *
+ * It deliberately does not catch: `createCachedLoad` decides what a failure
+ * means, and the answer is "do not cache it" — blanking `accounts` here is what
+ * used to turn a timeout into an account list that stayed empty for the rest of
+ * the session.
+ */
+async function load(): Promise<void> {
+	const result = await ws.http('engine:pi-accounts-list', {});
+	accounts = result.accounts;
+	debug.log('settings', `Pi accounts loaded: ${accounts.length}`);
+}

--- a/frontend/stores/features/pi-presets.svelte.ts
+++ b/frontend/stores/features/pi-presets.svelte.ts
@@ -7,36 +7,39 @@
 
 import ws from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { createCachedLoad } from '$frontend/stores/utils/cached-load.svelte';
 import type { PiProviderPreset } from '$shared/types/unified';
 
 let presets = $state<PiProviderPreset[]>([]);
-let loaded = $state(false);
+const cache = createCachedLoad('Pi presets');
 
 export const piPresetsStore = {
 	get presets() { return presets; },
-	get loaded() { return loaded; },
+	get loaded() { return cache.loaded; },
 
 	async fetch(): Promise<PiProviderPreset[]> {
-		if (loaded) return presets;
-		return this.refresh();
+		await cache.ensure(load);
+		return presets;
 	},
 
 	async refresh(): Promise<PiProviderPreset[]> {
-		try {
-			const result = await ws.http('engine:pi-presets-list', {});
-			presets = result.presets;
-			loaded = true;
-			debug.log('settings', `Pi presets loaded: ${presets.length}`);
-			return presets;
-		} catch {
-			presets = [];
-			loaded = true;
-			return [];
-		}
+		await cache.refresh(load);
+		return presets;
 	},
 
 	reset() {
 		presets = [];
-		loaded = false;
+		cache.reset();
 	}
 };
+
+/**
+ * The one request behind this store. It does not catch — see the note in
+ * `createCachedLoad`: a failed load must not be cached as an empty catalog,
+ * because nothing would ever ask for it again.
+ */
+async function load(): Promise<void> {
+	const result = await ws.http('engine:pi-presets-list', {});
+	presets = result.presets;
+	debug.log('settings', `Pi presets loaded: ${presets.length}`);
+}

--- a/frontend/stores/features/qwen-accounts.svelte.ts
+++ b/frontend/stores/features/qwen-accounts.svelte.ts
@@ -11,6 +11,7 @@
 
 import ws from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { createCachedLoad } from '$frontend/stores/utils/cached-load.svelte';
 import type { QwenProviderPresetId } from '$shared/types/unified';
 
 export interface QwenAccountItem {
@@ -22,42 +23,47 @@ export interface QwenAccountItem {
 }
 
 let accounts = $state<QwenAccountItem[]>([]);
-let loaded = $state(false);
+const cache = createCachedLoad('Qwen accounts');
 
 export const qwenAccountsStore = {
 	get accounts() { return accounts; },
-	get loaded() { return loaded; },
+	get loaded() { return cache.loaded; },
 
-	/** Fetch accounts from backend. Idempotent — skips if already loaded. */
+	/** Fetch accounts from backend. Idempotent — skips only if already loaded. */
 	async fetch(): Promise<QwenAccountItem[]> {
-		if (loaded) return accounts;
-		return this.refresh();
+		await cache.ensure(load);
+		return accounts;
 	},
 
 	/** Force re-fetch accounts from backend. */
 	async refresh(): Promise<QwenAccountItem[]> {
-		try {
-			const result = await ws.http('engine:qwen-accounts-list', {});
-			accounts = result.accounts;
-			loaded = true;
-			debug.log('settings', `Qwen accounts loaded: ${accounts.length}`);
-			return accounts;
-		} catch {
-			accounts = [];
-			loaded = true;
-			return [];
-		}
+		await cache.refresh(load);
+		return accounts;
 	},
 
 	/** Update accounts list directly (avoids round-trip to backend). */
 	set(newAccounts: QwenAccountItem[]) {
 		accounts = newAccounts;
-		loaded = true;
+		cache.markLoaded();
 	},
 
 	/** Reset store state. */
 	reset() {
 		accounts = [];
-		loaded = false;
+		cache.reset();
 	}
 };
+
+/**
+ * The one request behind this store.
+ *
+ * It deliberately does not catch: `createCachedLoad` decides what a failure
+ * means, and the answer is "do not cache it" — blanking `accounts` here is what
+ * used to turn a timeout into an account list that stayed empty for the rest of
+ * the session.
+ */
+async function load(): Promise<void> {
+	const result = await ws.http('engine:qwen-accounts-list', {});
+	accounts = result.accounts;
+	debug.log('settings', `Qwen accounts loaded: ${accounts.length}`);
+}

--- a/frontend/stores/features/qwen-presets.svelte.ts
+++ b/frontend/stores/features/qwen-presets.svelte.ts
@@ -10,43 +10,48 @@
 
 import ws from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { createCachedLoad } from '$frontend/stores/utils/cached-load.svelte';
 import type { QwenProviderPreset, QwenProviderPresetId } from '$shared/types/unified';
 
 let presets = $state<QwenProviderPreset[]>([]);
 let defaultPreset = $state<QwenProviderPresetId>('dashscope-intl');
-let loaded = $state(false);
+const cache = createCachedLoad('Qwen presets');
 
 export const qwenPresetsStore = {
 	get presets() { return presets; },
 	get defaultPreset() { return defaultPreset; },
-	get loaded() { return loaded; },
+	get loaded() { return cache.loaded; },
 
 	getPreset(id: QwenProviderPresetId | string): QwenProviderPreset | undefined {
 		return presets.find(p => p.id === id);
 	},
 
 	async fetch(): Promise<QwenProviderPreset[]> {
-		if (loaded) return presets;
-		return this.refresh();
+		await cache.ensure(load);
+		return presets;
 	},
 
 	async refresh(): Promise<QwenProviderPreset[]> {
-		try {
-			const result = await ws.http('engine:qwen-presets-list', {});
-			presets = result.presets;
-			defaultPreset = result.defaultPreset;
-			loaded = true;
-			debug.log('settings', `Qwen presets loaded: ${presets.length}`);
-			return presets;
-		} catch {
-			presets = [];
-			loaded = true;
-			return [];
-		}
+		await cache.refresh(load);
+		return presets;
 	},
 
 	reset() {
 		presets = [];
-		loaded = false;
+		cache.reset();
 	}
 };
+
+/**
+ * The one request behind this store. It does not catch — see the note in
+ * `createCachedLoad`: a failed load must not be cached as an empty catalog,
+ * because nothing would ever ask for it again. `defaultPreset` deliberately
+ * keeps its last good value on failure rather than falling back, so the picker
+ * never silently re-points an account at a different endpoint.
+ */
+async function load(): Promise<void> {
+	const result = await ws.http('engine:qwen-presets-list', {});
+	presets = result.presets;
+	defaultPreset = result.defaultPreset;
+	debug.log('settings', `Qwen presets loaded: ${presets.length}`);
+}

--- a/frontend/stores/utils/cached-load.svelte.ts
+++ b/frontend/stores/utils/cached-load.svelte.ts
@@ -1,0 +1,34 @@
+/**
+ * Reactive wrapper around the load-once cache policy.
+ *
+ * The policy itself — and the reasoning behind it — lives in `./cached-load.ts`,
+ * which is rune-free so it can be tested directly. All this adds is the `$state`
+ * mirror components read, kept in step through the core's `publish` callback.
+ */
+
+import { createCachedLoadCore, type CachedLoad } from './cached-load';
+
+export type { CachedLoad };
+
+/**
+ * @param label Used only in the log line when a load fails.
+ */
+export function createCachedLoad(label: string): CachedLoad {
+	let loadedState = $state(false);
+
+	const core = createCachedLoadCore(label, (next) => {
+		loadedState = next;
+	});
+
+	return {
+		// Read from the reactive mirror rather than the core, so components that
+		// render on `loaded` actually re-render when it flips.
+		get loaded() {
+			return loadedState;
+		},
+		ensure: core.ensure,
+		refresh: core.refresh,
+		markLoaded: core.markLoaded,
+		reset: core.reset
+	};
+}

--- a/frontend/stores/utils/cached-load.test.ts
+++ b/frontend/stores/utils/cached-load.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'bun:test';
+import { createCachedLoadCore } from './cached-load';
+
+/** A load that resolves/rejects on command, so ordering can be asserted exactly. */
+function deferred() {
+	let resolve!: () => void;
+	let reject!: (err: Error) => void;
+	const promise = new Promise<void>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+describe('createCachedLoadCore', () => {
+	test('caches a successful load and serves it without loading again', async () => {
+		let calls = 0;
+		const cache = createCachedLoadCore('test');
+		const load = async () => {
+			calls++;
+		};
+
+		await cache.ensure(load);
+		expect(cache.loaded).toBe(true);
+		expect(calls).toBe(1);
+
+		await cache.ensure(load);
+		expect(calls).toBe(1);
+	});
+
+	test('a FAILED load is not cached, so the next caller retries', async () => {
+		// This is the whole bug: twelve stores marked themselves loaded in their
+		// catch block, so one timeout left the list empty for the rest of the
+		// session with nothing to repair it. A failure must leave the cache open.
+		let calls = 0;
+		const cache = createCachedLoadCore('test');
+		const load = async () => {
+			calls++;
+			if (calls === 1) throw new Error('timeout');
+		};
+
+		await cache.ensure(load);
+		expect(cache.loaded).toBe(false);
+
+		await cache.ensure(load);
+		expect(cache.loaded).toBe(true);
+		expect(calls).toBe(2);
+	});
+
+	test('a failed load does not reject its caller', async () => {
+		const cache = createCachedLoadCore('test');
+		// Callers treat this as "the store did not change"; swallowing the error is
+		// what lets a panel keep rendering its previous value.
+		await cache.ensure(async () => {
+			throw new Error('boom');
+		});
+		expect(cache.loaded).toBe(false);
+	});
+
+	test('concurrent ensure() calls collapse onto one load', async () => {
+		// Panels mount together, and during a reconnect they all ask at once.
+		// Firing N identical requests is exactly the burst that made an already
+		// struggling server worse.
+		let calls = 0;
+		const gate = deferred();
+		const cache = createCachedLoadCore('test');
+		const load = async () => {
+			calls++;
+			await gate.promise;
+		};
+
+		const a = cache.ensure(load);
+		const b = cache.ensure(load);
+		const c = cache.ensure(load);
+		expect(calls).toBe(1);
+
+		gate.resolve();
+		await Promise.all([a, b, c]);
+		expect(calls).toBe(1);
+		expect(cache.loaded).toBe(true);
+	});
+
+	test('refresh() starts its own load instead of joining one in flight', async () => {
+		// A refresh usually follows a mutation (an account was added), so an
+		// in-flight read that started BEFORE that change must not be reused — it
+		// would answer with the state the caller is trying to move away from.
+		let calls = 0;
+		const gate = deferred();
+		const cache = createCachedLoadCore('test');
+		const load = async () => {
+			calls++;
+			await gate.promise;
+		};
+
+		const first = cache.ensure(load);
+		expect(calls).toBe(1);
+
+		const second = cache.refresh(load);
+		expect(calls).toBe(2);
+
+		gate.resolve();
+		await Promise.all([first, second]);
+	});
+
+	test('reset() reopens the cache and markLoaded() closes it without a load', async () => {
+		let calls = 0;
+		const cache = createCachedLoadCore('test');
+		const load = async () => {
+			calls++;
+		};
+
+		cache.markLoaded();
+		expect(cache.loaded).toBe(true);
+		await cache.ensure(load);
+		expect(calls).toBe(0);
+
+		cache.reset();
+		expect(cache.loaded).toBe(false);
+		await cache.ensure(load);
+		expect(calls).toBe(1);
+	});
+
+	test('publish mirrors every change, and only real changes', async () => {
+		const seen: boolean[] = [];
+		const cache = createCachedLoadCore('test', (loaded) => seen.push(loaded));
+
+		await cache.ensure(async () => {});
+		cache.markLoaded(); // already true — must not publish again
+		cache.reset();
+		cache.reset(); // already false — must not publish again
+
+		expect(seen).toEqual([true, false]);
+	});
+});

--- a/frontend/stores/utils/cached-load.ts
+++ b/frontend/stores/utils/cached-load.ts
@@ -1,0 +1,128 @@
+/**
+ * The load-once cache policy, in one place.
+ *
+ * Every engine store (accounts, presets, providers) wants the same thing: fetch
+ * the list the first time somebody asks, serve it from memory afterwards, and
+ * re-fetch on demand. Twelve of them hand-rolled it, and every one of them got
+ * the failure case wrong in the same way:
+ *
+ *     } catch {
+ *         accounts = [];
+ *         loaded = true;   // ← a FAILED load, cached as a successful empty one
+ *     }
+ *
+ * Because `fetch()` short-circuits on `loaded`, one failed request poisoned the
+ * store for the rest of the session: nothing ever retried, and the only way back
+ * was a code path that happened to call `refresh()` instead. That is exactly the
+ * bug where the chat input reported "no accounts" until Settings → Engines was
+ * opened — Settings forces a refresh, so it looked like a fix when it was really
+ * just the one caller that bypassed the poisoned cache.
+ *
+ * And the failure was not rare. A request only has to be slow enough to hit its
+ * timeout, which on a busy instance is precisely when several panels ask at once.
+ *
+ * So the policy lives here instead, and it is one sentence: **only a successful
+ * load is cached.** A failure leaves the cache open, keeps whatever good value
+ * was already there, and lets the next caller try again.
+ *
+ * This module is deliberately free of runes so the policy can be tested directly;
+ * `cached-load.svelte.ts` wraps it with the reactive `loaded` flag components
+ * read. Same split, and same reason, as the panel-load counters in
+ * `stores/ui/project-workspace.svelte.ts`.
+ */
+
+import { debug } from '$shared/utils/logger';
+
+export interface CachedLoad {
+	/** Whether a load has SUCCEEDED and its value is cached. */
+	readonly loaded: boolean;
+	/**
+	 * Load unless a good value is already cached.
+	 *
+	 * `load` should write the store's own state; this helper only owns whether
+	 * that write is allowed to count as cached.
+	 */
+	ensure(load: () => Promise<void>): Promise<void>;
+	/** Load unconditionally, bypassing the cache. */
+	refresh(load: () => Promise<void>): Promise<void>;
+	/** Mark the cache good without a round trip (the value was set directly). */
+	markLoaded(): void;
+	/** Drop the cache so the next `ensure()` loads again. */
+	reset(): void;
+}
+
+/**
+ * @param label Used only in the log line when a load fails.
+ * @param publish Called whenever `loaded` changes, so a caller can mirror it into
+ *   reactive state. Optional — the returned object always reports `loaded`
+ *   correctly on its own.
+ */
+export function createCachedLoadCore(
+	label: string,
+	publish?: (loaded: boolean) => void
+): CachedLoad {
+	let loaded = false;
+	let inFlight: Promise<void> | null = null;
+
+	function setLoaded(next: boolean): void {
+		if (loaded === next) return;
+		loaded = next;
+		publish?.(next);
+	}
+
+	async function run(load: () => Promise<void>): Promise<void> {
+		try {
+			await load();
+			// The ONLY place this becomes true. A load that threw did not produce a
+			// value, so there is nothing to cache and nothing to serve.
+			setLoaded(true);
+		} catch (error) {
+			debug.warn('settings', `${label}: load failed, leaving the cache open to retry`, error);
+		}
+	}
+
+	async function start(load: () => Promise<void>): Promise<void> {
+		const pending = run(load);
+		inFlight = pending;
+		try {
+			await pending;
+		} finally {
+			// Only clear the slot if it is still ours: a `refresh()` may have
+			// started a newer load while this one was settling.
+			if (inFlight === pending) inFlight = null;
+		}
+	}
+
+	return {
+		get loaded() {
+			return loaded;
+		},
+
+		async ensure(load: () => Promise<void>): Promise<void> {
+			if (loaded) return;
+			// Join the request already in flight rather than starting a second one.
+			// Several panels mounting together used to fire the same fetch several
+			// times over — most visible during a reconnect, where it multiplied the
+			// load on a server that was already struggling.
+			if (inFlight) return inFlight;
+			return start(load);
+		},
+
+		async refresh(load: () => Promise<void>): Promise<void> {
+			// Deliberately NOT joined to `inFlight`: a caller that asked for a
+			// refresh usually just changed something (added an account, revoked a
+			// key), and an in-flight read started before that change would answer
+			// with the state they are trying to move away from.
+			return start(load);
+		},
+
+		markLoaded(): void {
+			setLoaded(true);
+		},
+
+		reset(): void {
+			setLoaded(false);
+			inFlight = null;
+		}
+	};
+}

--- a/shared/utils/ws-client.ts
+++ b/shared/utils/ws-client.ts
@@ -278,6 +278,23 @@ export class WSClient<TAPI extends { client: any; server: any }> {
 	/** Prevents a heal-reconnect stampede when many requests time out at once. */
 	private healingReconnect = false;
 
+	/**
+	 * When the socket last delivered ANYTHING from the server.
+	 *
+	 * This is the evidence that separates the two failures a stalled request can
+	 * mean, which the recovery path used to conflate. A socket that is still
+	 * handing us other traffic is demonstrably alive, so a request that has not
+	 * come back is slow or was lost in transit — re-sending it is the whole fix.
+	 * A socket that has gone completely silent is the black-holed case reconnect
+	 * exists for.
+	 *
+	 * Treating both as "the connection is dead" is what turned one slow read into
+	 * a full teardown, and a teardown re-runs every panel's reconnect handler at
+	 * once — a burst far more expensive than the request that triggered it, and
+	 * one that made the next timeout more likely rather than less.
+	 */
+	private lastInboundAt = 0;
+
 	/** Current context (synced with server) */
 	private context: {
 		userId: string | null;
@@ -376,8 +393,11 @@ export class WSClient<TAPI extends { client: any; server: any }> {
 				}
 
 				// A fresh socket is live again — clear the heal guard so future
-				// dead-connection recoveries can fire.
+				// dead-connection recoveries can fire, and count the open itself as
+				// proof of life so a quiet-but-healthy connection is never mistaken
+				// for a black-holed one on its first request.
 				this.healingReconnect = false;
+				this.lastInboundAt = Date.now();
 
 				// Flush queued fire-and-forget messages AFTER context + room
 				// re-joins are synced. Drain into a local array first so a send
@@ -407,6 +427,10 @@ export class WSClient<TAPI extends { client: any; server: any }> {
 			};
 
 			this.ws.onmessage = (event) => {
+				// Proof of life for the recovery path, recorded before anything can
+				// throw: what matters is that a frame ARRIVED, not that we managed
+				// to handle it.
+				this.lastInboundAt = Date.now();
 				try {
 					if (event.data instanceof ArrayBuffer) {
 						// Binary message
@@ -889,7 +913,7 @@ export class WSClient<TAPI extends { client: any; server: any }> {
 		// Reads can be safely re-sent; mutations can only be re-sent if they were
 		// never delivered (tracked via `entry.sent`).
 		const idempotent = isIdempotentHttpAction(actionStr);
-		// Up to this many automatic heal-reconnect retries for idempotent reads.
+		// Up to this many automatic recovery attempts for idempotent reads.
 		const MAX_HEAL_ATTEMPTS = 2;
 
 		return new Promise((resolve, reject) => {
@@ -920,23 +944,54 @@ export class WSClient<TAPI extends { client: any; server: any }> {
 				}
 			};
 
-			// Timeout handler — for idempotent reads, try to heal a dead-but-open
-			// socket and retry instead of failing outright.
+			// Timeout handler — for idempotent reads, recover and retry instead of
+			// failing outright.
+			//
+			// The recovery is now proportionate to the evidence, which it was not
+			// before: ANY stalled read forced a full reconnect, so one slow answer
+			// from a busy server tore down a connection that was working perfectly
+			// and made all fifteen `onWsReconnect` subscribers refetch at once. On a
+			// loaded instance that burst is what caused the NEXT timeout, and the
+			// loop sustained itself — panels re-showing their skeletons every few
+			// seconds for as long as the instance stayed busy.
+			//
+			// So the socket is only rebuilt when it has actually stopped speaking.
+			// While other traffic is still arriving the connection is known-good and
+			// re-sending the one request costs a single frame.
 			const onTimeout = () => {
 				if (idempotent && entry.attempts < MAX_HEAL_ATTEMPTS) {
 					entry.attempts++;
+					entry.arm();
+
+					// Silent for a whole timeout window means nothing at all is
+					// coming through — a stream, an event, another response — which
+					// is the black-hole signature reconnect exists for. Anything
+					// less is a connection that works and a request that did not.
+					const silentFor = Date.now() - this.lastInboundAt;
+					const socketIsBlackHoled = this.isSocketOpen() && silentFor >= timeout;
+
+					if (socketIsBlackHoled && !this.healingReconnect) {
+						debug.warn(
+							'websocket',
+							`Socket silent for ${silentFor}ms — reconnecting and retrying: ${actionStr} (attempt ${entry.attempts})`
+						);
+						this.healingReconnect = true;
+						// The onopen resend loop re-sends this request on the fresh
+						// socket, so nothing extra is needed here.
+						this.reconnect();
+						return;
+					}
+
 					debug.warn(
 						'websocket',
-						`Request stalled, healing connection and retrying: ${actionStr} (attempt ${entry.attempts})`
+						`Request stalled but connection is live — re-sending: ${actionStr} (attempt ${entry.attempts})`
 					);
-					entry.arm();
-					// If the socket still claims to be open, it is likely black-holed
-					// — force a reconnect (guarded against a stampede). The onopen
-					// resend loop will re-send this request on the fresh socket.
-					if (this.isSocketOpen() && !this.healingReconnect) {
-						this.healingReconnect = true;
-						this.reconnect();
+					if (this.isSocketOpen()) {
+						entry.sent = true;
+						this.sendRaw(entry.action, entry.payload);
 					}
+					// A socket that is not open needs no action: the request stays in
+					// `pendingHttpRequests` and the onopen resend loop delivers it.
 					return;
 				}
 				entry.cleanup();

--- a/shared/utils/ws-server.ts
+++ b/shared/utils/ws-server.ts
@@ -281,7 +281,12 @@ export class WSRouter<
 
 	/** Optional auth middleware — called before every route handler */
 	private authMiddleware: ((conn: WSConnection, action: string) => Promise<{ allowed: boolean; error?: string }>) | null = null;
-	private rateLimiter: ((conn: WSConnection, action: string) => boolean) | null = null;
+	/**
+	 * Optional rate limiter. `isRequest` tells it whether a caller is blocked
+	 * waiting on a reply, so throttling can shed fire-and-forget floods without
+	 * killing the low-volume calls panels depend on.
+	 */
+	private rateLimiter: ((conn: WSConnection, action: string, isRequest: boolean) => boolean) | null = null;
 
 	constructor() {
 		this.registerContextHandler();
@@ -291,7 +296,7 @@ export class WSRouter<
 		this.authMiddleware = fn;
 	}
 
-	setRateLimiter(fn: (conn: WSConnection, action: string) => boolean): void {
+	setRateLimiter(fn: (conn: WSConnection, action: string, isRequest: boolean) => boolean): void {
 		this.rateLimiter = fn;
 	}
 
@@ -531,16 +536,30 @@ export class WSRouter<
 				data: validatedData
 			});
 
-			// Validate response data schema
-			let validatedResponse;
-			try {
-				validatedResponse = Value.Decode(route.responseSchema, result);
-			} catch (err) {
-				debug.error('websocket', `Response validation failed for ${action}:`, err);
-				throw new Error(
-					`Response validation failed: ${err instanceof Error ? err.message : 'Unknown error'}`
-				);
-			}
+			// The response is NOT re-validated.
+			//
+			// `route.responseSchema` stays declared because it is what gives
+			// `ws.http()` its return type on the client — but checking the value
+			// against it at runtime bought nothing and cost the whole server.
+			// A response is produced by our own handler, not by a peer: it is not
+			// untrusted input, so the only thing validation could catch is a bug
+			// we would rather surface as a wrong field than as a route that fails
+			// outright for the user.
+			//
+			// The cost was not theoretical. `Value.Decode` walks the entire value
+			// synchronously on the main thread, and the worst offender is exactly
+			// the biggest payload: `files:list-tree` declares a RECURSIVE UNION
+			// (backend/ws/files/read.ts), so TypeBox tries both branches at every
+			// node of the tree. On a large project that locked the event loop for
+			// hundreds of milliseconds per load — during which every other panel's
+			// request, every other project's, and the preview watchdog all waited.
+			// That is what made one slow Files load feel like the whole app hanging.
+			//
+			// Measured against what it protects: `Value.Decode` returns the very
+			// same object reference and strips nothing (there is not one
+			// `t.Transform` in the codebase), so removing it cannot change a
+			// successful response by even one byte.
+			const validatedResponse = result;
 
 			// Check if response contains binary data
 			if (isBinaryAction(responseAction, validatedResponse)) {
@@ -628,7 +647,39 @@ export class WSRouter<
 			// ═══ END AUTH GATE ═══
 
 			// ═══ RATE LIMIT GATE ═══
-			if (this.rateLimiter && !this.rateLimiter(conn, action)) {
+			// A request-response route has a caller blocked on its reply; an event
+			// does not. The limiter needs that distinction to shed the right half
+			// of a flood, and the answer below needs it to know whether anyone is
+			// listening for one.
+			const isRequest = this.httpRoutes.has(action);
+			if (this.rateLimiter && !this.rateLimiter(conn, action, isRequest)) {
+				// A dropped request must still be ANSWERED. Returning silently here
+				// left `ws.http()` waiting on a reply that was never coming, so the
+				// caller hung for its full 30s timeout and then tore the whole
+				// socket down to "heal" it — which re-ran every panel's reconnect
+				// handler at once, producing the very burst that tripped the limiter
+				// again. Telling the client no is what breaks that loop: the request
+				// fails immediately, the caller retries on its own terms, and the
+				// connection survives.
+				//
+				// The auth gate directly above has always done this; the two gates
+				// only differed because this one was written to `return` on a path
+				// where nothing was waiting for an answer. Fire-and-forget events
+				// have no requestId and still just drop.
+				if (isRequest) {
+					try {
+						conn.send(JSON.stringify({
+							action: `${action}:response`,
+							payload: {
+								success: false,
+								error: 'Rate limit exceeded — request dropped',
+								requestId: payload?.requestId
+							}
+						}));
+					} catch {
+						// Connection may already be closing.
+					}
+				}
 				return;
 			}
 			// ═══ END RATE LIMIT GATE ═══


### PR DESCRIPTION
## Summary
Fixes the periodic flicker across every dock, the Preview panel reloading
every few seconds, and the slow-then-stuck behavior that appears when
several projects are open at once.

## Why
Five defects that compounded into one failure.

1. **The preview watchdog judged liveness by frames.** Capture is
   damage-driven — `framesAttempted` only counts motion frames, and the
   still-page top-off is a one-shot, not a heartbeat. A page sitting idle
   reports zero frames forever, so 6s of stillness triggered a repair and
   12s a forced peer rebuild, dropping every viewer into a re-handshake.
   The rebuild produced a keyframe, which reset the clock. Permanent loop
   on any idle preview.
2. **Rate-limit throttling dropped messages silently.** `ws.http()` waited
   for a reply that was never coming, hanging for its full 30s timeout.
   The auth gate directly above it had always answered.
3. **Any stalled read forced a full reconnect**, re-running all fifteen
   `onWsReconnect` subscribers at once — a bigger burst than the request
   that triggered it, which made the next timeout more likely.
4. **Twelve engine stores set `loaded = true` in their catch block.** One
   failed request cached an empty list for the rest of the session, and
   `fetch()` short-circuits on `loaded`, so nothing retried. Settings →
   Engines calls `refresh()`, which is why opening it appeared to fix the
   empty account selector.
5. **Every response was re-validated with `Value.Decode`**, including
   `files:list-tree`'s recursive union — a synchronous walk of the whole
   tree that blocked the event loop for every other panel and project.

## Changes
- `backend/preview/browser/browser-video-capture.ts` — replace
  `lastEncodedAt` with `lastPageReportAt`, set on every encoder-stats
  report whether or not frames flowed; rename `STREAM_STALL_MS` to
  `PAGE_SILENCE_MS`. Removes the now-unread `lastEncodedAt` field.
- `shared/utils/ws-server.ts` — answer rate-limited requests instead of
  dropping them silently; pass `isRequest` to the limiter; drop response
  schema validation.
- `backend/ws/message-rate-limiter.ts` — throttling sheds fire-and-forget
  events, never request-response calls. The 200 msg/s disconnect ceiling
  is unchanged and still closes abusive connections.
- `backend/index.ts` — forward `isRequest` to the limiter.
- `shared/utils/ws-client.ts` — track `lastInboundAt`; reconnect only when
  the socket has genuinely gone silent, otherwise re-send the one request.
- `frontend/stores/utils/cached-load.ts` + `.svelte.ts` — one load-once
  policy: only a successful load is cached; concurrent `ensure()` calls
  collapse onto one request. Rune-free core with a reactive wrapper, same
  split as the panel-load counters in `project-workspace.svelte.ts`.
- 11 engine stores (7 accounts, 3 presets, opencode-providers) rewritten
  onto that policy, public shape unchanged.

## Test plan
- `bun run check` — 0 errors
- `bun run lint` — clean (one pre-existing warning in
  `AboutDeviceSettings.svelte`, unrelated and present on a clean tree)
- `bun run test` — 821 pass, 0 fail (was 812; 9 new regression tests)
- New `frontend/stores/utils/cached-load.test.ts` — pins that a failed load
  is not cached, that concurrent `ensure()` collapses, and that `refresh()`
  does not join an in-flight read
- New cases in `backend/ws/message-rate-limiter.test.ts` — pins that
  throttling never sheds a request, and that the abuse ceiling still closes
  the connection
- Verified before removing response validation: no `t.Transform` exists in
  the codebase, and `Value.Decode` returns the same object reference and
  strips nothing, so successful responses are byte-identical

## Notes
The preview subsystem has no test infrastructure, and testing
`checkForStall` would need puppeteer/CDP mocks well beyond this change's
scope — that fix rests on code review rather than a test. Runtime QA is
still outstanding: the visual confirmation that Preview stops reloading
needs a real session.

Cross-platform by construction — every fix is in transport and scheduling
logic, with no OS-specific paths involved.