### PR TITLE
fix(opencode): stop per-turn server churn and reclaim stale servers

### DIFF
--- a/backend/artifacts/sync.test.ts
+++ b/backend/artifacts/sync.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Materialization must be IDEMPOTENT on disk, not just in outcome.
+ *
+ * `materializeArtifacts` runs at every stream start. It used to rewrite each
+ * enabled artifact unconditionally, which left the content identical but moved
+ * the file's mtime — and the Open Code pool fingerprints exactly these files to
+ * decide whether its baked config changed. The result was a brand-new
+ * `opencode serve` process for every single turn. These tests pin the property
+ * that prevents it: no content change, no write.
+ */
+
+import { describe, expect, test, afterAll } from 'bun:test';
+import { rm, stat, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { materializeArtifacts } from './sync';
+import { resolveArtifact } from './matrix';
+import type { ArtifactContext } from './types';
+
+const CONTEXT: ArtifactContext = { engine: 'opencode', scope: 'global' };
+const SLUG = 'sync-idempotence-fixture';
+
+const targetDir = resolveArtifact('command', CONTEXT).locateEffective(CONTEXT);
+const targetFile = targetDir ? join(targetDir, `${SLUG}.md`) : '';
+
+/** Materialize a single command whose body is `document`. */
+async function materialize(document: string): Promise<void> {
+	await materializeArtifacts('command', CONTEXT, {
+		enabled: [{ slug: SLUG, name: 'Fixture', description: 'sync test', document }],
+		managedSlugs: [SLUG]
+	});
+}
+
+afterAll(async () => {
+	if (targetFile) await rm(targetFile, { force: true });
+});
+
+describe('materializeArtifacts', () => {
+	test('an unchanged artifact is not rewritten', async () => {
+		expect(targetDir).toBeTruthy();
+
+		await materialize('# Fixture\n\noriginal body\n');
+		const firstWrite = (await stat(targetFile)).mtimeMs;
+
+		// Space the calls out: two writes inside the same millisecond would pass
+		// this assertion even if the file had genuinely been rewritten.
+		await Bun.sleep(20);
+		await materialize('# Fixture\n\noriginal body\n');
+
+		expect((await stat(targetFile)).mtimeMs).toBe(firstWrite);
+	});
+
+	test('a changed artifact is written', async () => {
+		await materialize('# Fixture\n\noriginal body\n');
+		const firstWrite = (await stat(targetFile)).mtimeMs;
+
+		await Bun.sleep(20);
+		await materialize('# Fixture\n\nedited body\n');
+
+		expect((await stat(targetFile)).mtimeMs).toBeGreaterThan(firstWrite);
+		expect(await readFile(targetFile, 'utf8')).toContain('edited body');
+	});
+});

--- a/backend/artifacts/sync.ts
+++ b/backend/artifacts/sync.ts
@@ -10,7 +10,7 @@
  */
 
 import { join } from 'path';
-import { mkdir, readdir, rm, writeFile, cp, stat } from 'node:fs/promises';
+import { mkdir, readdir, readFile, rm, writeFile, cp, stat } from 'node:fs/promises';
 import { resolveArtifact } from './matrix';
 import { markersFor, writeManagedBlock } from './markers';
 import type { ArtifactContext, ArtifactType, ManagedArtifact } from './types';
@@ -37,10 +37,63 @@ async function pathExists(path: string): Promise<boolean> {
 	}
 }
 
