### PR TITLE
feat(workspace): add right-click context menu to project sidebar

### DIFF
--- a/frontend/components/workspace/DesktopNavigator.svelte
+++ b/frontend/components/workspace/DesktopNavigator.svelte
@@ -32,6 +32,9 @@
 	import SettingButton from '$frontend/components/settings/SettingButton.svelte';
 	import ProjectUserAvatars from '$frontend/components/common/display/ProjectUserAvatars.svelte';
 	import ProjectInfoModal from '$frontend/components/workspace/ProjectInfoModal.svelte';
+	import ProjectContextMenu, {
+		type ProjectContextMenuItem
+	} from '$frontend/components/workspace/ProjectContextMenu.svelte';
 	import ws from '$frontend/utils/ws';
 	import {
 		quickPanelsState,
@@ -65,6 +68,9 @@
 	let draggedProjectId = $state<string | null>(null);
 	let dragOverProjectId = $state<string | null>(null);
 	let expandedListEl = $state<HTMLElement>();
+	let contextMenuProject = $state<Project | null>(null);
+	let contextMenuX = $state(0);
+	let contextMenuY = $state(0);
 	let collapsedListEl = $state<HTMLElement>();
 
 	// Derived
@@ -82,6 +88,15 @@
 			(p) => p.name.toLowerCase().includes(query) || p.path.toLowerCase().includes(query)
 		);
 	});
+
+	const contextMenuItems = $derived<ProjectContextMenuItem[]>(
+		canManageProjects
+			? [
+					{ id: 'info', label: 'Info', icon: 'lucide:info' },
+					{ id: 'delete', label: 'Delete', icon: 'lucide:trash-2', danger: true }
+				]
+			: [{ id: 'info', label: 'Info', icon: 'lucide:info' }]
+	);
 
 	// Auto-scroll the active project into view — covers both clicking it directly
 	// and switching to it from elsewhere (e.g. the Command Palette).
@@ -180,6 +195,30 @@
 
 	function closeProjectInfo() {
 		showProjectInfo = false;
+	}
+
+	function openProjectContextMenu(project: Project, event: MouseEvent) {
+		event.preventDefault();
+		hideProjectTooltip();
+		contextMenuX = event.clientX;
+		contextMenuY = event.clientY;
+		contextMenuProject = project;
+	}
+
+	function closeProjectContextMenu() {
+		contextMenuProject = null;
+	}
+
+	function handleContextMenuSelect(action: string) {
+		const project = contextMenuProject;
+		if (!project) return;
+		if (action === 'info') {
+			projectInfoProject = project;
+			showProjectInfo = true;
+		} else if (action === 'delete' && canManageProjects) {
+			projectToDelete = project;
+			showDeleteDialog = true;
+		}
 	}
 
 	// Get project initials (max 2 characters)
@@ -342,6 +381,7 @@
 							ondrop={(event) => handleProjectDrop(event, project.id)}
 							ondragend={handleProjectDragEnd}
 							onclick={() => selectProject(project)}
+							oncontextmenu={(event) => openProjectContextMenu(project, event)}
 							onkeydown={(e) => e.key === 'Enter' && selectProject(project)}
 						>
 							<div class="relative shrink-0">
@@ -465,6 +505,7 @@
 						ondrop={(event) => handleProjectDrop(event, project.id)}
 						ondragend={handleProjectDragEnd}
 						onclick={() => selectProject(project)}
+						oncontextmenu={(event) => openProjectContextMenu(project, event)}
 						onmouseenter={(e) => showProjectTooltip(project, e)}
 						onmouseleave={hideProjectTooltip}
 					>
@@ -586,5 +627,16 @@
 <PortsModal bind:isOpen={quickPanelsState.portsOpen} onClose={closePortsDialog} />
 <ContainersModal bind:isOpen={quickPanelsState.containersOpen} onClose={closeContainersDialog} />
 <MemoryModal bind:isOpen={quickPanelsState.memoryOpen} onClose={closeMemoryDialog} />