-/** Mirror one canonical folder into a destination dir under `<slug>/` (replacing any stale copy). */
+/**
+ * Write only when the bytes differ.
+ *
+ * This runs at every stream start, and a no-op rewrite still moves mtime. The
+ * Open Code pool fingerprints these files to decide whether its baked config
+ * changed, so an unconditional write made every single turn spawn a fresh
+ * `opencode serve` process for a config that was byte-identical.
+ */
+async function writeFileIfChanged(filePath: string, content: string): Promise<void> {
+	try {
+		if ((await readFile(filePath, 'utf8')) === content) return;
+	} catch { /* missing or unreadable — fall through and write */ }
+	await writeFile(filePath, content, 'utf8');
+}
+
+/** Every file under `dir`, keyed by path relative to it. Missing dir → empty map. */
+async function fileStats(dir: string): Promise<Map<string, { size: number; mtimeMs: number }>> {
+	const out = new Map<string, { size: number; mtimeMs: number }>();
+	const walk = async (current: string, prefix: string): Promise<void> => {
+		let entries;
+		try {
+			entries = await readdir(current, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+			if (entry.isDirectory()) {
+				await walk(join(current, entry.name), relative);
+				continue;
+			}
+			try {
+				const info = await stat(join(current, entry.name));
+				out.set(relative, { size: info.size, mtimeMs: info.mtimeMs });
+			} catch { /* raced away */ }
+		}
+	};
+	await walk(dir, '');
+	return out;
+}
+
+/** True when `destDir` already holds a current copy — same files, same sizes, none of them older than the source. */
+async function folderInSync(sourceDir: string, destDir: string): Promise<boolean> {
+	const [source, dest] = await Promise.all([fileStats(sourceDir), fileStats(destDir)]);
+	if (source.size === 0 || source.size !== dest.size) return false;
+	for (const [relative, sourceInfo] of source) {
+		const destInfo = dest.get(relative);
+		if (!destInfo || destInfo.size !== sourceInfo.size || destInfo.mtimeMs < sourceInfo.mtimeMs) return false;
+	}
+	return true;
+}
+
+/** Mirror one canonical folder into a destination dir under `<slug>/`, skipping the copy when it is already current. */
 async function mirrorFolder(sourceDir: string, destDir: string, slug: string): Promise<void> {
 	if (!(await pathExists(sourceDir))) return;
 	const dest = join(destDir, slug);
+	if (await folderInSync(sourceDir, dest)) return;
 	await rm(dest, { recursive: true, force: true });
 	await mkdir(destDir, { recursive: true });
 	await cp(sourceDir, dest, { recursive: true });
@@ -104,7 +157,7 @@ export async function materializeArtifacts(
 			if (resolution.format === 'folder-md') {
 				if (item.sourceDir) await mirrorFolder(item.sourceDir, target, item.slug);
 			} else if (item.document != null) {
-				await writeFile(join(target, `${item.slug}.md`), item.document, 'utf8');
+				await writeFileIfChanged(join(target, `${item.slug}.md`), item.document);
 			}
 		}
 

--- a/backend/engine/adapters/opencode/server.ts
+++ b/backend/engine/adapters/opencode/server.ts
@@ -12,9 +12,15 @@
  * derived from the config itself rather than from a hand-maintained list of
  * "things that need a restart". A field added to the spawn config three features
  * from now is covered without anybody remembering that this file exists, and a
- * change that turns out not to alter any baked byte (toggling a connector off and
- * back on, editing a permission rule that is enforced per-prompt) produces the
- * same hash and reuses the running server.
+ * change that turns out not to alter any baked byte (editing a permission rule
+ * that is enforced per-prompt) produces the same hash and reuses the running
+ * server.
+ *
+ * One thing the bytes cannot express is folded in explicitly: the INTERNAL
+ * connector set. Those all sit behind a single `clopen-mcp` bridge entry, so
+ * toggling one changes what the bridge serves without changing the config at
+ * all — and Open Code reads its tool list once, when it connects. See
+ * `internalBridgeExposure`.
  *
  * This replaced a "Restart Server" button. The button was the only thing that
  * made a config edit take effect, which meant the product worked correctly only
@@ -43,17 +49,28 @@
  * longer current dies the moment its last holder leaves; a current one dies after
  * sitting unused for `IDLE_TTL_MS`.
  *
+ * Both rules are enforced by a TIMER, not by the next call to `acquireServer`.
+ * Reaping as a side effect of acquiring meant nothing was ever collected once
+ * Open Code went quiet — which is exactly when there is most to collect.
+ *
  * There is deliberately NO cap on the pool. A cap can only be enforced by killing
  * a server, and the servers it would reach for during a burst are the ones being
  * used — trading a bounded number of processes for broken chats. Idle servers are
  * already reaped, so the count settles on its own.
+ *
+ * ── Outliving us ────────────────────────────────────────────────────────────
+ * These are child processes that do NOT die with their parent, so every spawn is
+ * recorded in the DB and a fresh process sweeps what a crash left behind. The
+ * record carries the owning Clopen pid: a second instance sharing one `app.db`
+ * must not mistake the first's live servers for orphans.
  */
 
 import { join } from 'path';
-import { readdir, rename, stat } from 'fs/promises';
+import { readdir, readFile, rename, stat } from 'fs/promises';
+import { createServer } from 'node:net';
 import type { OpencodeClient } from '@opencode-ai/sdk';
 import type { Subprocess } from 'bun';
-import { getOpenCodeMcpConfig } from '../../../mcp';
+import { getOpenCodeMcpConfig, getEnabledServerNames, getEnabledToolsForServer } from '../../../mcp';
 import { engineQueries, settingsQueries } from '../../../database/queries';
 import { generateOpenCodeProviderConfig, parseCredentialMap } from './config';
 import type { OpenCodeInlineAgent } from '$backend/subagents';
@@ -64,11 +81,21 @@ import { getEngineUserConfigDir } from '$backend/utils/paths';
 import { debug } from '$shared/utils/logger';
 
 const OPENCODE_HOST = '127.0.0.1';
+/** Basic-auth user the server is started with; Open Code's own default name. */
+const OPENCODE_AUTH_USER = 'opencode';
 /** Legacy single-server keys persisted by pre-pool builds — cleaned up once. */
 const LEGACY_DB_KEY = 'opencode.server.url';
 const LEGACY_DB_KEY_DATADIR = 'opencode.server.datadir';
+/** Servers we spawned, so a restart after a crash can still reclaim them. */
+const REGISTRY_DB_KEY = 'opencode.server.registry';
 const HEALTH_TIMEOUT = 1500;
 const SERVER_START_TIMEOUT = 30_000; // 30s — generous for slow devices
+/** Attempts to win a port before giving up — covers losing the allocate→spawn race. */
+const PORT_ATTEMPTS = 3;
+/** How long a server gets to honour SIGTERM before it is killed outright. */
+const KILL_GRACE_MS = 2_000;
+/** How often the pool sweeps itself for idle, superseded and orphaned entries. */
+const MAINTENANCE_INTERVAL_MS = 60_000;
 /**
  * Session-data scope for a stream with no Profile constraint.
  *
@@ -94,8 +121,12 @@ export interface ServerInstance {
 	key: string;
 	/** Profile shape — identifies the DATA DIR, and is stable across config edits. */
 	scopeKey: string;
+	/** The spec this server was built for, so its key can be re-resolved without a stream. */
+	spec: ServerConfigSpec;
 	url: string;
 	client: OpencodeClient;
+	/** Basic-auth header for the raw `fetch` call sites that bypass the SDK client. */
+	authHeaders: Record<string, string>;
 	proc: Subprocess | null;
 	ownsProcess: boolean;
 	lastUsed: number;
@@ -128,13 +159,16 @@ interface SpawnPlan {
  * answered, and which models a custom provider advertises. Everything cheap is
  * assembled per call, so nothing that can change without the database noticing
  * gets to hide behind this cache.
+ *
+ * `enabledProviders`/`envVars` are deliberately NOT here even though they are
+ * config: they derive from the models.dev catalog in `settings`, which no
+ * revision trigger watches. Cached, a first run whose catalog had not been
+ * fetched yet would spawn every later server with no provider credentials.
  */
 interface CachedConfig {
 	revision: number;
 	mcpConfig: Record<string, unknown>;
-	enabledProviders: string[];
 	providerSection: Record<string, unknown>;
-	envVars: Record<string, string>;
 }
 
 const pool = new Map<string, ServerInstance>();
@@ -143,7 +177,9 @@ const initPromises = new Map<string, Promise<ServerInstance>>();
 const currentKeyByScope = new Map<string, string>();
 const configCache = new Map<string, CachedConfig>();
 const adoptedScopes = new Set<string>();
-let legacyCleaned = false;
+let orphanSweepDone = false;
+let maintenanceTimer: ReturnType<typeof setInterval> | null = null;
+let liveStreamSource: (() => Set<string>) | null = null;
 
 /** Short, stable FNV-1a hex hash — folds variable config (e.g. inline agent
  *  content) into a compact server-key segment so an edit spawns a fresh server. */
@@ -165,25 +201,171 @@ async function isServerAlive(url: string): Promise<boolean> {
 	}
 }
 
-/** One-time shutdown of a server spawned by an older single-server build. */
-async function cleanupLegacyServer(): Promise<void> {
-	if (legacyCleaned) return;
-	legacyCleaned = true;
-	const stored = settingsQueries.get(LEGACY_DB_KEY)?.value;
-	if (stored) {
-		try {
-			await fetch(`${stored}/shutdown`, { method: 'POST', signal: AbortSignal.timeout(2000) });
-		} catch { /* endpoint may not exist / already dead */ }
-		settingsQueries.delete(LEGACY_DB_KEY);
-		settingsQueries.delete(LEGACY_DB_KEY_DATADIR);
-		debug.log('engine', `Open Code: shut down legacy single-server (${stored})`);
+// ============================================================================
+// Processes
+// ============================================================================
+
+/**
+ * Ask the OS for a free port.
+ *
+ * `--port=0` cannot be used: Open Code reads it as "try 4096, fall back to an
+ * ephemeral port", so the first pooled server always squats the well-known
+ * default — taking it from the user's own `opencode serve`, and putting an
+ * unauthenticated agent API on a guessable port. Binding here and handing over
+ * the number the kernel picked is the only way to get a genuinely arbitrary one.
+ */
+function allocateEphemeralPort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const probe = createServer();
+		probe.once('error', reject);
+		probe.listen(0, OPENCODE_HOST, () => {
+			const address = probe.address();
+			const port = typeof address === 'object' && address ? address.port : 0;
+			probe.close(() => port ? resolve(port) : reject(new Error('Could not allocate a local port')));
+		});
+	});
+}
+
+/** Servers this build spawned, as last written to the DB. */
+interface RegisteredServer {
+	pid: number;
+	url: string;
+	key: string;
+	/**
+	 * The Clopen process that spawned it. Two Clopen instances share one
+	 * `app.db`, so without this a second one would read the first's registry at
+	 * boot and kill servers that are very much in use.
+	 */
+	ownerPid: number;
+}
+
+function readSpawnRegistry(): RegisteredServer[] {
+	try {
+		const stored = settingsQueries.get(REGISTRY_DB_KEY)?.value;
+		const parsed = stored ? JSON.parse(stored) : [];
+		return Array.isArray(parsed) ? parsed as RegisteredServer[] : [];
+	} catch {
+		return [];
 	}
 }
 
-function killInstance(inst: ServerInstance): void {
-	if (inst.ownsProcess && inst.proc) {
-		try { inst.proc.kill(); } catch { /* already gone */ }
+function writeSpawnRegistry(entries: RegisteredServer[]): void {
+	try {
+		settingsQueries.set(REGISTRY_DB_KEY, JSON.stringify(entries));
+	} catch (error) {
+		debug.warn('engine', 'Open Code: could not persist the spawn registry', error);
 	}
+}
+
+function registerSpawnedServer(entry: RegisteredServer): void {
+	writeSpawnRegistry([...readSpawnRegistry().filter(existing => existing.pid !== entry.pid), entry]);
+}
+
+function unregisterSpawnedServer(pid: number): void {
+	writeSpawnRegistry(readSpawnRegistry().filter(existing => existing.pid !== pid));
+}
+
+/** Whether a pid is currently running (regardless of what it is). */
+function processAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Whether `pid` is still one of our Open Code servers.
+ *
+ * A pid alone is not enough to kill on: the OS recycles them, and a registry
+ * entry can outlive its process by days. The command line has to confirm it.
+ */
+async function isOpenCodeProcess(pid: number): Promise<boolean> {
+	if (!processAlive(pid)) return false;
+	const command = process.platform === 'win32'
+		? ['tasklist', '/FI', `PID eq ${pid}`, '/FO', 'CSV', '/NH']
+		: ['ps', '-p', String(pid), '-o', 'command='];
+	try {
+		const probe = Bun.spawn(command, { stdout: 'pipe', stderr: 'ignore' });
+		const output = (await new Response(probe.stdout).text()).toLowerCase();
+		await probe.exited;
+		return output.includes('opencode') && (process.platform === 'win32' || output.includes('serve'));
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Kill servers left behind by a previous run.
+ *
+ * Graceful shutdown disposes the pool, but a crash — or the 5s force-exit that
+ * guards `bun --watch` restarts — does not. Without this the orphan keeps its
+ * port and its data-dir lock, and nothing in a fresh process can even see it.
+ */
+async function sweepOrphanedServers(): Promise<void> {
+	if (orphanSweepDone) return;
+	orphanSweepDone = true;
+
+	const legacyUrl = settingsQueries.get(LEGACY_DB_KEY)?.value;
+	if (legacyUrl) {
+		try {
+			await fetch(`${legacyUrl}/shutdown`, { method: 'POST', signal: AbortSignal.timeout(2000) });
+		} catch { /* endpoint may not exist / already dead */ }
+		settingsQueries.delete(LEGACY_DB_KEY);
+		settingsQueries.delete(LEGACY_DB_KEY_DATADIR);
+		debug.log('engine', `Open Code: shut down legacy single-server (${legacyUrl})`);
+	}
+
+	const registered = readSpawnRegistry();
+	if (registered.length === 0) return;
+
+	const stillOwned: RegisteredServer[] = [];
+	for (const entry of registered) {
+		// Another live Clopen owns it — leave both the process and its entry alone.
+		if (entry.ownerPid !== process.pid && processAlive(entry.ownerPid)) {
+			stillOwned.push(entry);
+			continue;
+		}
+		if (!(await isOpenCodeProcess(entry.pid))) continue;
+		try {
+			process.kill(entry.pid, 'SIGTERM');
+			debug.log('engine', `Open Code: killed orphaned server ${entry.url} (pid ${entry.pid}) from a previous run`);
+		} catch (error) {
+			debug.warn('engine', `Open Code: could not kill orphaned server pid ${entry.pid}`, error);
+		}
+	}
+	writeSpawnRegistry(stillOwned);
+}
+
+/**
+ * Stop a server for good: SIGTERM, then SIGKILL if it is still up.
+ *
+ * Fire-and-forget SIGTERM was not enough — a server that is slow to exit (Open
+ * Code checkpoints a large WAL on the way out) keeps its port bound after the
+ * pool has already dropped its handle, so nothing can reach it again.
+ */
+async function killInstance(inst: ServerInstance): Promise<void> {
+	const pid = inst.proc?.pid;
+	if (!inst.ownsProcess || !inst.proc) {
+		if (pid) unregisterSpawnedServer(pid);
+		return;
+	}
+
+	try { inst.proc.kill(); } catch { /* already gone */ }
+
+	let graceTimer: ReturnType<typeof setTimeout> | undefined;
+	const exited = await Promise.race([
+		inst.proc.exited.then(() => true).catch(() => true),
+		new Promise<boolean>(resolve => { graceTimer = setTimeout(() => resolve(false), KILL_GRACE_MS); })
+	]);
+	clearTimeout(graceTimer);
+
+	if (!exited) {
+		debug.warn('engine', `Open Code: server ${inst.url} ignored SIGTERM — sending SIGKILL`);
+		try { inst.proc.kill('SIGKILL'); } catch { /* raced */ }
+	}
+	if (pid) unregisterSpawnedServer(pid);
 }
 
 // ============================================================================
@@ -226,31 +408,37 @@ function dataDirForScope(scopeKey: string): string {
  *
  * Commands, subagent files and the AGENTS.md instruction block are written to
  * disk by the per-stream artifact sync, so their CONTENT never appears in the DB
- * and the config revision cannot see it change. Size + mtime is enough to notice
- * an edit and costs three stats. Missing paths contribute a stable marker rather
- * than throwing — an engine with no commands yet is the normal case.
+ * and the config revision cannot see it change. Missing paths contribute a
+ * stable marker rather than throwing — an engine with no commands yet is normal.
+ *
+ * Hashes CONTENT, not size + mtime. Every writer that materializes these files
+ * runs at every stream start, so keying on mtime made the fingerprint a clock:
+ * an identical rewrite moved it, and each turn spawned a new server for config
+ * that had not changed. Content is the property that actually matters, and it
+ * cannot be moved by a writer that merely runs again.
  */
 async function artifactFingerprint(): Promise<string> {
 	const base = join(getEngineUserConfigDir('opencode'), 'opencode');
 	const targets = [join(base, 'command'), join(base, 'agent'), join(base, 'AGENTS.md')];
 	const parts: string[] = [];
 
+	const fileEntry = async (path: string, label: string): Promise<string> => {
+		try {
+			return `${label}:${hashConfig(await readFile(path, 'utf8'))}`;
+		} catch {
+			return `${label}:gone`;
+		}
+	};
+
 	for (const path of targets) {
 		try {
 			const info = await stat(path);
 			if (info.isDirectory()) {
 				const names = (await readdir(path)).sort();
-				const entries = await Promise.all(names.map(async name => {
-					try {
-						const child = await stat(join(path, name));
-						return `${name}:${child.size}:${Math.floor(child.mtimeMs)}`;
-					} catch {
-						return `${name}:gone`;
-					}
-				}));
+				const entries = await Promise.all(names.map(name => fileEntry(join(path, name), name)));
 				parts.push(`${path}[${entries.join('|')}]`);
 			} else {
-				parts.push(`${path}:${info.size}:${Math.floor(info.mtimeMs)}`);
+				parts.push(await fileEntry(path, path));
 			}
 		} catch {
 			parts.push(`${path}:absent`);
@@ -258,6 +446,23 @@ async function artifactFingerprint(): Promise<string> {
 	}
 
 	return hashConfig(parts.join('\n'));
+}
+
+/**
+ * What the shared `clopen-mcp` bridge exposes, as a stable string.
+ *
+ * The bridge is a SINGLE config entry — one URL, one token — so adding or
+ * removing an internal connector changes no baked byte, and the running server
+ * would keep serving the tool list it read when it connected (the bridge binds
+ * its tool set at MCP-session initialize, and never sends `list_changed`).
+ * Folding the exposed set into the signature is what makes an internal toggle
+ * reach the engine at all.
+ */
+function internalBridgeExposure(): string {
+	return getEnabledServerNames()
+		.sort()
+		.map(name => `${name}(${getEnabledToolsForServer(name).sort().join(',')})`)
+		.join('|');
 }
 
 // ============================================================================
@@ -399,14 +604,10 @@ async function resolveConfig(spec: ServerConfigSpec, scopeKey: string): Promise<
 		});
 	}
 
-	const providerConfig = generateOpenCodeProviderConfig();
-
 	const resolved: CachedConfig = {
 		revision,
 		mcpConfig,
-		enabledProviders: providerConfig.enabledProviders,
 		providerSection: await buildProviderSection(),
-		envVars: providerConfig.envVars,
 	};
 	configCache.set(scopeKey, resolved);
 	return resolved;
@@ -425,10 +626,14 @@ async function resolveConfig(spec: ServerConfigSpec, scopeKey: string): Promise<
  * stream start, so folding its result in at assembly time makes the edit reach
  * the signature the way any other config change does.
  */
-function assembleConfigContent(cached: CachedConfig, inlineAgents?: Record<string, OpenCodeInlineAgent>): string {
+function assembleConfigContent(
+	cached: CachedConfig,
+	enabledProviders: string[],
+	inlineAgents?: Record<string, OpenCodeInlineAgent>
+): string {
 	const mergedConfig: Record<string, unknown> = {};
 	if (Object.keys(cached.mcpConfig).length > 0) mergedConfig.mcp = cached.mcpConfig;
-	if (cached.enabledProviders.length > 0) mergedConfig.enabled_providers = cached.enabledProviders;
+	if (enabledProviders.length > 0) mergedConfig.enabled_providers = enabledProviders;
 	if (inlineAgents && Object.keys(inlineAgents).length > 0) mergedConfig.agent = inlineAgents;
 	if (Object.keys(cached.providerSection).length > 0) mergedConfig.provider = cached.providerSection;
 	return Object.keys(mergedConfig).length > 0 ? JSON.stringify(mergedConfig) : '{}';
@@ -444,12 +649,17 @@ function assembleConfigContent(cached: CachedConfig, inlineAgents?: Record<strin
 async function resolvePlan(spec: ServerConfigSpec): Promise<SpawnPlan> {
 	const scopeKey = scopeKeyFor(spec);
 	const [config, fingerprint] = await Promise.all([resolveConfig(spec, scopeKey), artifactFingerprint()]);
-	const configContent = assembleConfigContent(config, spec.inlineAgents);
-	const signature = hashConfig(`${configContent}‖${JSON.stringify(config.envVars)}‖${fingerprint}`);
+	// Cheap and DB-derived, so it is resolved per call rather than cached — the
+	// models.dev catalog it reads lives in `settings`, which bumps no revision.
+	const providerConfig = generateOpenCodeProviderConfig();
+	const configContent = assembleConfigContent(config, providerConfig.enabledProviders, spec.inlineAgents);
+	const signature = hashConfig(
+		`${configContent}‖${JSON.stringify(providerConfig.envVars)}‖${fingerprint}‖${internalBridgeExposure()}`
+	);
 	const key = `${scopeKey}#${signature}`;
 
 	currentKeyByScope.set(scopeKey, key);
-	return { key, scopeKey, configContent, envVars: config.envVars };
+	return { key, scopeKey, configContent, envVars: providerConfig.envVars };
 }
 
 // ============================================================================
@@ -476,9 +686,71 @@ function reap(reason: string): void {
 		if (!superseded && !expired) continue;
 
 		debug.log('engine', `Open Code: reaping ${superseded ? 'superseded' : 'idle'} server ${inst.url} (${inst.key}) — ${reason}`);
-		killInstance(inst);
+		void killInstance(inst);
 		pool.delete(inst.key);
 	}
+	if (pool.size === 0) stopMaintenance();
+}
+
+/**
+ * Sweep the pool on a timer.
+ *
+ * Reaping used to happen only as a side effect of acquiring or releasing a
+ * server, which made both of its rules unenforceable once Open Code went quiet:
+ * the idle TTL never came due, and a holder leaked by a torn-down stream pinned
+ * its server until the next config change — potentially forever. A server that
+ * nothing needs must stop because time passed, not because someone happened to
+ * ask for another one.
+ */
+function startMaintenance(): void {
+	if (maintenanceTimer || pool.size === 0) return;
+	maintenanceTimer = setInterval(() => {
+		if (liveStreamSource) reconcileServerHolders(liveStreamSource());
+		else reap('idle sweep');
+	}, MAINTENANCE_INTERVAL_MS);
+	maintenanceTimer.unref?.();
+	debug.log('engine', 'Open Code: pool maintenance started');
+}
+
+function stopMaintenance(): void {
+	if (!maintenanceTimer) return;
+	clearInterval(maintenanceTimer);
+	maintenanceTimer = null;
+	debug.log('engine', 'Open Code: pool empty, maintenance stopped');
+}
+
+/**
+ * Tell the pool where to read the live stream set. Injected because the stream
+ * manager sits above the engine layer and must not be imported from here.
+ */
+export function setLiveStreamSource(source: () => Set<string>): void {
+	liveStreamSource = source;
+}
+
+/**
+ * Re-resolve every pooled server's key so a settled config change makes stale
+ * ones reapable immediately.
+ *
+ * Without this only the default scope was ever revisited: a Profile server kept
+ * being its own scope's "current" key, so it was neither superseded nor idle,
+ * and it went on running with the config — including the credentials — the user
+ * had just replaced. This costs no spawn; it only recomputes keys.
+ */
+export async function revalidatePool(): Promise<void> {
+	// One pass per scope, using its most recently spawned server. `resolvePlan`
+	// WRITES the scope's current key, so revalidating an older instance after a
+	// newer one would hand "current" back to the server being replaced.
+	const newestByScope = new Map<string, ServerInstance>();
+	for (const inst of pool.values()) newestByScope.set(inst.scopeKey, inst);
+
+	for (const [scopeKey, inst] of newestByScope) {
+		try {
+			await resolvePlan(inst.spec);
+		} catch (error) {
+			debug.warn('engine', `Open Code: could not revalidate scope "${scopeKey}"`, error);
+		}
+	}
+	reap('config revalidation');
 }
 
 /**
@@ -565,7 +837,7 @@ async function adoptLegacyScopeDir(scopeKey: string, dataDir: string): Promise<v
  * reaper's grace window covers those.
  */
 export async function acquireServer(spec: ServerConfigSpec, holderId?: string): Promise<ServerInstance> {
-	await cleanupLegacyServer();
+	await sweepOrphanedServers();
 
 	const plan = await resolvePlan(spec);
 	const existing = pool.get(plan.key);
@@ -576,7 +848,7 @@ export async function acquireServer(spec: ServerConfigSpec, holderId?: string): 
 			reap('server reuse');
 			return existing;
 		}
-		killInstance(existing);
+		void killInstance(existing);
 		pool.delete(plan.key);
 	}
 
@@ -587,9 +859,10 @@ export async function acquireServer(spec: ServerConfigSpec, holderId?: string): 
 		return inst;
 	}
 
-	const p = spawnServer(plan)
+	const pendingSpawn = spawnServer(plan, spec)
 		.then(inst => {
 			pool.set(plan.key, inst);
+			startMaintenance();
 			// Only now that a healthy replacement exists is the old one expendable.
 			// Spawning before killing means a config that cannot start leaves the
 			// user with the previous working server rather than with nothing.
@@ -597,9 +870,9 @@ export async function acquireServer(spec: ServerConfigSpec, holderId?: string): 
 			return inst;
 		})
 		.finally(() => { initPromises.delete(plan.key); });
-	initPromises.set(plan.key, p);
+	initPromises.set(plan.key, pendingSpawn);
 
-	const inst = await p;
+	const inst = await pendingSpawn;
 	if (holderId) inst.holders.add(holderId);
 	return inst;
 }
@@ -613,8 +886,45 @@ export function releaseServer(key: string, holderId: string): void {
 	reap('holder released');
 }
 
-async function spawnServer(plan: SpawnPlan): Promise<ServerInstance> {
-	debug.log('engine', `Spawning Open Code server for key "${plan.key}"...`);
+/** True for the one failure worth retrying on a different port: anything but a slow start. */
+function isRetriableSpawnFailure(error: unknown): boolean {
+	return !(error instanceof Error && error.message.includes('Timeout waiting for opencode server'));
+}
+
+/**
+ * Spawn a server, retrying if it loses the race for its port.
+ *
+ * The port is allocated by binding a socket and handing over the number the
+ * kernel picked, so between closing that socket and Open Code binding it there
+ * is a window another process can win. An explicit port has no fallback inside
+ * Open Code, so the retry is ours to do.
+ */
+async function spawnServer(plan: SpawnPlan, spec: ServerConfigSpec): Promise<ServerInstance> {
+	// Random per process: the server exposes an agent API that can run shell
+	// commands, and it is unauthenticated unless this is set.
+	const password = crypto.randomUUID();
+	let lastError: unknown;
+
+	for (let attempt = 1; attempt <= PORT_ATTEMPTS; attempt++) {
+		const port = await allocateEphemeralPort();
+		try {
+			return await spawnServerOnce(plan, spec, port, password);
+		} catch (error) {
+			lastError = error;
+			if (!isRetriableSpawnFailure(error) || attempt === PORT_ATTEMPTS) throw error;
+			debug.warn('engine', `Open Code: spawn on port ${port} failed (attempt ${attempt}/${PORT_ATTEMPTS}), retrying`, error);
+		}
+	}
+	throw lastError;
+}
+
+async function spawnServerOnce(
+	plan: SpawnPlan,
+	spec: ServerConfigSpec,
+	port: number,
+	password: string
+): Promise<ServerInstance> {
+	debug.log('engine', `Spawning Open Code server for key "${plan.key}" on port ${port}...`);
 
 	// Isolate Open Code state under Clopen's dir (XDG overrides) — never mixes with
 	// the user's own CLI usage. CONFIG is shared across pooled servers (commands +
@@ -637,7 +947,7 @@ async function spawnServer(plan: SpawnPlan): Promise<ServerInstance> {
 			'Open Code is missing its CLI. Open Settings → Stack to install it before using this engine.'
 		);
 	}
-	const args = [cli.path, 'serve', `--hostname=${OPENCODE_HOST}`, '--port=0'];
+	const args = [cli.path, 'serve', `--hostname=${OPENCODE_HOST}`, `--port=${port}`];
 
 	const proc = Bun.spawn(args, {
 		stdout: 'pipe',
@@ -650,6 +960,10 @@ async function spawnServer(plan: SpawnPlan): Promise<ServerInstance> {
 			XDG_STATE_HOME: dataDir,
 			XDG_CACHE_HOME: dataDir,
 			OPENCODE_CONFIG_CONTENT: plan.configContent,
+			// Set explicitly so an inherited value from the user's shell cannot
+			// leave us holding a password the server did not start with.
+			OPENCODE_SERVER_USERNAME: OPENCODE_AUTH_USER,
+			OPENCODE_SERVER_PASSWORD: password,
 		},
 	});
 
@@ -690,41 +1004,26 @@ async function spawnServer(plan: SpawnPlan): Promise<ServerInstance> {
 		});
 	});
 
+	// Applies to the SSE event stream too — the SDK merges client-level headers
+	// into every request, including `event.subscribe`.
+	const authHeaders = { Authorization: `Basic ${btoa(`${OPENCODE_AUTH_USER}:${password}`)}` };
 	const { createOpencodeClient } = await loadEngineSdk<typeof import('@opencode-ai/sdk')>('opencode', '@opencode-ai/sdk');
-	const client = createOpencodeClient({ baseUrl: url });
+	const client = createOpencodeClient({ baseUrl: url, headers: authHeaders });
+
+	if (proc.pid) registerSpawnedServer({ pid: proc.pid, url, key: plan.key, ownerPid: process.pid });
 	debug.log('engine', `Open Code server ready (key "${plan.key}", ${url}, data dir: ${dataDir})`);
 	return {
 		key: plan.key,
 		scopeKey: plan.scopeKey,
+		spec,
 		url,
 		client,
+		authHeaders,
 		proc,
 		ownsProcess: true,
 		lastUsed: Date.now(),
 		holders: new Set<string>(),
 	};
-}
-
-/**
- * Bring every pooled scope up to date with the current config.
- *
- * Called after a config change settles and no stream is running: the replacement
- * is spawned and verified now, so the user's next message does not pay for it.
- * When streams ARE running this is skipped entirely — the next stream to start
- * resolves the new key on its own, and the running ones keep the server they
- * were bound to. A failure here is logged and nothing else: the existing server
- * stays in the pool, and the real error surfaces in chat when a turn actually
- * needs the config that cannot start.
- */
-export async function refreshPool(specForScope: Map<string, ServerConfigSpec>): Promise<void> {
-	for (const [scopeKey, spec] of specForScope) {
-		try {
-			await acquireServer(spec);
-		} catch (error) {
-			debug.warn('engine', `Open Code: warm-up for scope "${scopeKey}" failed; keeping the current server`, error);
-		}
-	}
-	reap('post warm-up');
 }
 
 /** The scopes currently backed by a pooled server, for warm-up. */
@@ -740,18 +1039,17 @@ export async function ensureClient(): Promise<OpencodeClient> {
 	return (await acquireServer({})).client;
 }
 
-/** The DEFAULT server's client, if up (back-compat for callers with no stream context). */
-export function getClient(): OpencodeClient | null {
+/**
+ * The DEFAULT server, if up — for callers with no stream context.
+ *
+ * Returns the instance rather than a bare url or client because the raw
+ * `fetch` call sites need its auth header too, and a url without the header
+ * that goes with it is a 401 waiting to happen.
+ */
+export function getDefaultServer(): ServerInstance | null {
 	const inst = defaultInstance();
 	if (inst) inst.lastUsed = Date.now();
-	return inst?.client ?? null;
-}
-
-/** The DEFAULT server's URL, if up. */
-export function getServerUrl(): string | null {
-	const inst = defaultInstance();
-	if (inst) inst.lastUsed = Date.now();
-	return inst?.url ?? null;
+	return inst ?? null;
 }
 
 function defaultInstance(): ServerInstance | undefined {
@@ -769,13 +1067,21 @@ function defaultInstance(): ServerInstance | undefined {
  * Dispose the whole pool. `forRestart` is accepted for signature compatibility
  * with the previous single-server API; every pooled server we own is killed
  * either way (there is no external-server-reuse path anymore).
+ *
+ * Kills run concurrently and are awaited: shutdown is bounded by one grace
+ * period, and a child process that outlives us keeps both its port and its
+ * data-dir lock.
  */
 export async function disposeOpenCodeClient(_forRestart = false): Promise<void> {
-	for (const inst of pool.values()) killInstance(inst);
+	stopMaintenance();
+	await Promise.all([...pool.values()].map(inst => killInstance(inst)));
 	pool.clear();
 	initPromises.clear();
 	currentKeyByScope.clear();
 	configCache.clear();
+	// Nothing of OURS is running any more. Stated rather than derived, because the
+	// per-kill updates race each other — but another Clopen's entries stay.
+	writeSpawnRegistry(readSpawnRegistry().filter(entry => entry.ownerPid !== process.pid));
 	settingsQueries.delete(LEGACY_DB_KEY);
 	settingsQueries.delete(LEGACY_DB_KEY_DATADIR);
 	debug.log('engine', 'Open Code pool disposed');

--- a/backend/engine/adapters/opencode/stream.ts
+++ b/backend/engine/adapters/opencode/stream.ts
@@ -42,7 +42,7 @@ import {
 	mapToolName,
 	TOOL_NAME_MAP,
 } from './message-converter';
-import { ensureClient, acquireServer, releaseServer, getClient, getServerUrl, type ServerInstance } from './server';
+import { ensureClient, acquireServer, releaseServer, getDefaultServer, type ServerInstance } from './server';
 import { syncSkills } from '$backend/skills';
 import { syncEngineArtifacts, buildArtifactsPromptContext } from '$backend/engine/artifact-sync';
 import { artifactFilter } from '$backend/profiles';
@@ -887,7 +887,7 @@ export class OpenCodeEngine implements AIEngine {
 		//    The pool hold is still held here on purpose — handing the server back
 		//    first could let it be reaped out from under this very call.
 		for (const run of targets) {
-			const client = run.server?.client ?? getClient();
+			const client = run.server?.client ?? getDefaultServer()?.client;
 			const { sessionId, projectPath } = run;
 			if (!client || !sessionId) continue;
 			try {
@@ -948,8 +948,8 @@ export class OpenCodeEngine implements AIEngine {
 	 * POST /question/{requestID}/reply to send user answers back to the OpenCode server.
 	 */
 	private replyToQuestion(run: OpenCodeRun | null, requestId: string, orderedAnswers: string[][]): void {
-		const serverUrl = run?.server?.url ?? getServerUrl();
-		if (!serverUrl) {
+		const server = run?.server ?? getDefaultServer();
+		if (!server) {
 			debug.warn('engine', 'replyToQuestion: Server URL not available');
 			return;
 		}
@@ -959,12 +959,12 @@ export class OpenCodeEngine implements AIEngine {
 		// a shared "current server" would post this reply into the wrong one and
 		// leave the asking session waiting forever.
 		const dirParam = run?.projectPath ? `?directory=${encodeURIComponent(run.projectPath)}` : '';
-		const url = `${serverUrl}/question/${requestId}/reply${dirParam}`;
+		const url = `${server.url}/question/${requestId}/reply${dirParam}`;
 		debug.log('engine', `Replying to question ${requestId}:`, orderedAnswers);
 
 		fetch(url, {
 			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
+			headers: { 'Content-Type': 'application/json', ...server.authHeaders },
 			body: JSON.stringify({ answers: orderedAnswers }),
 		}).then(async res => {
 			if (res.ok) {
@@ -986,15 +986,15 @@ export class OpenCodeEngine implements AIEngine {
 		// still-running one when there is exactly one, else the shared client.
 		const running = this.runs.all();
 		const run = running.length === 1 ? running[0] : null;
-		const serverUrl = run?.server?.url ?? getServerUrl();
-		if (!serverUrl) {
+		const server = run?.server ?? getDefaultServer();
+		if (!server) {
 			debug.warn('engine', 'fetchAndReplyToQuestion: Server URL not available');
 			return;
 		}
 
 		try {
 			const dirParam = run?.projectPath ? `?directory=${encodeURIComponent(run.projectPath)}` : '';
-			const res = await fetch(`${serverUrl}/question${dirParam}`);
+			const res = await fetch(`${server.url}/question${dirParam}`, { headers: server.authHeaders });
 			if (!res.ok) {
 				debug.error('engine', `Failed to list pending questions: ${res.status}`);
 				return;
@@ -1029,14 +1029,14 @@ export class OpenCodeEngine implements AIEngine {
 	 * the v2 permission.reply method.
 	 */
 	private replyPermission(run: OpenCodeRun, permissionId: string, sessionId: string, response: 'once' | 'reject'): void {
-		const serverUrl = run.server?.url ?? getServerUrl();
-		if (!serverUrl) return;
+		const server = run.server ?? getDefaultServer();
+		if (!server) return;
 		const verb = response === 'reject' ? 'rejected' : 'approved';
 
 		// Try v2 endpoint first (/permission/{requestID}/reply), fall back to v1
-		fetch(`${serverUrl}/permission/${permissionId}/reply`, {
+		fetch(`${server.url}/permission/${permissionId}/reply`, {
 			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
+			headers: { 'Content-Type': 'application/json', ...server.authHeaders },
 			body: JSON.stringify({ reply: response }),
 		}).then(res => {
 			if (res.ok) {
@@ -1044,7 +1044,7 @@ export class OpenCodeEngine implements AIEngine {
 				return;
 			}
 			// v2 endpoint not available — try v1
-			const client = run.server?.client ?? getClient();
+			const client = run.server?.client ?? getDefaultServer()?.client;
 			if (client) {
 				client.postSessionIdPermissionsPermissionId({
 					path: { id: sessionId, permissionID: permissionId },

--- a/backend/engine/hot-reload.ts
+++ b/backend/engine/hot-reload.ts
@@ -34,6 +34,8 @@ import {
 	acquireServer,
 	pooledScopeKeys,
 	reconcileServerHolders,
+	revalidatePool,
+	setLiveStreamSource,
 	DEFAULT_SCOPE_KEY,
 } from './adapters/opencode/server';
 import { debug } from '$shared/utils/logger';
@@ -51,7 +53,6 @@ let started = false;
  * talk to a server anyway.
  */
 async function warmDefaultScope(): Promise<void> {
-	if (!pooledScopeKeys().includes(DEFAULT_SCOPE_KEY)) return;
 	try {
 		await acquireServer({});
 		debug.log('engine', 'Open Code default server re-warmed for the new config');
@@ -71,6 +72,10 @@ export function startEngineHotReload(): void {
 	if (started) return;
 	started = true;
 
+	// The pool sweeps itself on a timer; this is where it learns which holds are
+	// still backed by a running stream.
+	setLiveStreamSource(() => new Set(streamManager.getActiveStreams().map(s => s.streamId)));
+
 	onEngineConfigChanged(revision => {
 		// Holder bookkeeping is reconciled against the live stream set first, so
 		// "is anything running" and "is this server still needed" are answered from
@@ -83,16 +88,26 @@ export function startEngineHotReload(): void {
 		// that is mid-answer.
 		retireAllEngines();
 
-		if (liveStreams.length > 0) {
-			debug.log(
-				'engine',
-				`Engine config now at revision ${revision}; ${liveStreams.length} stream(s) in flight — ` +
-				'applying it to the next turn and draining the old server behind them'
-			);
-			return;
-		}
+		// Read BEFORE revalidating: revalidation is what makes the outgoing default
+		// server reapable, so asking afterwards would report the scope as unused
+		// and skip the warm-up on exactly the change that needs it.
+		const defaultScopeInUse = pooledScopeKeys().includes(DEFAULT_SCOPE_KEY);
 
-		void warmDefaultScope();
+		// Re-resolve every pooled scope's key, not just the default one. A Profile
+		// server is otherwise still its own scope's current key, so it is neither
+		// superseded nor idle and goes on serving the config — and the credentials —
+		// that were just replaced. Held servers are unaffected: they are pinned.
+		void revalidatePool().then(() => {
+			if (liveStreams.length > 0) {
+				debug.log(
+					'engine',
+					`Engine config now at revision ${revision}; ${liveStreams.length} stream(s) in flight — ` +
+					'applying it to the next turn and draining the old server behind them'
+				);
+				return;
+			}
+			if (defaultScopeInUse) return warmDefaultScope();
+		});
 	});
 
 	debug.log('engine', 'Engine hot-reload active');

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -333,6 +333,11 @@ async function gracefulShutdown() {
 		// and browser teardown below — otherwise the old process keeps those
 		// sockets open long enough to overlap the new process ("too many clients").
 		await connectionManager.closeAll();
+		// Engines next, because they own CHILD PROCESSES. Everything below is
+		// in-process cleanup that dies with us anyway, but an `opencode serve`
+		// we fail to kill outlives the restart holding its port and data-dir
+		// lock — and the 5s force-exit above used to fire before we got here.
+		await disposeAllEngines();
 		// Same reasoning for SSH: stop the forwards' listeners and close every
 		// transport so their remote sessions and bound ports are released now.
 		await sshForwardManager.stopAll();
@@ -359,8 +364,6 @@ async function gracefulShutdown() {
 		stopMemoryMaintenance();
 		stopExtractionRunner();
 		await flushEpisodicIngest();
-		// Dispose all AI engines
-		await disposeAllEngines();
 		// Close database connection
 		closeDatabase();
 		debug.log('server', '✅ Graceful shutdown completed');


### PR DESCRIPTION
## Summary
Open Code spawned a new `opencode serve` process on every message, never
stopped the ones it replaced, and always squatted port 4096 with an
unauthenticated agent API. This makes the pool key on config that actually
changed, and makes servers stop when nothing needs them.

## Why
The pool's artifact fingerprint keyed on `size + mtime`, while
`materializeArtifacts` rewrote each enabled command file at every stream
start whether or not the bytes differed. A no-op rewrite therefore moved
the pool signature and routed the turn to a brand-new process. On my
machine `engine_config_revision` had not moved since 01:53, yet a respawn
happened at 14:15:24 — the same second the command files were rewritten.

Nothing collected the replaced servers. `reap()` only ran as a side effect
of acquiring or releasing a server, so the 30-minute idle TTL was
unenforceable once Open Code went quiet; one server had held 4096 for over
five hours. It held 4096 because `--port=0` reads as "try 4096, fall back
to ephemeral" inside Open Code, not as "give me an ephemeral port".

Two config changes also failed to respawn a server when they should have —
see Changes.

## Changes
- `backend/artifacts/sync.ts` — write only when content differs; skip a
  folder mirror whose destination is already current.
- `backend/engine/adapters/opencode/server.ts`
  - fingerprint hashes file CONTENT instead of size + mtime
  - ports are pre-allocated by binding a socket and passed as an explicit
    `--port=<n>`, with retries for the allocate→spawn race
  - each server starts with a random `OPENCODE_SERVER_PASSWORD`; the SDK
    client and the raw `fetch` call sites carry the basic-auth header
  - `reap()` runs on a 60s unref'd timer that also reconciles holders;
    it starts when the pool fills and stops when it empties
  - `killInstance` escalates SIGTERM → SIGKILL and is awaited
  - every spawn is recorded in `settings` with its owning Clopen pid, and
    a fresh process sweeps orphans a crash left behind
  - `revalidatePool()` replaces the unused `refreshPool()`: it re-resolves
    every pooled scope's key so stale Profile servers become reapable
  - the internal MCP connector set joins the signature — all internal
    servers sit behind one bridge entry, so toggling one changed no baked
    byte and never reached the running engine
  - `enabledProviders`/`envVars` leave `configCache`: they derive from the
    models.dev catalog in `settings`, which no revision trigger watches
- `backend/engine/adapters/opencode/stream.ts` — `getClient`/`getServerUrl`
  collapse into `getDefaultServer()` so a URL always travels with its auth
  header.
- `backend/engine/hot-reload.ts` — wires the live-stream source and
  revalidates the whole pool on a settled config change.
- `backend/index.ts` — engine teardown moves ahead of SSH, browser and
  memory-flush cleanup, which were racing the 5s force-exit.

## Test plan
- `bun run check` — 0 errors
- `bun run lint` — 0 errors
- `bun run test` — 846 pass, 0 fail
- new `backend/artifacts/sync.test.ts` pins write idempotence; verified it
  fails when `writeFileIfChanged` is reverted to `writeFile`
- `--port=0` semantics confirmed against the shipped binary and by running
  a second `opencode serve` while 4096 was held (it landed on 53920)

## Security impact
The pooled server exposes an agent API that can run shell commands, and it
logged `OPENCODE_SERVER_PASSWORD is not set; server is unsecured` on a
fixed, guessable localhost port. Any local process could drive it, or
attach to it with `opencode attach http://localhost:4096`. It now listens
on an OS-assigned port behind a per-process random basic-auth password.

## Notes
Runtime QA is still pending — this passes type-check and the suite, but has
not been exercised against a live `opencode serve`. The part most worth
watching is basic auth on the SSE event stream: the SDK merges client-level
headers in `beforeRequest`, which `fn.sse` also goes through, but that is
read from the SDK source rather than observed.

Adding an internal MCP connector now respawns the server. That is the
correct behaviour — the bridge binds its tool list at MCP-session
initialize and never sends `tools/list_changed` — but it is a behaviour
change, and internal connectors are code-synced so it should be rare.

## Follow-ups
`resolveConfig` still drops an MCP connector whose endpoint does not answer
within 1.5s, and caches that outcome for the whole config revision. A
transient blip can leave a long-lived server without a connector. Baking a
runtime property into an identity deserves its own PR.