+
+<!-- Project Context Menu -->
+{#if contextMenuProject}
+	<ProjectContextMenu
+		items={contextMenuItems}
+		x={contextMenuX}
+		y={contextMenuY}
+		onSelect={handleContextMenuSelect}
+		onClose={closeProjectContextMenu}
+	/>
+{/if}
 
 <ProjectInfoModal bind:isOpen={showProjectInfo} onClose={closeProjectInfo} project={projectInfoProject} />

--- a/frontend/components/workspace/ProjectContextMenu.svelte
+++ b/frontend/components/workspace/ProjectContextMenu.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import { portal } from '$frontend/utils/portal';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import type { IconName } from '$shared/types/ui/icons';
+
+	export interface ProjectContextMenuItem {
+		id: string;
+		label: string;
+		icon: IconName;
+		danger?: boolean;
+	}
+
+	interface Props {
+		items: ProjectContextMenuItem[];
+		x: number;
+		y: number;
+		onSelect: (id: string) => void;
+		onClose: () => void;
+	}
+
+	const { items, x, y, onSelect, onClose }: Props = $props();
+
+	let menuElement = $state<HTMLDivElement>();
+	let pos = $state({ top: 0, left: 0 });
+
+	// Flip the menu back inside the viewport once its size is known
+	$effect(() => {
+		pos = { top: y, left: x };
+		if (!menuElement) return;
+		const rect = menuElement.getBoundingClientRect();
+		const left = x + rect.width > window.innerWidth - 8 ? window.innerWidth - rect.width - 8 : x;
+		const top = y + rect.height > window.innerHeight - 8 ? window.innerHeight - rect.height - 8 : y;
+		pos = { top, left };
+	});
+
+	function handlePointerDown(event: MouseEvent) {
+		if (menuElement && !menuElement.contains(event.target as Node)) onClose();
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			onClose();
+		}
+	}
+
+	$effect(() => {
+		// Defer listeners so the opening right-click does not close the menu
+		const timer = setTimeout(() => {
+			document.addEventListener('mousedown', handlePointerDown);
+			document.addEventListener('contextmenu', handlePointerDown);
+		}, 0);
+		window.addEventListener('keydown', handleKeydown);
+		window.addEventListener('resize', onClose);
+		return () => {
+			clearTimeout(timer);
+			document.removeEventListener('mousedown', handlePointerDown);
+			document.removeEventListener('contextmenu', handlePointerDown);
+			window.removeEventListener('keydown', handleKeydown);
+			window.removeEventListener('resize', onClose);
+		};
+	});
+</script>
+
+<div
+	bind:this={menuElement}
+	use:portal
+	class="fixed z-[10001] min-w-40 py-1 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg shadow-xl text-sm"
+	style="top: {pos.top}px; left: {pos.left}px;"
+	role="menu"
+	tabindex="-1"
+>
+	{#each items as item (item.id)}
+		<button
+			type="button"
+			class="flex items-center gap-2.5 w-full text-left px-3 py-1.5 bg-transparent border-none cursor-pointer transition-colors duration-150 {item.danger
+				? 'text-red-600 dark:text-red-400 hover:bg-red-500/10'
+				: 'text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800'}"
+			role="menuitem"
+			onclick={() => {
+				onSelect(item.id);
+				onClose();
+			}}
+		>
+			<Icon name={item.icon} class="w-4 h-4 shrink-0" />
+			<span>{item.label}</span>
+		</button>
+	{/each}
+</div>


### PR DESCRIPTION
## Summary
Right-clicking a project in the desktop navigation sidebar now opens a context menu with Info and Delete.

## Why
Project actions were only reachable via inline icon buttons — unavailable in the collapsed rail and visually crowding the expanded row.

## Changes
- New `ProjectContextMenu.svelte`: portal-rendered, viewport-aware positioning, closes on outside click / Escape / resize.
- `DesktopNavigator.svelte`: `oncontextmenu` on expanded rows and collapsed buttons; menu actions reuse the existing info modal and delete dialog. Delete is admin-only.

## Notes
Inline Info/Delete buttons are unchanged. Mobile navigator untouched. `bun run check` and `bun run lint` pass.