### PR TITLE
feat(worktrees): add isolated project copies for parallel sessions

### DIFF
--- a/backend/database/migrations/070_create_worktrees_table.ts
+++ b/backend/database/migrations/070_create_worktrees_table.ts
@@ -1,0 +1,67 @@
+/**
+ * Migration: Worktrees — isolated copies of a project that sessions can run in.
+ * Purpose: let several tasks run in parallel without touching the main tree.
+ */
+
+import type { DatabaseConnection } from '$shared/types/database/connection';
+import { debug } from '$shared/utils/logger';
+
+export const description = 'Create worktrees table and bind chat sessions to a worktree';
+
+export const up = (db: DatabaseConnection): void => {
+	debug.log('migration', '📋 Creating worktrees table...');
+
+	// `base_tree` is the merge base: a TreeMap (relative path → blob hash) of the
+	// main tree captured when the worktree was cloned. Apply/sync compare against
+	// it, so it must survive restarts — hence a column rather than memory.
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS worktrees (
+			id              TEXT PRIMARY KEY,
+			project_id      TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+			name            TEXT NOT NULL,
+			slug            TEXT NOT NULL,
+			path            TEXT NOT NULL,
+			status          TEXT NOT NULL DEFAULT 'active'
+			                CHECK (status IN ('active','applied','archived')),
+			clone_mode      TEXT NOT NULL DEFAULT 'copy'
+			                CHECK (clone_mode IN ('reflink','copy')),
+			base_tree       TEXT NOT NULL,
+			created_by      TEXT,
+			created_at      TEXT NOT NULL,
+			last_opened_at  TEXT,
+			last_applied_at TEXT
+		)
+	`);
+
+	db.exec(`
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_worktrees_project_slug
+		ON worktrees(project_id, slug)
+	`);
+
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_worktrees_project
+		ON worktrees(project_id)
+	`);
+
+	debug.log('migration', '📋 Binding chat sessions to worktrees...');
+
+	// NULL = the session runs in the main project tree.
+	db.exec(`ALTER TABLE chat_sessions ADD COLUMN worktree_id TEXT`);
+
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_chat_sessions_worktree
+		ON chat_sessions(worktree_id)
+	`);
+
+	debug.log('migration', '✅ Worktrees ready');
+};
+
+export const down = (db: DatabaseConnection): void => {
+	debug.log('migration', '🗑️ Dropping worktrees...');
+	db.exec('DROP INDEX IF EXISTS idx_chat_sessions_worktree');
+	db.exec('DROP INDEX IF EXISTS idx_worktrees_project');
+	db.exec('DROP INDEX IF EXISTS idx_worktrees_project_slug');
+	db.exec('DROP TABLE IF EXISTS worktrees');
+	debug.warn('migration', '⚠️ chat_sessions.worktree_id remains (SQLite drop-column)');
+	debug.log('migration', '✅ Worktrees rollback completed');
+};

--- a/backend/database/migrations/index.ts
+++ b/backend/database/migrations/index.ts
@@ -68,6 +68,7 @@ import * as migration066 from './066_create_memory_graph';
 import * as migration067 from './067_add_memory_graph_layout';
 import * as migration068 from './068_create_engine_config_revision';
 import * as migration069 from './069_create_ssh_client_tables';
+import * as migration070 from './070_create_worktrees_table';
 
 // Export all migrations in order
 export const migrations = [
@@ -484,6 +485,12 @@ export const migrations = [
 		description: migration069.description,
 		up: migration069.up,
 		down: migration069.down
+	},
+	{
+		id: '070',
+		description: migration070.description,
+		up: migration070.up,
+		down: migration070.down
 	}
 ];
 

--- a/backend/database/queries/index.ts
+++ b/backend/database/queries/index.ts
@@ -5,6 +5,7 @@ export { messageQueries } from './message-queries';
 export { settingsQueries } from './settings-queries';
 export { dbUtils } from './utils-queries';
 export { snapshotQueries } from './snapshot-queries';
+export { worktreeQueries } from './worktree-queries';
 export { checkpointQueries } from './checkpoint-queries';
 export { engineQueries } from './engine-queries';
 export { authQueries } from './auth-queries';

--- a/backend/database/queries/session-queries.ts
+++ b/backend/database/queries/session-queries.ts
@@ -41,8 +41,8 @@ export const sessionQueries = {
 		const newSession = { id, ...session };
 
 		db.prepare(`
-			INSERT INTO chat_sessions (id, project_id, title, engine, head_session_id, head_message_id, started_at, ended_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			INSERT INTO chat_sessions (id, project_id, title, engine, head_session_id, head_message_id, started_at, ended_at, worktree_id)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`).run(
 			id,
 			session.project_id,
@@ -51,7 +51,8 @@ export const sessionQueries = {
 			session.head_session_id || null,
 			session.head_message_id || null,
 			session.started_at,
-			session.ended_at || null
+			session.ended_at || null,
+			session.worktree_id || null
 		);
 
 		return newSession;
@@ -104,6 +105,14 @@ export const sessionQueries = {
 	},
 
 	/** Persist the active profile for a session (NULL clears it). */
+	/** Bind a session to a worktree; null puts it back on the main project tree. */
+	setWorktree(id: string, worktreeId: string | null): void {
+		const db = getDatabase();
+		db.prepare(`
+			UPDATE chat_sessions SET worktree_id = ? WHERE id = ?
+		`).run(worktreeId, id);
+	},
+
 	updateProfile(id: string, profileId: number | null): void {
 		const db = getDatabase();
 		db.prepare(`
@@ -440,14 +449,37 @@ export const sessionQueries = {
 	 * Get the active shared session for a project
 	 * Returns the most recent session that hasn't ended
 	 */
-	getActiveSessionForProject(projectId: string): ChatSession | null {
+	/**
+	 * Most recent active session, optionally restricted to one worktree.
+	 * `worktreeId` undefined means "any"; null means "the main tree only".
+	 */
+	getActiveSessionForProject(projectId: string, worktreeId?: string | null): ChatSession | null {
 		const db = getDatabase();
+
+		if (worktreeId === undefined) {
+			return db.prepare(`
+				SELECT * FROM chat_sessions
+				WHERE project_id = ? AND ended_at IS NULL
+				ORDER BY started_at DESC
+				LIMIT 1
+			`).get(projectId) as ChatSession | null;
+		}
+
+		if (worktreeId === null) {
+			return db.prepare(`
+				SELECT * FROM chat_sessions
+				WHERE project_id = ? AND ended_at IS NULL AND worktree_id IS NULL
+				ORDER BY started_at DESC
+				LIMIT 1
+			`).get(projectId) as ChatSession | null;
+		}
+
 		return db.prepare(`
-			SELECT * FROM chat_sessions 
-			WHERE project_id = ? AND ended_at IS NULL
+			SELECT * FROM chat_sessions
+			WHERE project_id = ? AND ended_at IS NULL AND worktree_id = ?
 			ORDER BY started_at DESC
 			LIMIT 1
-		`).get(projectId) as ChatSession | null;
+		`).get(projectId, worktreeId) as ChatSession | null;
 	},
 
 	/**
@@ -468,10 +500,16 @@ export const sessionQueries = {
 	 * When forceNew=true, creates a new session WITHOUT ending existing ones
 	 * (multiple sessions can be active in parallel).
 	 */
-	getOrCreateSharedSession(projectId: string, projectName: string, forceNew: boolean = false): ChatSession {
+	getOrCreateSharedSession(
+		projectId: string,
+		projectName: string,
+		forceNew: boolean = false,
+		worktreeId: string | null = null
+	): ChatSession {
 		if (!forceNew) {
-			// Return most recent active session if exists
-			const activeSession = this.getActiveSessionForProject(projectId);
+			// Reuse only within the same tree — a session bound to a worktree is
+			// not a substitute for one on main, and vice versa.
+			const activeSession = this.getActiveSessionForProject(projectId, worktreeId);
 			if (activeSession) {
 				return activeSession;
 			}
@@ -484,7 +522,8 @@ export const sessionQueries = {
 			title: `Shared Chat - ${projectName} (${new Date().toLocaleString()})`,
 			started_at: now,
 			ended_at: undefined,
-			head_session_id: undefined
+			head_session_id: undefined,
+			worktree_id: worktreeId
 		});
 	},
 

--- a/backend/database/queries/worktree-queries.ts
+++ b/backend/database/queries/worktree-queries.ts
@@ -1,0 +1,148 @@
+/**
+ * Database queries for worktrees — isolated project copies that sessions run in.
+ */
+
+import type { Worktree, WorktreeCloneMode, WorktreeStatus } from '$shared/types/database/schema';
+import type { TreeMap } from '../../snapshot/blob-store';
+import { getDatabase } from '../index';
+
+export const worktreeQueries = {
+	getByProjectId(projectId: string): Worktree[] {
+		const db = getDatabase();
+		return db.prepare(`
+			SELECT * FROM worktrees
+			WHERE project_id = ?
+			ORDER BY created_at DESC
+		`).all(projectId) as Worktree[];
+	},
+
+	getById(id: string): Worktree | null {
+		const db = getDatabase();
+		return db.prepare(`SELECT * FROM worktrees WHERE id = ?`).get(id) as Worktree | null;
+	},
+
+	getByPath(worktreePath: string): Worktree | null {
+		const db = getDatabase();
+		return db.prepare(`SELECT * FROM worktrees WHERE path = ?`).get(worktreePath) as Worktree | null;
+	},
+
+	getBySlug(projectId: string, slug: string): Worktree | null {
+		const db = getDatabase();
+		return db.prepare(`
+			SELECT * FROM worktrees WHERE project_id = ? AND slug = ?
+		`).get(projectId, slug) as Worktree | null;
+	},
+
+	create(input: {
+		project_id: string;
+		name: string;
+		slug: string;
+		path: string;
+		clone_mode: WorktreeCloneMode;
+		base_tree: TreeMap;
+		created_by?: string | null;
+	}): Worktree {
+		const db = getDatabase();
+		const id = crypto.randomUUID();
+		const now = new Date().toISOString();
+
+		const worktree: Worktree = {
+			id,
+			project_id: input.project_id,
+			name: input.name,
+			slug: input.slug,
+			path: input.path,
+			status: 'active',
+			clone_mode: input.clone_mode,
+			base_tree: JSON.stringify(input.base_tree),
+			created_by: input.created_by ?? null,
+			created_at: now,
+			last_opened_at: now,
+			last_applied_at: null
+		};
+
+		db.prepare(`
+			INSERT INTO worktrees (
+				id, project_id, name, slug, path, status, clone_mode,
+				base_tree, created_by, created_at, last_opened_at, last_applied_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+		`).run(
+			worktree.id,
+			worktree.project_id,
+			worktree.name,
+			worktree.slug,
+			worktree.path,
+			worktree.status,
+			worktree.clone_mode,
+			worktree.base_tree,
+			worktree.created_by,
+			worktree.created_at,
+			worktree.last_opened_at
+		);
+
+		return worktree;
+	},
+
+	rename(id: string, name: string): void {
+		const db = getDatabase();
+		db.prepare(`UPDATE worktrees SET name = ? WHERE id = ?`).run(name, id);
+	},
+
+	touch(id: string): void {
+		const db = getDatabase();
+		db.prepare(`UPDATE worktrees SET last_opened_at = ? WHERE id = ?`)
+			.run(new Date().toISOString(), id);
+	},
+
+	setStatus(id: string, status: WorktreeStatus): void {
+		const db = getDatabase();
+		db.prepare(`UPDATE worktrees SET status = ? WHERE id = ?`).run(status, id);
+	},
+
+	/** Record a successful apply and re-base the worktree onto the tree it just produced. */
+	markApplied(id: string, baseTree: TreeMap): void {
+		const db = getDatabase();
+		db.prepare(`
+			UPDATE worktrees SET status = 'applied', last_applied_at = ?, base_tree = ?
+			WHERE id = ?
+		`).run(new Date().toISOString(), JSON.stringify(baseTree), id);
+	},
+
+	/** Re-base without changing status — used by sync-from-main. */
+	updateBaseTree(id: string, baseTree: TreeMap): void {
+		const db = getDatabase();
+		db.prepare(`UPDATE worktrees SET base_tree = ? WHERE id = ?`)
+			.run(JSON.stringify(baseTree), id);
+	},
+
+	delete(id: string): void {
+		const db = getDatabase();
+		// Sessions outlive their worktree: they fall back to the main tree rather
+		// than disappearing with it, so only the pointer is cleared.
+		db.prepare(`UPDATE chat_sessions SET worktree_id = NULL WHERE worktree_id = ?`).run(id);
+		db.prepare(`DELETE FROM worktrees WHERE id = ?`).run(id);
+	},
+
+	deleteByProjectId(projectId: string): Worktree[] {
+		const db = getDatabase();
+		const worktrees = this.getByProjectId(projectId);
+		db.prepare(`DELETE FROM worktrees WHERE project_id = ?`).run(projectId);
+		return worktrees;
+	},
+
+	countSessions(worktreeId: string): number {
+		const db = getDatabase();
+		const row = db.prepare(`
+			SELECT COUNT(*) AS total FROM chat_sessions WHERE worktree_id = ?
+		`).get(worktreeId) as { total: number } | undefined;
+		return row?.total ?? 0;
+	},
+
+	parseBaseTree(worktree: Worktree): TreeMap {
+		try {
+			return JSON.parse(worktree.base_tree) as TreeMap;
+		} catch {
+			return {};
+		}
+	}
+};

--- a/backend/files/file-watcher.ts
+++ b/backend/files/file-watcher.ts
@@ -33,6 +33,7 @@ import { stat, readdir } from 'node:fs/promises';
 import { join, relative, normalize, sep } from 'node:path';
 import { ws } from '$backend/utils/ws';
 import { debug } from '$shared/utils/logger';
+import { isScopeOfProject, scopeProjectId } from '$shared/utils/workspace-scope';
 import { resolveGitDirs, type GitDirTarget } from '$backend/git/git-dirs';
 import {
 	beginWatchedDiscovery,
@@ -413,7 +414,7 @@ class FileWatcherManager {
 					'file',
 					`Watch ceiling (${MAX_WATCHED_DIRS} dirs) reached for project ${pw.projectId}; deeper directories will not report changes`
 				);
-				ws.emit.project(pw.projectId, 'files:watch-error', {
+				ws.emit.project(scopeProjectId(pw.projectId), 'files:watch-error', {
 					projectId: pw.projectId,
 					error: `Project is too large to watch entirely (${MAX_WATCHED_DIRS}+ directories). Changes in deeply nested folders may not appear automatically.`
 				});
@@ -592,6 +593,17 @@ class FileWatcherManager {
 	}
 
 	/**
+	 * Release every workspace of a project — the main tree and each worktree.
+	 * Watchers are keyed per workspace, so releasing the project id alone would
+	 * leave a deleted project's worktree watchers running.
+	 */
+	releaseProjectScopes(projectId: string): void {
+		for (const key of [...this.watchers.keys(), ...this.viewers.keys()]) {
+			if (isScopeOfProject(key, projectId)) this.releaseProject(key);
+		}
+	}
+
+	/**
 	 * Check if a project is being watched
 	 */
 	isWatching(projectId: string): boolean {
@@ -733,7 +745,7 @@ class FileWatcherManager {
 		projectWatcher.debounceTimer = null;
 
 		// Emit changes to users currently viewing the project
-		ws.emit.project(projectId, 'files:changed', {
+		ws.emit.project(scopeProjectId(projectId), 'files:changed', {
 			projectId,
 			changes,
 			timestamp: Date.now()
@@ -948,7 +960,7 @@ class FileWatcherManager {
 			projectWatcher.gitDebounceTimer = null;
 			const repoPaths = Array.from(projectWatcher.pendingGitRepos);
 			projectWatcher.pendingGitRepos.clear();
-			ws.emit.project(projectId, 'git:changed', {
+			ws.emit.project(scopeProjectId(projectId), 'git:changed', {
 				projectId,
 				repoPaths,
 				timestamp: Date.now()
@@ -985,7 +997,7 @@ class FileWatcherManager {
 				'file',
 				`Watcher for project ${projectId} faulted ${attempt} times; giving up on automatic restart`
 			);
-			ws.emit.project(projectId, 'files:watch-error', {
+			ws.emit.project(scopeProjectId(projectId), 'files:watch-error', {
 				projectId,
 				error: 'File watching stopped after repeated failures. Refresh to retry.'
 			});
@@ -1017,7 +1029,7 @@ class FileWatcherManager {
 			// reconcile — deliberately NOT via `files:changed`, which means "these
 			// specific paths changed" and made consumers tear down and rebuild live
 			// views (the open diff editor) on every restart.
-			ws.emit.project(projectId, 'files:resync', {
+			ws.emit.project(scopeProjectId(projectId), 'files:resync', {
 				projectId,
 				timestamp: Date.now()
 			});

--- a/backend/mcp/internal/servers/browser-automation/context.ts
+++ b/backend/mcp/internal/servers/browser-automation/context.ts
@@ -11,6 +11,8 @@
 import { browserMcpControl, browserPreviewServiceManager, type BrowserPreviewService } from '$backend/preview';
 import type { BrowserTab } from '$backend/preview/browser/types';
 import { projectContextService } from '$backend/mcp/internal/project-context';
+import { sessionQueries } from '$backend/database/queries';
+import { makeScopeKey } from '$shared/utils/workspace-scope';
 import { debug } from '$shared/utils/logger';
 
 /**
@@ -22,10 +24,10 @@ import { debug } from '$shared/utils/logger';
  * because acting on a guessed project is worth noticing in the logs.
  */
 export function getPreviewService(projectId?: string): BrowserPreviewService {
-	if (projectId) return browserPreviewServiceManager.getService(projectId);
+	if (projectId) return browserPreviewServiceManager.getService(scopeForProject(projectId));
 
 	const contextProjectId = projectContextService.getCurrentProjectId();
-	if (contextProjectId) return browserPreviewServiceManager.getService(contextProjectId);
+	if (contextProjectId) return browserPreviewServiceManager.getService(scopeForProject(contextProjectId));
 
 	const activeProjects = browserPreviewServiceManager.getActiveProjects();
 	if (activeProjects.length > 0) {
@@ -34,6 +36,18 @@ export function getPreviewService(projectId?: string): BrowserPreviewService {
 	}
 
 	throw new Error('No active browser preview service found. Project isolation requires projectId.');
+}
+
+/**
+ * Workspace scope of the session driving this call, so an agent working in a
+ * worktree drives that worktree's browser rather than the main tree's.
+ */
+function scopeForProject(projectId: string): string {
+	const chatSessionId = projectContextService.getCurrentChatSessionId();
+	const worktreeId = chatSessionId
+		? sessionQueries.getById(chatSessionId)?.worktree_id ?? null
+		: null;
+	return makeScopeKey(projectId, worktreeId);
 }
 
 /** The chat session driving this call — MCP control is scoped to it. */

--- a/backend/preview/browser/browser-preview-service.ts
+++ b/backend/preview/browser/browser-preview-service.ts
@@ -12,6 +12,7 @@ import { browserMcpControl } from './browser-mcp-control.js';
 import { ws } from '$backend/utils/ws';
 import { getViewportDimensions } from '$shared/constants/preview.js';
 import { debug } from '$shared/utils/logger';
+import { scopeProjectId } from '$shared/utils/workspace-scope';
 import type {
 	BrowserTab,
 	BrowserTabInfo,
@@ -1107,13 +1108,18 @@ class BrowserPreviewServiceManager {
 	private setupWebSocketForwarding(service: BrowserPreviewService, projectId: string): void {
 		debug.log('preview', `🔌 Setting up WebSocket forwarding for project: ${projectId}...`);
 
+		// `projectId` is a workspace scope key: it separates a worktree's tabs from
+		// the main tree's. Rooms are keyed by the real project, so events go there
+		// and each client filters on the scope carried in the payload.
+		const roomId = scopeProjectId(projectId);
+
 		// Forward WebCodecs events.
 		//
 		// The room is the whole project, so several viewers of the same tab all
 		// receive these. `viewerId` is what lets each of them recognise the half
 		// of the handshake that is theirs.
 		service.on('preview:browser-webcodecs-ice-candidate', (data) => {
-			ws.emit.project(projectId, 'preview:browser-stream-ice', {
+			ws.emit.project(roomId, 'preview:browser-stream-ice', {
 				sessionId: data.sessionId,
 				viewerId: data.viewerId,
 				candidate: data.candidate,
@@ -1122,25 +1128,25 @@ class BrowserPreviewServiceManager {
 		});
 
 		service.on('preview:browser-webcodecs-connection-state', (data) => {
-			ws.emit.project(projectId, 'preview:browser-stream-state', data);
+			ws.emit.project(roomId, 'preview:browser-stream-state', data);
 		});
 
 		service.on('preview:browser-cursor-change', (data) => {
-			ws.emit.project(projectId, 'preview:browser-cursor-change', data);
+			ws.emit.project(roomId, 'preview:browser-cursor-change', data);
 		});
 
 		// Forward navigation events
 		service.on('preview:browser-navigation-loading', (data) => {
-			ws.emit.project(projectId, 'preview:browser-navigation-loading', data);
+			ws.emit.project(roomId, 'preview:browser-navigation-loading', data);
 		});
 
 		service.on('preview:browser-navigation', (data) => {
-			ws.emit.project(projectId, 'preview:browser-navigation', data);
+			ws.emit.project(roomId, 'preview:browser-navigation', data);
 		});
 
 		// Forward SPA navigation events (pushState/replaceState — URL-only update)
 		service.on('preview:browser-navigation-spa', (data) => {
-			ws.emit.project(projectId, 'preview:browser-navigation-spa', data);
+			ws.emit.project(roomId, 'preview:browser-navigation-spa', data);
 		});
 
 		// Forward tab events. Each carries projectId so the frontend can drop
@@ -1149,113 +1155,113 @@ class BrowserPreviewServiceManager {
 		// project the user is now viewing.
 		service.on('preview:browser-tab-opened', (data) => {
 			debug.log('preview', `🚀 Forwarding preview:browser-tab-opened to project ${projectId}:`, data);
-			ws.emit.project(projectId, 'preview:browser-tab-opened', { ...data, projectId });
+			ws.emit.project(roomId, 'preview:browser-tab-opened', { ...data, projectId });
 		});
 
 		service.on('preview:browser-tab-closed', (data) => {
-			ws.emit.project(projectId, 'preview:browser-tab-closed', { ...data, projectId });
+			ws.emit.project(roomId, 'preview:browser-tab-closed', { ...data, projectId });
 		});
 
 		service.on('preview:browser-tab-switched', (data) => {
-			ws.emit.project(projectId, 'preview:browser-tab-switched', { ...data, projectId });
+			ws.emit.project(roomId, 'preview:browser-tab-switched', { ...data, projectId });
 		});
 
 		service.on('preview:browser-tab-navigated', (data) => {
-			ws.emit.project(projectId, 'preview:browser-tab-navigated', { ...data, projectId });
+			ws.emit.project(roomId, 'preview:browser-tab-navigated', { ...data, projectId });
 		});
 
 		service.on('preview:browser-viewport-changed', (data) => {
-			ws.emit.project(projectId, 'preview:browser-viewport-changed', { ...data, projectId });
+			ws.emit.project(roomId, 'preview:browser-viewport-changed', { ...data, projectId });
 		});
 
 		service.on('preview:browser-fullscreen-state', (data) => {
-			ws.emit.project(projectId, 'preview:browser-fullscreen-state', { ...data, projectId });
+			ws.emit.project(roomId, 'preview:browser-fullscreen-state', { ...data, projectId });
 		});
 
 		// Forward live tab metadata (title, favicon, back/forward availability)
 		service.on('preview:browser-tab-meta', (data) => {
-			ws.emit.project(projectId, 'preview:browser-tab-meta', { ...data, projectId });
+			ws.emit.project(roomId, 'preview:browser-tab-meta', { ...data, projectId });
 		});
 
 		// Forward host-capability requests (geolocation, camera, clipboard, …)
 		// and relayed downloads — both are answered by the viewer's own browser.
 		service.on('preview:browser-host-request', (data) => {
-			ws.emit.project(projectId, 'preview:browser-host-request', data);
+			ws.emit.project(roomId, 'preview:browser-host-request', data);
 		});
 
 		// Answered (or expired) — every viewer that was shown this prompt drops it.
 		service.on('preview:browser-host-request-settled', (data) => {
-			ws.emit.project(projectId, 'preview:browser-host-request-settled', data);
+			ws.emit.project(roomId, 'preview:browser-host-request-settled', data);
 		});
 
 		service.on('preview:browser-download', (data) => {
-			ws.emit.project(projectId, 'preview:browser-download', data);
+			ws.emit.project(roomId, 'preview:browser-download', data);
 		});
 
 		// Forward console events
 		service.on('preview:browser-console-message', (data) => {
-			ws.emit.project(projectId, 'preview:browser-console-message', data);
+			ws.emit.project(roomId, 'preview:browser-console-message', data);
 		});
 
 		service.on('preview:browser-console-clear', (data) => {
-			ws.emit.project(projectId, 'preview:browser-console-clear', data);
+			ws.emit.project(roomId, 'preview:browser-console-clear', data);
 		});
 
 		// Forward dialog events
 		service.on('preview:browser-dialog', (data) => {
-			ws.emit.project(projectId, 'preview:browser-dialog', data);
+			ws.emit.project(roomId, 'preview:browser-dialog', data);
 		});
 
 		// A dialog belongs to the page, not to whoever answered it: every viewer
 		// was shown the same prompt, so all of them are told it is settled.
 		service.on('preview:browser-dialog-closed', (data) => {
-			ws.emit.project(projectId, 'preview:browser-dialog-closed', data);
+			ws.emit.project(roomId, 'preview:browser-dialog-closed', data);
 		});
 
 		service.on('preview:browser-print', (data) => {
-			ws.emit.project(projectId, 'preview:browser-print', data);
+			ws.emit.project(roomId, 'preview:browser-print', data);
 		});
 
 		// Forward native UI events
 		service.on('preview:browser-native-picker', (data) => {
-			ws.emit.project(projectId, 'preview:browser-native-picker', data);
+			ws.emit.project(roomId, 'preview:browser-native-picker', data);
 		});
 
 		service.on('preview:browser-select', (data) => {
-			ws.emit.project(projectId, 'preview:browser-select', data);
+			ws.emit.project(roomId, 'preview:browser-select', data);
 		});
 
 		service.on('preview:browser-context-menu', (data) => {
-			ws.emit.project(projectId, 'preview:browser-context-menu', data);
+			ws.emit.project(roomId, 'preview:browser-context-menu', data);
 		});
 
 		service.on('preview:browser-copy-to-clipboard', (data) => {
-			ws.emit.project(projectId, 'preview:browser-copy-to-clipboard', data);
+			ws.emit.project(roomId, 'preview:browser-copy-to-clipboard', data);
 		});
 
 		service.on('preview:browser-open-url-new-tab', (data) => {
-			ws.emit.project(projectId, 'preview:browser-open-url-new-tab', data);
+			ws.emit.project(roomId, 'preview:browser-open-url-new-tab', data);
 		});
 
 		service.on('preview:browser-download-image', (data) => {
-			ws.emit.project(projectId, 'preview:browser-download-image', data);
+			ws.emit.project(roomId, 'preview:browser-download-image', data);
 		});
 
 		service.on('preview:browser-open-url-host', (data) => {
-			ws.emit.project(projectId, 'preview:browser-open-url-host', data);
+			ws.emit.project(roomId, 'preview:browser-open-url-host', data);
 		});
 
 		service.on('preview:browser-open-inspector', (data) => {
-			ws.emit.project(projectId, 'preview:browser-open-inspector', data);
+			ws.emit.project(roomId, 'preview:browser-open-inspector', data);
 		});
 
 		service.on('preview:browser-copy-image-to-clipboard', (data) => {
-			ws.emit.project(projectId, 'preview:browser-copy-image-to-clipboard', data);
+			ws.emit.project(roomId, 'preview:browser-copy-image-to-clipboard', data);
 		});
 
 		// Forward new window events
 		service.on('preview:browser-new-window', (data) => {
-			ws.emit.project(projectId, 'preview:browser-new-window', data);
+			ws.emit.project(roomId, 'preview:browser-new-window', data);
 		});
 
 		// MCP control events come from the singleton browserMcpControl, so their

--- a/backend/preview/browser/browser-tab-manager.ts
+++ b/backend/preview/browser/browser-tab-manager.ts
@@ -8,6 +8,7 @@ import { BrowserAudioCapture } from './browser-audio-capture';
 import { cursorTrackingScript } from './scripts/cursor-tracking';
 import { browserMcpControl } from './browser-mcp-control';
 import { debug } from '$shared/utils/logger';
+import { scopeSlug } from '$shared/utils/workspace-scope';
 
 // Tab cleanup configuration
 const INACTIVE_TIMEOUT = 5 * 60 * 1000; // 5 minutes
@@ -83,7 +84,9 @@ export class BrowserTabManager extends EventEmitter {
 			preNavigationSetup?: (page: Page, tabId: string) => Promise<void>;
 		}
 	): Promise<BrowserTab> {
-		const tabId = `tab-${this.nextTabNumber++}`;
+		// The counter restarts per workspace, so the scope token is what stops a
+		// worktree's `tab-1` from being matched as the main tree's on the client.
+		const tabId = `tab-${scopeSlug(this.projectId)}-${this.nextTabNumber++}`;
 		const finalUrl = url || 'about:blank';
 
 		debug.log('preview', `🟡🟡🟡 Creating new tab: ${tabId} for project: ${this.projectId} 🟡🟡🟡`);

--- a/backend/projects/project-cleanup.integration.test.ts
+++ b/backend/projects/project-cleanup.integration.test.ts
@@ -3,7 +3,7 @@ import { projectCleanupRegistry, runProjectCleanups } from './project-cleanup-re
 
 import './project-cleanup';
 
-const DEFAULT_CLEANUP_HANDLERS = ['engine', 'mcp-context', 'file-watcher', 'presence'] as const;
+const DEFAULT_CLEANUP_HANDLERS = ['engine', 'mcp-context', 'file-watcher', 'presence', 'worktrees'] as const;
 
 describe('project cleanup integration', () => {
 	test('registers default backend handlers when project-cleanup is loaded', () => {

--- a/backend/projects/project-cleanup.ts
+++ b/backend/projects/project-cleanup.ts
@@ -6,6 +6,7 @@ import { projectContextService } from '../mcp';
 import { fileWatcher } from '../files/file-watcher';
 import { clearProjectPresence } from '../project/status-manager';
 import { registerProjectCleanup } from './project-cleanup-registry';
+import { removeProjectWorktrees } from '../worktrees';
 
 registerProjectCleanup({
 	name: 'engine',
@@ -20,7 +21,7 @@ registerProjectCleanup({
 registerProjectCleanup({
 	name: 'file-watcher',
 	run: (projectId) => {
-		fileWatcher.releaseProject(projectId);
+		fileWatcher.releaseProjectScopes(projectId);
 	}
 });
 
@@ -29,4 +30,9 @@ registerProjectCleanup({
 	run: (projectId) => {
 		clearProjectPresence(projectId);
 	}
+});
+
+registerProjectCleanup({
+	name: 'worktrees',
+	run: (projectId) => removeProjectWorktrees(projectId)
 });

--- a/backend/snapshot/snapshot-service.ts
+++ b/backend/snapshot/snapshot-service.ts
@@ -21,6 +21,7 @@ import { getSnapshotFiles } from './gitignore';
 import { fileWatcher } from '../files/file-watcher';
 import type { MessageSnapshot, SessionScopedChanges } from '$shared/types/database/schema';
 import { calculateFileChangeStats } from '$shared/utils/diff-calculator';
+import { makeScopeKey } from '$shared/utils/workspace-scope';
 import { debug } from '$shared/utils/logger';
 
 interface SnapshotMetadata {
@@ -218,8 +219,11 @@ export class SnapshotService {
 			}
 
 			// The dirty set is no longer the snapshot source, but clear it so it does
-			// not grow unbounded for the Files panel UI.
-			fileWatcher.clearDirtyFiles(projectId);
+			// not grow unbounded for the Files panel UI. Keyed per workspace, so a
+			// worktree session must not clear the main tree's set.
+			fileWatcher.clearDirtyFiles(
+				makeScopeKey(projectId, sessionQueries.getById(sessionId)?.worktree_id ?? null)
+			);
 
 			// No changes vs the baseline → reuse the existing head snapshot.
 			if (Object.keys(sessionChanges).length === 0 && previousSnapshot) {

--- a/backend/terminal/ptykit.ts
+++ b/backend/terminal/ptykit.ts
@@ -7,13 +7,14 @@
  * There is no second WebSocket — the server is driven over Clopen's existing
  * app-wide socket via `handleFrame` (see `backend/ws/terminal/tunnel.ts`).
  *
- * - `namespace` = Clopen `projectId` (collaborative room + anti-hijack scope).
+ * - `namespace` = workspace scope key (project, or one of its worktrees).
  * - `authorize` bridges to Clopen's project-access check.
  */
 
 import { PtyKitManager } from '@myrialabs/ptykit/core';
 import { createPtyKitServer } from '@myrialabs/ptykit/server';
 import { projectQueries } from '$backend/database/queries';
+import { isScopeOfProject, makeScopeKey, scopeProjectId } from '$shared/utils/workspace-scope';
 
 /** Terminal-friendly env, matching the previous `createCleanPtyEnv` overrides. */
 const TERMINAL_ENV = {
@@ -46,19 +47,47 @@ export const ptyKitServer = createPtyKitServer(ptyKitManager, {
 	authorize: (ctx) => {
 		const userId = ctx.conn.data.userId;
 		if (typeof userId !== 'string' || !userId) return false;
-		return projectQueries.userHasProject(userId, ctx.namespace);
+		// The namespace separates worktrees; access is still the project's call.
+		const allowed = projectQueries.userHasProject(userId, scopeProjectId(ctx.namespace));
+		if (allowed) knownNamespaces.add(ctx.namespace);
+		return allowed;
 	}
 });
 
 /**
- * Kill every PTY session belonging to a project (namespace). Used on project
- * delete/remove to reap orphaned shells. Returns the number killed.
+ * Namespaces this process has served. PtyKit lists sessions per namespace only,
+ * so reaping a whole project needs the set of its workspace scopes.
  */
-export function cleanupProjectSessions(projectId: string): number {
+const knownNamespaces = new Set<string>();
+
+/** Kill every session in one namespace. */
+function killNamespace(namespace: string): number {
 	let killed = 0;
-	for (const session of ptyKitManager.list(projectId)) {
+	for (const session of ptyKitManager.list(namespace)) {
 		ptyKitManager.killSession(session.sessionId, 'SIGKILL');
 		killed++;
 	}
+	return killed;
+}
+
+/**
+ * Kill every PTY session belonging to a project, across the main tree and all
+ * of its worktrees. Used on project delete/remove to reap orphaned shells.
+ */
+export function cleanupProjectSessions(projectId: string): number {
+	let killed = 0;
+	for (const namespace of knownNamespaces) {
+		if (!isScopeOfProject(namespace, projectId)) continue;
+		killed += killNamespace(namespace);
+		knownNamespaces.delete(namespace);
+	}
+	return killed;
+}
+
+/** Kill every PTY session inside one worktree — used when it is deleted. */
+export function cleanupWorktreeSessions(projectId: string, worktreeId: string): number {
+	const namespace = makeScopeKey(projectId, worktreeId);
+	const killed = killNamespace(namespace);
+	knownNamespaces.delete(namespace);
 	return killed;
 }

--- a/backend/utils/ws.ts
+++ b/backend/utils/ws.ts
@@ -64,6 +64,8 @@ interface WSMetrics {
 interface ConnectionState {
 	userId: string | null;
 	projectId: string | null;
+	/** Worktree this connection is viewing; null = the main project tree */
+	worktreeId: string | null;
 	/** Chat session IDs this connection is subscribed to */
 	chatSessionIds: Set<string>;
 	/** Cleanup functions called automatically on unregister (connection close) */
@@ -149,7 +151,7 @@ class WSServer {
 		const id = crypto.randomUUID();
 		this.rawToId.set(raw, id);
 		this.connections.set(id, conn);
-		this.connectionState.set(id, { userId: null, projectId: null, chatSessionIds: new Set(), cleanups: new Set(), authenticated: false, role: null, sessionTokenHash: null, lastSessionCheck: 0 });
+		this.connectionState.set(id, { userId: null, projectId: null, worktreeId: null, chatSessionIds: new Set(), cleanups: new Set(), authenticated: false, role: null, sessionTokenHash: null, lastSessionCheck: 0 });
 
 		this.metrics.totalConnections = this.connections.size;
 		debug.log('websocket', `Connection registered: ${id} (total: ${this.connections.size})`);
@@ -366,6 +368,9 @@ class WSServer {
 		// Update connection state
 		if (state) {
 			state.projectId = projectId;
+			// A worktree belongs to one project; carrying it across would point
+			// the connection at a tree the new project does not own.
+			if (oldProjectId !== projectId) state.worktreeId = null;
 		}
 
 		// Add to new project room by ID (Map.set replaces if same key → no duplicates)
@@ -388,6 +393,21 @@ class WSServer {
 
 		this.metrics.activeProjects = this.projectRooms.size;
 		debug.log('websocket', `Connection ${wsId} set to project: ${projectId}`);
+	}
+
+	/** Set the worktree this connection is viewing (null = main tree). */
+	setWorktree(conn: WSConnection, worktreeId: string | null): void {
+		const wsId = this.ensureRegistered(conn);
+		const state = this.connectionState.get(wsId);
+		if (state) state.worktreeId = worktreeId;
+		debug.log('websocket', `Connection ${wsId} set to worktree: ${worktreeId ?? 'main'}`);
+	}
+
+	/** Worktree this connection is viewing, or null for the main project tree. */
+	getWorktreeId(conn: WSConnection): string | null {
+		const id = this.resolveId(conn);
+		if (!id) return null;
+		return this.connectionState.get(id)?.worktreeId ?? null;
 	}
 
 	/**

--- a/backend/worktrees/clone.ts
+++ b/backend/worktrees/clone.ts
@@ -1,0 +1,222 @@
+/**
+ * Materialising a worktree from the main tree.
+ *
+ * Preferred path is a copy-on-write clone (`COPYFILE_FICLONE`): on APFS, btrfs
+ * and reflink-capable XFS this is near-instant and costs no extra disk until a
+ * file is written, so the worktree can carry everything the project needs to
+ * actually run — `.git`, `node_modules`, `.env` — not just tracked files.
+ *
+ * Where reflink is unavailable (different volume, ext4 without reflink, NTFS)
+ * a real byte copy of that much data would be unacceptable, so the clone falls
+ * back to gitignore-eligible files plus `.git` and the caller is told to run a
+ * setup command for dependencies.
+ */
+
+import fs from 'fs/promises';
+import { constants as fsConstants, type Dirent } from 'fs';
+import path from 'path';
+import type { WorktreeCloneMode } from '$shared/types/database/schema';
+import { debug } from '$shared/utils/logger';
+import { getSnapshotFiles } from '../snapshot/gitignore';
+
+/** Above this many entries a full-tree walk is refused and the lean clone is used. */
+const MAX_FULL_CLONE_ENTRIES = 200_000;
+
+/** Never copied — process-local state that must not be shared between trees. */
+const NEVER_CLONE = new Set(['.DS_Store', '.clopen-reflink-probe']);
+
+export interface CloneResult {
+	mode: WorktreeCloneMode;
+	fileCount: number;
+	/** True when ignored files (dependencies, .env) were carried over. */
+	carriedIgnoredFiles: boolean;
+}
+
+/**
+ * Probe whether `targetDir` can hold reflinks of files from `sourceDir`.
+ * Uses a real file from the project so the answer accounts for both filesystems.
+ */
+export async function probeReflinkSupport(sourceDir: string, targetDir: string): Promise<boolean> {
+	const probeSource = await findProbeFile(sourceDir);
+	if (!probeSource) return false;
+
+	const probeTarget = path.join(targetDir, '.clopen-reflink-probe');
+	try {
+		await fs.copyFile(probeSource, probeTarget, fsConstants.COPYFILE_FICLONE_FORCE);
+		return true;
+	} catch {
+		return false;
+	} finally {
+		await fs.rm(probeTarget, { force: true }).catch(() => {});
+	}
+}
+
+/** Find a small regular file to probe with; returns null for an empty project. */
+async function findProbeFile(dirPath: string): Promise<string | null> {
+	let entries: Dirent[];
+	try {
+		entries = await fs.readdir(dirPath, { withFileTypes: true });
+	} catch {
+		return null;
+	}
+
+	for (const entry of entries) {
+		if (!entry.isFile()) continue;
+		const full = path.join(dirPath, entry.name);
+		try {
+			const stat = await fs.stat(full);
+			if (stat.size > 0 && stat.size < 1024 * 1024) return full;
+		} catch {
+			// Unreadable — try the next one
+		}
+	}
+
+	// No usable file at the top level; one level down is enough to decide.
+	for (const entry of entries) {
+		if (!entry.isDirectory() || entry.name === '.git') continue;
+		const nested = await findProbeFile(path.join(dirPath, entry.name));
+		if (nested) return nested;
+	}
+
+	return null;
+}
+
+/**
+ * Clone `sourceRoot` into `targetRoot`.
+ * `targetRoot` must already exist and be empty.
+ */
+export async function cloneTree(sourceRoot: string, targetRoot: string): Promise<CloneResult> {
+	const canReflink = await probeReflinkSupport(sourceRoot, targetRoot);
+
+	if (canReflink) {
+		const entries = await enumerateFullTree(sourceRoot);
+		if (entries !== null) {
+			const fileCount = await copyEntries(sourceRoot, targetRoot, entries);
+			debug.log('worktree', `Cloned ${fileCount} entries via reflink: ${targetRoot}`);
+			return { mode: 'reflink', fileCount, carriedIgnoredFiles: true };
+		}
+		debug.warn('worktree', `Tree too large for a full clone, falling back to tracked files: ${sourceRoot}`);
+	}
+
+	const lean = await enumerateLeanTree(sourceRoot);
+	const fileCount = await copyEntries(sourceRoot, targetRoot, lean);
+	debug.log('worktree', `Cloned ${fileCount} tracked files: ${targetRoot}`);
+	return { mode: canReflink ? 'reflink' : 'copy', fileCount, carriedIgnoredFiles: false };
+}
+
+/** Relative paths of everything under a root, split by kind. */
+interface TreeEntries {
+	dirs: string[];
+	files: string[];
+	symlinks: string[];
+}
+
+/**
+ * Walk everything under `root`, including ignored files and `.git`.
+ * Returns null when the tree exceeds `MAX_FULL_CLONE_ENTRIES`.
+ */
+async function enumerateFullTree(root: string): Promise<TreeEntries | null> {
+	const entries: TreeEntries = { dirs: [], files: [], symlinks: [] };
+	const queue: string[] = [''];
+	let total = 0;
+
+	while (queue.length > 0) {
+		const relativeDir = queue.pop() as string;
+		let dirEntries: Dirent[];
+		try {
+			dirEntries = await fs.readdir(path.join(root, relativeDir), { withFileTypes: true });
+		} catch {
+			continue;
+		}
+
+		for (const entry of dirEntries) {
+			if (NEVER_CLONE.has(entry.name)) continue;
+			const relativePath = relativeDir ? path.join(relativeDir, entry.name) : entry.name;
+
+			if (++total > MAX_FULL_CLONE_ENTRIES) return null;
+
+			if (entry.isSymbolicLink()) {
+				entries.symlinks.push(relativePath);
+			} else if (entry.isDirectory()) {
+				entries.dirs.push(relativePath);
+				queue.push(relativePath);
+			} else if (entry.isFile()) {
+				entries.files.push(relativePath);
+			}
+		}
+	}
+
+	return entries;
+}
+
+/** Tracked/untracked-not-ignored files, plus `.git` so the Git panel still works. */
+async function enumerateLeanTree(root: string): Promise<TreeEntries> {
+	const entries: TreeEntries = { dirs: [], files: [], symlinks: [] };
+	const dirs = new Set<string>();
+
+	const snapshotFiles = await getSnapshotFiles(root);
+	for (const absolute of snapshotFiles) {
+		const relativePath = path.relative(root, absolute);
+		if (!relativePath || relativePath.startsWith('..')) continue;
+		entries.files.push(relativePath);
+		collectParentDirs(relativePath, dirs);
+	}
+
+	const gitDir = await enumerateFullTree(path.join(root, '.git'));
+	if (gitDir) {
+		dirs.add('.git');
+		for (const dir of gitDir.dirs) dirs.add(path.join('.git', dir));
+		for (const file of gitDir.files) entries.files.push(path.join('.git', file));
+		for (const link of gitDir.symlinks) entries.symlinks.push(path.join('.git', link));
+	}
+
+	entries.dirs = [...dirs].sort((a, b) => a.length - b.length);
+	return entries;
+}
+
+function collectParentDirs(relativePath: string, into: Set<string>): void {
+	let parent = path.dirname(relativePath);
+	while (parent && parent !== '.' && parent !== path.sep) {
+		into.add(parent);
+		parent = path.dirname(parent);
+	}
+}
+
+/** Create the directories, then clone files and re-create symlinks. */
+async function copyEntries(sourceRoot: string, targetRoot: string, entries: TreeEntries): Promise<number> {
+	for (const relativeDir of entries.dirs) {
+		await fs.mkdir(path.join(targetRoot, relativeDir), { recursive: true });
+	}
+
+	let copied = 0;
+
+	for (const relativeFile of entries.files) {
+		const source = path.join(sourceRoot, relativeFile);
+		const target = path.join(targetRoot, relativeFile);
+		try {
+			await fs.mkdir(path.dirname(target), { recursive: true });
+			// FICLONE (not FORCE): reflink where the filesystem supports it,
+			// plain copy where it does not, without a second code path.
+			await fs.copyFile(source, target, fsConstants.COPYFILE_FICLONE);
+			copied++;
+		} catch (error) {
+			debug.warn('worktree', `Skipped ${relativeFile}: ${error}`);
+		}
+	}
+
+	// Symlinks are re-created, never followed — following them would duplicate
+	// whatever they point at and break links that are relative by design.
+	for (const relativeLink of entries.symlinks) {
+		try {
+			const linkTarget = await fs.readlink(path.join(sourceRoot, relativeLink));
+			const target = path.join(targetRoot, relativeLink);
+			await fs.mkdir(path.dirname(target), { recursive: true });
+			await fs.symlink(linkTarget, target);
+			copied++;
+		} catch (error) {
+			debug.warn('worktree', `Skipped symlink ${relativeLink}: ${error}`);
+		}
+	}
+
+	return copied;
+}

--- a/backend/worktrees/index.ts
+++ b/backend/worktrees/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Worktrees — isolated copies of a project that chat sessions can run in.
+ */
+
+export {
+	createWorktree,
+	countPendingChanges,
+	executeTransfer,
+	getWorktreeDiskUsage,
+	previewTransfer,
+	removeProjectWorktrees,
+	removeWorktree,
+	type TransferDirection,
+	type TransferPreview,
+	type TransferResult,
+	type WorktreeChange,
+	type WorktreeConflictPreview,
+	type WorktreeCreateResult
+} from './service';
+
+export {
+	resolveSessionPath,
+	resolveSessionRoot,
+	resolveWorktreeRoot,
+	type SessionRoot
+} from './resolve';
+
+export { planMerge, type MergeEntry, type MergePlan, type MergeResolution } from './merge';
+export { getProjectWorktreesDir, getWorktreePath, getWorktreesRootDir, isPathInside, slugifyWorktreeName, uniqueWorktreeSlug } from './paths';

--- a/backend/worktrees/merge.test.ts
+++ b/backend/worktrees/merge.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test';
+import { planMerge } from './merge';
+
+const HASH_A = 'aaaa';
+const HASH_B = 'bbbb';
+const HASH_C = 'cccc';
+
+describe('planMerge', () => {
+	test('carries a file the source added', () => {
+		const plan = planMerge({}, { 'new.ts': HASH_A }, {});
+
+		expect(plan.entries).toHaveLength(1);
+		expect(plan.entries[0]).toMatchObject({
+			path: 'new.ts',
+			status: 'added',
+			conflict: false
+		});
+	});
+
+	test('carries a file the source modified', () => {
+		const plan = planMerge({ 'a.ts': HASH_A }, { 'a.ts': HASH_B }, { 'a.ts': HASH_A });
+
+		expect(plan.entries[0]).toMatchObject({ path: 'a.ts', status: 'modified', conflict: false });
+	});
+
+	test('carries a file the source deleted', () => {
+		const plan = planMerge({ 'a.ts': HASH_A }, {}, { 'a.ts': HASH_A });
+
+		expect(plan.entries[0]).toMatchObject({ path: 'a.ts', status: 'deleted', conflict: false });
+	});
+
+	test('ignores files the source never touched', () => {
+		// The target moved on alone — a transfer must not drag it back to the base.
+		const plan = planMerge({ 'a.ts': HASH_A }, { 'a.ts': HASH_A }, { 'a.ts': HASH_B });
+
+		expect(plan.entries).toHaveLength(0);
+	});
+
+	test('ignores files where both sides made the same change', () => {
+		const plan = planMerge({ 'a.ts': HASH_A }, { 'a.ts': HASH_B }, { 'a.ts': HASH_B });
+
+		expect(plan.entries).toHaveLength(0);
+	});
+
+	test('flags a file both sides changed differently', () => {
+		const plan = planMerge({ 'a.ts': HASH_A }, { 'a.ts': HASH_B }, { 'a.ts': HASH_C });
+
+		expect(plan.conflicts).toHaveLength(1);
+		expect(plan.conflicts[0]).toMatchObject({
+			path: 'a.ts',
+			status: 'modified',
+			conflict: true,
+			baseHash: HASH_A,
+			sourceHash: HASH_B,
+			targetHash: HASH_C
+		});
+	});
+
+	test('flags a source edit against a target deletion', () => {
+		const plan = planMerge({ 'a.ts': HASH_A }, { 'a.ts': HASH_B }, {});
+
+		expect(plan.conflicts[0]).toMatchObject({
+			path: 'a.ts',
+			status: 'modified',
+			conflict: true,
+			targetHash: null
+		});
+	});
+
+	test('treats an add on both sides with different content as a conflict', () => {
+		const plan = planMerge({}, { 'a.ts': HASH_A }, { 'a.ts': HASH_B });
+
+		expect(plan.conflicts[0]).toMatchObject({ path: 'a.ts', status: 'added', conflict: true });
+	});
+
+	test('leaves an empty plan when nothing diverged', () => {
+		const tree = { 'a.ts': HASH_A, 'b.ts': HASH_B };
+		const plan = planMerge(tree, { ...tree }, { ...tree });
+
+		expect(plan.entries).toHaveLength(0);
+		expect(plan.conflicts).toHaveLength(0);
+	});
+
+	test('returns entries in a stable path order', () => {
+		const plan = planMerge(
+			{},
+			{ 'z.ts': HASH_A, 'a.ts': HASH_A, 'm.ts': HASH_A },
+			{}
+		);
+
+		expect(plan.entries.map((entry) => entry.path)).toEqual(['a.ts', 'm.ts', 'z.ts']);
+	});
+});

--- a/backend/worktrees/merge.ts
+++ b/backend/worktrees/merge.ts
@@ -1,0 +1,232 @@
+/**
+ * Three-way merge between a worktree and the main tree.
+ *
+ * The merge base is the tree recorded when the worktree was cloned, so a file
+ * is only in play when the source side actually changed it. When the target
+ * side changed the same file the entry is a conflict — resolvable line-by-line
+ * through `git merge-file` when both sides are text, and whole-file otherwise.
+ *
+ * `source` and `target` are direction-agnostic: applying runs worktree → main,
+ * syncing runs main → worktree, and both use this same planner.
+ */
+
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import type { TreeMap } from '../snapshot/blob-store';
+import { execGit } from '../git/git-executor';
+import { resolveBinary } from '../utils/cli';
+import { debug } from '$shared/utils/logger';
+import { readBlobText } from './tree';
+
+export type MergeEntryStatus = 'added' | 'modified' | 'deleted';
+
+/** What to do with one file: take the source side, keep the target, or merge both. */
+export type MergeResolution = 'source' | 'target' | 'merge';
+
+export interface MergeEntry {
+	path: string;
+	status: MergeEntryStatus;
+	baseHash: string | null;
+	sourceHash: string | null;
+	targetHash: string | null;
+	/** Target also moved away from the base, so taking the source would discard work. */
+	conflict: boolean;
+	/** A clean line-level merge of both sides is available. */
+	autoMergeable: boolean;
+}
+
+export interface MergePlan {
+	entries: MergeEntry[];
+	conflicts: MergeEntry[];
+}
+
+/**
+ * Decide which files transfer from source to target.
+ *
+ * Pure: the three trees are all it reads, which is what makes the interesting
+ * cases (both sides identical, both sides deleted, target-only edits) testable
+ * without touching a disk.
+ */
+export function planMerge(base: TreeMap, source: TreeMap, target: TreeMap): MergePlan {
+	const paths = new Set<string>([
+		...Object.keys(base),
+		...Object.keys(source),
+		...Object.keys(target)
+	]);
+
+	const entries: MergeEntry[] = [];
+
+	for (const filePath of [...paths].sort()) {
+		const baseHash = base[filePath] ?? null;
+		const sourceHash = source[filePath] ?? null;
+		const targetHash = target[filePath] ?? null;
+
+		// The source side never touched this file — nothing to carry over.
+		if (sourceHash === baseHash) continue;
+
+		// Both sides landed on the same content; the transfer is already done.
+		if (sourceHash === targetHash) continue;
+
+		const status: MergeEntryStatus =
+			sourceHash === null ? 'deleted' : baseHash === null ? 'added' : 'modified';
+
+		entries.push({
+			path: filePath,
+			status,
+			baseHash,
+			sourceHash,
+			targetHash,
+			conflict: targetHash !== baseHash,
+			autoMergeable: false
+		});
+	}
+
+	return { entries, conflicts: entries.filter((entry) => entry.conflict) };
+}
+
+/**
+ * Mark conflicts that `git merge-file` can resolve on its own.
+ * Runs before the user is asked anything, so the dialog only shows the files
+ * that genuinely need a decision.
+ */
+export async function markAutoMergeable(
+	plan: MergePlan,
+	sourceRoot: string,
+	targetRoot: string
+): Promise<MergePlan> {
+	if (!resolveBinary('git')) return plan;
+
+	for (const entry of plan.conflicts) {
+		// A deletion on either side has no text to merge.
+		if (entry.status === 'deleted' || entry.targetHash === null) continue;
+		const merged = await mergeFileContents(entry, sourceRoot, targetRoot);
+		entry.autoMergeable = merged !== null;
+	}
+
+	return plan;
+}
+
+/**
+ * Three-way merge one file's text. Returns null when it cannot be merged
+ * cleanly — conflicting edits, a missing base blob, or binary content.
+ */
+export async function mergeFileContents(
+	entry: MergeEntry,
+	sourceRoot: string,
+	targetRoot: string
+): Promise<string | null> {
+	if (entry.baseHash === null || entry.sourceHash === null || entry.targetHash === null) {
+		return null;
+	}
+
+	const baseText = await readBlobText(entry.baseHash);
+	if (baseText === null) return null;
+
+	const sourceText = await readText(path.join(sourceRoot, entry.path));
+	const targetText = await readText(path.join(targetRoot, entry.path));
+	if (sourceText === null || targetText === null) return null;
+
+	const scratch = await fs.mkdtemp(path.join(os.tmpdir(), 'clopen-merge-'));
+	try {
+		const currentFile = path.join(scratch, 'current');
+		const baseFile = path.join(scratch, 'base');
+		const otherFile = path.join(scratch, 'other');
+
+		await Promise.all([
+			fs.writeFile(currentFile, targetText),
+			fs.writeFile(baseFile, baseText),
+			fs.writeFile(otherFile, sourceText)
+		]);
+
+		// `-p` prints the result instead of rewriting `current`; a non-zero exit
+		// is the conflict count, not a failure to run.
+		const result = await execGit(
+			['merge-file', '-p', currentFile, baseFile, otherFile],
+			scratch,
+			{ okExitCodes: [1] }
+		);
+
+		return result.exitCode === 0 ? result.stdout : null;
+	} catch (error) {
+		debug.warn('worktree', `merge-file failed for ${entry.path}: ${error}`);
+		return null;
+	} finally {
+		await fs.rm(scratch, { recursive: true, force: true }).catch(() => {});
+	}
+}
+
+/** Read a file as text, or null when it is missing or contains a NUL byte. */
+async function readText(filePath: string): Promise<string | null> {
+	try {
+		const buffer = await fs.readFile(filePath);
+		if (buffer.includes(0)) return null;
+		return buffer.toString('utf-8');
+	} catch {
+		return null;
+	}
+}
+
+export interface MergeApplyResult {
+	written: string[];
+	deleted: string[];
+	skipped: string[];
+	failed: string[];
+}
+
+/**
+ * Carry the planned changes into `targetRoot`.
+ *
+ * `resolutions` only has to cover conflicts; clean entries default to taking
+ * the source side, which is the whole point of the transfer.
+ */
+export async function applyMergePlan(
+	plan: MergePlan,
+	sourceRoot: string,
+	targetRoot: string,
+	resolutions: Record<string, MergeResolution> = {}
+): Promise<MergeApplyResult> {
+	const result: MergeApplyResult = { written: [], deleted: [], skipped: [], failed: [] };
+
+	for (const entry of plan.entries) {
+		const resolution: MergeResolution = entry.conflict
+			? resolutions[entry.path] ?? 'target'
+			: 'source';
+
+		if (resolution === 'target') {
+			result.skipped.push(entry.path);
+			continue;
+		}
+
+		const targetPath = path.join(targetRoot, entry.path);
+
+		try {
+			if (resolution === 'merge') {
+				const merged = await mergeFileContents(entry, sourceRoot, targetRoot);
+				if (merged === null) {
+					result.failed.push(entry.path);
+					continue;
+				}
+				await fs.mkdir(path.dirname(targetPath), { recursive: true });
+				await fs.writeFile(targetPath, merged);
+				result.written.push(entry.path);
+				continue;
+			}
+
+			if (entry.status === 'deleted') {
+				await fs.rm(targetPath, { force: true });
+				result.deleted.push(entry.path);
+				continue;
+			}
+
+			await fs.mkdir(path.dirname(targetPath), { recursive: true });
+			await fs.copyFile(path.join(sourceRoot, entry.path), targetPath);
+			result.written.push(entry.path);
+		} catch (error) {
+			debug.warn('worktree', `Failed to transfer ${entry.path}: ${error}`);
+			result.failed.push(entry.path);
+		}
+	}
+
+	return result;
+}

--- a/backend/worktrees/paths.test.ts
+++ b/backend/worktrees/paths.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import path from 'path';
+import { isPathInside, slugifyWorktreeName, uniqueWorktreeSlug } from './paths';
+
+describe('slugifyWorktreeName', () => {
+	test('lowercases and hyphenates', () => {
+		expect(slugifyWorktreeName('Refactor Auth')).toBe('refactor-auth');
+	});
+
+	test('strips characters that cannot be a directory name', () => {
+		expect(slugifyWorktreeName('fix/../etc passwd')).toBe('fix-etc-passwd');
+	});
+
+	test('trims leading and trailing separators', () => {
+		expect(slugifyWorktreeName('  --hello--  ')).toBe('hello');
+	});
+
+	test('returns empty when nothing usable survives', () => {
+		expect(slugifyWorktreeName('///')).toBe('');
+	});
+
+	test('caps the length', () => {
+		expect(slugifyWorktreeName('a'.repeat(200)).length).toBe(48);
+	});
+});
+
+describe('uniqueWorktreeSlug', () => {
+	test('uses the plain slug when free', () => {
+		expect(uniqueWorktreeSlug('Feature X', new Set())).toBe('feature-x');
+	});
+
+	test('suffixes on collision', () => {
+		expect(uniqueWorktreeSlug('Feature X', new Set(['feature-x']))).toBe('feature-x-2');
+		expect(uniqueWorktreeSlug('Feature X', new Set(['feature-x', 'feature-x-2']))).toBe('feature-x-3');
+	});
+
+	test('falls back to a default stem for unusable names', () => {
+		expect(uniqueWorktreeSlug('///', new Set())).toBe('worktree');
+	});
+});
+
+describe('isPathInside', () => {
+	const root = path.join('/tmp', 'clopen-root');
+
+	test('accepts the root itself', () => {
+		expect(isPathInside(root, root)).toBe(true);
+	});
+
+	test('accepts a nested path', () => {
+		expect(isPathInside(root, path.join(root, 'src', 'index.ts'))).toBe(true);
+	});
+
+	test('rejects an escape', () => {
+		expect(isPathInside(root, path.join(root, '..', 'elsewhere'))).toBe(false);
+	});
+
+	test('rejects a sibling with a shared prefix', () => {
+		expect(isPathInside(root, `${root}-other`)).toBe(false);
+	});
+});

--- a/backend/worktrees/paths.ts
+++ b/backend/worktrees/paths.ts
@@ -1,0 +1,60 @@
+/**
+ * Worktree location and naming.
+ *
+ * Worktrees live outside the project directory. Inside it they would be picked
+ * up as nested repos by the Git panel, walked by the file watcher, and shown to
+ * the agent as part of its own tree.
+ */
+
+import path from 'path';
+import { getClopenDir } from '../utils/paths';
+
+/** Root that holds every worktree of every project. */
+export function getWorktreesRootDir(): string {
+	return path.join(getClopenDir(), 'worktrees');
+}
+
+/** Directory that holds one project's worktrees. */
+export function getProjectWorktreesDir(projectId: string): string {
+	return path.join(getWorktreesRootDir(), projectId);
+}
+
+/** Absolute path of a single worktree. */
+export function getWorktreePath(projectId: string, slug: string): string {
+	return path.join(getProjectWorktreesDir(projectId), slug);
+}
+
+/**
+ * Turn a display name into a directory-safe slug.
+ * Returns an empty string when nothing usable survives — callers substitute one.
+ */
+export function slugifyWorktreeName(name: string): string {
+	return name
+		.toLowerCase()
+		.normalize('NFKD')
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+		.slice(0, 48);
+}
+
+/**
+ * Pick a slug not already used by this project.
+ * `taken` is the set of existing slugs; a numeric suffix is added on collision.
+ */
+export function uniqueWorktreeSlug(name: string, taken: Set<string>): string {
+	const base = slugifyWorktreeName(name) || 'worktree';
+	if (!taken.has(base)) return base;
+
+	for (let suffix = 2; suffix < 1000; suffix++) {
+		const candidate = `${base}-${suffix}`;
+		if (!taken.has(candidate)) return candidate;
+	}
+
+	return `${base}-${Date.now()}`;
+}
+
+/** Whether `candidate` sits inside `root` (or is `root` itself). */
+export function isPathInside(root: string, candidate: string): boolean {
+	const relative = path.relative(path.resolve(root), path.resolve(candidate));
+	return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}

--- a/backend/worktrees/resolve.ts
+++ b/backend/worktrees/resolve.ts
@@ -1,0 +1,67 @@
+/**
+ * Resolving the working root of a chat session.
+ *
+ * Anything that runs on behalf of a session — the engine, snapshots, file
+ * reads — must use this rather than the path the client sent. The client's
+ * value is a view preference; the session's worktree is the fact, and letting
+ * the two disagree is how an isolated task ends up writing into the main tree.
+ */
+
+import { existsSync } from 'fs';
+import { projectQueries, sessionQueries, worktreeQueries } from '../database/queries';
+import { debug } from '$shared/utils/logger';
+
+export interface SessionRoot {
+	path: string;
+	projectId: string;
+	worktreeId: string | null;
+	worktreeName: string | null;
+}
+
+/**
+ * Root directory a worktree points at, or the project path when `worktreeId` is
+ * null. Falls back to the project when the worktree directory has vanished —
+ * a session must stay usable even if its worktree was deleted outside Clopen.
+ */
+export function resolveWorktreeRoot(projectId: string, worktreeId: string | null): SessionRoot {
+	const project = projectQueries.getById(projectId);
+	const projectPath = project?.path ?? '';
+
+	if (!worktreeId) {
+		return { path: projectPath, projectId, worktreeId: null, worktreeName: null };
+	}
+
+	const worktree = worktreeQueries.getById(worktreeId);
+	if (!worktree || worktree.project_id !== projectId) {
+		return { path: projectPath, projectId, worktreeId: null, worktreeName: null };
+	}
+
+	if (!existsSync(worktree.path)) {
+		debug.warn('worktree', `Worktree directory missing, using main tree: ${worktree.path}`);
+		return { path: projectPath, projectId, worktreeId: null, worktreeName: null };
+	}
+
+	return {
+		path: worktree.path,
+		projectId,
+		worktreeId: worktree.id,
+		worktreeName: worktree.name
+	};
+}
+
+/** Working root for a session, or null when the session is unknown. */
+export function resolveSessionRoot(sessionId: string): SessionRoot | null {
+	const session = sessionQueries.getById(sessionId);
+	if (!session) return null;
+	return resolveWorktreeRoot(session.project_id, session.worktree_id ?? null);
+}
+
+/**
+ * Working root for a session, preferring the session's own binding and falling
+ * back to the caller-supplied path when the session cannot be resolved.
+ */
+export function resolveSessionPath(sessionId: string | undefined, fallbackPath: string): string {
+	if (!sessionId) return fallbackPath;
+	const root = resolveSessionRoot(sessionId);
+	return root?.path || fallbackPath;
+}

--- a/backend/worktrees/service.ts
+++ b/backend/worktrees/service.ts
@@ -1,0 +1,315 @@
+/**
+ * Worktree lifecycle: create, inspect, transfer, remove.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import type { Worktree } from '$shared/types/database/schema';
+import type { TreeMap } from '../snapshot/blob-store';
+import { projectQueries, worktreeQueries } from '../database/queries';
+import { fileWatcher } from '../files/file-watcher';
+import { debug } from '$shared/utils/logger';
+import { cleanupWorktreeSessions } from '../terminal/ptykit';
+import { browserPreviewServiceManager } from '../preview';
+import { makeScopeKey } from '$shared/utils/workspace-scope';
+import { cloneTree } from './clone';
+import {
+	applyMergePlan,
+	markAutoMergeable,
+	planMerge,
+	type MergeEntry,
+	type MergePlan,
+	type MergeResolution
+} from './merge';
+import { getProjectWorktreesDir, getWorktreePath, uniqueWorktreeSlug } from './paths';
+import { hashTree, readBlobText } from './tree';
+
+/** Worktree → main is `apply`; main → worktree is `sync`. */
+export type TransferDirection = 'apply' | 'sync';
+
+/** Conflict previews are truncated — the dialog shows a diff, not a whole file. */
+const MAX_PREVIEW_BYTES = 256 * 1024;
+
+export interface WorktreeChange {
+	path: string;
+	status: MergeEntry['status'];
+	conflict: boolean;
+	autoMergeable: boolean;
+}
+
+export interface WorktreeConflictPreview extends WorktreeChange {
+	sourceContent?: string;
+	targetContent?: string;
+}
+
+export interface TransferPreview {
+	direction: TransferDirection;
+	changes: WorktreeChange[];
+	conflicts: WorktreeConflictPreview[];
+}
+
+export interface TransferResult {
+	written: number;
+	deleted: number;
+	skipped: number;
+	failed: string[];
+}
+
+export interface WorktreeCreateResult {
+	worktree: Worktree;
+	fileCount: number;
+	carriedIgnoredFiles: boolean;
+}
+
+/**
+ * Clone the project into a new worktree.
+ *
+ * The base tree is hashed *after* the clone so the recorded merge base matches
+ * what the worktree actually starts from, and its blobs are stored so a
+ * three-way merge is still possible once both sides have moved on.
+ */
+export async function createWorktree(input: {
+	projectId: string;
+	name: string;
+	createdBy?: string | null;
+}): Promise<WorktreeCreateResult> {
+	const project = projectQueries.getById(input.projectId);
+	if (!project) throw new Error('Project not found');
+
+	const projectExists = await pathExists(project.path);
+	if (!projectExists) throw new Error(`Project path does not exist: ${project.path}`);
+
+	const takenSlugs = new Set(worktreeQueries.getByProjectId(input.projectId).map((row) => row.slug));
+	const slug = uniqueWorktreeSlug(input.name, takenSlugs);
+	const targetPath = getWorktreePath(input.projectId, slug);
+
+	if (await pathExists(targetPath)) {
+		// Left behind by a crashed create — the DB row is the source of truth.
+		await fs.rm(targetPath, { recursive: true, force: true });
+	}
+	await fs.mkdir(targetPath, { recursive: true });
+
+	let clone;
+	try {
+		clone = await cloneTree(project.path, targetPath);
+	} catch (error) {
+		await fs.rm(targetPath, { recursive: true, force: true }).catch(() => {});
+		throw error;
+	}
+
+	const baseTree = await hashTree(targetPath, true);
+
+	const worktree = worktreeQueries.create({
+		project_id: input.projectId,
+		name: input.name.trim() || slug,
+		slug,
+		path: targetPath,
+		clone_mode: clone.mode,
+		base_tree: baseTree,
+		created_by: input.createdBy ?? null
+	});
+
+	debug.log('worktree', `Created worktree "${worktree.name}" (${clone.mode}) at ${targetPath}`);
+	return { worktree, fileCount: clone.fileCount, carriedIgnoredFiles: clone.carriedIgnoredFiles };
+}
+
+/** Delete the worktree directory and its row. Sessions fall back to the main tree. */
+export async function removeWorktree(worktreeId: string): Promise<void> {
+	const worktree = worktreeQueries.getById(worktreeId);
+	if (!worktree) return;
+
+	// Shells and browser tabs live in the worktree's own scope; without this they
+	// would outlive the directory they were opened in.
+	releaseWorkspaceScope(worktree.project_id, worktree.id);
+
+	await fs.rm(worktree.path, { recursive: true, force: true }).catch((error) => {
+		debug.warn('worktree', `Could not remove ${worktree.path}: ${error}`);
+	});
+	worktreeQueries.delete(worktreeId);
+	debug.log('worktree', `Removed worktree ${worktree.name}`);
+}
+
+/** Remove every worktree of a project — used when the project itself is deleted. */
+export async function removeProjectWorktrees(projectId: string): Promise<void> {
+	for (const worktree of worktreeQueries.deleteByProjectId(projectId)) {
+		releaseWorkspaceScope(projectId, worktree.id);
+	}
+	await fs.rm(getProjectWorktreesDir(projectId), { recursive: true, force: true }).catch(() => {});
+}
+
+/** Tear down the per-workspace resources a worktree owns. */
+function releaseWorkspaceScope(projectId: string, worktreeId: string): void {
+	const scopeKey = makeScopeKey(projectId, worktreeId);
+	try {
+		cleanupWorktreeSessions(projectId, worktreeId);
+		void browserPreviewServiceManager.removeService(scopeKey);
+		fileWatcher.releaseProject(scopeKey);
+	} catch (error) {
+		debug.warn('worktree', `Scope cleanup failed for ${scopeKey}: ${error}`);
+	}
+}
+
+/**
+ * Disk actually occupied by a worktree, in kilobytes.
+ *
+ * `du` reports allocated blocks rather than apparent size, so a reflink clone
+ * correctly shows near-zero until its files are written to. Returns null where
+ * `du` is unavailable (Windows) rather than reporting a misleading number.
+ */
+export async function getWorktreeDiskUsage(worktreePath: string): Promise<number | null> {
+	if (process.platform === 'win32') return null;
+
+	try {
+		const proc = Bun.spawn(['du', '-sk', worktreePath], { stdout: 'pipe', stderr: 'ignore' });
+		const output = await new Response(proc.stdout).text();
+		await proc.exited;
+		const kilobytes = Number.parseInt(output.trim().split(/\s+/)[0] ?? '', 10);
+		return Number.isFinite(kilobytes) ? kilobytes : null;
+	} catch {
+		return null;
+	}
+}
+
+/** Resolve which trees are source and target for a direction. */
+function resolveEnds(worktree: Worktree, direction: TransferDirection) {
+	const project = projectQueries.getById(worktree.project_id);
+	if (!project) throw new Error('Project not found');
+
+	return direction === 'apply'
+		? { sourceRoot: worktree.path, targetRoot: project.path }
+		: { sourceRoot: project.path, targetRoot: worktree.path };
+}
+
+/** Build the plan for a transfer, hashing both live trees against the stored base. */
+async function buildPlan(
+	worktree: Worktree,
+	direction: TransferDirection
+): Promise<{ plan: MergePlan; sourceRoot: string; targetRoot: string; baseTree: TreeMap }> {
+	const { sourceRoot, targetRoot } = resolveEnds(worktree, direction);
+	const baseTree = worktreeQueries.parseBaseTree(worktree);
+
+	const [sourceTree, targetTree] = await Promise.all([hashTree(sourceRoot), hashTree(targetRoot)]);
+
+	const plan = await markAutoMergeable(
+		planMerge(baseTree, sourceTree, targetTree),
+		sourceRoot,
+		targetRoot
+	);
+
+	return { plan, sourceRoot, targetRoot, baseTree };
+}
+
+/** What a transfer would do, including previews for every file needing a decision. */
+export async function previewTransfer(
+	worktreeId: string,
+	direction: TransferDirection
+): Promise<TransferPreview> {
+	const worktree = requireWorktree(worktreeId);
+	const { plan, sourceRoot, targetRoot } = await buildPlan(worktree, direction);
+
+	const changes: WorktreeChange[] = plan.entries.map((entry) => ({
+		path: entry.path,
+		status: entry.status,
+		conflict: entry.conflict,
+		autoMergeable: entry.autoMergeable
+	}));
+
+	const conflicts: WorktreeConflictPreview[] = [];
+	for (const entry of plan.conflicts) {
+		conflicts.push({
+			path: entry.path,
+			status: entry.status,
+			conflict: true,
+			autoMergeable: entry.autoMergeable,
+			sourceContent: await previewContent(sourceRoot, entry.path, entry.sourceHash),
+			targetContent: await previewContent(targetRoot, entry.path, entry.targetHash)
+		});
+	}
+
+	return { direction, changes, conflicts };
+}
+
+/**
+ * Run the transfer, then re-base the worktree onto the main tree as it now
+ * stands. Without the re-base every later transfer would re-propose the same
+ * files, including the ones the user deliberately declined.
+ */
+export async function executeTransfer(
+	worktreeId: string,
+	direction: TransferDirection,
+	resolutions: Record<string, MergeResolution>
+): Promise<TransferResult> {
+	const worktree = requireWorktree(worktreeId);
+	const { plan, sourceRoot, targetRoot } = await buildPlan(worktree, direction);
+
+	const applied = await applyMergePlan(plan, sourceRoot, targetRoot, resolutions);
+
+	const project = projectQueries.getById(worktree.project_id);
+	const newBase = project ? await hashTree(project.path, true) : null;
+
+	if (newBase) {
+		if (direction === 'apply') {
+			worktreeQueries.markApplied(worktreeId, newBase);
+		} else {
+			worktreeQueries.updateBaseTree(worktreeId, newBase);
+		}
+	}
+
+	debug.log(
+		'worktree',
+		`Transfer ${direction} on ${worktree.name}: ${applied.written.length} written, ${applied.deleted.length} deleted, ${applied.skipped.length} skipped`
+	);
+
+	return {
+		written: applied.written.length,
+		deleted: applied.deleted.length,
+		skipped: applied.skipped.length,
+		failed: applied.failed
+	};
+}
+
+/** Count of files a worktree has diverged by, for the manager list. */
+export async function countPendingChanges(worktreeId: string): Promise<number> {
+	const worktree = worktreeQueries.getById(worktreeId);
+	if (!worktree) return 0;
+
+	try {
+		const { plan } = await buildPlan(worktree, 'apply');
+		return plan.entries.length;
+	} catch {
+		return 0;
+	}
+}
+
+function requireWorktree(worktreeId: string): Worktree {
+	const worktree = worktreeQueries.getById(worktreeId);
+	if (!worktree) throw new Error('Worktree not found');
+	return worktree;
+}
+
+/** Current content of one side, falling back to the blob when the file is gone. */
+async function previewContent(
+	root: string,
+	relativePath: string,
+	hash: string | null
+): Promise<string | undefined> {
+	if (hash === null) return undefined;
+
+	try {
+		const buffer = await fs.readFile(path.join(root, relativePath));
+		if (buffer.includes(0)) return '(binary file)';
+		return buffer.subarray(0, MAX_PREVIEW_BYTES).toString('utf-8');
+	} catch {
+		const text = await readBlobText(hash);
+		return text ?? undefined;
+	}
+}
+
+async function pathExists(target: string): Promise<boolean> {
+	try {
+		await fs.access(target);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/backend/worktrees/tree.ts
+++ b/backend/worktrees/tree.ts
@@ -1,0 +1,59 @@
+/**
+ * Hashing a tree into the Checkpoints blob store.
+ *
+ * Worktree merges are three-way, so the base content has to outlive the tree it
+ * came from — the blobs are what make a merge base recoverable after both sides
+ * have moved on.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { blobStore, type TreeMap } from '../snapshot/blob-store';
+import { getSnapshotFiles } from '../snapshot/gitignore';
+import { debug } from '$shared/utils/logger';
+
+/** Mirrors the snapshot service cap — larger files are never tracked. */
+export const MAX_TRACKED_FILE_SIZE = 5 * 1024 * 1024;
+
+/**
+ * Hash every snapshot-eligible file under `root`.
+ * When `storeBlobs` is set, contents are written to the blob store so they can
+ * be read back as a merge base later.
+ */
+export async function hashTree(root: string, storeBlobs = false): Promise<TreeMap> {
+	if (storeBlobs) await blobStore.init();
+
+	const files = await getSnapshotFiles(root);
+	const tree: TreeMap = {};
+
+	for (const absolute of files) {
+		try {
+			const stat = await fs.stat(absolute);
+			if (stat.size > MAX_TRACKED_FILE_SIZE) continue;
+
+			const relativePath = path.relative(root, absolute).replace(/\\/g, '/');
+			const result = await blobStore.hashFile(relativePath, absolute);
+			tree[relativePath] = result.hash;
+
+			if (storeBlobs && !(await blobStore.hasBlob(result.hash))) {
+				const content = result.content ?? (await fs.readFile(absolute));
+				await blobStore.storeBlob(content);
+			}
+		} catch {
+			// Unreadable file — leave it out of the tree
+		}
+	}
+
+	debug.log('worktree', `Hashed ${Object.keys(tree).length} files under ${root}`);
+	return tree;
+}
+
+/** Read a blob back as text, or null when it is missing or not decodable. */
+export async function readBlobText(hash: string): Promise<string | null> {
+	try {
+		const buffer = await blobStore.readBlob(hash);
+		return buffer.toString('utf-8');
+	} catch {
+		return null;
+	}
+}

--- a/backend/ws/access.ts
+++ b/backend/ws/access.ts
@@ -2,6 +2,7 @@ import type { WSConnection } from '$shared/utils/ws-server';
 import type { Project, ChatSession, DatabaseMessage } from '$shared/types/database/schema';
 import { ws } from '$backend/utils/ws';
 import { projectQueries, sessionQueries, messageQueries } from '$backend/database/queries';
+import { resolveWorktreeRoot } from '$backend/worktrees';
 
 export function requireProjectAccess(conn: WSConnection, projectId: string): Project {
 	const userId = ws.getUserId(conn);
@@ -16,6 +17,23 @@ export function requireProjectAccess(conn: WSConnection, projectId: string): Pro
 	}
 
 	return project;
+}
+
+/**
+ * Project access plus the workspace root the connection is viewing.
+ *
+ * Anything that runs against a repository or a tree must use `root`: a worktree
+ * is its own checkout, and resolving to `project.path` silently ran every git
+ * command against the main tree instead.
+ */
+export function requireProjectWorkspace(conn: WSConnection, projectId: string): {
+	project: Project;
+	root: string;
+	worktreeId: string | null;
+} {
+	const project = requireProjectAccess(conn, projectId);
+	const resolved = resolveWorktreeRoot(projectId, ws.getWorktreeId(conn));
+	return { project, root: resolved.path || project.path, worktreeId: resolved.worktreeId };
 }
 
 export function requireCurrentProjectAccess(conn: WSConnection): {

--- a/backend/ws/artifacts/generate.ts
+++ b/backend/ws/artifacts/generate.ts
@@ -14,7 +14,7 @@ import { createRouter } from '$shared/utils/ws-server';
 import { debug } from '$shared/utils/logger';
 import { generateArtifact, type GeneratableType } from '$backend/artifacts';
 import type { EngineType } from '$shared/types/unified';
-import { requireProjectAccess } from '../access';
+import { requireProjectWorkspace } from '../access';
 
 export const artifactGenerateHandler = createRouter()
 	.http('artifacts:generate', {
@@ -40,7 +40,7 @@ export const artifactGenerateHandler = createRouter()
 
 		// Optional project only decides the engine process cwd; generation has no
 		// project side effects. Falls back to the Clopen data dir when absent.
-		const projectPath = data.projectId ? requireProjectAccess(conn, data.projectId).path : undefined;
+		const projectPath = data.projectId ? requireProjectWorkspace(conn, data.projectId).root : undefined;
 
 		const fields = await generateArtifact(data.artifactType as GeneratableType, data.purpose, {
 			engine: data.engine as EngineType,

--- a/backend/ws/chat/stream.ts
+++ b/backend/ws/chat/stream.ts
@@ -17,6 +17,7 @@ import { ws } from '$backend/utils/ws';
 import { broadcastPresence } from '../projects/status';
 import { sessionQueries, messageQueries } from '../../database/queries';
 import { requireSessionAccess } from '../access';
+import { resolveSessionPath } from '../../worktrees';
 
 /**
  * Broadcast presence + notify project members when a chat message may flip the
@@ -228,15 +229,21 @@ export const streamHandler = createRouter()
 		requireSessionAccess(conn, data.chatSessionId);
 		const projectId = ws.getProjectId(conn);
 
+		// The client's projectPath is a view preference; the session's worktree is
+		// the fact. Resolving server-side is what keeps an isolated session from
+		// writing into the main tree when the two disagree.
+		const workingRoot = resolveSessionPath(data.chatSessionId, data.projectPath);
+
 		try {
 			debug.log('chat', 'WS chat:stream received:', {
 				chatSessionId: data.chatSessionId,
-				projectId
+				projectId,
+				workingRoot
 			});
 
 			// Start background stream
 			const streamId = await streamManager.startStream({
-				projectPath: data.projectPath,
+				projectPath: workingRoot,
 				projectId,
 				prompt: data.prompt,
 				chatSessionId: data.chatSessionId,

--- a/backend/ws/files/panel-state-scope.test.ts
+++ b/backend/ws/files/panel-state-scope.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Panel state is stored one row per (user, project) but must be separated per
+ * workspace inside it. Sharing one entry carried open tabs — including unsaved
+ * buffers — from the main tree into a worktree, which read as the edit having
+ * crossed between them.
+ *
+ * The envelope logic is what enforces that separation, so it is exercised here
+ * against the same shape the handlers read and write.
+ */
+import { describe, expect, test } from 'bun:test';
+
+interface ScopedPanelState {
+	v: 2;
+	scopes: Record<string, string>;
+}
+
+function parseStored(raw: string | null): ScopedPanelState {
+	if (!raw) return { v: 2, scopes: {} };
+	try {
+		const parsed = JSON.parse(raw) as ScopedPanelState;
+		if (parsed && parsed.v === 2 && typeof parsed.scopes === 'object') return parsed;
+	} catch {
+		// unparseable → treated as absent
+	}
+	return { v: 2, scopes: {} };
+}
+
+function isLegacyState(raw: string | null): boolean {
+	if (!raw) return false;
+	try {
+		return (JSON.parse(raw) as { v?: number })?.v !== 2;
+	} catch {
+		return false;
+	}
+}
+
+/** Mirrors files:set-panel-state. */
+function writeScope(raw: string | null, projectId: string, scopeKey: string, state: string | null): string {
+	const stored = parseStored(raw);
+	if (isLegacyState(raw) && raw) stored.scopes[projectId] = raw;
+	if (state === null) delete stored.scopes[scopeKey];
+	else stored.scopes[scopeKey] = state;
+	return JSON.stringify(stored);
+}
+
+/** Mirrors files:get-panel-state. */
+function readScope(raw: string | null, projectId: string, scopeKey: string): string | null {
+	if (isLegacyState(raw)) return scopeKey === projectId ? raw : null;
+	return parseStored(raw).scopes[scopeKey] ?? null;
+}
+
+const PROJECT = 'proj-1';
+const MAIN = PROJECT;
+const WORKTREE = 'proj-1~wt-1';
+
+describe('files panel state scoping', () => {
+	test('a worktree does not see the main tree state', () => {
+		const stored = writeScope(null, PROJECT, MAIN, '{"openTabs":["a.ts"]}');
+		expect(readScope(stored, PROJECT, MAIN)).toBe('{"openTabs":["a.ts"]}');
+		expect(readScope(stored, PROJECT, WORKTREE)).toBeNull();
+	});
+
+	test('writing one workspace keeps the other', () => {
+		let stored = writeScope(null, PROJECT, MAIN, 'main-state');
+		stored = writeScope(stored, PROJECT, WORKTREE, 'worktree-state');
+
+		expect(readScope(stored, PROJECT, MAIN)).toBe('main-state');
+		expect(readScope(stored, PROJECT, WORKTREE)).toBe('worktree-state');
+	});
+
+	test('two worktrees of one project stay separate', () => {
+		const second = 'proj-1~wt-2';
+		let stored = writeScope(null, PROJECT, WORKTREE, 'first');
+		stored = writeScope(stored, PROJECT, second, 'second');
+
+		expect(readScope(stored, PROJECT, WORKTREE)).toBe('first');
+		expect(readScope(stored, PROJECT, second)).toBe('second');
+	});
+
+	test('legacy flat state belongs to the main tree only', () => {
+		const legacy = '{"v":1,"openTabs":[]}';
+		expect(readScope(legacy, PROJECT, MAIN)).toBe(legacy);
+		expect(readScope(legacy, PROJECT, WORKTREE)).toBeNull();
+	});
+
+	test('the first worktree write preserves legacy main state', () => {
+		const legacy = '{"v":1,"openTabs":[]}';
+		const stored = writeScope(legacy, PROJECT, WORKTREE, 'worktree-state');
+
+		expect(readScope(stored, PROJECT, MAIN)).toBe(legacy);
+		expect(readScope(stored, PROJECT, WORKTREE)).toBe('worktree-state');
+	});
+
+	test('clearing one workspace leaves the others intact', () => {
+		let stored = writeScope(null, PROJECT, MAIN, 'main-state');
+		stored = writeScope(stored, PROJECT, WORKTREE, 'worktree-state');
+		stored = writeScope(stored, PROJECT, WORKTREE, null);
+
+		expect(readScope(stored, PROJECT, MAIN)).toBe('main-state');
+		expect(readScope(stored, PROJECT, WORKTREE)).toBeNull();
+	});
+});

--- a/backend/ws/files/path-access.test.ts
+++ b/backend/ws/files/path-access.test.ts
@@ -27,6 +27,7 @@ const mockGetAllForUser = mock(() => [] as Array<{ id: string; path: string }>);
 const mockGetAll = mock(() => [] as Array<{ id: string; path: string }>);
 const mockUserHasProject = mock(() => false);
 const mockGetByPath = mock(() => null as { id: string; path: string } | null);
+const mockGetById = mock(() => null as { id: string; path: string } | null);
 
 mock.module('../../database/queries/project-queries', () => ({
 	projectQueries: {
@@ -34,6 +35,19 @@ mock.module('../../database/queries/project-queries', () => ({
 		getAll: mockGetAll,
 		userHasProject: mockUserHasProject,
 		getByPath: mockGetByPath,
+		getById: mockGetById,
+	}
+}));
+
+// A project's accessible area now includes its worktrees, so the lookup is part
+// of the data layer this test models.
+const mockWorktreesByProject = mock(() => [] as Array<{ id: string; path: string }>);
+const mockWorktreeByPath = mock(() => null as { id: string; project_id: string; path: string } | null);
+
+mock.module('../../database/queries/worktree-queries', () => ({
+	worktreeQueries: {
+		getByProjectId: mockWorktreesByProject,
+		getByPath: mockWorktreeByPath,
 	}
 }));
 
@@ -52,7 +66,7 @@ mock.module('../access', () => ({
 }));
 
 // Import after mocking
-const { requireFilePathAccess, requireSharedFilePathAccess, findContainingProjectId } = await import('./path-access');
+const { requireFilePathAccess, requireSharedFilePathAccess, findContainingProjectId, resolveProjectForRoot, requireWorkspaceRootAccess } = await import('./path-access');
 
 let testDir: string;
 
@@ -69,6 +83,84 @@ describe('path-access symlink resolution', () => {
 
 	afterEach(async () => {
 		await rm(testDir, { recursive: true, force: true });
+		mockWorktreesByProject.mockReturnValue([]);
+		mockWorktreeByPath.mockReturnValue(null);
+	});
+
+	test('allows a path inside a worktree of an accessible project', async () => {
+		const projectPath = join(testDir, 'project');
+		const worktreePath = join(testDir, 'worktrees', 'feature');
+		await mkdir(projectPath, { recursive: true });
+		await mkdir(worktreePath, { recursive: true });
+		await writeFile(join(worktreePath, 'index.ts'), 'export {};');
+
+		mockGetAllForUser.mockReturnValue([{ id: 'proj-1', path: projectPath }]);
+		mockWorktreesByProject.mockReturnValue([{ id: 'wt-1', path: worktreePath }]);
+
+		const target = join(worktreePath, 'index.ts');
+		await expect(requireFilePathAccess({} as any, target)).resolves.toBe(target);
+	});
+
+	test('still denies a worktree of a project the user cannot access', async () => {
+		const worktreePath = join(testDir, 'worktrees', 'other');
+		await mkdir(worktreePath, { recursive: true });
+		await writeFile(join(worktreePath, 'secret.txt'), 'nope');
+
+		mockGetAllForUser.mockReturnValue([]);
+		mockWorktreesByProject.mockReturnValue([{ id: 'wt-1', path: worktreePath }]);
+
+		await expect(
+			requireFilePathAccess({} as any, join(worktreePath, 'secret.txt'))
+		).rejects.toThrow('Access denied');
+	});
+
+	test('resolves a worktree root back to its owning project', async () => {
+		const worktreePath = join(testDir, 'worktrees', 'feature');
+		mockGetByPath.mockReturnValue(null);
+		mockWorktreeByPath.mockReturnValue({ id: 'wt-1', project_id: 'proj-1', path: worktreePath });
+		mockGetById.mockReturnValue({ id: 'proj-1', path: join(testDir, 'project') });
+
+		expect(resolveProjectForRoot(worktreePath)?.id).toBe('proj-1');
+	});
+
+	test('returns the worktree root, not the project root, for a worktree path', async () => {
+		// The regression this guards: handlers validated the requested root and
+		// then operated on `project.path`, so opening a file in a worktree listed
+		// and read the main tree instead.
+		const projectPath = join(testDir, 'project');
+		const worktreePath = join(testDir, 'worktrees', 'feature');
+
+		mockGetByPath.mockReturnValue(null);
+		mockWorktreeByPath.mockReturnValue({ id: 'wt-1', project_id: 'proj-1', path: worktreePath });
+		mockGetById.mockReturnValue({ id: 'proj-1', path: projectPath });
+		mockGetRole.mockImplementation(() => 'admin');
+
+		const resolved = requireWorkspaceRootAccess({} as any, worktreePath);
+		expect(resolved.root).toBe(worktreePath);
+		expect(resolved.worktreeId).toBe('wt-1');
+		expect(resolved.project.id).toBe('proj-1');
+	});
+
+	test('returns the project root for the main tree', async () => {
+		const projectPath = join(testDir, 'project');
+
+		mockWorktreeByPath.mockReturnValue(null);
+		mockGetByPath.mockReturnValue({ id: 'proj-1', path: projectPath });
+		mockGetRole.mockImplementation(() => 'admin');
+
+		const resolved = requireWorkspaceRootAccess({} as any, projectPath);
+		expect(resolved.root).toBe(projectPath);
+		expect(resolved.worktreeId).toBeNull();
+	});
+
+	test('denies an unknown root', async () => {
+		mockWorktreeByPath.mockReturnValue(null);
+		mockGetByPath.mockReturnValue(null);
+		mockGetRole.mockImplementation(() => 'admin');
+
+		expect(() => requireWorkspaceRootAccess({} as any, join(testDir, 'nowhere'))).toThrow(
+			'Access denied'
+		);
 	});
 
 	test('blocks read through symlink to external directory', async () => {

--- a/backend/ws/files/path-access.ts
+++ b/backend/ws/files/path-access.ts
@@ -2,6 +2,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:pat
 import { realpath } from 'node:fs/promises';
 
 import { projectQueries } from '../../database/queries/project-queries';
+import { worktreeQueries } from '../../database/queries/worktree-queries';
 import { ws } from '$backend/utils/ws';
 import type { WSConnection } from '$shared/utils/ws-server';
 import type { Project } from '$shared/types/database/schema';
@@ -36,15 +37,56 @@ async function isPathInside(rootPath: string, candidatePath: string): Promise<bo
 	return rel === '' || (!!rel && !rel.startsWith('..') && !isAbsolute(rel));
 }
 
-export function requireProjectPathAccess(conn: WSConnection, projectPath: string): Project {
-	const project = projectQueries.getByPath(projectPath);
+/**
+ * Resolve a workspace root to the project that owns it.
+ *
+ * A worktree root is not a registered project, so a plain project lookup
+ * rejects it — which is what made the Files panel deny access to every path
+ * inside a worktree.
+ */
+export function resolveProjectForRoot(rootPath: string): Project | null {
+	const project = projectQueries.getByPath(rootPath);
+	if (project) return project;
+
+	const worktree = worktreeQueries.getByPath(rootPath);
+	if (!worktree) return null;
+
+	return projectQueries.getById(worktree.project_id);
+}
+
+export interface WorkspaceRoot {
+	/** The project that owns the workspace — what access is decided on. */
+	project: Project;
+	/** The directory the caller asked for: the project, or one of its worktrees. */
+	root: string;
+	worktreeId: string | null;
+}
+
+/**
+ * Grant access to a workspace root and hand back the root that was requested.
+ *
+ * Returning the root rather than only the project is the point: callers used to
+ * validate a path and then operate on `project.path`, which was identical until
+ * worktrees existed and silently became "list the main tree" afterwards.
+ */
+export function requireWorkspaceRootAccess(conn: WSConnection, rootPath: string): WorkspaceRoot {
+	const worktree = worktreeQueries.getByPath(rootPath);
+	const project = worktree
+		? projectQueries.getById(worktree.project_id)
+		: projectQueries.getByPath(rootPath);
+
 	if (!project) {
 		throw new Error('Access denied');
 	}
-	if (ws.getRole(conn) === 'admin') {
-		return project;
+	if (ws.getRole(conn) !== 'admin') {
+		requireProjectAccess(conn, project.id);
 	}
-	return requireProjectAccess(conn, project.id);
+
+	return {
+		project,
+		root: worktree ? worktree.path : project.path,
+		worktreeId: worktree?.id ?? null
+	};
 }
 
 export async function requireFilePathAccess(conn: WSConnection, filePath: string): Promise<string> {
@@ -65,10 +107,17 @@ export async function requireFilePathAccessFor(filePath: string, role: string | 
 		throw new Error('Access denied');
 	}
 
+	// A project's accessible area is its own tree plus every worktree cloned
+	// from it — both are workspaces the user is already entitled to.
 	const projects = projectQueries.getAllForUser(userId);
 	for (const project of projects) {
 		if (await isPathInside(project.path, normalizedPath)) {
 			return normalizedPath;
+		}
+		for (const worktree of worktreeQueries.getByProjectId(project.id)) {
+			if (await isPathInside(worktree.path, normalizedPath)) {
+				return normalizedPath;
+			}
 		}
 	}
 

--- a/backend/ws/files/read.ts
+++ b/backend/ws/files/read.ts
@@ -26,7 +26,7 @@ import { requireProjectAccess } from '../access';
 import {
 	filterAccessibleExpandedPaths,
 	requireFilePathAccess,
-	requireProjectPathAccess,
+	requireWorkspaceRootAccess,
 	requireSharedFilePathAccess
 } from './path-access';
 
@@ -72,8 +72,9 @@ export const readHandler = createRouter()
 			])
 		)
 	}, async ({ data, conn }) => {
-		const project = requireProjectPathAccess(conn, data.project_path);
-		const projectPath = project.path;
+		// The requested root, not the project's: for a worktree these differ, and
+		// listing the project would hand back the main tree's files and paths.
+		const { root: projectPath } = requireWorkspaceRootAccess(conn, data.project_path);
 
 		if (!(await existsSync(projectPath))) {
 			throw new Error('Project path does not exist');
@@ -186,6 +187,8 @@ export const readHandler = createRouter()
 	.http('files:read-file-at', {
 		data: t.Object({
 			projectId: t.String(),
+			// Workspace root the file lives in; absent means the project itself.
+			rootPath: t.Optional(t.String()),
 			filePath: t.String(),
 			ref: t.Optional(t.String())
 		}),
@@ -194,16 +197,18 @@ export const readHandler = createRouter()
 			ref: t.String()
 		})
 	}, async ({ data, conn }) => {
-		requireProjectAccess(conn, data.projectId);
-		const project = projectQueries.getById(data.projectId);
-		if (!project) throw new Error('Access denied');
+		// A worktree is its own checkout, so the gutter diff has to resolve
+		// against the tree the file is in rather than the project's.
+		const { root } = data.rootPath
+			? requireWorkspaceRootAccess(conn, data.rootPath)
+			: { root: requireProjectAccess(conn, data.projectId).path };
 
 		const ref = data.ref || 'HEAD';
 
-		// Make filePath relative to project root for `git show`
+		// Make filePath relative to the workspace root for `git show`
 		let relativePath = data.filePath;
 		if (isAbsolute(data.filePath)) {
-			relativePath = relative(project.path, data.filePath);
+			relativePath = relative(root, data.filePath);
 		}
 		// Normalize path separators for git
 		relativePath = relativePath.replace(/\\/g, '/');
@@ -212,8 +217,8 @@ export const readHandler = createRouter()
 		// repo's `git show HEAD:file` returns nothing for files tracked
 		// inside a nested repo and gitignored by the parent, so the editor
 		// gutter diff would silently go empty for subrepo files without this.
-		const repo = await findRepoForFile(project.path, relativePath);
-		const cwd = repo?.repoPath ?? project.path;
+		const repo = await findRepoForFile(root, relativePath);
+		const cwd = repo?.repoPath ?? root;
 		const gitFilePath = repo?.relativeFilePath ?? relativePath;
 
 		const content = await gitService.getFileAtRef(cwd, ref, gitFilePath);

--- a/backend/ws/files/search.ts
+++ b/backend/ws/files/search.ts
@@ -3,7 +3,7 @@ import { createRouter } from '$shared/utils/ws-server';
 import { debug } from '$shared/utils/logger';
 import { join, extname, basename, relative } from 'path';
 import { readdir } from 'fs/promises';
-import { requireProjectPathAccess } from './path-access';
+import { requireWorkspaceRootAccess } from './path-access';
 import { validateFileSize } from '../../files/file-size-limit';
 
 // Heuristic patterns that indicate potential ReDoS risk:
@@ -407,13 +407,13 @@ export const fileSearchHandler = createRouter()
 		response: t.Array(FileSearchResultSchema)
 	}, async ({ data, conn }) => {
 		const { project_path, query } = data;
-		const project = requireProjectPathAccess(conn, project_path);
+		const { root } = requireWorkspaceRootAccess(conn, project_path);
 
 		if (!query || query.trim().length === 0) {
 			return [];
 		}
 
-		return await searchFilesByName(project.path, query);
+		return await searchFilesByName(root, query);
 	})
 	.http('files:search-code', {
 		data: t.Object({
@@ -446,13 +446,13 @@ export const fileSearchHandler = createRouter()
 			include_pattern,
 			exclude_pattern
 		} = data;
-		const project = requireProjectPathAccess(conn, project_path);
+		const { root } = requireWorkspaceRootAccess(conn, project_path);
 
 		if (!query || query.trim().length === 0) {
 			return [];
 		}
 
-		return await searchCodeContent(project.path, query, {
+		return await searchCodeContent(root, query, {
 			caseSensitive: case_sensitive,
 			wholeWord: whole_word,
 			useRegex: use_regex,
@@ -491,13 +491,13 @@ export const fileSearchHandler = createRouter()
 			include_pattern,
 			exclude_pattern
 		} = data;
-		const project = requireProjectPathAccess(conn, project_path);
+		const { root } = requireWorkspaceRootAccess(conn, project_path);
 
 		if (!search_query || search_query.trim().length === 0) {
 			return { results: [], totalReplacements: 0, totalFiles: 0 };
 		}
 
-		const results = await replaceInFiles(project.path, search_query, replace_with, {
+		const results = await replaceInFiles(root, search_query, replace_with, {
 			caseSensitive: case_sensitive,
 			wholeWord: whole_word,
 			useRegex: use_regex,

--- a/backend/ws/files/state.ts
+++ b/backend/ws/files/state.ts
@@ -1,10 +1,14 @@
 /**
  * Files Panel State Handlers
  *
- * Persist per-user-per-project files panel state (expanded folders,
- * open tabs, scroll positions, view mode). Single source of truth in DB
- * so that the state survives browser refresh and follows the user across
- * devices.
+ * Persist per-user-per-workspace files panel state (expanded folders, open
+ * tabs, scroll positions, view mode). Single source of truth in DB so that the
+ * state survives browser refresh and follows the user across devices.
+ *
+ * The row is per (user, project), but the state inside it is per workspace: a
+ * project and each of its worktrees keep separate entries. Sharing one entry
+ * carried open tabs — including unsaved buffers — from the main tree into a
+ * worktree, which read as the edit having crossed between them.
  */
 
 import { t } from 'elysia';
@@ -13,10 +17,50 @@ import { projectQueries } from '../../database/queries/project-queries';
 import { ws as wsServer } from '../../utils/ws';
 import { requireProjectAccess } from '../access';
 
+/** Stored shape: opaque per-scope state strings under one version marker. */
+interface ScopedPanelState {
+	v: 2;
+	scopes: Record<string, string>;
+}
+
+function parseStored(raw: string | null): ScopedPanelState {
+	if (!raw) return { v: 2, scopes: {} };
+
+	try {
+		const parsed = JSON.parse(raw) as ScopedPanelState | Record<string, unknown>;
+		if (
+			typeof parsed === 'object' && parsed !== null &&
+			(parsed as ScopedPanelState).v === 2 &&
+			typeof (parsed as ScopedPanelState).scopes === 'object'
+		) {
+			return parsed as ScopedPanelState;
+		}
+	} catch {
+		// Fall through — anything unparseable is treated as absent.
+	}
+
+	// Pre-worktree state was a bare panel-state document; it belongs to the main
+	// tree, so existing users keep their tabs instead of starting empty.
+	return { v: 2, scopes: {} };
+}
+
+/** Whether `raw` is legacy (flat) state rather than the scoped envelope. */
+function isLegacyState(raw: string | null): boolean {
+	if (!raw) return false;
+	try {
+		const parsed = JSON.parse(raw) as { v?: number };
+		return parsed?.v !== 2;
+	} catch {
+		return false;
+	}
+}
+
 export const filesStateHandler = createRouter()
 	.http('files:get-panel-state', {
 		data: t.Object({
-			projectId: t.String()
+			projectId: t.String(),
+			// Absent means the main tree, which is also where legacy state lives.
+			scopeKey: t.Optional(t.String())
 		}),
 		response: t.Object({
 			state: t.Union([t.String(), t.Null()])
@@ -24,19 +68,37 @@ export const filesStateHandler = createRouter()
 	}, async ({ data, conn }) => {
 		requireProjectAccess(conn, data.projectId);
 		const userId = wsServer.getUserId(conn);
-		const state = projectQueries.getFilesPanelState(userId, data.projectId);
-		return { state };
+		const raw = projectQueries.getFilesPanelState(userId, data.projectId);
+
+		const scopeKey = data.scopeKey || data.projectId;
+		if (isLegacyState(raw)) {
+			return { state: scopeKey === data.projectId ? raw : null };
+		}
+
+		return { state: parseStored(raw).scopes[scopeKey] ?? null };
 	})
 
 	.http('files:set-panel-state', {
 		data: t.Object({
 			projectId: t.String(),
+			scopeKey: t.Optional(t.String()),
 			state: t.Union([t.String(), t.Null()])
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
 		requireProjectAccess(conn, data.projectId);
 		const userId = wsServer.getUserId(conn);
-		projectQueries.setFilesPanelState(userId, data.projectId, data.state);
+
+		const raw = projectQueries.getFilesPanelState(userId, data.projectId);
+		const scopeKey = data.scopeKey || data.projectId;
+
+		// Read-modify-write so writing one workspace never drops another's entry.
+		const stored = parseStored(raw);
+		if (isLegacyState(raw) && raw) stored.scopes[data.projectId] = raw;
+
+		if (data.state === null) delete stored.scopes[scopeKey];
+		else stored.scopes[scopeKey] = data.state;
+
+		projectQueries.setFilesPanelState(userId, data.projectId, JSON.stringify(stored));
 		return { ok: true };
 	});

--- a/backend/ws/files/watch.ts
+++ b/backend/ws/files/watch.ts
@@ -12,7 +12,8 @@ import { createRouter } from '$shared/utils/ws-server';
 import { fileWatcher } from '$backend/files/file-watcher';
 import { debug } from '$shared/utils/logger';
 import { ws } from '$backend/utils/ws';
-import { projectQueries } from '../../database/queries/project-queries';
+import { makeScopeKey } from '$shared/utils/workspace-scope';
+import { requireWorkspaceRootAccess } from './path-access';
 import { requireProjectAccess } from '../access';
 
 // Connection ids that already have a disconnect cleanup registered, so we
@@ -28,10 +29,10 @@ export const watchHandler = createRouter()
 	}, async ({ data, conn }) => {
 		const { projectPath } = data;
 
-		const project = projectQueries.getByPath(projectPath);
-		if (!project) throw new Error('Access denied');
-		requireProjectAccess(conn, project.id);
-		const projectId = project.id;
+		// The root may be the project or one of its worktrees; watchers are keyed
+		// per workspace so two trees of one project never share a watcher.
+		const { project, worktreeId } = requireWorkspaceRootAccess(conn, projectPath);
+		const projectId = makeScopeKey(project.id, worktreeId);
 
 		try {
 			const connId = ws.getConnectionId(conn);
@@ -54,7 +55,7 @@ export const watchHandler = createRouter()
 
 			if (success) {
 				// Broadcast confirmation (frontend filters by projectId)
-				ws.emit.project(projectId, 'files:watching', {
+				ws.emit.project(project.id, 'files:watching', {
 					projectId,
 					watching: true,
 					timestamp: Date.now()
@@ -63,14 +64,14 @@ export const watchHandler = createRouter()
 				debug.log('file', `Started watching project ${projectId}`);
 			} else {
 				// Broadcast error (frontend filters by projectId)
-				ws.emit.project(projectId, 'files:watch-error', {
+				ws.emit.project(project.id, 'files:watch-error', {
 					projectId,
 					error: 'Failed to start file watcher'
 				});
 			}
 		} catch (error) {
 			debug.error('file', 'Error starting file watch:', error);
-			ws.emit.project(projectId, 'files:watch-error', {
+			ws.emit.project(project.id, 'files:watch-error', {
 				projectId,
 				error: error instanceof Error ? error.message : 'Unknown error'
 			});
@@ -88,14 +89,15 @@ export const watchHandler = createRouter()
 		})
 	}, async ({ data, conn }) => {
 		let projectId: string;
+		let roomProjectId: string;
 		if (data.projectPath) {
-			const project = projectQueries.getByPath(data.projectPath);
-			if (!project) return; // unknown path — nothing to unwatch
-			requireProjectAccess(conn, project.id);
-			projectId = project.id;
+			const { project, worktreeId } = requireWorkspaceRootAccess(conn, data.projectPath);
+			roomProjectId = project.id;
+			projectId = makeScopeKey(project.id, worktreeId);
 		} else {
 			// Backwards-compatible fallback for callers that don't send a path.
-			projectId = ws.getProjectId(conn);
+			roomProjectId = ws.getProjectId(conn);
+			projectId = roomProjectId;
 		}
 
 		try {
@@ -110,7 +112,7 @@ export const watchHandler = createRouter()
 			// Broadcast the ACTUAL resulting state — other devices may still be
 			// viewing this project, in which case the watcher is still alive and
 			// they must not be told it stopped.
-			ws.emit.project(projectId, 'files:watching', {
+			ws.emit.project(roomProjectId, 'files:watching', {
 				projectId,
 				watching: fileWatcher.isWatching(projectId),
 				timestamp: Date.now()

--- a/backend/ws/git/branch-name.ts
+++ b/backend/ws/git/branch-name.ts
@@ -19,7 +19,7 @@ import {
 	TEST_BRANCH_NAME_PREFIX
 } from '$shared/constants/git';
 import { debug } from '$shared/utils/logger';
-import { requireProjectAccess } from '../access';
+import { requireProjectWorkspace } from '../access';
 
 const INVALID_BRANCH_SEPARATOR_CHARS = /[\s\0~^:?*[\]\\]+/g;
 const GENERATED_BRANCH_PREFIXES = [
@@ -144,8 +144,8 @@ export const branchNameHandler = createRouter()
 			branchName: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 
 		const diffResult = await execGit(['diff', '--cached'], cwd);
 		const rawDiff = diffResult.stdout;

--- a/backend/ws/git/branch.ts
+++ b/backend/ws/git/branch.ts
@@ -6,7 +6,7 @@ import { t } from 'elysia';
 import path from 'node:path';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { requireProjectAccess } from '../access';
+import { requireProjectWorkspace } from '../access';
 import { debug } from '$shared/utils/logger';
 
 const BranchSchema = t.Object({
@@ -72,8 +72,8 @@ export const branchHandler = createRouter()
 			nested: t.Optional(t.Array(NestedRepoInfoSchema))
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		return await gitService.getBranches(project.path, data.selectedRemote);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		return await gitService.getBranches(root, data.selectedRemote);
 	})
 
 	.http('git:create-branch', {
@@ -87,8 +87,8 @@ export const branchHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.createBranch(cwd, data.name, data.startPoint);
 		return { ok: true };
 	})
@@ -102,8 +102,8 @@ export const branchHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.switchBranch(cwd, data.name);
 		return { ok: true };
 	})
@@ -116,8 +116,8 @@ export const branchHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.checkoutCommit(cwd, data.commitHash);
 		return { ok: true };
 	})
@@ -132,8 +132,8 @@ export const branchHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.deleteBranch(cwd, data.name, data.force);
 		return { ok: true };
 	})
@@ -147,8 +147,8 @@ export const branchHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.renameBranch(cwd, data.oldName, data.newName);
 		return { ok: true };
 	})
@@ -165,7 +165,7 @@ export const branchHandler = createRouter()
 			message: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.mergeBranch(cwd, data.branchName, data.noFastForward ?? false);
 	});

--- a/backend/ws/git/commit-message.ts
+++ b/backend/ws/git/commit-message.ts
@@ -12,7 +12,7 @@ import { resolveGenerationTarget } from '../../engine/resolve-model';
 import type { EngineType } from '$shared/types/unified';
 import type { GeneratedCommitMessage } from '$shared/types/git';
 import { debug } from '$shared/utils/logger';
-import { requireProjectAccess } from '../access';
+import { requireProjectWorkspace } from '../access';
 
 // Schema is shaped to satisfy OpenAI's strict structured-output mode (used by
 // Codex via `outputSchema`): every object must declare `additionalProperties:
@@ -74,8 +74,8 @@ export const commitMessageHandler = createRouter()
 			message: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 
 		// Get raw staged diff text
 		const diffResult = await execGit(['diff', '--cached'], cwd);

--- a/backend/ws/git/commit.ts
+++ b/backend/ws/git/commit.ts
@@ -6,7 +6,7 @@ import { t } from 'elysia';
 import path from 'node:path';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { requireProjectAccess } from '../access';
+import { requireProjectWorkspace } from '../access';
 import { debug } from '$shared/utils/logger';
 
 /**
@@ -36,8 +36,8 @@ export const commitHandler = createRouter()
 			hash: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		const hash = await gitService.commit(cwd, data.message);
 		return { hash };
 	})
@@ -52,8 +52,8 @@ export const commitHandler = createRouter()
 			hash: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		const hash = await gitService.amendCommit(cwd, data.message);
 		return { hash };
 	})
@@ -66,8 +66,8 @@ export const commitHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.undoLastCommit(cwd, data.mode);
 		return { ok: true };
 	})
@@ -83,8 +83,8 @@ export const commitHandler = createRouter()
 			message: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.revertCommit(cwd, data.ref);
 	})
 
@@ -99,8 +99,8 @@ export const commitHandler = createRouter()
 			message: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.cherryPick(cwd, data.hashes);
 	})
 
@@ -111,8 +111,8 @@ export const commitHandler = createRouter()
 		}),
 		response: t.Object({ message: t.String() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		const message = await gitService.cleanUntracked(cwd);
 		return { message };
 	})
@@ -124,8 +124,8 @@ export const commitHandler = createRouter()
 		}),
 		response: t.Object({ message: t.String() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		const message = await gitService.optimize(cwd);
 		return { message };
 	})
@@ -142,7 +142,7 @@ export const commitHandler = createRouter()
 			message: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.npmVersion(cwd, data.bump);
 	});

--- a/backend/ws/git/conflict.ts
+++ b/backend/ws/git/conflict.ts
@@ -7,7 +7,7 @@ import path from 'node:path';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
 import { findNestedRepoPaths, findRepoForFile } from '../../git/nested-repos';
-import { requireProjectAccess } from '../access';
+import { requireProjectWorkspace } from '../access';
 import { debug } from '$shared/utils/logger';
 
 function resolveRepoCwd(projectPath: string, repoPath: string | undefined): string | null {
@@ -45,15 +45,15 @@ export const conflictHandler = createRouter()
 			markers: t.Array(ConflictMarkerSchema)
 		}))
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const conflicts = await gitService.getConflictFiles(project.path);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const conflicts = await gitService.getConflictFiles(root);
 
 		try {
-			const nestedRepoPaths = await findNestedRepoPaths(project.path);
+			const nestedRepoPaths = await findNestedRepoPaths(root);
 			for (const repoPath of nestedRepoPaths) {
 				try {
 					const nestedConflicts = await gitService.getConflictFiles(repoPath);
-					const prefix = path.relative(project.path, repoPath).replace(/\\/g, '/') + '/';
+					const prefix = path.relative(root, repoPath).replace(/\\/g, '/') + '/';
 					for (const conflict of nestedConflicts) {
 						conflicts.push({
 							...conflict,
@@ -80,9 +80,9 @@ export const conflictHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const repo = await findRepoForFile(project.path, data.filePath);
-		const cwd = repo?.repoPath ?? project.path;
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const repo = await findRepoForFile(root, data.filePath);
+		const cwd = repo?.repoPath ?? root;
 		const filePath = repo?.relativeFilePath ?? data.filePath;
 		await gitService.resolveConflict(
 			cwd,
@@ -100,8 +100,8 @@ export const conflictHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath) ?? project.path;
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath) ?? root;
 		await gitService.abortMerge(cwd);
 		return { ok: true };
 	});

--- a/backend/ws/git/diff.ts
+++ b/backend/ws/git/diff.ts
@@ -7,7 +7,7 @@ import path from 'node:path';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
 import { findRepoForFile } from '../../git/nested-repos';
-import { requireProjectAccess } from '../access';
+import { requireProjectWorkspace } from '../access';
 import { debug } from '$shared/utils/logger';
 
 const DiffHunkLineSchema = t.Object({
@@ -58,14 +58,14 @@ export const diffHandler = createRouter()
 		}),
 		response: t.Array(FileDiffSchema)
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
 		// Route the diff to the nested repo that owns the file (if any) —
 		// the outer repo's `git diff` returns nothing for files that are
 		// tracked inside a nested repo and gitignored by the parent.
 		const repo = data.filePath
-			? await findRepoForFile(project.path, data.filePath)
+			? await findRepoForFile(root, data.filePath)
 			: null;
-		const cwd = repo?.repoPath ?? project.path;
+		const cwd = repo?.repoPath ?? root;
 		const filePath = repo?.relativeFilePath ?? data.filePath;
 		return await gitService.getDiffUnstaged(cwd, filePath);
 	})
@@ -77,11 +77,11 @@ export const diffHandler = createRouter()
 		}),
 		response: t.Array(FileDiffSchema)
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
 		const repo = data.filePath
-			? await findRepoForFile(project.path, data.filePath)
+			? await findRepoForFile(root, data.filePath)
 			: null;
-		const cwd = repo?.repoPath ?? project.path;
+		const cwd = repo?.repoPath ?? root;
 		const filePath = repo?.relativeFilePath ?? data.filePath;
 		return await gitService.getDiffStaged(cwd, filePath);
 	})
@@ -98,7 +98,7 @@ export const diffHandler = createRouter()
 			body: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.getDiffCommit(cwd, data.commitHash);
 	});

--- a/backend/ws/git/ignored.ts
+++ b/backend/ws/git/ignored.ts
@@ -1,7 +1,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { execGit } from '../../git/git-executor';
-import { requireProjectAccess } from '../access';
+import { requireProjectWorkspace } from '../access';
 import path from 'path';
 
 export const ignoredHandler = createRouter()
@@ -13,11 +13,11 @@ export const ignoredHandler = createRouter()
 			ignored: t.Array(t.String())
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
 		const ignored: string[] = [];
 
 		try {
-			const isRepo = await execGit(['rev-parse', '--is-inside-work-tree'], project.path, 5_000)
+			const isRepo = await execGit(['rev-parse', '--is-inside-work-tree'], root, 5_000)
 				.then(r => r.exitCode === 0)
 				.catch(() => false);
 
@@ -26,31 +26,31 @@ export const ignoredHandler = createRouter()
 			// Get ignored files (leaf paths)
 			const filesResult = await execGit(
 				['ls-files', '--others', '--ignored', '--exclude-standard'],
-				project.path,
+				root,
 				30_000
 			);
 			if (filesResult.exitCode === 0) {
-				const sep = project.path.includes('\\') ? '\\' : '/';
+				const sep = root.includes('\\') ? '\\' : '/';
 				for (const line of filesResult.stdout.split('\n')) {
 					const relPath = line.trim();
 					if (!relPath) continue;
-					ignored.push(path.join(project.path, relPath.replace(/\//g, sep)));
+					ignored.push(path.join(root, relPath.replace(/\//g, sep)));
 				}
 			}
 
 			// Get ignored directories (shown with --directory flag)
 			const dirsResult = await execGit(
 				['ls-files', '--others', '--ignored', '--exclude-standard', '--directory'],
-				project.path,
+				root,
 				30_000
 			);
 			if (dirsResult.exitCode === 0) {
 				const seen = new Set(ignored);
-				const sep = project.path.includes('\\') ? '\\' : '/';
+				const sep = root.includes('\\') ? '\\' : '/';
 				for (const line of dirsResult.stdout.split('\n')) {
 					const relPath = line.trim().replace(/\/$/, '');
 					if (!relPath) continue;
-					const absPath = path.join(project.path, relPath.replace(/\//g, sep));
+					const absPath = path.join(root, relPath.replace(/\//g, sep));
 					if (!seen.has(absPath)) {
 						ignored.push(absPath);
 						seen.add(absPath);

--- a/backend/ws/git/log.ts
+++ b/backend/ws/git/log.ts
@@ -6,7 +6,7 @@ import { t } from 'elysia';
 import path from 'node:path';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { requireProjectAccess } from '../access';
+import { requireProjectWorkspace } from '../access';
 import { debug } from '$shared/utils/logger';
 
 /**
@@ -50,8 +50,8 @@ export const logHandler = createRouter()
 			hasMore: t.Boolean()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.getLog(
 			cwd,
 			data.limit ?? 50,

--- a/backend/ws/git/remote.ts
+++ b/backend/ws/git/remote.ts
@@ -6,7 +6,7 @@ import { t } from 'elysia';
 import path from 'node:path';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
-import { requireProjectAccess } from '../access';
+import { requireProjectWorkspace } from '../access';
 import { debug } from '$shared/utils/logger';
 
 /**
@@ -37,8 +37,8 @@ export const remoteHandler = createRouter()
 			pushUrl: t.String()
 		}))
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.getRemotes(cwd);
 	})
 
@@ -52,8 +52,8 @@ export const remoteHandler = createRouter()
 			message: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		const message = await gitService.fetch(cwd, data.remote);
 		return { message };
 	})
@@ -71,8 +71,8 @@ export const remoteHandler = createRouter()
 			message: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.pull(cwd, data.remote, data.branch, data.rebase);
 	})
 
@@ -94,8 +94,8 @@ export const remoteHandler = createRouter()
 			message: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.pushAdvanced(cwd, data.mode, data.remote, data.branch);
 	})
 
@@ -108,8 +108,8 @@ export const remoteHandler = createRouter()
 			message: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		const message = await gitService.fetchAll(cwd);
 		return { message };
 	})
@@ -127,8 +127,8 @@ export const remoteHandler = createRouter()
 			message: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.push(cwd, data.remote, data.branch, data.force);
 	})
 
@@ -141,8 +141,8 @@ export const remoteHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.addRemote(cwd, data.name, data.url);
 		return { ok: true };
 	})
@@ -156,8 +156,8 @@ export const remoteHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.setRemoteUrl(cwd, data.name, data.url);
 		return { ok: true };
 	})
@@ -171,8 +171,8 @@ export const remoteHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.renameRemote(cwd, data.oldName, data.newName);
 		return { ok: true };
 	})
@@ -187,8 +187,8 @@ export const remoteHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		if (data.oldName !== data.newName) {
 			await gitService.renameRemote(cwd, data.oldName, data.newName);
 		}
@@ -204,8 +204,8 @@ export const remoteHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.removeRemote(cwd, data.name);
 		return { ok: true };
 	})
@@ -219,8 +219,8 @@ export const remoteHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.deleteRemoteBranch(cwd, data.remote, data.branch);
 		return { ok: true };
 	})
@@ -236,8 +236,8 @@ export const remoteHandler = createRouter()
 			date: t.String()
 		}))
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.stashList(cwd);
 	})
 
@@ -250,8 +250,8 @@ export const remoteHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.stashSave(cwd, data.message, data.staged);
 		return { ok: true };
 	})
@@ -268,8 +268,8 @@ export const remoteHandler = createRouter()
 			message: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.stashPop(cwd, data.index);
 	})
 
@@ -281,8 +281,8 @@ export const remoteHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.stashDrop(cwd, data.index);
 		return { ok: true };
 	})
@@ -313,8 +313,8 @@ export const remoteHandler = createRouter()
 			isBinary: t.Boolean()
 		}))
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.stashDiff(cwd, data.index);
 	})
 
@@ -331,8 +331,8 @@ export const remoteHandler = createRouter()
 			isAnnotated: t.Boolean()
 		}))
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.getTags(cwd);
 	})
 
@@ -346,8 +346,8 @@ export const remoteHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.createTag(cwd, data.name, data.message, data.commitHash);
 		return { ok: true };
 	})
@@ -360,8 +360,8 @@ export const remoteHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		await gitService.deleteTag(cwd, data.name);
 		return { ok: true };
 	})
@@ -378,7 +378,7 @@ export const remoteHandler = createRouter()
 			message: t.String()
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = resolveRepoCwd(project.path, data.repoPath);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.pushTag(cwd, data.name, data.remote);
 	});

--- a/backend/ws/git/staging.ts
+++ b/backend/ws/git/staging.ts
@@ -7,7 +7,7 @@ import path from 'node:path';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
 import { findRepoForFile } from '../../git/nested-repos';
-import { requireProjectAccess } from '../access';
+import { requireProjectWorkspace } from '../access';
 import { debug } from '$shared/utils/logger';
 
 function resolveRepoCwd(projectPath: string, repoPath: string | undefined): string | null {
@@ -30,9 +30,9 @@ export const stagingHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const repo = await findRepoForFile(project.path, data.filePath);
-		const cwd = repo?.repoPath ?? project.path;
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const repo = await findRepoForFile(root, data.filePath);
+		const cwd = repo?.repoPath ?? root;
 		const filePath = repo?.relativeFilePath ?? data.filePath;
 		await gitService.stageFile(cwd, filePath);
 		return { ok: true };
@@ -45,8 +45,8 @@ export const stagingHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = data.repoPath ? (resolveRepoCwd(project.path, data.repoPath) ?? project.path) : project.path;
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = data.repoPath ? (resolveRepoCwd(root, data.repoPath) ?? root) : root;
 		await gitService.stageAll(cwd);
 		return { ok: true };
 	})
@@ -58,9 +58,9 @@ export const stagingHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const repo = await findRepoForFile(project.path, data.filePath);
-		const cwd = repo?.repoPath ?? project.path;
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const repo = await findRepoForFile(root, data.filePath);
+		const cwd = repo?.repoPath ?? root;
 		const filePath = repo?.relativeFilePath ?? data.filePath;
 		await gitService.unstageFile(cwd, filePath);
 		return { ok: true };
@@ -73,8 +73,8 @@ export const stagingHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = data.repoPath ? (resolveRepoCwd(project.path, data.repoPath) ?? project.path) : project.path;
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = data.repoPath ? (resolveRepoCwd(root, data.repoPath) ?? root) : root;
 		await gitService.unstageAll(cwd);
 		return { ok: true };
 	})
@@ -86,9 +86,9 @@ export const stagingHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const repo = await findRepoForFile(project.path, data.filePath);
-		const cwd = repo?.repoPath ?? project.path;
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const repo = await findRepoForFile(root, data.filePath);
+		const cwd = repo?.repoPath ?? root;
 		const filePath = repo?.relativeFilePath ?? data.filePath;
 		await gitService.discardFile(cwd, filePath);
 		return { ok: true };
@@ -101,8 +101,8 @@ export const stagingHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		const cwd = data.repoPath ? (resolveRepoCwd(project.path, data.repoPath) ?? project.path) : project.path;
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = data.repoPath ? (resolveRepoCwd(root, data.repoPath) ?? root) : root;
 		await gitService.discardAll(cwd);
 		return { ok: true };
 	});

--- a/backend/ws/git/status.ts
+++ b/backend/ws/git/status.ts
@@ -6,7 +6,7 @@ import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { gitService } from '../../git/git-service';
 import { findNestedRepoPaths } from '../../git/nested-repos';
-import { requireProjectAccess } from '../access';
+import { requireProjectWorkspace } from '../access';
 import { relative as pathRelative } from 'path';
 
 export const statusHandler = createRouter()
@@ -42,9 +42,9 @@ export const statusHandler = createRouter()
 			}))
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
 
-		const isRepo = await gitService.isRepo(project.path);
+		const isRepo = await gitService.isRepo(root);
 		if (!isRepo) {
 			return {
 				isRepo: false,
@@ -61,14 +61,14 @@ export const statusHandler = createRouter()
 		// findNestedRepoPaths cache + inflight dedup also keeps concurrent
 		// callers (status + branches triggered together) from walking twice.
 		const [status, nestedRepoPaths] = await Promise.all([
-			gitService.getStatus(project.path),
+			gitService.getStatus(root),
 			// Discovery failing must not cost the user the outer repo's status.
-			findNestedRepoPaths(project.path).catch(() => [] as string[])
+			findNestedRepoPaths(root).catch(() => [] as string[])
 		]);
 
 		if (nestedRepoPaths.length > 0) {
 			const nestedPrefixes = nestedRepoPaths.map(
-				(repoPath) => pathRelative(project.path, repoPath).replace(/\\/g, '/') + '/'
+				(repoPath) => pathRelative(root, repoPath).replace(/\\/g, '/') + '/'
 			);
 
 			// Drop outer-repo entries that fall under a nested repo's prefix.
@@ -103,7 +103,7 @@ export const statusHandler = createRouter()
 
 			for (const entry of nestedStatuses) {
 				if (!entry) continue;
-				const prefix = pathRelative(project.path, entry.repoPath).replace(/\\/g, '/') + '/';
+				const prefix = pathRelative(root, entry.repoPath).replace(/\\/g, '/') + '/';
 				const withPrefix = (f: typeof entry.nestedStatus.staged[number]) => ({
 					...f,
 					path: prefix + f.path,
@@ -126,8 +126,8 @@ export const statusHandler = createRouter()
 		}),
 		response: t.Object({ ok: t.Boolean() })
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
-		await gitService.init(project.path, data.defaultBranch);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		await gitService.init(root, data.defaultBranch);
 		return { ok: true };
 	})
 
@@ -140,9 +140,9 @@ export const statusHandler = createRouter()
 			root: t.Optional(t.String())
 		})
 	}, async ({ data, conn }) => {
-		const project = requireProjectAccess(conn, data.projectId);
+		const { root } = requireProjectWorkspace(conn, data.projectId);
 
-		const isRepo = await gitService.isRepo(project.path);
-		const root = isRepo ? await gitService.getRoot(project.path) : undefined;
-		return { isRepo, root: root ?? undefined };
+		const isRepo = await gitService.isRepo(root);
+		const repoRoot = isRepo ? await gitService.getRoot(root) : undefined;
+		return { isRepo, root: repoRoot ?? undefined };
 	});

--- a/backend/ws/index.ts
+++ b/backend/ws/index.ts
@@ -43,6 +43,7 @@ import { permissionsRouter } from './permissions';
 import { profilesRouter } from './profiles';
 import { artifactsRouter } from './artifacts';
 import { memoryRouter } from './memory';
+import { worktreesRouter } from './worktrees';
 
 // ============================================
 // Main App Router - Merge All Module Routers
@@ -63,6 +64,9 @@ export const wsRouter = createRouter()
 
 	// Snapshot System
 	.merge(snapshotRouter)
+
+	// Worktrees (isolated project copies)
+	.merge(worktreesRouter)
 
 	// CRUD Operations
 	.merge(projectsRouter)

--- a/backend/ws/preview/access.ts
+++ b/backend/ws/preview/access.ts
@@ -12,6 +12,7 @@ import type { WSConnection } from '$shared/utils/ws-server';
 import { ws } from '$backend/utils/ws';
 import { requireCurrentProjectAccess, requireProjectAccess } from '../access';
 import { browserPreviewServiceManager } from '../../preview/index';
+import { makeScopeKey, scopeProjectId } from '$shared/utils/workspace-scope';
 
 type PreviewService = ReturnType<typeof browserPreviewServiceManager.getService>;
 type Tab = NonNullable<ReturnType<PreviewService['getActiveTab']>>;
@@ -24,7 +25,11 @@ export interface BrowserPreviewContext {
 
 export function requireBrowserPreviewAccess(conn: WSConnection): BrowserPreviewContext {
 	const { userId, projectId } = requireCurrentProjectAccess(conn);
-	const previewService = browserPreviewServiceManager.getService(projectId);
+	// Tabs are scoped to the tree being viewed, so a worktree's preview never
+	// shows the main project's pages.
+	const previewService = browserPreviewServiceManager.getService(
+		makeScopeKey(projectId, ws.getWorktreeId(conn))
+	);
 	return { userId, projectId, previewService };
 }
 
@@ -38,11 +43,14 @@ export function requireBrowserPreviewAccess(conn: WSConnection): BrowserPreviewC
  */
 export function requireBrowserPreviewAccessFor(
 	conn: WSConnection,
-	projectId: string
+	scopeKey: string
 ): BrowserPreviewContext {
+	// The caller passes a workspace scope key; membership is always decided on
+	// the project it belongs to.
+	const projectId = scopeProjectId(scopeKey);
 	requireProjectAccess(conn, projectId); // throws if the caller isn't a member
 	const userId = ws.getUserId(conn);
-	const previewService = browserPreviewServiceManager.getService(projectId);
+	const previewService = browserPreviewServiceManager.getService(scopeKey);
 	return { userId, projectId, previewService };
 }
 

--- a/backend/ws/sessions/crud.ts
+++ b/backend/ws/sessions/crud.ts
@@ -14,7 +14,7 @@ import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import type { EngineType } from '$shared/types/unified';
 import type { ChatSession } from '$shared/types/database/schema';
-import { sessionQueries, messageQueries, projectQueries, snapshotQueries } from '../../database/queries';
+import { sessionQueries, messageQueries, projectQueries, snapshotQueries, worktreeQueries } from '../../database/queries';
 import { ws } from '$backend/utils/ws';
 import { streamManager } from '../../chat/stream-manager';
 import { snapshotService } from '../../snapshot/snapshot-service';
@@ -44,6 +44,8 @@ const sessionSchema = t.Object({
 	head_session_id: t.Optional(t.String()),
 	head_title: t.Optional(t.String()),
 	head_summary: t.Optional(t.String()),
+	// Isolation
+	worktree_id: t.Optional(t.Union([t.String(), t.Null()])),
 	// Activity tracking
 	sender_id: t.Optional(t.String()),
 	sender_name: t.Optional(t.String()),
@@ -78,7 +80,15 @@ function serializeSession(session: ChatSession) {
 		message_count: session.message_count ?? undefined,
 		user_count: session.user_count ?? undefined,
 		last_message_at: session.last_message_at ?? undefined,
+		worktree_id: session.worktree_id ?? null,
 	};
+}
+
+/** Validate a requested worktree belongs to this project; anything else is main. */
+function resolveRequestedWorktree(projectId: string, worktreeId: string | null | undefined): string | null {
+	if (!worktreeId) return null;
+	const worktree = worktreeQueries.getById(worktreeId);
+	return worktree && worktree.project_id === projectId ? worktree.id : null;
 }
 
 export const crudHandler = createRouter()
@@ -125,7 +135,8 @@ export const crudHandler = createRouter()
 	.http('sessions:create', {
 		data: t.Object({
 			title: t.Optional(t.String()),
-			engine: t.Optional(t.Union([t.Literal('claude-code'), t.Literal('opencode'), t.Literal('copilot'), t.Literal('codex'), t.Literal('qwen'), t.Literal('pi'), t.Literal('cline'), t.Literal('cursor')]))
+			engine: t.Optional(t.Union([t.Literal('claude-code'), t.Literal('opencode'), t.Literal('copilot'), t.Literal('codex'), t.Literal('qwen'), t.Literal('pi'), t.Literal('cline'), t.Literal('cursor')])),
+			worktreeId: t.Optional(t.Union([t.String(), t.Null()]))
 		}),
 		response: sessionSchema
 	}, async ({ data, conn }) => {
@@ -136,7 +147,8 @@ export const crudHandler = createRouter()
 			project_id: projectId,
 			title: data.title || 'New Chat Session',
 			engine,
-			started_at: now
+			started_at: now,
+			worktree_id: resolveRequestedWorktree(projectId, data.worktreeId)
 		});
 
 		return serializeSession(session);
@@ -166,20 +178,23 @@ export const crudHandler = createRouter()
 	// Get or create shared session
 	.http('sessions:get-shared', {
 		data: t.Object({
-			forceNew: t.Optional(t.Boolean())
+			forceNew: t.Optional(t.Boolean()),
+			worktreeId: t.Optional(t.Union([t.String(), t.Null()]))
 		}),
 		response: sessionSchema
 	}, async ({ data, conn }) => {
 		const { projectId, project } = requireCurrentProjectAccess(conn);
+		const worktreeId = resolveRequestedWorktree(projectId, data.worktreeId);
 
 		// Check if an active session already exists BEFORE get-or-create
-		const existingActiveSession = (data.forceNew) ? null : sessionQueries.getActiveSessionForProject(projectId);
+		const existingActiveSession = (data.forceNew) ? null : sessionQueries.getActiveSessionForProject(projectId, worktreeId);
 
 		// Get or create shared session
 		const session = sessionQueries.getOrCreateSharedSession(
 			projectId,
 			project.name,
-			data.forceNew || false
+			data.forceNew || false,
+			worktreeId
 		);
 
 		const sessionResponse = serializeSession(session);

--- a/backend/ws/snapshot/restore.ts
+++ b/backend/ws/snapshot/restore.ts
@@ -8,7 +8,7 @@
 
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
-import { messageQueries, sessionQueries, projectQueries, checkpointQueries } from '../../database/queries';
+import { messageQueries, sessionQueries, checkpointQueries } from '../../database/queries';
 import { snapshotService } from '../../snapshot/snapshot-service';
 import { streamManager } from '../../chat/stream-manager';
 import { debug } from '$shared/utils/logger';
@@ -22,6 +22,7 @@ import {
 } from '../../snapshot/helpers';
 import { ws } from '$backend/utils/ws';
 import { requireSessionAccess } from '../access';
+import { resolveSessionRoot } from '../../worktrees';
 
 export const restoreHandler = createRouter()
 	/**
@@ -52,13 +53,9 @@ export const restoreHandler = createRouter()
 
 		debug.log('snapshot', `Checking restore conflicts for checkpoint ${messageId} in session ${sessionId}`);
 
-		// Resolve project path for reading file contents
-		let projectPath: string | undefined;
-		const session = sessionQueries.getById(sessionId);
-		if (session) {
-			const project = projectQueries.getById(session.project_id);
-			if (project) projectPath = project.path;
-		}
+		// Read file contents from the tree this session actually runs in —
+		// its worktree when it has one, the project otherwise.
+		const projectPath = resolveSessionRoot(sessionId)?.path || undefined;
 
 		// Build checkpoint path for branch-aware conflict detection
 		let targetPath: string[] | undefined;
@@ -147,10 +144,10 @@ export const restoreHandler = createRouter()
 			let filesRestored = 0;
 			let filesSkipped = 0;
 
-			const project = projectQueries.getById(session.project_id);
-			if (project) {
+			const sessionRoot = resolveSessionRoot(sessionId);
+			if (sessionRoot?.path) {
 				const result = await snapshotService.restoreSessionScoped(
-					project.path,
+					sessionRoot.path,
 					sessionId,
 					null, // null = restore to initial (before all snapshots)
 					conflictResolutions
@@ -327,10 +324,10 @@ export const restoreHandler = createRouter()
 		let filesRestored = 0;
 		let filesSkipped = 0;
 
-		const project = projectQueries.getById(session.project_id);
-		if (project) {
+		const sessionRoot = resolveSessionRoot(sessionId);
+		if (sessionRoot?.path) {
 			const result = await snapshotService.restoreSessionScoped(
-				project.path,
+				sessionRoot.path,
 				sessionId,
 				resolvedCheckpointId,
 				conflictResolutions,

--- a/backend/ws/worktrees/crud.ts
+++ b/backend/ws/worktrees/crud.ts
@@ -1,0 +1,187 @@
+/**
+ * Worktree CRUD
+ *
+ * Listing, creating, renaming and deleting the isolated project copies that
+ * chat sessions can run in.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import type { WSConnection } from '$shared/utils/ws-server';
+import type { Worktree } from '$shared/types/database/schema';
+import { sessionQueries, worktreeQueries } from '../../database/queries';
+import {
+	countPendingChanges,
+	createWorktree,
+	getWorktreeDiskUsage,
+	removeWorktree
+} from '../../worktrees';
+import { ws } from '$backend/utils/ws';
+import { debug } from '$shared/utils/logger';
+import { requireCurrentProjectAccess, requireSessionAccess } from '../access';
+
+export const worktreeSchema = t.Object({
+	id: t.String(),
+	project_id: t.String(),
+	name: t.String(),
+	slug: t.String(),
+	path: t.String(),
+	status: t.Union([t.Literal('active'), t.Literal('applied'), t.Literal('archived')]),
+	clone_mode: t.Union([t.Literal('reflink'), t.Literal('copy')]),
+	created_by: t.Optional(t.String()),
+	created_at: t.String(),
+	last_opened_at: t.Optional(t.String()),
+	last_applied_at: t.Optional(t.String()),
+	sessionCount: t.Number()
+});
+
+/**
+ * Convert a row → response. `base_tree` is deliberately dropped: it is a full
+ * hash map of the project and has no use on the client.
+ */
+export function serializeWorktree(worktree: Worktree) {
+	return {
+		id: worktree.id,
+		project_id: worktree.project_id,
+		name: worktree.name,
+		slug: worktree.slug,
+		path: worktree.path,
+		status: worktree.status,
+		clone_mode: worktree.clone_mode,
+		created_by: worktree.created_by ?? undefined,
+		created_at: worktree.created_at,
+		last_opened_at: worktree.last_opened_at ?? undefined,
+		last_applied_at: worktree.last_applied_at ?? undefined,
+		sessionCount: worktreeQueries.countSessions(worktree.id)
+	};
+}
+
+/** Tell everyone in the project that the worktree list moved. */
+function broadcastWorktrees(projectId: string): void {
+	ws.emit.project(projectId, 'worktrees:changed', {
+		projectId,
+		worktrees: worktreeQueries.getByProjectId(projectId).map(serializeWorktree)
+	});
+}
+
+export const worktreeCrudHandler = createRouter()
+	.http('worktrees:list', {
+		data: t.Object({}),
+		response: t.Array(worktreeSchema)
+	}, async ({ conn }) => {
+		const { projectId } = requireCurrentProjectAccess(conn);
+		return worktreeQueries.getByProjectId(projectId).map(serializeWorktree);
+	})
+
+	.http('worktrees:create', {
+		data: t.Object({
+			name: t.String({ minLength: 1, maxLength: 80 })
+		}),
+		response: t.Object({
+			worktree: worktreeSchema,
+			fileCount: t.Number(),
+			carriedIgnoredFiles: t.Boolean()
+		})
+	}, async ({ data, conn }) => {
+		const { projectId, userId } = requireCurrentProjectAccess(conn);
+
+		const result = await createWorktree({
+			projectId,
+			name: data.name,
+			createdBy: userId
+		});
+
+		broadcastWorktrees(projectId);
+
+		return {
+			worktree: serializeWorktree(result.worktree),
+			fileCount: result.fileCount,
+			carriedIgnoredFiles: result.carriedIgnoredFiles
+		};
+	})
+
+	.http('worktrees:rename', {
+		data: t.Object({
+			id: t.String({ minLength: 1 }),
+			name: t.String({ minLength: 1, maxLength: 80 })
+		}),
+		response: worktreeSchema
+	}, async ({ data, conn }) => {
+		const worktree = requireWorktreeAccess(conn, data.id);
+		worktreeQueries.rename(worktree.id, data.name.trim());
+		broadcastWorktrees(worktree.project_id);
+
+		const updated = worktreeQueries.getById(worktree.id);
+		if (!updated) throw new Error('Worktree not found');
+		return serializeWorktree(updated);
+	})
+
+	.http('worktrees:delete', {
+		data: t.Object({
+			id: t.String({ minLength: 1 })
+		}),
+		response: t.Object({ success: t.Boolean() })
+	}, async ({ data, conn }) => {
+		const worktree = requireWorktreeAccess(conn, data.id);
+		await removeWorktree(worktree.id);
+		broadcastWorktrees(worktree.project_id);
+		debug.log('worktree', `Deleted worktree ${worktree.name}`);
+		return { success: true };
+	})
+
+	/** Divergence and disk footprint — computed on demand, never in the list. */
+	.http('worktrees:status', {
+		data: t.Object({
+			id: t.String({ minLength: 1 })
+		}),
+		response: t.Object({
+			pendingChanges: t.Number(),
+			diskKilobytes: t.Optional(t.Number())
+		})
+	}, async ({ data, conn }) => {
+		const worktree = requireWorktreeAccess(conn, data.id);
+		const [pendingChanges, diskKilobytes] = await Promise.all([
+			countPendingChanges(worktree.id),
+			getWorktreeDiskUsage(worktree.path)
+		]);
+
+		return { pendingChanges, diskKilobytes: diskKilobytes ?? undefined };
+	})
+
+	/** Bind (or unbind) a chat session to a worktree. */
+	.http('worktrees:assign-session', {
+		data: t.Object({
+			sessionId: t.String({ minLength: 1 }),
+			worktreeId: t.Union([t.String(), t.Null()])
+		}),
+		response: t.Object({ success: t.Boolean() })
+	}, async ({ data, conn }) => {
+		const session = requireSessionAccess(conn, data.sessionId);
+
+		if (data.worktreeId !== null) {
+			const worktree = worktreeQueries.getById(data.worktreeId);
+			if (!worktree || worktree.project_id !== session.project_id) {
+				throw new Error('Worktree not found');
+			}
+			worktreeQueries.touch(worktree.id);
+		}
+
+		sessionQueries.setWorktree(session.id, data.worktreeId);
+		ws.emit.project(session.project_id, 'worktrees:session-assigned', {
+			sessionId: session.id,
+			worktreeId: data.worktreeId
+		});
+
+		return { success: true };
+	});
+
+/** A worktree is reachable exactly when its project is. */
+export function requireWorktreeAccess(conn: WSConnection, worktreeId: string): Worktree {
+	const worktree = worktreeQueries.getById(worktreeId);
+	if (!worktree) throw new Error('Access denied');
+
+	const { projectId } = requireCurrentProjectAccess(conn);
+	if (worktree.project_id !== projectId) throw new Error('Access denied');
+
+	return worktree;
+}

--- a/backend/ws/worktrees/index.ts
+++ b/backend/ws/worktrees/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Worktrees Router
+ *
+ * Structure:
+ * - crud.ts: list/create/rename/delete/status and session binding
+ * - transfer.ts: two-phase apply (worktree → main) and sync (main → worktree)
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { worktreeCrudHandler } from './crud';
+import { worktreeTransferHandler } from './transfer';
+
+export const worktreesRouter = createRouter()
+	.merge(worktreeCrudHandler)
+	.merge(worktreeTransferHandler)
+	// Collaborative broadcast events (Server → Client)
+	.emit('worktrees:changed', t.Object({
+		projectId: t.String(),
+		worktrees: t.Array(t.Any())
+	}))
+	.emit('worktrees:session-assigned', t.Object({
+		sessionId: t.String(),
+		worktreeId: t.Union([t.String(), t.Null()])
+	}))
+	.emit('worktrees:transferred', t.Object({
+		worktreeId: t.String(),
+		projectId: t.String(),
+		direction: t.Union([t.Literal('apply'), t.Literal('sync')]),
+		written: t.Number(),
+		deleted: t.Number(),
+		skipped: t.Number()
+	}));

--- a/backend/ws/worktrees/transfer.ts
+++ b/backend/ws/worktrees/transfer.ts
@@ -1,0 +1,88 @@
+/**
+ * Moving work between a worktree and the main tree.
+ *
+ * Two phases, mirroring the checkpoint restore flow: preview first so the user
+ * sees what would change and resolves anything contested, then execute.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { executeTransfer, previewTransfer } from '../../worktrees';
+import type { MergeResolution } from '../../worktrees';
+import { ws } from '$backend/utils/ws';
+import { debug } from '$shared/utils/logger';
+import { requireWorktreeAccess } from './crud';
+
+const directionSchema = t.Union([t.Literal('apply'), t.Literal('sync')]);
+
+const changeSchema = t.Object({
+	path: t.String(),
+	status: t.Union([t.Literal('added'), t.Literal('modified'), t.Literal('deleted')]),
+	conflict: t.Boolean(),
+	autoMergeable: t.Boolean()
+});
+
+export const worktreeTransferHandler = createRouter()
+	/** Phase 1: what would change, and what needs a decision. */
+	.http('worktrees:preview-transfer', {
+		data: t.Object({
+			id: t.String({ minLength: 1 }),
+			direction: directionSchema
+		}),
+		response: t.Object({
+			direction: directionSchema,
+			changes: t.Array(changeSchema),
+			conflicts: t.Array(t.Object({
+				...changeSchema.properties,
+				sourceContent: t.Optional(t.String()),
+				targetContent: t.Optional(t.String())
+			}))
+		})
+	}, async ({ data, conn }) => {
+		const worktree = requireWorktreeAccess(conn, data.id);
+		const preview = await previewTransfer(worktree.id, data.direction);
+
+		debug.log(
+			'worktree',
+			`Preview ${data.direction} for ${worktree.name}: ${preview.changes.length} changes, ${preview.conflicts.length} conflicts`
+		);
+
+		return preview;
+	})
+
+	/** Phase 2: carry the changes across using the user's resolutions. */
+	.http('worktrees:transfer', {
+		data: t.Object({
+			id: t.String({ minLength: 1 }),
+			direction: directionSchema,
+			resolutions: t.Optional(t.Record(
+				t.String(),
+				t.Union([t.Literal('source'), t.Literal('target'), t.Literal('merge')])
+			))
+		}),
+		response: t.Object({
+			written: t.Number(),
+			deleted: t.Number(),
+			skipped: t.Number(),
+			failed: t.Array(t.String())
+		})
+	}, async ({ data, conn }) => {
+		const worktree = requireWorktreeAccess(conn, data.id);
+
+		const result = await executeTransfer(
+			worktree.id,
+			data.direction,
+			(data.resolutions ?? {}) as Record<string, MergeResolution>
+		);
+
+		ws.emit.project(worktree.project_id, 'worktrees:transferred', {
+			worktreeId: worktree.id,
+			projectId: worktree.project_id,
+			direction: data.direction,
+			written: result.written,
+			deleted: result.deleted,
+			skipped: result.skipped
+		});
+
+		return result;
+	});

--- a/frontend/components/files/FileViewer.svelte
+++ b/frontend/components/files/FileViewer.svelte
@@ -438,7 +438,7 @@
 		// Only fetch when git is tracking this file
 		if (!gitStatusState.isRepo) return;
 
-		ws.http('files:read-file-at', { projectId, filePath: path, ref: 'HEAD' })
+		ws.http('files:read-file-at', { projectId, rootPath: projectPath, filePath: path, ref: 'HEAD' })
 			.then((res) => {
 				if (file?.path !== path) return; // file changed mid-flight
 				headContent = res.content;
@@ -459,7 +459,7 @@
 		// Force re-fetch of HEAD next render cycle by clearing the cache key
 		const path = file?.path || '';
 		if (path && headContentForPath === path && projectId) {
-			ws.http('files:read-file-at', { projectId, filePath: path, ref: 'HEAD' })
+			ws.http('files:read-file-at', { projectId, rootPath: projectPath, filePath: path, ref: 'HEAD' })
 				.then((res) => {
 					if (file?.path !== path) return;
 					headContent = res.content;

--- a/frontend/components/terminal/Terminal.svelte
+++ b/frontend/components/terminal/Terminal.svelte
@@ -10,6 +10,7 @@
 <script lang="ts">
 	import { terminalStore } from '$frontend/stores/features/terminal.svelte';
 	import { projectState } from '$frontend/stores/core/projects.svelte';
+	import { currentScopeKey } from '$frontend/stores/features/worktrees.svelte';
 	import { terminalService, terminalProjectManager } from '$frontend/services/terminal';
 	import { ptyClient, registerSession, unregisterSession } from '$frontend/services/terminal/ptykit-client';
 	import { settings } from '$frontend/stores/features/settings.svelte';
@@ -26,7 +27,9 @@
 	// Project-aware state
 	const hasActiveProject = $derived(projectState.currentProject !== null);
 	const projectPath = $derived(projectState.currentProject?.path || '');
-	const projectId = $derived(projectState.currentProject?.id || '');
+	// Shells are grouped by workspace scope, so a worktree's terminals never show
+	// up alongside the main tree's.
+	const projectId = $derived(currentScopeKey() || projectState.currentProject?.id || '');
 
 	const activeSessionId = $derived(terminalStore.activeSessionId);
 	const sessions = $derived(terminalStore.sessions);

--- a/frontend/components/terminal/TerminalView.svelte
+++ b/frontend/components/terminal/TerminalView.svelte
@@ -5,11 +5,13 @@
 	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import { terminalStore } from '$frontend/stores/features/terminal.svelte';
 	import { projectState } from '$frontend/stores/core/projects.svelte';
+	import { currentScopeKey } from '$frontend/stores/features/worktrees.svelte';
 	
 	// Project-aware state
 	const hasActiveProject = $derived(projectState.currentProject !== null);
 	const projectPath = $derived(projectState.currentProject?.path || '');
-	const projectId = $derived(projectState.currentProject?.id || '');
+	// Workspace scope, so terminals stay inside the tree they belong to.
+	const projectId = $derived(currentScopeKey() || projectState.currentProject?.id || '');
 	
 	function createNewSession() {
 		terminalStore.createNewSession(undefined, hasActiveProject ? projectPath : undefined, hasActiveProject ? projectId : undefined);

--- a/frontend/components/workspace/DesktopNavigator.svelte
+++ b/frontend/components/workspace/DesktopNavigator.svelte
@@ -21,6 +21,7 @@
 	import Dialog from '$frontend/components/common/overlay/Dialog.svelte';
 	import ViewMenu from '$frontend/components/workspace/ViewMenu.svelte';
 	import ToolsMenu from '$frontend/components/workspace/ToolsMenu.svelte';
+	import WorktreeSwitcher from '$frontend/components/worktree/WorktreeSwitcher.svelte';
 	import QuickSearchButton from '$frontend/components/workspace/QuickSearchButton.svelte';
 	import TunnelModal from '$frontend/components/tunnel/TunnelModal.svelte';
 	import RemoteAccessPanel from '$frontend/components/remote-access/RemoteAccessPanel.svelte';
@@ -455,6 +456,7 @@
 
 			<!-- Footer Actions -->
 			<footer class="flex flex-col p-3 border-t border-slate-200 dark:border-slate-800" in:fade={{ duration: 150 }}>
+				<WorktreeSwitcher />
 				<ToolsMenu
 					onRemoteAccess={openRemoteAccessDialog}
 					onPublicTunnel={openTunnelDialog}
@@ -525,6 +527,7 @@
 			</div>
 
 			<footer class="flex flex-col gap-2 py-3 px-2 border-t border-slate-200 dark:border-slate-800">
+				<WorktreeSwitcher collapsed={true} />
 				<ToolsMenu
 					collapsed={true}
 					onRemoteAccess={openRemoteAccessDialog}

--- a/frontend/components/workspace/MobileNavigator.svelte
+++ b/frontend/components/workspace/MobileNavigator.svelte
@@ -7,6 +7,7 @@
 	import { openSettingsModal } from '$frontend/stores/ui/settings-modal.svelte';
 	import { addNotification } from '$frontend/stores/ui/notification.svelte';
 	import ToolsMenu from '$frontend/components/workspace/ToolsMenu.svelte';
+	import WorktreeSwitcher from '$frontend/components/worktree/WorktreeSwitcher.svelte';
 	import TunnelModal from '$frontend/components/tunnel/TunnelModal.svelte';
 	import RemoteAccessPanel from '$frontend/components/remote-access/RemoteAccessPanel.svelte';
 	import DbClientModal from '$frontend/components/db-client/DbClientModal.svelte';
@@ -190,6 +191,7 @@
 		aria-label="Action Buttons"
 	>
 		<!-- Tools (Remote Access, Public Tunnel, DB Client) -->
+		<WorktreeSwitcher collapsed={true} mobile={true} />
 		<ToolsMenu
 			collapsed={true}
 			mobile={true}

--- a/frontend/components/workspace/PanelHeader.svelte
+++ b/frontend/components/workspace/PanelHeader.svelte
@@ -47,6 +47,7 @@
 	// Mobile detection
 	let isMobile = $state(false);
 
+
 	// Touchscreen detection
 	let isTouchDevice = $state(false);
 
@@ -201,6 +202,7 @@
 			{/each}
 		</div>
 
+
 		{#if showActionsMenu}
 			<div class="fixed inset-0 z-40" onclick={closeActionsMenu}></div>
 			<div
@@ -295,6 +297,14 @@
 						<Icon name="lucide:undo-2" class={isMobile ? 'w-4.5 h-4.5' : 'w-4 h-4'} />
 					</button>
 				{/if}
+				<button
+					type="button"
+					class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
+					onclick={() => chatPanelRef?.panelActions?.newIsolatedChat()}
+					title="New Isolated Chat"
+				>
+					<Icon name="lucide:git-fork" class={isMobile ? 'w-4.5 h-4.5' : 'w-4 h-4'} />
+				</button>
 				<button
 					type="button"
 					class="flex items-center justify-center {isMobile ? 'w-9 h-8' : 'w-6 h-6'} bg-transparent border-none rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"

--- a/frontend/components/workspace/panels/ChatPanel.svelte
+++ b/frontend/components/workspace/panels/ChatPanel.svelte
@@ -10,6 +10,7 @@
 	import TaskProgress from '$frontend/components/chat/widgets/TaskProgress.svelte';
 	import RateLimit from '$frontend/components/chat/widgets/RateLimit.svelte';
 	import TimelineModal from '$frontend/components/checkpoint/TimelineModal.svelte';
+	import CreateWorktreeModal from '$frontend/components/worktree/CreateWorktreeModal.svelte';
 	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import Button from '$frontend/components/common/display/Button.svelte';
 	import { debug } from '$shared/utils/logger';
@@ -44,6 +45,9 @@
 
 	// Checkpoints modal state
 	let showCheckpoints = $state(false);
+
+	// "New isolated chat" — creating the worktree also lands a session in it.
+	let showNewWorktree = $state(false);
 
 	function openCheckpoints() {
 		showCheckpoints = true;
@@ -201,6 +205,7 @@
 	export const panelActions = {
 		checkpoints: openCheckpoints,
 		newChat: startNewChat,
+		newIsolatedChat: () => { showNewWorktree = true; },
 		hasMessages: () => sessionState.messages.length > 0
 	};
 </script>
@@ -272,6 +277,11 @@
 				{/if}
 			{/if}
 		</div>
+
+		<CreateWorktreeModal
+			bind:isOpen={showNewWorktree}
+			onClose={() => (showNewWorktree = false)}
+		/>
 
 		<!-- Checkpoint Modal -->
 		<TimelineModal

--- a/frontend/components/workspace/panels/FilesPanel.svelte
+++ b/frontend/components/workspace/panels/FilesPanel.svelte
@@ -60,6 +60,7 @@
 
 <script lang="ts">
 	import { projectState } from '$frontend/stores/core/projects.svelte';
+	import { currentScopeKey } from '$frontend/stores/features/worktrees.svelte';
 	import FileTree from '$frontend/components/files/FileTree.svelte';
 	import FileViewer from '$frontend/components/files/FileViewer.svelte';
 	import Icon from '$frontend/components/common/display/Icon.svelte';
@@ -106,6 +107,9 @@
 	const hasActiveProject = $derived(projectState.currentProject !== null);
 	const projectPath = $derived(projectState.currentProject?.path || '');
 	const projectId = $derived(projectState.currentProject?.id || '');
+	// File-watch events are keyed by workspace, so a worktree's changes never
+	// reach a panel viewing the main tree.
+	const watchScope = $derived(currentScopeKey() || projectId);
 
 	// File watcher state
 	let isWatching = $state(false);
@@ -265,6 +269,9 @@
 	// projectFileStates is at module level to survive component destruction (mobile/desktop switch)
 	let lastProjectPath = $state<string>('');
 	let lastProjectId = $state<string>('');
+	// Workspace the panel last persisted for; the outgoing state must be written
+	// under it, not under the scope the panel has already advanced to.
+	let lastProjectScope = $state<string>('');
 
 	// Container width detection for 2-column layout
 	let containerRef = $state<HTMLDivElement | null>(null);
@@ -357,7 +364,7 @@
 	// Persist using explicit project refs — required when switching projects
 	// because $derived projectId/projectPath have already advanced to the new
 	// project by the time the change-effect fires.
-	function persistStateForProject(targetId: string, targetPath: string) {
+	function persistStateForProject(targetId: string, targetPath: string, targetScope = watchScope) {
 		if (!targetId || !targetPath) return;
 		// Capture unsaved editor buffers for this project so dirty edits survive a
 		// switch (openTabs still holds this project's tabs when called on switch).
@@ -372,6 +379,7 @@
 		projectFileStates.set(targetPath, state);
 		ws.http('files:set-panel-state', {
 			projectId: targetId,
+			scopeKey: targetScope,
 			state: JSON.stringify(state)
 		}).catch((err) => debug.error('file', 'Failed to persist panel state:', err));
 	}
@@ -1994,6 +2002,7 @@
 	$effect(() => {
 		const currentProjectId = projectId;
 		const currentProjectPath = projectPath;
+		const currentScope = watchScope;
 
 		if (!hasActiveProject) {
 			openTabs = [];
@@ -2001,6 +2010,7 @@
 			viewMode = 'tree';
 			lastProjectPath = '';
 			lastProjectId = '';
+			lastProjectScope = '';
 			isInitialLoad = true;
 			panelStateLoaded = false;
 			return;
@@ -2015,7 +2025,7 @@
 				clearTimeout(panelStateSaveTimer);
 				panelStateSaveTimer = null;
 			}
-			persistStateForProject(lastProjectId, lastProjectPath);
+			persistStateForProject(lastProjectId, lastProjectPath, lastProjectScope || lastProjectId);
 		}
 
 		if (lastProjectPath !== currentProjectPath) {
@@ -2039,16 +2049,17 @@
 
 		lastProjectPath = currentProjectPath;
 		lastProjectId = currentProjectId;
+		lastProjectScope = currentScope;
 
 		// Sync git status for the new project
 		syncGitStatusForProject();
 		refreshIgnoredPaths();
 
 		// Restore from DB then load the tree
-		restoreAndLoad(currentProjectId, currentProjectPath);
+		restoreAndLoad(currentProjectId, currentProjectPath, currentScope);
 	});
 
-	async function restoreAndLoad(targetProjectId: string, targetProjectPath: string) {
+	async function restoreAndLoad(targetProjectId: string, targetProjectPath: string, targetScope = watchScope) {
 		// Hold the Files panel's skeleton for the WHOLE restore, not just the tree
 		// fetch: the panel state round-trip happens first, and without this the
 		// panel would show an empty tree for its duration.
@@ -2065,7 +2076,10 @@
 
 			// Always fetch DB state too — it may be newer (cross-device, refresh)
 			try {
-				const result = await ws.http('files:get-panel-state', { projectId: targetProjectId });
+				const result = await ws.http('files:get-panel-state', {
+					projectId: targetProjectId,
+					scopeKey: targetScope
+				});
 				if (projectId !== targetProjectId) return; // race: project changed mid-fetch
 				if (result?.state) {
 					try {
@@ -2165,7 +2179,7 @@
 		let accumulatedChanges: Array<{ path: string; type: 'created' | 'modified' | 'deleted'; timestamp: string }> = [];
 
 		const unsubChanges = ws.on('files:changed', (payload) => {
-			if (payload.projectId !== projectId) return;
+			if (payload.projectId !== watchScope) return;
 			if (payload.changes.length === 0) return;
 
 			// Accumulate changes from all events before debounce fires
@@ -2185,17 +2199,17 @@
 		// have changed, so re-read the tree in place (scroll and expansion kept)
 		// rather than reconciling a phantom change list.
 		const unsubResync = ws.on('files:resync', (payload) => {
-			if (payload.projectId !== projectId) return;
+			if (payload.projectId !== watchScope) return;
 			void loadProjectFiles(true);
 		});
 
 		const unsubWatching = ws.on('files:watching', (payload) => {
-			if (payload.projectId !== projectId) return;
+			if (payload.projectId !== watchScope) return;
 			isWatching = payload.watching;
 		});
 
 		const unsubError = ws.on('files:watch-error', (payload) => {
-			if (payload.projectId !== projectId) return;
+			if (payload.projectId !== watchScope) return;
 			debug.error('file', `Watch error: ${payload.error}`);
 		});
 

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -5,6 +5,7 @@
 	import Modal from '$frontend/components/common/overlay/Modal.svelte';
 	import Dialog from '$frontend/components/common/overlay/Dialog.svelte';
 	import { projectState } from '$frontend/stores/core/projects.svelte';
+	import { currentScopeKey } from '$frontend/stores/features/worktrees.svelte';
 	import { showError, showInfo } from '$frontend/stores/ui/notification.svelte';
 	import { debug } from '$shared/utils/logger';
 	import { scale } from 'svelte/transition';
@@ -62,6 +63,9 @@
 	// Derived state
 	const hasActiveProject = $derived(projectState.currentProject !== null);
 	const projectId = $derived(projectState.currentProject?.id || '');
+	// File-watch events are keyed by workspace, so a worktree's changes never
+	// reach a panel viewing the main tree.
+	const watchScope = $derived(currentScopeKey() || projectId);
 
 	// Git state
 	let isRepo = $state(false);
@@ -78,7 +82,7 @@
 	// Action-bar busy flags are keyed per-project in the workspace store, so an
 	// operation started for one project keeps its spinner (and clears the right
 	// project's flag) even after the user switches projects mid-run.
-	const ops = $derived(getGitOps(projectId));
+	const ops = $derived(getGitOps(watchScope));
 	const isCommitting = $derived(ops.isCommitting);
 
 	// Repo is in a transitional state (detached HEAD or an in-progress operation
@@ -190,7 +194,7 @@
 			type: 'error',
 			confirmText: 'Delete',
 			onConfirm: async () => {
-				await runGitOp(projectId, 'isBranching', async () => {
+				await runGitOp(watchScope, 'isBranching', async () => {
 					const key = nestedRemoteBranchKey(remote, branch, repoPath);
 					deletingRemoteBranch = key;
 					try {
@@ -748,7 +752,7 @@
 		if (!projectId) return;
 		const name = nestedNewBranchName(nested.relPath).trim();
 		if (!name) return;
-		await runGitOp(projectId, 'isBranching', async () => {
+		await runGitOp(watchScope, 'isBranching', async () => {
 		try {
 			await ws.http('git:create-branch', { projectId, name, repoPath: nested.path });
 			showInfo('Branch Created', `Created "${name}" in ${nested.relPath}.`);
@@ -762,7 +766,7 @@
 		}, nested.path);
 	}
 	async function handleSwitchNestedBranch(nested: GitNestedRepoInfo, name: string) {
-		await runGitOp(projectId, 'isBranching', async () => {
+		await runGitOp(watchScope, 'isBranching', async () => {
 		try {
 			await ws.http('git:switch-branch', { projectId, name, repoPath: nested.path });
 			showInfo('Switched Branch', `Switched to "${name}" in ${nested.relPath}.`);
@@ -780,7 +784,7 @@
 			type: 'error',
 			confirmText: 'Delete',
 			onConfirm: async () => {
-				await runGitOp(projectId, 'isBranching', async () => {
+				await runGitOp(watchScope, 'isBranching', async () => {
 					try {
 						await ws.http('git:delete-branch', { projectId, name, repoPath: nested.path });
 						await loadBranches();
@@ -793,7 +797,7 @@
 							confirmText: 'Force Delete',
 							// Its own guard: answered after the first attempt released.
 							onConfirm: async () => {
-								await runGitOp(projectId, 'isBranching', async () => {
+								await runGitOp(watchScope, 'isBranching', async () => {
 									try {
 										await ws.http('git:delete-branch', { projectId, name, force: true, repoPath: nested.path });
 										await loadBranches();
@@ -823,7 +827,7 @@
 		const url = (nestedNewRemoteUrls[relPath] ?? '').trim();
 		if (!name || !url) return;
 		const nestedPath = branchInfo?.nested?.find(entry => entry.relPath === relPath)?.path;
-		await runGitOp(projectId, 'isConfiguring', async () => {
+		await runGitOp(watchScope, 'isConfiguring', async () => {
 		nestedAddingRemote = { ...nestedAddingRemote, [relPath]: true };
 		try {
 			const nested = branchInfo?.nested?.find(n => n.relPath === relPath);
@@ -850,7 +854,7 @@
 		const newUrl = (nestedEditRemoteUrls[relPath] ?? '').trim();
 		if (!oldName || !newName || !newUrl) return;
 		const nestedPath = branchInfo?.nested?.find(entry => entry.relPath === relPath)?.path;
-		await runGitOp(projectId, 'isConfiguring', async () => {
+		await runGitOp(watchScope, 'isConfiguring', async () => {
 		nestedSavingRemote = { ...nestedSavingRemote, [relPath]: true };
 		try {
 			const nested = branchInfo?.nested?.find(n => n.relPath === relPath);
@@ -877,7 +881,7 @@
 			confirmText: 'Remove',
 			onConfirm: async () => {
 				const nested = branchInfo?.nested?.find(entry => entry.relPath === relPath);
-				await runGitOp(projectId, 'isConfiguring', async () => {
+				await runGitOp(watchScope, 'isConfiguring', async () => {
 					try {
 						await ws.http('git:remove-remote', { projectId, name, repoPath: nested?.path });
 						await loadBranches();
@@ -892,7 +896,7 @@
 
 	async function handleNestedFetchRemote(remote: string, relPath: string) {
 		const nestedPath = branchInfo?.nested?.find(entry => entry.relPath === relPath)?.path;
-		await runGitOp(projectId, 'isFetching', async () => {
+		await runGitOp(watchScope, 'isFetching', async () => {
 		nestedFetchingRemote = { ...nestedFetchingRemote, [relPath]: remote };
 		try {
 			const nested = branchInfo?.nested?.find(n => n.relPath === relPath);
@@ -1273,7 +1277,11 @@
 	const isTwoColumnMode = $derived(containerWidth >= TWO_COLUMN_THRESHOLD);
 
 	// Track last project for re-fetch
+	// The workspace the panel last reset for. Keyed on the scope, not the project:
+	// a worktree switch keeps the project id, so keying on it left the panel
+	// showing the previous tree's repository until it was remounted.
 	let lastProjectId = $state('');
+	let lastGitScope = $state('');
 
 	// (File watcher subscription managed by $effect with auto-cleanup)
 
@@ -1327,7 +1335,7 @@
 	// ============================
 
 	async function handleInit() {
-		await runGitOp(projectId, 'isConfiguring', async () => {
+		await runGitOp(watchScope, 'isConfiguring', async () => {
 		isInitializing = true;
 		try {
 			await ws.http('git:init', { projectId, defaultBranch: 'main' });
@@ -1703,7 +1711,7 @@
 			type: 'warning',
 			confirmText: 'Remove',
 			onConfirm: async () => {
-				await runGitOp(projectId, 'isConfiguring', async () => {
+				await runGitOp(watchScope, 'isConfiguring', async () => {
 					try {
 						await ws.http('git:remove-remote', { projectId, name });
 						await loadRemotes();
@@ -1720,7 +1728,7 @@
 		const oldName = editingRemote;
 		const newName = editRemoteName.trim();
 		const newUrl = editRemoteUrl.trim();
-		await runGitOp(projectId, 'isConfiguring', async () => {
+		await runGitOp(watchScope, 'isConfiguring', async () => {
 		savingRemote = true;
 		try {
 			await ws.http('git:edit-remote', { projectId, oldName, newName, newUrl });
@@ -1747,7 +1755,7 @@
 	}
 
 	async function handleFetchRemote(remote: string) {
-		await runGitOp(projectId, 'isFetching', async () => {
+		await runGitOp(watchScope, 'isFetching', async () => {
 		fetchingRemote = remote;
 		try {
 			const result = await ws.http('git:fetch', { projectId, remote }) as { message: string };
@@ -1763,7 +1771,7 @@
 
 	async function handleAddRemote() {
 		if (!newRemoteName.trim() || !newRemoteUrl.trim()) return;
-		await runGitOp(projectId, 'isConfiguring', async () => {
+		await runGitOp(watchScope, 'isConfiguring', async () => {
 		addingRemote = true;
 		try {
 			await ws.http('git:add-remote', { projectId, name: newRemoteName.trim(), url: newRemoteUrl.trim() });
@@ -1782,7 +1790,7 @@
 	}
 
 	async function handlePushBranch(branch: string, repoPath?: string) {
-		await runGitOp(projectId, 'isPushing', async () => {
+		await runGitOp(watchScope, 'isPushing', async () => {
 		pushingBranch = branch;
 		try {
 			const result = await ws.http('git:push', { projectId, branch, repoPath }) as { success: boolean; message: string };
@@ -1824,7 +1832,7 @@
 	}
 
 	async function handlePushBranchForce(branch: string, repoPath?: string) {
-		await runGitOp(projectId, 'isPushing', async () => {
+		await runGitOp(watchScope, 'isPushing', async () => {
 		pushingBranch = branch;
 		try {
 			const result = await ws.http('git:push-advanced', {
@@ -1887,7 +1895,7 @@
 	}
 
 	async function handleCherryPick(hash: string, repoPath?: string) {
-		await runGitOp(projectId, 'isMoreBusy', async () => {
+		await runGitOp(watchScope, 'isMoreBusy', async () => {
 		try {
 			const result = await ws.http('git:cherry-pick', { projectId, hashes: [hash], repoPath }) as { success: boolean; message: string };
 			showInfo(result.success ? 'Cherry-picked' : 'Cherry-pick failed', result.message);
@@ -1962,7 +1970,7 @@
 			type: 'error',
 			confirmText: 'Discard',
 			onConfirm: async () => {
-				await runGitOp(projectId, 'isStaging', async () => {
+				await runGitOp(watchScope, 'isStaging', async () => {
 					try {
 						await ws.http('git:discard', { projectId, filePath: path });
 						await loadStatus();
@@ -2449,7 +2457,7 @@
 	// ============================
 
 	async function switchBranch(name: string) {
-		await runGitOp(projectId, 'isBranching', async () => {
+		await runGitOp(watchScope, 'isBranching', async () => {
 			try {
 				await ws.http('git:switch-branch', { projectId, name });
 				await loadAll();
@@ -2473,7 +2481,7 @@
 			type: 'warning',
 			confirmText: 'Checkout',
 			onConfirm: async () => {
-				await runGitOp(projectId, 'isBranching', async () => {
+				await runGitOp(watchScope, 'isBranching', async () => {
 					try {
 						await ws.http('git:checkout-commit', { projectId, commitHash: hash, repoPath });
 						selectedCommit = null;
@@ -2537,7 +2545,7 @@
 		const parts = remoteBranch.split('/');
 		const localName = parts.slice(1).join('/');
 		if (repoPath) {
-			await runGitOp(projectId, 'isBranching', async () => {
+			await runGitOp(watchScope, 'isBranching', async () => {
 				try {
 					await ws.http('git:create-branch', { projectId, name: localName, startPoint: remoteBranch, repoPath });
 					showInfo('Branch Created', `Checked out "${localName}" from ${remoteBranch}.`);
@@ -2671,7 +2679,7 @@
 		// outcome callers branch on is captured here. A skipped run reads as
 		// failure, which is the honest answer: no branch was created.
 		let created = false;
-		await runGitOp(projectId, 'isBranching', async () => {
+		await runGitOp(watchScope, 'isBranching', async () => {
 			try {
 				await ws.http('git:create-branch', { projectId, name, repoPath });
 				showInfo('Branch Created', `Switched to "${name}".`);
@@ -2703,7 +2711,7 @@
 			inputPlaceholder: 'New branch name',
 			onConfirm: async (newName) => {
 				if (!newName || newName === oldName) return;
-				await runGitOp(projectId, 'isBranching', async () => {
+				await runGitOp(watchScope, 'isBranching', async () => {
 				try {
 					await ws.http('git:rename-branch', { projectId, oldName, newName, repoPath });
 					const pushed = repoPath
@@ -2736,7 +2744,7 @@
 			type: 'error',
 			confirmText: 'Delete',
 			onConfirm: async () => {
-				await runGitOp(projectId, 'isBranching', async () => {
+				await runGitOp(watchScope, 'isBranching', async () => {
 					try {
 						await ws.http('git:delete-branch', { projectId, name });
 						await loadBranches();
@@ -2750,7 +2758,7 @@
 							// Its own guard: this dialog is answered long after the
 							// first attempt released the flag.
 							onConfirm: async () => {
-								await runGitOp(projectId, 'isBranching', async () => {
+								await runGitOp(watchScope, 'isBranching', async () => {
 									try {
 										await ws.http('git:delete-branch', { projectId, name, force: true });
 										await Promise.all([loadBranches(), loadRemotes()]);
@@ -2811,7 +2819,7 @@
 		if (!projectId || !name) return;
 		const activeRepoPath = repoPath ?? mergeRepoPath ?? undefined;
 		const isNested = Boolean(activeRepoPath);
-		const isBusy = getGitOps(projectId, activeRepoPath).isMoreBusy;
+		const isBusy = getGitOps(watchScope, activeRepoPath).isMoreBusy;
 		if (isBusy) return;
 		if (!isNested && blockedWhileBusy('merge')) return;
 
@@ -3008,7 +3016,7 @@
 
 	/** The More menu's slice of `runGitOp`, kept as a name its callers already use. */
 	async function runMore(fn: () => Promise<void>, repoPath?: string) {
-		await runGitOp(projectId, 'isMoreBusy', fn, repoPath);
+		await runGitOp(watchScope, 'isMoreBusy', fn, repoPath);
 	}
 
 	async function pushVariant(mode: 'with-tags' | 'all-tags' | 'force-lease' | 'force', label: string, repoPath?: string, branch?: string, remote?: string) {
@@ -3378,7 +3386,7 @@
 	// ============================
 
 	async function resolveConflict(filePath: string, resolution: 'ours' | 'theirs' | 'custom', customContent?: string) {
-		await runGitOp(projectId, 'isResolving', async () => {
+		await runGitOp(watchScope, 'isResolving', async () => {
 		try {
 			await ws.http('git:resolve-conflict', { projectId, filePath, resolution, customContent });
 			await loadConflicts();
@@ -3460,7 +3468,7 @@ ${bodies}`;
 			type: 'error',
 			confirmText: 'Abort Merge',
 			onConfirm: async () => {
-				await runGitOp(projectId, 'isResolving', async () => {
+				await runGitOp(watchScope, 'isResolving', async () => {
 				try {
 					let targetRepoPath: string | undefined = undefined;
 					const anyConflictFile = conflictFiles[0]?.path || conflictInitialPath;
@@ -3522,7 +3530,7 @@ ${bodies}`;
 	}
 
 	async function handleStashSave() {
-		await runGitOp(projectId, 'isStashing', async () => {
+		await runGitOp(watchScope, 'isStashing', async () => {
 		try {
 			await ws.http('git:stash-save', {
 				projectId,
@@ -3577,7 +3585,7 @@ ${bodies}`;
 	// makes the second click impossible, and `isStashing` disables the section's
 	// buttons so it reads as busy rather than as nothing happening.
 	async function handleStashPop(entry: StashEntryExtended) {
-		await runGitOp(projectId, 'isStashing', async () => {
+		await runGitOp(watchScope, 'isStashing', async () => {
 		try {
 			const result = await ws.http('git:stash-pop', { projectId, index: entry.index, repoPath: entry.repoPath });
 			await Promise.all([loadStash(), loadStatus()]);
@@ -3609,7 +3617,7 @@ ${bodies}`;
 			type: 'error',
 			confirmText: 'Drop',
 			onConfirm: async () => {
-				await runGitOp(projectId, 'isStashing', async () => {
+				await runGitOp(watchScope, 'isStashing', async () => {
 					try {
 						await ws.http('git:stash-drop', { projectId, index: entry.index, repoPath: entry.repoPath });
 						await loadStash();
@@ -3727,7 +3735,7 @@ ${bodies}`;
 
 	async function handleCreateTag() {
 		if (!newTagName.trim()) return;
-		await runGitOp(projectId, 'isTagging', async () => {
+		await runGitOp(watchScope, 'isTagging', async () => {
 		try {
 			await ws.http('git:create-tag', {
 				projectId,
@@ -3755,7 +3763,7 @@ ${bodies}`;
 			type: 'error',
 			confirmText: 'Delete',
 			onConfirm: async () => {
-				await runGitOp(projectId, 'isTagging', async () => {
+				await runGitOp(watchScope, 'isTagging', async () => {
 					try {
 						await ws.http('git:delete-tag', { projectId, name, repoPath });
 						await loadTags();
@@ -3769,7 +3777,7 @@ ${bodies}`;
 	}
 
 	async function handlePushTag(name: string, repoPath?: string) {
-		await runGitOp(projectId, 'isTagging', async () => {
+		await runGitOp(watchScope, 'isTagging', async () => {
 		try {
 			const result = await ws.http('git:push-tag', { projectId, name, repoPath });
 			if (!result.success) {
@@ -3800,10 +3808,12 @@ ${bodies}`;
 
 	$effect(() => {
 		if (hasActiveProject && projectId) {
-			const prevId = untrack(() => lastProjectId);
-			if (projectId !== prevId) {
+			const scope = watchScope;
+			const prevScope = untrack(() => lastGitScope);
+			if (scope !== prevScope) {
 				untrack(() => {
 					lastProjectId = projectId;
+					lastGitScope = scope;
 
 					// Heavy data (open diffs, history) is always re-fetched lazily.
 					resetAllViewTabs();
@@ -3849,7 +3859,7 @@ ${bodies}`;
 					// is handled by the workspace coordinator (snapshot provider +
 					// flush-before-switch), so we ONLY restore here — never save the
 					// already-cleared draft (that previously clobbered it).
-					const restored = loadGitUiState(projectId);
+					const restored = loadGitUiState(watchScope);
 					if (restored) {
 						activeView = restored.activeView;
 						leftPanelWidth = restored.leftPanelWidth;
@@ -3870,8 +3880,8 @@ ${bodies}`;
 					// authoritative, so an in-flight AI generation's result (which
 					// writes straight to that project's draft) is never clobbered by a
 					// stale restore. Mirror the resolved draft into the live commit box.
-					if (!hasCommitDraft(projectId)) setCommitDraft(projectId, restored?.commitMessage ?? '');
-					gitDraft.commitMessage = getCommitDraft(projectId);
+					if (!hasCommitDraft(watchScope)) setCommitDraft(watchScope, restored?.commitMessage ?? '');
+					gitDraft.commitMessage = getCommitDraft(watchScope);
 
 					// Once git status is loaded (isRepo known), re-open the restored
 					// diff tab and load the data behind the restored view. We do this
@@ -3894,7 +3904,7 @@ ${bodies}`;
 			activeView,
 			leftPanelWidth,
 			selectedRemote,
-			commitMessage: getCommitDraft(projectId),
+			commitMessage: getCommitDraft(watchScope),
 			selectedCommitHash: selectedCommit?.hash ?? null,
 			activeDiff: activeTab
 				? {
@@ -4066,7 +4076,7 @@ ${bodies}`;
 		if (!hasActiveProject || !projectId) return;
 
 		const unsub = ws.on('files:changed', (payload: any) => {
-			if (payload.projectId !== projectId) return;
+			if (payload.projectId !== watchScope) return;
 			// An empty change list carries no information; refreshing on it just
 			// churns git and the open diff for nothing.
 			if (payload.changes.length === 0) return;
@@ -4076,7 +4086,7 @@ ${bodies}`;
 		// The watcher was rebuilt and may have missed events. Reconcile everything:
 		// what was missed is by definition unknown, so no section can be trusted.
 		const unsubResync = ws.on('files:resync', (payload: any) => {
-			if (payload.projectId !== projectId) return;
+			if (payload.projectId !== watchScope) return;
 			scheduleGitRefresh(true);
 		});
 
@@ -4100,7 +4110,7 @@ ${bodies}`;
 		if (!hasActiveProject || !projectId) return;
 
 		const unsub = ws.on('git:changed', (payload: any) => {
-			if (payload.projectId !== projectId) return;
+			if (payload.projectId !== watchScope) return;
 			// Full refresh: index/HEAD/refs moved, so branches, remotes, stash, tags,
 			// contributors and the log can all be stale.
 			scheduleGitRefresh(true);
@@ -4284,7 +4294,7 @@ ${bodies}`;
 			</div>
 			{#if !branch.isCurrent}
 			<div class="flex items-center gap-1 shrink-0">
-				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleSwitchNestedBranch(nested, branch.name); }} title="Switch to this branch" disabled={getGitOps(projectId, nested.path).isBranching}><Icon name="lucide:arrow-right" class="w-3.5 h-3.5" /></button>
+				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleSwitchNestedBranch(nested, branch.name); }} title="Switch to this branch" disabled={getGitOps(watchScope, nested.path).isBranching}><Icon name="lucide:arrow-right" class="w-3.5 h-3.5" /></button>
 				{#if !nestedPushed.has(branch.name)}
 					{#if pushingBranch === branch.name}
 						<div class="flex items-center justify-center w-6 h-6 rounded-md text-emerald-500"><Icon name="lucide:loader-circle" class="w-3.5 h-3.5 animate-spin" /></div>
@@ -4293,7 +4303,7 @@ ${bodies}`;
 					{/if}
 				{/if}
 				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); mergeNestedBranch(branch.name, nested.path); }} title="Merge into current branch"><Icon name="lucide:git-merge" class="w-3.5 h-3.5" /></button>
-				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleDeleteNestedBranch(nested, branch.name); }} title="Delete branch" disabled={getGitOps(projectId, nested.path).isBranching}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
+				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleDeleteNestedBranch(nested, branch.name); }} title="Delete branch" disabled={getGitOps(watchScope, nested.path).isBranching}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
 			</div>
 			{:else}
 			<div class="flex items-center gap-1 shrink-0">
@@ -4307,7 +4317,7 @@ ${bodies}`;
 				{#if branch.behind > 0}
 					<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); handlePull(nested.path, getNestedSelectedRemote(nested)); }} title="Pull ({branch.behind} behind)"><Icon name="lucide:download" class="w-3.5 h-3.5" /></button>
 				{/if}
-				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-orange-500/10 hover:text-orange-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); renameBranch(branch.name, nested.path); }} title="Rename branch" disabled={getGitOps(projectId, nested.path).isBranching}><Icon name="lucide:pen-line" class="w-3.5 h-3.5" /></button>
+				<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-orange-500/10 hover:text-orange-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); renameBranch(branch.name, nested.path); }} title="Rename branch" disabled={getGitOps(watchScope, nested.path).isBranching}><Icon name="lucide:pen-line" class="w-3.5 h-3.5" /></button>
 			</div>
 			{/if}
 		</div>
@@ -4438,16 +4448,16 @@ ${bodies}`;
 				<!-- Nested commit form -->
 				<CommitForm
 					stagedCount={nestedStaged.length}
-					isCommitting={getGitOps(projectId, nested.path).isCommitting}
+					isCommitting={getGitOps(watchScope, nested.path).isCommitting}
 					onCommit={(msg) => handleCommit(msg, nested.path)}
 					hasRemotes={nestedRemoteNames(nested).length > 0}
 					selectedRemote={getNestedSelectedRemote(nested)}
 					currentBranch={nested.info.current}
 					branchAhead={nested.info.ahead ?? 0}
 					branchBehind={nested.info.behind ?? 0}
-					isPushing={getGitOps(projectId, nested.path).isPushing}
-					isPulling={getGitOps(projectId, nested.path).isPulling}
-					isMoreBusy={getGitOps(projectId, nested.path).isMoreBusy}
+					isPushing={getGitOps(watchScope, nested.path).isPushing}
+					isPulling={getGitOps(watchScope, nested.path).isPulling}
+					isMoreBusy={getGitOps(watchScope, nested.path).isMoreBusy}
 					repoBusy={Boolean(nested.info.detached || nested.info.operation)}
 					repoBusyReason={nested.info.operation ? `A ${nested.info.operation} is in progress` : nested.info.detached ? 'HEAD is detached' : ''}
 					repoPath={nested.path}
@@ -4494,7 +4504,7 @@ ${bodies}`;
 						onStash={() => openStashPrompt('staged', nested.path)}
 						onViewDiff={(file, sec) => viewDiff(file, sec)}
 						{aiChangesSet}
-						busy={getGitOps(projectId, nested.path).isStaging}
+						busy={getGitOps(watchScope, nested.path).isStaging}
 					/>
 					<ChangesSection
 						title="Changes"
@@ -4509,7 +4519,7 @@ ${bodies}`;
 						onDiscardAll={() => discardAll(nested.path)}
 						onViewDiff={(file, sec) => viewDiff(file, sec)}
 						{aiChangesSet}
-						busy={getGitOps(projectId, nested.path).isStaging}
+						busy={getGitOps(watchScope, nested.path).isStaging}
 					/>
 					{#if nestedTotalChanges === 0 && !isLoading}
 						<div class="flex flex-col items-center justify-center gap-2 py-6 text-slate-500 text-xs">
@@ -4684,7 +4694,7 @@ ${bodies}`;
 													{/if}
 													<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); nestedEditingRemote = { ...nestedEditingRemote, [nested.relPath]: remoteName }; nestedEditRemoteNames = { ...nestedEditRemoteNames, [nested.relPath]: remoteName }; }} title="Edit remote"><Icon name="lucide:pencil" class="w-3.5 h-3.5" /></button>
 													<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); void handleNestedFetchRemote(remoteName, nested.relPath); }} title="Fetch"><Icon name="lucide:refresh-cw" class="w-3.5 h-3.5" /></button>
-													<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleNestedRemoveRemote(remoteName, nested.relPath); }} title="Disconnect" disabled={getGitOps(projectId, nested.path).isConfiguring}><Icon name="lucide:unlink" class="w-3.5 h-3.5" /></button>
+													<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleNestedRemoveRemote(remoteName, nested.relPath); }} title="Disconnect" disabled={getGitOps(watchScope, nested.path).isConfiguring}><Icon name="lucide:unlink" class="w-3.5 h-3.5" /></button>
 												</div>
 											{/if}
 										</div>
@@ -4704,9 +4714,9 @@ ${bodies}`;
 														<div class="flex items-center justify-center w-6 h-6 text-slate-400 shrink-0"><Icon name="lucide:loader-circle" class="w-3.5 h-3.5 animate-spin" /></div>
 													{:else}
 														<div class="flex items-center gap-1 shrink-0">
-															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); checkoutRemoteBranch(branch.name, nested.path); }} title="Checkout locally" disabled={getGitOps(projectId, nested.path).isBranching}><Icon name="lucide:arrow-right" class="w-3.5 h-3.5" /></button>
+															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); checkoutRemoteBranch(branch.name, nested.path); }} title="Checkout locally" disabled={getGitOps(watchScope, nested.path).isBranching}><Icon name="lucide:arrow-right" class="w-3.5 h-3.5" /></button>
 															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); copyToClipboard(branch.name); }} title="Copy branch name"><Icon name="lucide:copy" class="w-3.5 h-3.5" /></button>
-															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleDeleteRemoteBranch(remoteName, shortName, nested.path); }} title="Delete branch" disabled={getGitOps(projectId, nested.path).isBranching}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
+															<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleDeleteRemoteBranch(remoteName, shortName, nested.path); }} title="Delete branch" disabled={getGitOps(watchScope, nested.path).isBranching}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
 														</div>
 													{/if}
 												</div>
@@ -4864,7 +4874,7 @@ ${bodies}`;
 									<button type="button" class="flex-1 px-2 py-1 text-xs font-medium rounded transition-colors cursor-pointer border-none {stashStagedOnly ? 'bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 shadow-sm' : 'bg-transparent text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}" onclick={() => stashStagedOnly = true}>Staged only</button>
 								</div>
 								<div class="flex gap-1.5">
-									<button type="button" class="flex-1 px-3 py-1.5 text-xs font-medium rounded-md bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer border-none disabled:opacity-40 disabled:cursor-not-allowed" onclick={handleStashSave} disabled={getGitOps(projectId, nested.path).isStashing}>Stash Changes</button>
+									<button type="button" class="flex-1 px-3 py-1.5 text-xs font-medium rounded-md bg-violet-600 text-white hover:bg-violet-700 transition-colors cursor-pointer border-none disabled:opacity-40 disabled:cursor-not-allowed" onclick={handleStashSave} disabled={getGitOps(watchScope, nested.path).isStashing}>Stash Changes</button>
 									<button type="button" class="px-3 py-1.5 text-xs font-medium bg-transparent border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors cursor-pointer" onclick={() => { showStashSaveForm = false; stashMessage = ''; stashStagedOnly = false; stashRepoPath = undefined; }}>Cancel</button>
 								</div>
 							</div>
@@ -4903,8 +4913,8 @@ ${bodies}`;
 											</p>
 										</div>
 										<div class="flex items-center gap-1 shrink-0">
-											<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-emerald-500/10 hover:text-emerald-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashPop(entry); }} title="Pop" disabled={getGitOps(projectId, nested.path).isStashing}><Icon name="lucide:archive-restore" class="w-3.5 h-3.5" /></button>
-											<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashDrop(entry); }} title="Drop" disabled={getGitOps(projectId, nested.path).isStashing}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
+											<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-emerald-500/10 hover:text-emerald-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashPop(entry); }} title="Pop" disabled={getGitOps(watchScope, nested.path).isStashing}><Icon name="lucide:archive-restore" class="w-3.5 h-3.5" /></button>
+											<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashDrop(entry); }} title="Drop" disabled={getGitOps(watchScope, nested.path).isStashing}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
 										</div>
 									</div>
 									{#if stashExpanded}
@@ -5014,7 +5024,7 @@ ${bodies}`;
 												? 'bg-violet-600 text-white hover:bg-violet-700'
 												: 'bg-slate-200 dark:bg-slate-700 text-slate-400 dark:text-slate-500 cursor-not-allowed'}"
 										onclick={handleCreateTag}
-										disabled={!newTagName.trim() || getGitOps(projectId, nested.path).isTagging}
+										disabled={!newTagName.trim() || getGitOps(watchScope, nested.path).isTagging}
 									>
 										Create Tag
 									</button>
@@ -5068,7 +5078,7 @@ ${bodies}`;
 											type="button"
 											class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-blue-500/10 hover:text-blue-500 transition-colors bg-transparent border-none cursor-pointer"
 											onclick={() => handlePushTag(tag.name, nested.path)}
-											disabled={getGitOps(projectId, nested.path).isTagging}
+											disabled={getGitOps(watchScope, nested.path).isTagging}
 											title="Push tag to remote"
 										>
 											<Icon name="lucide:arrow-up-from-line" class="w-3.5 h-3.5" />
@@ -5077,7 +5087,7 @@ ${bodies}`;
 											type="button"
 											class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer"
 											onclick={() => handleDeleteTag(tag.name, nested.path)}
-											disabled={getGitOps(projectId, nested.path).isTagging}
+											disabled={getGitOps(watchScope, nested.path).isTagging}
 											title="Delete tag"
 										>
 											<Icon name="lucide:trash-2" class="w-3.5 h-3.5" />

--- a/frontend/components/workspace/panels/TerminalPanel.svelte
+++ b/frontend/components/workspace/panels/TerminalPanel.svelte
@@ -5,6 +5,7 @@
 	import LoadingSpinner from '$frontend/components/common/feedback/LoadingSpinner.svelte';
 	import { terminalStore } from '$frontend/stores/features/terminal.svelte';
 	import { projectState } from '$frontend/stores/core/projects.svelte';
+	import { currentScopeKey } from '$frontend/stores/features/worktrees.svelte';
 
 	// Props
 	interface Props {
@@ -15,7 +16,8 @@
 
 	const hasActiveProject = $derived(projectState.currentProject !== null);
 	const projectPath = $derived(projectState.currentProject?.path || '');
-	const projectId = $derived(projectState.currentProject?.id || '');
+	// Workspace scope, so terminals stay inside the tree they belong to.
+	const projectId = $derived(currentScopeKey() || projectState.currentProject?.id || '');
 
 	// Terminal reference
 	let terminalRef: any = $state();

--- a/frontend/components/worktree/CreateWorktreeModal.svelte
+++ b/frontend/components/worktree/CreateWorktreeModal.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	import Modal from '$frontend/components/common/overlay/Modal.svelte';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import Button from '$frontend/components/common/display/Button.svelte';
+	import { addNotification } from '$frontend/stores/ui/notification.svelte';
+	import { projectState } from '$frontend/stores/core/projects.svelte';
+	import {
+		createWorktree,
+		switchWorktreeContext,
+		worktreeState
+	} from '$frontend/stores/features/worktrees.svelte';
+
+	interface Props {
+		isOpen: boolean;
+		onClose: () => void;
+		/** Move the workspace into the new worktree once it exists. */
+		switchOnCreate?: boolean;
+	}
+
+	let { isOpen = $bindable(false), onClose, switchOnCreate = true }: Props = $props();
+
+	let name = $state('');
+	let inputElement = $state<HTMLInputElement>();
+
+	const projectName = $derived(projectState.currentProject?.name ?? '');
+	const canSubmit = $derived(name.trim().length > 0 && !worktreeState.isCreating);
+
+	function handleOpened() {
+		name = '';
+		inputElement?.focus();
+	}
+
+	function handleClose() {
+		if (worktreeState.isCreating) return;
+		isOpen = false;
+		onClose();
+	}
+
+	async function submit() {
+		if (!canSubmit) return;
+
+		try {
+			const worktree = await createWorktree(name.trim());
+			isOpen = false;
+			onClose();
+
+			if (worktree) {
+				addNotification({
+					type: 'success',
+					title: 'Worktree created',
+					message: `"${worktree.name}" is ready — an isolated copy of ${projectName}.`,
+					duration: 4000
+				});
+				if (switchOnCreate) await switchWorktreeContext(worktree.id);
+			}
+		} catch (error) {
+			addNotification({
+				type: 'error',
+				title: 'Could not create worktree',
+				message: error instanceof Error ? error.message : String(error),
+				duration: 5000
+			});
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			void submit();
+		}
+	}
+</script>
+
+<Modal bind:isOpen onClose={handleClose} onOpened={handleOpened} title="New worktree" size="md">
+	<div class="space-y-4">
+		<p class="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+			A worktree is a private copy of <span class="font-medium text-slate-800 dark:text-slate-200">{projectName}</span>.
+			Work done in it — by you or by the agent — never touches the main project until you apply it.
+		</p>
+
+		<div class="space-y-1.5">
+			<label for="worktree-name" class="text-xs font-semibold text-slate-600 dark:text-slate-400 uppercase tracking-wider">
+				Name
+			</label>
+			<input
+				id="worktree-name"
+				bind:this={inputElement}
+				bind:value={name}
+				onkeydown={handleKeydown}
+				type="text"
+				maxlength="80"
+				placeholder="e.g. refactor auth"
+				disabled={worktreeState.isCreating}
+				class="w-full px-3 py-2 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-700 rounded-lg text-sm text-slate-900 dark:text-slate-100 outline-none focus:border-violet-500/50 disabled:opacity-60"
+			/>
+		</div>
+
+	</div>
+
+	{#snippet footer()}
+		<div class="flex justify-end gap-2">
+			<Button variant="ghost" onclick={handleClose} disabled={worktreeState.isCreating}>Cancel</Button>
+			<Button variant="primary" class="gap-2" onclick={submit} disabled={!canSubmit}>
+				{#if worktreeState.isCreating}
+					<Icon name="lucide:loader-circle" class="w-4 h-4 animate-spin" />
+					Creating…
+				{:else}
+					Create worktree
+				{/if}
+			</Button>
+		</div>
+	{/snippet}
+</Modal>

--- a/frontend/components/worktree/WorktreeSwitcher.svelte
+++ b/frontend/components/worktree/WorktreeSwitcher.svelte
@@ -1,0 +1,325 @@
+<script lang="ts">
+	/**
+	 * The one place worktrees are seen and acted on: switch between trees, and
+	 * run each tree's actions inline. A separate manager screen would only be a
+	 * second copy of this list.
+	 */
+	import { scale } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { clickOutside } from '$frontend/utils/click-outside';
+	import { projectState } from '$frontend/stores/core/projects.svelte';
+	import { showConfirm } from '$frontend/stores/ui/dialog.svelte';
+	import { addNotification } from '$frontend/stores/ui/notification.svelte';
+	import {
+		activeContextName,
+		deleteWorktree,
+		fetchWorktreeStatus,
+		isInWorktree,
+		renameWorktree,
+		switchWorktreeContext,
+		worktreeState,
+		type TransferDirection,
+		type WorktreeSummary
+	} from '$frontend/stores/features/worktrees.svelte';
+	import { debug } from '$shared/utils/logger';
+	import CreateWorktreeModal from './CreateWorktreeModal.svelte';
+	import WorktreeTransferModal from './WorktreeTransferModal.svelte';
+
+	interface Props {
+		collapsed?: boolean;
+		mobile?: boolean;
+	}
+
+	const { collapsed = false, mobile = false }: Props = $props();
+
+	let isOpen = $state(false);
+	let showCreate = $state(false);
+	let showTransfer = $state(false);
+	let transferWorktree = $state<WorktreeSummary | null>(null);
+	let transferDirection = $state<TransferDirection>('apply');
+
+	let pendingByWorktree = $state<Record<string, number>>({});
+	let renamingId = $state<string | null>(null);
+	let renameValue = $state('');
+
+	const hasProject = $derived(projectState.currentProject !== null);
+	const contextName = $derived(activeContextName());
+	const inWorktree = $derived(isInWorktree());
+	const worktrees = $derived(worktreeState.worktrees);
+
+	function toggleMenu() {
+		isOpen = !isOpen;
+		if (isOpen) void loadPending();
+	}
+
+	function closeMenu() {
+		isOpen = false;
+		renamingId = null;
+	}
+
+	/** Divergence is computed per worktree, so it loads only while the menu is up. */
+	async function loadPending() {
+		const next: Record<string, number> = {};
+		for (const worktree of worktreeState.worktrees) {
+			try {
+				next[worktree.id] = (await fetchWorktreeStatus(worktree.id)).pendingChanges;
+			} catch (error) {
+				debug.warn('worktree', `Status failed for ${worktree.name}:`, error);
+			}
+		}
+		pendingByWorktree = next;
+	}
+
+	async function selectContext(worktreeId: string | null) {
+		closeMenu();
+		await switchWorktreeContext(worktreeId);
+	}
+
+	function openCreate() {
+		closeMenu();
+		showCreate = true;
+	}
+
+	function startTransfer(worktree: WorktreeSummary, direction: TransferDirection) {
+		closeMenu();
+		transferWorktree = worktree;
+		transferDirection = direction;
+		showTransfer = true;
+	}
+
+	function startRename(worktree: WorktreeSummary) {
+		renamingId = worktree.id;
+		renameValue = worktree.name;
+	}
+
+	async function commitRename() {
+		const id = renamingId;
+		const name = renameValue.trim();
+		renamingId = null;
+		if (!id || !name) return;
+
+		try {
+			await renameWorktree(id, name);
+		} catch (error) {
+			addNotification({
+				type: 'error',
+				title: 'Rename failed',
+				message: error instanceof Error ? error.message : String(error),
+				duration: 4000
+			});
+		}
+	}
+
+	async function remove(worktree: WorktreeSummary) {
+		const pending = pendingByWorktree[worktree.id] ?? 0;
+		const warning =
+			pending > 0
+				? ` It has ${pending} change${pending === 1 ? '' : 's'} that were never applied to Main — they will be lost.`
+				: '';
+
+		closeMenu();
+		const confirmed = await showConfirm({
+			title: `Delete "${worktree.name}"?`,
+			message: `The worktree directory and everything in it is removed.${warning}`,
+			type: 'warning',
+			confirmText: 'Delete'
+		});
+		if (!confirmed) return;
+
+		try {
+			await deleteWorktree(worktree.id);
+		} catch (error) {
+			addNotification({
+				type: 'error',
+				title: 'Delete failed',
+				message: error instanceof Error ? error.message : String(error),
+				duration: 4000
+			});
+		}
+	}
+
+	function summaryFor(worktree: WorktreeSummary): string {
+		const parts = [`${worktree.sessionCount} chat${worktree.sessionCount === 1 ? '' : 's'}`];
+		const pending = pendingByWorktree[worktree.id];
+		if (pending !== undefined) parts.push(`${pending} pending`);
+		if (worktree.status === 'applied') parts.push('applied');
+		return parts.join(' · ');
+	}
+
+	const actionButtonClass =
+		'flex items-center justify-center w-6 h-6 rounded-md text-slate-500 transition-colors duration-150';
+</script>
+
+{#if hasProject}
+	<div class="relative" use:clickOutside={closeMenu}>
+		{#if collapsed}
+			<button
+				type="button"
+				class="flex items-center justify-center bg-transparent border-none cursor-pointer transition-all duration-150 relative
+					{mobile ? 'w-9 h-8 rounded-md active:bg-violet-500/10' : 'w-9 h-9 rounded-lg hover:bg-violet-500/10'}
+					{inWorktree ? 'text-amber-600 dark:text-amber-400' : 'text-slate-500 hover:text-slate-900 dark:hover:text-slate-100'}
+					{isOpen ? 'bg-violet-500/10' : ''}"
+				onclick={toggleMenu}
+				aria-label="Worktree"
+				aria-expanded={isOpen}
+				title="Worktree: {contextName}"
+			>
+				<Icon name="lucide:git-fork" class={mobile ? 'w-4.5 h-4.5' : 'w-5 h-5'} />
+				{#if inWorktree}
+					<span
+						class="absolute top-0.5 right-0.5 w-2 h-2 rounded-full bg-amber-500 border-2 border-slate-50 dark:border-slate-900/95"
+					></span>
+				{/if}
+			</button>
+		{:else}
+			<button
+				type="button"
+				class="flex items-center gap-2.5 w-full py-2.5 px-3 bg-transparent border-none rounded-lg text-sm cursor-pointer transition-all duration-150 hover:bg-violet-500/10
+					{inWorktree ? 'text-amber-700 dark:text-amber-400' : 'text-slate-500 hover:text-slate-900 dark:hover:text-slate-100'}
+					{isOpen ? 'bg-violet-500/10' : ''}"
+				onclick={toggleMenu}
+				aria-label="Worktree"
+				aria-expanded={isOpen}
+			>
+				<Icon name="lucide:git-fork" class="w-4 h-4 shrink-0" />
+				<span class="flex-1 text-left truncate">{contextName}</span>
+				<Icon name="lucide:chevron-up" class="w-3.5 h-3.5 shrink-0 opacity-60" />
+			</button>
+		{/if}
+
+		{#if isOpen}
+			<div
+				class="absolute {mobile ? 'top-full right-0 mt-1' : 'bottom-full left-0 mb-1'} w-72 bg-white dark:bg-slate-800 border border-violet-500/20 rounded-lg shadow-2xl shadow-slate-900/20 dark:shadow-black/40 z-50 overflow-hidden"
+				transition:scale={{ duration: 150, easing: cubicOut, start: 0.95, opacity: 0 }}
+			>
+				<div class="py-1.5 max-h-[28rem] overflow-y-auto">
+					<div class="px-3 py-1.5 text-xs font-semibold text-slate-600 dark:text-slate-500 uppercase tracking-wider">
+						Worktree
+					</div>
+
+					<button
+						type="button"
+						class="flex items-center gap-3 w-full px-3 py-2.5 bg-transparent border-none text-left cursor-pointer transition-all duration-150 hover:bg-violet-500/10"
+						onclick={() => selectContext(null)}
+					>
+						<Icon name="lucide:folder" class="w-4 h-4 shrink-0 {inWorktree ? 'text-slate-500' : 'text-violet-600 dark:text-violet-400'}" />
+						<div class="flex flex-col min-w-0 flex-1">
+							<span class="text-sm font-medium text-slate-800 dark:text-slate-200">Main</span>
+							<span class="text-xs text-slate-500 dark:text-slate-500 truncate">The project itself</span>
+						</div>
+						{#if !inWorktree}
+							<Icon name="lucide:check" class="w-4 h-4 shrink-0 text-violet-600 dark:text-violet-400" />
+						{/if}
+					</button>
+
+					{#each worktrees as worktree (worktree.id)}
+						{@const isActive = worktreeState.activeId === worktree.id}
+						<div class="px-3 py-2 transition-colors duration-150 hover:bg-violet-500/5">
+							<div class="flex items-center gap-3">
+								<Icon
+									name="lucide:git-fork"
+									class="w-4 h-4 shrink-0 {isActive ? 'text-amber-600 dark:text-amber-400' : 'text-slate-500'}"
+								/>
+
+								{#if renamingId === worktree.id}
+									<!-- svelte-ignore a11y_autofocus -->
+									<input
+										autofocus
+										bind:value={renameValue}
+										onblur={commitRename}
+										onkeydown={(event) => {
+											if (event.key === 'Enter') commitRename();
+											if (event.key === 'Escape') renamingId = null;
+										}}
+										class="flex-1 min-w-0 px-2 py-1 bg-white dark:bg-slate-900 border border-violet-500/50 rounded text-sm text-slate-900 dark:text-slate-100 outline-none"
+									/>
+								{:else}
+									<button
+										type="button"
+										class="flex flex-col min-w-0 flex-1 bg-transparent border-none text-left cursor-pointer p-0"
+										title={worktree.path}
+										onclick={() => selectContext(worktree.id)}
+									>
+										<span class="text-sm font-medium text-slate-800 dark:text-slate-200 truncate w-full">
+											{worktree.name}
+										</span>
+										<span class="text-xs text-slate-500 dark:text-slate-500 truncate w-full">
+											{summaryFor(worktree)}
+										</span>
+									</button>
+
+									{#if isActive}
+										<Icon name="lucide:check" class="w-4 h-4 shrink-0 text-amber-600 dark:text-amber-400" />
+									{/if}
+								{/if}
+							</div>
+
+							{#if renamingId !== worktree.id}
+								<div class="flex items-center gap-1 mt-1.5 pl-7">
+									<button
+										type="button"
+										class="{actionButtonClass} hover:bg-violet-500/10 hover:text-violet-600"
+										title="Apply to Main"
+										aria-label="Apply to Main"
+										onclick={() => startTransfer(worktree, 'apply')}
+									>
+										<Icon name="lucide:arrow-up-from-line" class="w-3.5 h-3.5" />
+									</button>
+									<button
+										type="button"
+										class="{actionButtonClass} hover:bg-violet-500/10 hover:text-violet-600"
+										title="Sync from Main"
+										aria-label="Sync from Main"
+										onclick={() => startTransfer(worktree, 'sync')}
+									>
+										<Icon name="lucide:arrow-down-to-line" class="w-3.5 h-3.5" />
+									</button>
+									<button
+										type="button"
+										class="{actionButtonClass} hover:bg-violet-500/10 hover:text-violet-600"
+										title="Rename"
+										aria-label="Rename"
+										onclick={() => startRename(worktree)}
+									>
+										<Icon name="lucide:pencil" class="w-3.5 h-3.5" />
+									</button>
+									<button
+										type="button"
+										class="{actionButtonClass} hover:bg-red-500/10 hover:text-red-500"
+										title="Delete"
+										aria-label="Delete"
+										onclick={() => remove(worktree)}
+									>
+										<Icon name="lucide:trash-2" class="w-3.5 h-3.5" />
+									</button>
+								</div>
+							{/if}
+						</div>
+					{/each}
+
+					<div class="my-1 h-px bg-slate-200 dark:bg-slate-700"></div>
+
+					<!-- Secondary action: lighter than the tree rows it sits under. -->
+					<button
+						type="button"
+						class="flex items-center gap-2 w-full px-3 py-1.5 bg-transparent border-none text-left cursor-pointer text-slate-600 dark:text-slate-400 transition-colors duration-150 hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
+						onclick={openCreate}
+					>
+						<Icon name="lucide:plus" class="w-3.5 h-3.5 shrink-0" />
+						<span class="text-xs font-medium">New worktree…</span>
+					</button>
+				</div>
+			</div>
+		{/if}
+	</div>
+
+	<CreateWorktreeModal bind:isOpen={showCreate} onClose={() => (showCreate = false)} />
+
+	<WorktreeTransferModal
+		bind:isOpen={showTransfer}
+		worktree={transferWorktree}
+		direction={transferDirection}
+		onClose={() => (showTransfer = false)}
+	/>
+{/if}

--- a/frontend/components/worktree/WorktreeTransferModal.svelte
+++ b/frontend/components/worktree/WorktreeTransferModal.svelte
@@ -1,0 +1,261 @@
+<script lang="ts">
+	/**
+	 * Moving work between a worktree and the main project.
+	 *
+	 * Two phases so nothing lands unseen: the preview lists every file that would
+	 * change, and any file both sides touched has to be resolved before the
+	 * transfer runs. Where a clean line-level merge exists it is offered as the
+	 * default, so the all-or-nothing choice is the exception rather than the rule.
+	 */
+	import Modal from '$frontend/components/common/overlay/Modal.svelte';
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import Button from '$frontend/components/common/display/Button.svelte';
+	import DiffBlock from '$frontend/components/chat/tools/variants/classic/components/DiffBlock.svelte';
+	import { addNotification } from '$frontend/stores/ui/notification.svelte';
+	import {
+		previewTransfer,
+		runTransfer,
+		worktreeState,
+		type MergeResolution,
+		type TransferDirection,
+		type TransferPreview,
+		type WorktreeSummary
+	} from '$frontend/stores/features/worktrees.svelte';
+	import { debug } from '$shared/utils/logger';
+	import type { IconName } from '$shared/types/ui/icons';
+
+	interface Props {
+		isOpen: boolean;
+		worktree: WorktreeSummary | null;
+		direction: TransferDirection;
+		onClose: () => void;
+	}
+
+	let { isOpen = $bindable(false), worktree, direction, onClose }: Props = $props();
+
+	let preview = $state<TransferPreview | null>(null);
+	let isLoading = $state(false);
+	let resolutions = $state<Record<string, MergeResolution>>({});
+	let expandedPaths = $state<Set<string>>(new Set());
+
+	const sourceLabel = $derived(direction === 'apply' ? worktree?.name ?? 'worktree' : 'Main');
+	const targetLabel = $derived(direction === 'apply' ? 'Main' : worktree?.name ?? 'worktree');
+	const title = $derived(direction === 'apply' ? 'Apply to Main' : 'Sync from Main');
+
+	const cleanChanges = $derived(preview?.changes.filter((change) => !change.conflict) ?? []);
+	const conflicts = $derived(preview?.conflicts ?? []);
+	const hasChanges = $derived((preview?.changes.length ?? 0) > 0);
+
+	async function loadPreview() {
+		if (!worktree) return;
+
+		isLoading = true;
+		preview = null;
+		resolutions = {};
+
+		try {
+			const result = await previewTransfer(worktree.id, direction);
+			preview = result;
+
+			// Default every conflict to the safest outcome that keeps both sides'
+			// work: a clean merge where one exists, otherwise leave the target alone.
+			const defaults: Record<string, MergeResolution> = {};
+			for (const conflict of result.conflicts) {
+				defaults[conflict.path] = conflict.autoMergeable ? 'merge' : 'target';
+			}
+			resolutions = defaults;
+			expandedPaths = new Set();
+		} catch (error) {
+			debug.error('worktree', 'Preview failed:', error);
+			addNotification({
+				type: 'error',
+				title: 'Could not read changes',
+				message: error instanceof Error ? error.message : String(error),
+				duration: 5000
+			});
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	function handleClose() {
+		if (worktreeState.isTransferring) return;
+		isOpen = false;
+		preview = null;
+		onClose();
+	}
+
+	async function confirm() {
+		if (!worktree || !preview) return;
+
+		try {
+			const result = await runTransfer(worktree.id, direction, resolutions);
+			isOpen = false;
+			preview = null;
+			onClose();
+
+			const kept = result.skipped > 0 ? `, ${result.skipped} kept as-is` : '';
+			addNotification({
+				type: result.failed.length > 0 ? 'warning' : 'success',
+				title: title,
+				message: `${result.written} written, ${result.deleted} removed${kept}${
+					result.failed.length > 0 ? ` — ${result.failed.length} failed` : ''
+				}.`,
+				duration: 5000
+			});
+		} catch (error) {
+			addNotification({
+				type: 'error',
+				title: 'Transfer failed',
+				message: error instanceof Error ? error.message : String(error),
+				duration: 5000
+			});
+		}
+	}
+
+	function toggleDiff(filePath: string) {
+		const next = new Set(expandedPaths);
+		if (next.has(filePath)) next.delete(filePath);
+		else next.add(filePath);
+		expandedPaths = next;
+	}
+
+	function statusIcon(status: string): IconName {
+		if (status === 'added') return 'lucide:file-plus';
+		if (status === 'deleted') return 'lucide:file-minus';
+		return 'lucide:file-pen';
+	}
+
+	function statusColor(status: string): string {
+		if (status === 'added') return 'text-green-600 dark:text-green-400';
+		if (status === 'deleted') return 'text-red-600 dark:text-red-400';
+		return 'text-amber-600 dark:text-amber-400';
+	}
+</script>
+
+<Modal bind:isOpen onClose={handleClose} onOpened={loadPreview} {title} size="lg">
+	<div class="space-y-4">
+		<p class="text-sm text-slate-600 dark:text-slate-400">
+			Changes move from <span class="font-medium text-slate-800 dark:text-slate-200">{sourceLabel}</span>
+			into <span class="font-medium text-slate-800 dark:text-slate-200">{targetLabel}</span>.
+		</p>
+
+		{#if isLoading}
+			<div class="flex items-center gap-2.5 py-10 justify-center text-sm text-slate-500">
+				<Icon name="lucide:loader-circle" class="w-4 h-4 animate-spin" />
+				Comparing both trees…
+			</div>
+		{:else if !hasChanges}
+			<div class="flex flex-col items-center gap-2.5 py-10 text-sm text-slate-500">
+				<Icon name="lucide:check-check" class="w-8 h-8 opacity-40" />
+				<span>Nothing to transfer — {targetLabel} is already up to date.</span>
+			</div>
+		{:else}
+			{#if conflicts.length > 0}
+				<div class="space-y-2">
+					<div class="flex items-center gap-2 text-xs font-semibold text-amber-600 dark:text-amber-400 uppercase tracking-wider">
+						<Icon name="lucide:triangle-alert" class="w-3.5 h-3.5" />
+						Changed on both sides ({conflicts.length})
+					</div>
+
+					<div class="space-y-1.5">
+						{#each conflicts as conflict (conflict.path)}
+							<div class="p-2.5 rounded-lg border border-amber-500/30 bg-amber-500/5">
+								<div class="flex items-center gap-2 mb-2">
+									<Icon name={statusIcon(conflict.status)} class="w-3.5 h-3.5 shrink-0 {statusColor(conflict.status)}" />
+									<span class="text-xs font-mono text-slate-700 dark:text-slate-300 truncate flex-1">{conflict.path}</span>
+									{#if conflict.sourceContent !== undefined && conflict.targetContent !== undefined}
+										<button
+											type="button"
+											class="shrink-0 px-1.5 py-0.5 rounded text-3xs font-medium text-slate-500 hover:text-slate-800 dark:hover:text-slate-200 hover:bg-slate-200/70 dark:hover:bg-slate-700/70 transition-colors duration-150"
+											onclick={() => toggleDiff(conflict.path)}
+										>
+											{expandedPaths.has(conflict.path) ? 'Hide diff' : 'View diff'}
+										</button>
+									{/if}
+								</div>
+
+								{#if expandedPaths.has(conflict.path)}
+									<div class="mb-2 max-h-64 overflow-y-auto">
+										<DiffBlock
+											oldString={conflict.targetContent ?? ''}
+											newString={conflict.sourceContent ?? ''}
+											label="{targetLabel} → {sourceLabel}"
+										/>
+									</div>
+								{/if}
+
+								<div class="flex flex-wrap gap-1.5">
+									{#if conflict.autoMergeable}
+										<button
+											type="button"
+											class="px-2 py-1 rounded-md text-xs font-medium transition-colors duration-150 {resolutions[conflict.path] === 'merge'
+												? 'bg-violet-600 text-white'
+												: 'bg-slate-200/70 dark:bg-slate-700/70 text-slate-700 dark:text-slate-300 hover:bg-violet-500/20'}"
+											onclick={() => (resolutions = { ...resolutions, [conflict.path]: 'merge' })}
+										>
+											Merge both
+										</button>
+									{/if}
+									<button
+										type="button"
+										class="px-2 py-1 rounded-md text-xs font-medium transition-colors duration-150 {resolutions[conflict.path] === 'source'
+											? 'bg-violet-600 text-white'
+											: 'bg-slate-200/70 dark:bg-slate-700/70 text-slate-700 dark:text-slate-300 hover:bg-violet-500/20'}"
+										onclick={() => (resolutions = { ...resolutions, [conflict.path]: 'source' })}
+									>
+										Take {sourceLabel}
+									</button>
+									<button
+										type="button"
+										class="px-2 py-1 rounded-md text-xs font-medium transition-colors duration-150 {resolutions[conflict.path] === 'target'
+											? 'bg-violet-600 text-white'
+											: 'bg-slate-200/70 dark:bg-slate-700/70 text-slate-700 dark:text-slate-300 hover:bg-violet-500/20'}"
+										onclick={() => (resolutions = { ...resolutions, [conflict.path]: 'target' })}
+									>
+										Keep {targetLabel}
+									</button>
+								</div>
+							</div>
+						{/each}
+					</div>
+				</div>
+			{/if}
+
+			{#if cleanChanges.length > 0}
+				<div class="space-y-2">
+					<div class="text-xs font-semibold text-slate-600 dark:text-slate-500 uppercase tracking-wider">
+						Transfers cleanly ({cleanChanges.length})
+					</div>
+					<div class="max-h-64 overflow-y-auto rounded-lg border border-slate-200 dark:border-slate-700 divide-y divide-slate-200 dark:divide-slate-700">
+						{#each cleanChanges as change (change.path)}
+							<div class="flex items-center gap-2 px-2.5 py-1.5">
+								<Icon name={statusIcon(change.status)} class="w-3.5 h-3.5 shrink-0 {statusColor(change.status)}" />
+								<span class="text-xs font-mono text-slate-700 dark:text-slate-300 truncate">{change.path}</span>
+							</div>
+						{/each}
+					</div>
+				</div>
+			{/if}
+		{/if}
+	</div>
+
+	{#snippet footer()}
+		<div class="flex justify-end gap-2">
+			<Button variant="ghost" onclick={handleClose} disabled={worktreeState.isTransferring}>Cancel</Button>
+			<Button
+				variant="primary"
+				class="gap-2"
+				onclick={confirm}
+				disabled={!hasChanges || isLoading || worktreeState.isTransferring}
+			>
+				{#if worktreeState.isTransferring}
+					<Icon name="lucide:loader-circle" class="w-4 h-4 animate-spin" />
+					Transferring…
+				{:else}
+					{title}
+				{/if}
+			</Button>
+		</div>
+	{/snippet}
+</Modal>

--- a/frontend/stores/core/projects.svelte.ts
+++ b/frontend/stores/core/projects.svelte.ts
@@ -70,6 +70,46 @@ export function currentProjectPath() {
 	return projectState.currentProject?.path || '';
 }
 
+/**
+ * Root override installed when the active session runs in a worktree.
+ *
+ * `currentProject` is what every panel reads to find the tree it works on, so
+ * overriding its path here is what makes Files, Git, Terminal and Preview
+ * follow the session into its worktree — rather than each panel having to know
+ * worktrees exist. Identity is untouched: the id still points at the real
+ * project, so sessions, settings and engine config resolve to the parent.
+ */
+let projectRootOverride: { projectId: string; path: string } | null = null;
+
+/** The project's own path, ignoring any worktree override. */
+export function mainProjectPath(): string {
+	const id = projectState.currentProject?.id;
+	if (!id) return '';
+	return projectState.projects.find((p) => p.id === id)?.path || projectState.currentProject?.path || '';
+}
+
+function withRootOverride(project: Project): Project {
+	if (!projectRootOverride || projectRootOverride.projectId !== project.id) return project;
+	return { ...project, path: projectRootOverride.path };
+}
+
+/** Point the workspace at `path` (a worktree) or back at the project (null). */
+export function setProjectRootOverride(projectId: string, path: string | null): void {
+	const next = path ? { projectId, path } : null;
+	const unchanged =
+		(next === null && projectRootOverride === null) ||
+		(next !== null && projectRootOverride?.projectId === next.projectId &&
+			projectRootOverride?.path === next.path);
+	if (unchanged) return;
+
+	projectRootOverride = next;
+
+	const record = projectState.projects.find((p) => p.id === projectId);
+	if (record && projectState.currentProject?.id === projectId) {
+		projectState.currentProject = withRootOverride(record);
+	}
+}
+
 // ========================================
 // PROJECT MANAGEMENT
 // ========================================
@@ -111,6 +151,12 @@ export async function setCurrentProject(project: Project | null) {
 		return;
 	}
 
+	// Drop the outgoing project's worktree context before anything loads, so the
+	// docks activate against the new project's main tree rather than a tree that
+	// belongs to the project being left.
+	const { clearWorktreeState } = await import('$frontend/stores/features/worktrees.svelte');
+	clearWorktreeState();
+
 	const token = beginProjectSwitch();
 
 	// Raise the barrier as early as possible so no frame of the outgoing project
@@ -151,7 +197,7 @@ export async function setCurrentProject(project: Project | null) {
 		await activateProjectWorkspace(
 			newProjectId ?? null,
 			() => {
-				if (project) projectState.currentProject = project;
+				if (project) projectState.currentProject = withRootOverride(project);
 			},
 			token
 		);
@@ -176,11 +222,23 @@ export async function setCurrentProject(project: Project | null) {
 	if (!project) {
 		appState.isRestoring = false;
 		persistCurrentProjectId(null);
+		const { clearWorktreeState } = await import('$frontend/stores/features/worktrees.svelte');
+		clearWorktreeState();
 		debug.log('project', 'Project cleared');
 		return;
 	}
 
 	persistCurrentProjectId(project.id);
+
+	// Worktrees must land before the session does: the session names the tree it
+	// runs in by id, and resolving that id to a path needs the list.
+	const { initWorktreeEvents, loadWorktrees } = await import('$frontend/stores/features/worktrees.svelte');
+	initWorktreeEvents();
+	await loadWorktrees();
+	if (!isCurrentSwitch(token)) {
+		releaseChat?.();
+		return;
+	}
 
 	// Everything below runs AFTER the reveal, behind the chat panel's skeleton.
 	try {
@@ -275,7 +333,7 @@ async function refreshProjectRecord(projectId: string): Promise<void> {
 		}
 		// Only adopt it as current if the user hasn't moved on in the meantime.
 		if (projectState.currentProject?.id === projectId) {
-			projectState.currentProject = updatedProject;
+			projectState.currentProject = withRootOverride(updatedProject);
 		}
 	} catch (error) {
 		debug.error('project', 'Error updating project last opened:', error);
@@ -296,7 +354,7 @@ export function updateProject(updatedProject: Project) {
 
 		// Update current project if it's the same
 		if (projectState.currentProject?.id === updatedProject.id) {
-			projectState.currentProject = updatedProject;
+			projectState.currentProject = withRootOverride(updatedProject);
 		}
 	}
 	updateRecentProjects();
@@ -314,6 +372,7 @@ export function removeProject(projectId: string) {
 	// Clear current project if it's being removed
 	if (projectState.currentProject?.id === projectId) {
 		projectState.currentProject = null;
+		if (projectRootOverride?.projectId === projectId) projectRootOverride = null;
 	}
 
 	// Clean up in-memory state to prevent memory leaks
@@ -412,9 +471,23 @@ export async function loadProjects(restoreProjectId?: string | null) {
 					// screen, so the restored layout is ready on first paint.
 					// Publish currentProject via the post-restore hook (batched with
 					// the layout swap) for parity with the project-switch path.
+					const { clearWorktreeState } = await import(
+						'$frontend/stores/features/worktrees.svelte'
+					);
+					clearWorktreeState();
+
 					await activateProjectWorkspace(existingProject.id, () => {
-						projectState.currentProject = existingProject;
+						projectState.currentProject = withRootOverride(existingProject);
 					});
+
+					// Same ordering rule as a project switch: the worktree list has to
+					// be here before a session names one, or the restored session would
+					// render against the main tree.
+					const { initWorktreeEvents, loadWorktrees } = await import(
+						'$frontend/stores/features/worktrees.svelte'
+					);
+					initWorktreeEvents();
+					await loadWorktrees();
 
 					// Start tracking the restored project
 					if (typeof window !== 'undefined') {

--- a/frontend/stores/core/sessions.svelte.ts
+++ b/frontend/stores/core/sessions.svelte.ts
@@ -119,6 +119,11 @@ export async function setCurrentSession(session: ChatSession | null, skipLoadMes
 	// session re-detects its state via catchupActiveStream on switch.
 	syncGlobalStateFromSession(session?.id ?? null);
 
+	// Point the workspace at the tree this session runs in, before anything else
+	// asks the server for files, terminals or preview tabs.
+	const { syncWorktreeContextFromSession } = await import('$frontend/stores/features/worktrees.svelte');
+	await syncWorktreeContextFromSession(session);
+
 	// Clear unread status when viewing a session
 	if (session) {
 		markSessionRead(session.id);
@@ -148,6 +153,8 @@ export async function setCurrentSession(session: ChatSession | null, skipLoadMes
 					sessionState.sessions[idx] = freshSession;
 				}
 				sessionState.currentSession = freshSession;
+
+				await syncWorktreeContextFromSession(freshSession);
 			}
 		} catch {
 			// Ignore - proceed with existing session data
@@ -171,10 +178,15 @@ export async function setCurrentSession(session: ChatSession | null, skipLoadMes
 	}
 }
 
-export async function createSession(projectId: string, title: string, forceNew: boolean = false): Promise<ChatSession | null> {
+export async function createSession(projectId: string, title: string, forceNew: boolean = false, worktreeId?: string | null): Promise<ChatSession | null> {
 	try {
+		// A new chat inherits the tree the user is currently working in, unless the
+		// caller names one explicitly (the "new isolated chat" shortcut).
+		const { worktreeState } = await import('$frontend/stores/features/worktrees.svelte');
+		const targetWorktreeId = worktreeId === undefined ? worktreeState.activeId : worktreeId;
+
 		// For shared sessions, we want to get or create a shared session for the project
-		const session = await ws.http('sessions:get-shared', { forceNew });
+		const session = await ws.http('sessions:get-shared', { forceNew, worktreeId: targetWorktreeId });
 
 		// When forceNew is true, mark all other sessions for this project as ended in frontend state
 		// This ensures switching projects and back won't restore the old session
@@ -203,9 +215,9 @@ export async function createSession(projectId: string, title: string, forceNew: 
 	}
 }
 
-export async function createNewChatSession(projectId: string): Promise<ChatSession | null> {
+export async function createNewChatSession(projectId: string, worktreeId?: string | null): Promise<ChatSession | null> {
 	// Force create a new session (ends current shared session if exists)
-	return createSession(projectId, 'New Chat Session', true);
+	return createSession(projectId, 'New Chat Session', true, worktreeId);
 }
 
 export function updateSession(updatedSession: ChatSession) {

--- a/frontend/stores/features/git-status.svelte.ts
+++ b/frontend/stores/features/git-status.svelte.ts
@@ -7,6 +7,7 @@
  */
 
 import { projectState } from '$frontend/stores/core/projects.svelte';
+import { currentScopeKey } from '$frontend/stores/features/worktrees.svelte';
 import ws, { onWsReconnect } from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
 import type { GitFileChange, GitStatus } from '$shared/types/git';
@@ -148,18 +149,18 @@ export function refreshGitStatus(delay = 250): void {
 export function initGitStatus(): void {
 	if (unsubscribeFiles || unsubscribeGit) return;
 	unsubscribeFiles = ws.on('files:changed', (payload) => {
-		if (payload.projectId !== projectState.currentProject?.id) return;
+		if (payload.projectId !== currentScopeKey()) return;
 		// An empty change list says nothing changed — refreshing on it would spawn
 		// a git process for no reason.
 		if (payload.changes.length === 0) return;
 		refreshGitStatus(500);
 	});
 	unsubscribeGit = ws.on('git:changed', (payload) => {
-		if (payload.projectId !== projectState.currentProject?.id) return;
+		if (payload.projectId !== currentScopeKey()) return;
 		refreshGitStatus(150);
 	});
 	unsubscribeResync = ws.on('files:resync', (payload) => {
-		if (payload.projectId !== projectState.currentProject?.id) return;
+		if (payload.projectId !== currentScopeKey()) return;
 		refreshGitStatus(500);
 	});
 	// Every `git:changed` sent while the socket was down was delivered to nobody,

--- a/frontend/stores/features/git-workspace.svelte.ts
+++ b/frontend/stores/features/git-workspace.svelte.ts
@@ -24,6 +24,7 @@ import {
 	getActiveWorkspaceProjectId
 } from '$frontend/stores/ui/project-workspace.svelte';
 import { registerProjectCleanup } from '$frontend/utils/project-state-cleanup';
+import { isScopeOfProject } from '$shared/utils/workspace-scope';
 
 export type GitView = 'changes' | 'log' | 'branches' | 'more';
 
@@ -286,7 +287,15 @@ registerDock({
 });
 
 registerProjectCleanup((projectId) => {
-	pending.delete(projectId);
-	delete commitDrafts[projectId];
-	delete gitOps[projectId];
+	// Entries are keyed per workspace, so a project's worktrees have their own —
+	// deleting the project id alone would strand them.
+	for (const key of [...pending.keys()]) {
+		if (isScopeOfProject(key, projectId)) pending.delete(key);
+	}
+	for (const key of Object.keys(commitDrafts)) {
+		if (isScopeOfProject(key, projectId)) delete commitDrafts[key];
+	}
+	for (const key of Object.keys(gitOps)) {
+		if (isScopeOfProject(key, projectId)) delete gitOps[key];
+	}
 });

--- a/frontend/stores/features/ignored-paths.svelte.ts
+++ b/frontend/stores/features/ignored-paths.svelte.ts
@@ -1,4 +1,5 @@
 import { projectState } from '$frontend/stores/core/projects.svelte';
+import { currentScopeKey } from '$frontend/stores/features/worktrees.svelte';
 import ws from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
 
@@ -60,13 +61,13 @@ export function initIgnoredPaths(): void {
 	refreshIgnoredPaths(0);
 	if (unsubscribeFiles || unsubscribeGit) return;
 	unsubscribeFiles = ws.on('files:changed', (payload) => {
-		if (payload.projectId !== projectState.currentProject?.id) return;
+		if (payload.projectId !== currentScopeKey()) return;
 		// Nothing actually changed — don't spend a round trip on it.
 		if (payload.changes.length === 0) return;
 		refreshIgnoredPaths(500);
 	});
 	unsubscribeGit = ws.on('git:changed', (payload) => {
-		if (payload.projectId !== projectState.currentProject?.id) return;
+		if (payload.projectId !== currentScopeKey()) return;
 		refreshIgnoredPaths(150);
 	});
 }

--- a/frontend/stores/features/preview-tabs-workspace.svelte.ts
+++ b/frontend/stores/features/preview-tabs-workspace.svelte.ts
@@ -30,6 +30,7 @@ import {
 } from '$frontend/components/preview/browser/core/tab-operations.svelte';
 import { browserCleanup } from '$frontend/components/preview/browser/core/cleanup.svelte';
 import { setInteractionProjectId } from '$frontend/components/preview/browser/core/interactions.svelte';
+import { currentScopeKey } from '$frontend/stores/features/worktrees.svelte';
 import { registerDock, getActiveWorkspaceProjectId } from '$frontend/stores/ui/project-workspace.svelte';
 import ws, { onWsReconnect } from '$frontend/utils/ws';
 import { debug } from '$shared/utils/logger';
@@ -322,10 +323,10 @@ function materializeBlankTab(slot: TabSnapshotSlot): string {
  * Rebuild the singleton tab-list for `projectId` by reconciling the persisted
  * snapshot (slot order + blank tabs) with the backend's live sessions.
  */
-async function reconcileTabs(projectId: string): Promise<void> {
+async function reconcileTabs(projectId: string, scopeKey: string): Promise<void> {
 	let backendTabs: ExistingTabInfo[] = [];
 	try {
-		const result = await getExistingTabs(projectId);
+		const result = await getExistingTabs(scopeKey);
 		if (result && result.count > 0) {
 			backendTabs = result.tabs;
 			debug.log('preview', `✅ [dock load] Found ${result.count} backend tabs for project ${projectId}`);
@@ -388,7 +389,7 @@ async function reconcileTabs(projectId: string): Promise<void> {
 		previewTabManager.switchTab(activeFrontendId);
 		const activeTab = previewTabManager.getTab(activeFrontendId);
 		if (activeTab?.sessionId) {
-			await switchToBackendTab(activeTab.sessionId, projectId);
+			await switchToBackendTab(activeTab.sessionId, scopeKey);
 		}
 	}
 }
@@ -431,7 +432,7 @@ registerDock({
 		// Update the interactions module's projectId so any subsequent sends use it.
 		setInteractionProjectId(projectId);
 
-		await reconcileTabs(projectId);
+		await reconcileTabs(projectId, currentScopeKey() || projectId);
 
 		// Authoritative seeding: when neither snapshot nor backend produced any
 		// tabs, drop a single empty tab while the panel still shows its loading
@@ -465,12 +466,16 @@ registerDock({
  * Unstamped events (older backend / no projectId) are accepted so we never drop
  * legitimate events we can't attribute.
  */
+/**
+ * Events carry a workspace scope key, not a bare project id — a worktree's tabs
+ * must not reach a viewer sitting on the main tree of the same project.
+ */
 function isEventForActiveProject(data: { projectId?: string } | null | undefined): boolean {
 	const eventProjectId = data?.projectId;
 	if (!eventProjectId) return true;
-	const activeProjectId = getActiveWorkspaceProjectId();
-	if (!activeProjectId) return true;
-	return eventProjectId === activeProjectId;
+	const activeScope = currentScopeKey() || getActiveWorkspaceProjectId();
+	if (!activeScope) return true;
+	return eventProjectId === activeScope;
 }
 
 let tabSyncInitialized = false;
@@ -498,7 +503,8 @@ export function initPreviewTabSync(): void {
 		if (!projectId) return;
 
 		debug.log('preview', '🔁 [dock] Reconnected — re-reading agent state from backend');
-		void getExistingTabs(projectId).then((result) => {
+		const scopeKey = currentScopeKey() || projectId;
+		void getExistingTabs(scopeKey).then((result) => {
 			// A project switch may have landed while this was in flight; its own
 			// load() is authoritative and must not be overwritten by this answer.
 			if (getActiveWorkspaceProjectId() !== projectId) return;
@@ -709,4 +715,23 @@ export function initPreviewTabSync(): void {
 		if (!isEventForActiveProject(data)) return;
 		setBackendTabFullscreen(data.tabId, !!data.active);
 	});
+}
+
+/**
+ * Rebuild the tab list for the workspace now on screen.
+ *
+ * A worktree switch keeps the same project, so the dock's own load never fires
+ * — but the tabs belong to the tree, not the project, and must be re-read.
+ */
+export async function reloadPreviewTabsForScope(projectId: string, scopeKey: string): Promise<void> {
+	previewTabManager.clearAllTabs();
+	browserCleanup.clearAll();
+	restoredSnapshot = null;
+	setInteractionProjectId(projectId);
+
+	await reconcileTabs(projectId, scopeKey);
+
+	if (previewTabManager.getAllTabs().length === 0) {
+		previewTabManager.createTab('');
+	}
 }

--- a/frontend/stores/features/terminal-workspace.svelte.ts
+++ b/frontend/stores/features/terminal-workspace.svelte.ts
@@ -91,7 +91,13 @@ registerDock({
 		try {
 			// Dynamic import to avoid a static cycle (the manager imports this module).
 			const { terminalProjectManager } = await import('$frontend/services/terminal');
-			await terminalProjectManager.switchToProject(projectId, project.path);
+			const { currentScopeKey } = await import('$frontend/stores/features/worktrees.svelte');
+			// Shells belong to the tree they were opened in, so the scope key —
+			// not the project id — is what groups them.
+			await terminalProjectManager.switchToProject(
+				currentScopeKey() || projectId,
+				projectState.currentProject?.path ?? project.path
+			);
 		} catch (err) {
 			debug.error('terminal', 'Failed to restore terminal tabs for project:', projectId, err);
 		}

--- a/frontend/stores/features/terminal.svelte.ts
+++ b/frontend/stores/features/terminal.svelte.ts
@@ -9,6 +9,7 @@ import { terminalSessionManager } from '$frontend/services/terminal';
 import { addNotification } from '../ui/notification.svelte';
 import { markTerminalDirty } from './terminal-workspace.svelte';
 import { debug } from '$shared/utils/logger';
+import { scopeSlug } from '$shared/utils/workspace-scope';
 interface TerminalState {
 	sessions: TerminalSession[];
 	activeSessionId: string | null;
@@ -74,9 +75,10 @@ export const terminalStore = {
 		}
 
 		terminalState.nextSessionId = sessionNumber + 1;
-		// Always include projectId in sessionId to ensure uniqueness across projects
-		const sanitizedProjectId = projectId.replace(/[^a-zA-Z0-9]/g, '').substring(0, 8);
-		const sessionId = `${sanitizedProjectId}-terminal-${sessionNumber}`;
+		// The prefix carries the workspace, not just the project: stripping it left
+		// Main and its worktrees minting the same id, and PtyKit rejects an id held
+		// by another namespace — so "Terminal 1" in a worktree simply never opened.
+		const sessionId = `${scopeSlug(projectId)}-terminal-${sessionNumber}`;
 		const sessionName = `Terminal ${sessionNumber}`;
 		// Use provided directory or project path, but default to current working directory if invalid
 		const workingDirectory = directory || projectPath || '~';

--- a/frontend/stores/features/worktrees.svelte.ts
+++ b/frontend/stores/features/worktrees.svelte.ts
@@ -1,0 +1,366 @@
+/**
+ * Worktrees Store
+ *
+ * A worktree is an isolated copy of the project that sessions can run in, so
+ * several tasks can proceed at once without touching each other's files.
+ *
+ * The active context is not stored separately — it is whatever the current chat
+ * session is bound to. That keeps one fact in one place: switching context IS
+ * switching to a session in that tree, and a session can never appear to run
+ * somewhere other than where it actually runs.
+ */
+
+import ws from '$frontend/utils/ws';
+import type { ChatSession } from '$shared/types/database/schema';
+import { projectState, setProjectRootOverride } from '$frontend/stores/core/projects.svelte';
+import { raiseSwitchBarrier, lowerSwitchBarrier } from '$frontend/stores/ui/project-workspace.svelte';
+import { makeScopeKey, parseScopeKey } from '$shared/utils/workspace-scope';
+import { debug } from '$shared/utils/logger';
+
+export type WorktreeStatus = 'active' | 'applied' | 'archived';
+export type WorktreeCloneMode = 'reflink' | 'copy';
+export type TransferDirection = 'apply' | 'sync';
+export type MergeResolution = 'source' | 'target' | 'merge';
+
+export interface WorktreeSummary {
+	id: string;
+	project_id: string;
+	name: string;
+	slug: string;
+	path: string;
+	status: WorktreeStatus;
+	clone_mode: WorktreeCloneMode;
+	created_by?: string;
+	created_at: string;
+	last_opened_at?: string;
+	last_applied_at?: string;
+	sessionCount: number;
+}
+
+export interface WorktreeChange {
+	path: string;
+	status: 'added' | 'modified' | 'deleted';
+	conflict: boolean;
+	autoMergeable: boolean;
+}
+
+export interface WorktreeConflict extends WorktreeChange {
+	sourceContent?: string;
+	targetContent?: string;
+}
+
+export interface TransferPreview {
+	direction: TransferDirection;
+	changes: WorktreeChange[];
+	conflicts: WorktreeConflict[];
+}
+
+interface WorktreeState {
+	worktrees: WorktreeSummary[];
+	/** Worktree the viewed session runs in; null = the main project tree. */
+	activeId: string | null;
+	isLoading: boolean;
+	isCreating: boolean;
+	isTransferring: boolean;
+}
+
+export const worktreeState = $state<WorktreeState>({
+	worktrees: [],
+	activeId: null,
+	isLoading: false,
+	isCreating: false,
+	isTransferring: false
+});
+
+// ========================================
+// DERIVED VALUES
+// ========================================
+
+export function activeWorktree(): WorktreeSummary | null {
+	if (!worktreeState.activeId) return null;
+	return worktreeState.worktrees.find((w) => w.id === worktreeState.activeId) ?? null;
+}
+
+export function worktreeById(id: string | null | undefined): WorktreeSummary | null {
+	if (!id) return null;
+	return worktreeState.worktrees.find((w) => w.id === id) ?? null;
+}
+
+/** Label for the context chip — the main tree has no worktree record. */
+export function activeContextName(): string {
+	return activeWorktree()?.name ?? 'Main';
+}
+
+export function isInWorktree(): boolean {
+	return worktreeState.activeId !== null;
+}
+
+/**
+ * Key for the workspace currently on screen.
+ *
+ * Terminal sessions and preview tabs are stored under this rather than the raw
+ * project id, which is what keeps a worktree's shells and pages out of the main
+ * tree's — and out of every other worktree's.
+ */
+export function currentScopeKey(): string {
+	const projectId = projectState.currentProject?.id;
+	if (!projectId) return '';
+	return makeScopeKey(projectId, worktreeState.activeId);
+}
+
+// ========================================
+// LOADING
+// ========================================
+
+export async function loadWorktrees(): Promise<void> {
+	if (!projectState.currentProject) {
+		worktreeState.worktrees = [];
+		return;
+	}
+
+	worktreeState.isLoading = true;
+	try {
+		worktreeState.worktrees = (await ws.http('worktrees:list', {})) as WorktreeSummary[];
+		// The docks have just loaded against the main tree, so that is the scope
+		// the panels actually hold until a session says otherwise.
+		lastAppliedScope ??= makeScopeKey(projectState.currentProject.id, null);
+	} catch (error) {
+		debug.error('worktree', 'Failed to load worktrees:', error);
+		worktreeState.worktrees = [];
+	} finally {
+		worktreeState.isLoading = false;
+	}
+}
+
+/**
+ * Re-point the workspace at the tree the given session runs in.
+ * Called on every session change, so the panels can never drift from the agent.
+ */
+/**
+ * Scope the panels were last loaded for. A project switch is already handled by
+ * the workspace coordinator's dock loads; only a change of *tree within the same
+ * project* needs the panels re-keyed here.
+ */
+let lastAppliedScope: string | null = null;
+
+export async function syncWorktreeContextFromSession(session: ChatSession | null): Promise<void> {
+	const projectId = projectState.currentProject?.id;
+	if (!projectId) {
+		worktreeState.activeId = null;
+		lastAppliedScope = null;
+		return;
+	}
+
+	const previousScope = lastAppliedScope;
+	const worktreeId = session?.worktree_id ?? null;
+	worktreeState.activeId = worktreeId;
+
+	const worktree = worktreeById(worktreeId);
+	setProjectRootOverride(projectId, worktree?.path ?? null);
+
+	// The server scopes terminals and preview tabs off the connection, so it has
+	// to learn about the switch before either is asked for.
+	await ws.setWorktree(worktree ? worktreeId : null);
+
+	const scopeKey = currentScopeKey();
+	lastAppliedScope = scopeKey;
+
+	const samePreviousProject =
+		previousScope !== null && parseScopeKey(previousScope).projectId === projectId;
+	if (samePreviousProject && previousScope !== scopeKey) {
+		await refreshRootDependentPanels();
+	}
+}
+
+// ========================================
+// CONTEXT SWITCHING
+// ========================================
+
+/**
+ * Move the workspace into `worktreeId` (null = main).
+ *
+ * Reuses an existing active session in that tree when there is one so the user
+ * comes back to their work rather than to an empty chat, and creates one only
+ * when the tree has none.
+ */
+export async function switchWorktreeContext(worktreeId: string | null): Promise<void> {
+	const project = projectState.currentProject;
+	if (!project) return;
+	if (worktreeState.activeId === worktreeId) return;
+
+	const { sessionState, setCurrentSession, getSessionsForProject } = await import(
+		'$frontend/stores/core/sessions.svelte'
+	);
+
+	// Barrier held across the swap: the panels between the old root and the new
+	// session are showing another tree's files.
+	raiseSwitchBarrier();
+	try {
+		const existing = getSessionsForProject(project.id)
+			.filter((session) => !session.ended_at && (session.worktree_id ?? null) === worktreeId)
+			.sort((a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime())[0];
+
+		let target = existing ?? null;
+		if (!target) {
+			target = (await ws.http('sessions:get-shared', {
+				forceNew: true,
+				worktreeId
+			})) as ChatSession;
+
+			// The server also broadcasts the new session, so guard against holding
+			// it twice.
+			const existingIndex = sessionState.sessions.findIndex((s) => s.id === target?.id);
+			if (existingIndex === -1) sessionState.sessions.push(target);
+			else sessionState.sessions[existingIndex] = target;
+		}
+
+		await syncWorktreeContextFromSession(target);
+		await setCurrentSession(target);
+	} catch (error) {
+		debug.error('worktree', 'Failed to switch worktree context:', error);
+	} finally {
+		lowerSwitchBarrier();
+	}
+}
+
+/**
+ * Re-key the panels that hold per-workspace state.
+ *
+ * A worktree switch keeps the same project, so the workspace coordinator's own
+ * dock loads never fire — yet terminals and preview tabs belong to the tree, not
+ * the project, and would otherwise still be the previous one's.
+ */
+async function refreshRootDependentPanels(): Promise<void> {
+	const project = projectState.currentProject;
+	if (!project) return;
+	const scopeKey = currentScopeKey();
+
+	try {
+		const { syncGitStatusForProject } = await import('$frontend/stores/features/git-status.svelte');
+		syncGitStatusForProject();
+	} catch (error) {
+		debug.warn('worktree', 'Git refresh after context switch failed:', error);
+	}
+
+	try {
+		const { terminalProjectManager } = await import('$frontend/services/terminal');
+		await terminalProjectManager.switchToProject(scopeKey, project.path);
+	} catch (error) {
+		debug.warn('worktree', 'Terminal switch after context switch failed:', error);
+	}
+
+	try {
+		const { reloadPreviewTabsForScope } = await import(
+			'$frontend/stores/features/preview-tabs-workspace.svelte'
+		);
+		await reloadPreviewTabsForScope(project.id, scopeKey);
+	} catch (error) {
+		debug.warn('worktree', 'Preview reload after context switch failed:', error);
+	}
+}
+
+// ========================================
+// MUTATIONS
+// ========================================
+
+export async function createWorktree(name: string): Promise<WorktreeSummary | null> {
+	if (!projectState.currentProject) return null;
+
+	worktreeState.isCreating = true;
+	try {
+		const result = await ws.http('worktrees:create', { name });
+		await loadWorktrees();
+		return result.worktree as WorktreeSummary;
+	} catch (error) {
+		debug.error('worktree', 'Failed to create worktree:', error);
+		throw error;
+	} finally {
+		worktreeState.isCreating = false;
+	}
+}
+
+export async function renameWorktree(id: string, name: string): Promise<void> {
+	await ws.http('worktrees:rename', { id, name });
+	await loadWorktrees();
+}
+
+/** Delete a worktree; the workspace falls back to main when it was the active one. */
+export async function deleteWorktree(id: string): Promise<void> {
+	const wasActive = worktreeState.activeId === id;
+	await ws.http('worktrees:delete', { id });
+	await loadWorktrees();
+	if (wasActive) await switchWorktreeContext(null);
+}
+
+export async function fetchWorktreeStatus(
+	id: string
+): Promise<{ pendingChanges: number; diskKilobytes?: number }> {
+	return (await ws.http('worktrees:status', { id })) as {
+		pendingChanges: number;
+		diskKilobytes?: number;
+	};
+}
+
+export async function previewTransfer(
+	id: string,
+	direction: TransferDirection
+): Promise<TransferPreview> {
+	return (await ws.http('worktrees:preview-transfer', { id, direction })) as TransferPreview;
+}
+
+export async function runTransfer(
+	id: string,
+	direction: TransferDirection,
+	resolutions: Record<string, MergeResolution> = {}
+): Promise<{ written: number; deleted: number; skipped: number; failed: string[] }> {
+	worktreeState.isTransferring = true;
+	try {
+		const result = await ws.http('worktrees:transfer', { id, direction, resolutions });
+		await loadWorktrees();
+		await refreshRootDependentPanels();
+		return result;
+	} finally {
+		worktreeState.isTransferring = false;
+	}
+}
+
+/** Bind an existing session to a worktree without changing the viewed session. */
+export async function assignSessionToWorktree(
+	sessionId: string,
+	worktreeId: string | null
+): Promise<void> {
+	await ws.http('worktrees:assign-session', { sessionId, worktreeId });
+}
+
+// ========================================
+// COLLABORATIVE EVENTS
+// ========================================
+
+let eventsBound = false;
+
+export function initWorktreeEvents(): void {
+	if (eventsBound) return;
+	eventsBound = true;
+
+	ws.on('worktrees:changed', (payload) => {
+		if (payload.projectId !== projectState.currentProject?.id) return;
+		worktreeState.worktrees = payload.worktrees as WorktreeSummary[];
+
+		// A worktree the viewed session sits in may have just been deleted by
+		// someone else; re-resolving keeps the root override honest.
+		if (worktreeState.activeId && !worktreeById(worktreeState.activeId)) {
+			void switchWorktreeContext(null);
+		}
+	});
+
+	ws.on('worktrees:transferred', (payload) => {
+		if (payload.projectId !== projectState.currentProject?.id) return;
+		void refreshRootDependentPanels();
+	});
+}
+
+export function clearWorktreeState(): void {
+	worktreeState.worktrees = [];
+	worktreeState.activeId = null;
+	lastAppliedScope = null;
+}

--- a/shared/types/database/schema.ts
+++ b/shared/types/database/schema.ts
@@ -14,6 +14,31 @@ export interface Project {
 	default_profile_id?: number | null; // Shared per-project default Profile (null = none)
 }
 
+/** Isolation status of a worktree copy. */
+export type WorktreeStatus = 'active' | 'applied' | 'archived';
+
+/** How the worktree directory was materialised from the main tree. */
+export type WorktreeCloneMode = 'reflink' | 'copy';
+
+/**
+ * An isolated copy of a project that sessions can run in. `base_tree` is the
+ * merge base — a JSON TreeMap of the main tree at clone time.
+ */
+export interface Worktree {
+	id: string;
+	project_id: string;
+	name: string;
+	slug: string;
+	path: string;
+	status: WorktreeStatus;
+	clone_mode: WorktreeCloneMode;
+	base_tree: string;
+	created_by?: string | null;
+	created_at: string;
+	last_opened_at?: string | null;
+	last_applied_at?: string | null;
+}
+
 export interface ChatSession {
 	// ── Identity ──
 	id: string;
@@ -31,6 +56,7 @@ export interface ChatSession {
 	account_name?: string; // Display name of the selected account
 	profile_id?: number | null; // Active Profile bundle for this session (null = use project default / none)
 	reasoning_effort?: string | null; // Reasoning/thinking level token (native per engine; null = engine default)
+	worktree_id?: string | null; // Isolated worktree this session runs in (null = main project tree)
 
 	// ── HEAD state (re-derived when HEAD changes: undo/redo/restore/branch) ──
 	head_message_id?: string; // Git-like HEAD pointer to current branch tip

--- a/shared/utils/logger.ts
+++ b/shared/utils/logger.ts
@@ -10,6 +10,7 @@ export type LogLabel =
 	| 'chat'
 	| 'checkpoint'
 	| 'snapshot'
+	| 'worktree'
 	
 	// Preview
 	| 'preview'

--- a/shared/utils/workspace-scope.test.ts
+++ b/shared/utils/workspace-scope.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test';
+import { isScopeOfProject, makeScopeKey, parseScopeKey, scopeProjectId, scopeSlug } from './workspace-scope';
+
+const PROJECT = '0f8c2a1e-1111-4a2b-9c3d-000000000001';
+const WORKTREE = '5b7d3c9f-2222-4e6a-8b1c-000000000002';
+
+describe('makeScopeKey', () => {
+	test('is the project id itself for the main tree', () => {
+		expect(makeScopeKey(PROJECT, null)).toBe(PROJECT);
+		expect(makeScopeKey(PROJECT)).toBe(PROJECT);
+		expect(makeScopeKey(PROJECT, '')).toBe(PROJECT);
+	});
+
+	test('joins project and worktree for a worktree', () => {
+		expect(makeScopeKey(PROJECT, WORKTREE)).toBe(`${PROJECT}~${WORKTREE}`);
+	});
+});
+
+describe('parseScopeKey', () => {
+	test('reads back a main-tree key', () => {
+		expect(parseScopeKey(PROJECT)).toEqual({ projectId: PROJECT, worktreeId: null });
+	});
+
+	test('reads back a worktree key', () => {
+		expect(parseScopeKey(makeScopeKey(PROJECT, WORKTREE))).toEqual({
+			projectId: PROJECT,
+			worktreeId: WORKTREE
+		});
+	});
+
+	test('treats a trailing separator as the main tree', () => {
+		expect(parseScopeKey(`${PROJECT}~`)).toEqual({ projectId: PROJECT, worktreeId: null });
+	});
+});
+
+describe('scopeProjectId', () => {
+	test('is what every access check runs against', () => {
+		expect(scopeProjectId(makeScopeKey(PROJECT, WORKTREE))).toBe(PROJECT);
+		expect(scopeProjectId(PROJECT)).toBe(PROJECT);
+	});
+});
+
+describe('isScopeOfProject', () => {
+	test('matches the project and each of its worktrees', () => {
+		expect(isScopeOfProject(PROJECT, PROJECT)).toBe(true);
+		expect(isScopeOfProject(makeScopeKey(PROJECT, WORKTREE), PROJECT)).toBe(true);
+	});
+
+	test('rejects another project', () => {
+		const other = '9999aaaa-3333-4c4d-8e5f-000000000003';
+		expect(isScopeOfProject(makeScopeKey(other, WORKTREE), PROJECT)).toBe(false);
+	});
+
+	test('rejects a project id that merely shares a prefix', () => {
+		expect(isScopeOfProject(`${PROJECT}-extra`, PROJECT)).toBe(false);
+	});
+});
+
+describe('scopeSlug', () => {
+	test('distinguishes a worktree from its project', () => {
+		expect(scopeSlug(PROJECT)).not.toBe(scopeSlug(makeScopeKey(PROJECT, WORKTREE)));
+	});
+
+	test('distinguishes two worktrees of the same project', () => {
+		const other = 'aaaa1111-4444-4f7b-9d2e-000000000004';
+		expect(scopeSlug(makeScopeKey(PROJECT, WORKTREE))).not.toBe(
+			scopeSlug(makeScopeKey(PROJECT, other))
+		);
+	});
+
+	test('is stable and alphanumeric so it survives id sanitisation', () => {
+		const slug = scopeSlug(makeScopeKey(PROJECT, WORKTREE));
+		expect(slug).toBe(scopeSlug(makeScopeKey(PROJECT, WORKTREE)));
+		expect(slug).toMatch(/^[a-zA-Z0-9]+$/);
+	});
+
+	test('keeps the main-tree token short and project-derived', () => {
+		expect(scopeSlug(PROJECT)).toBe('0f8c2a1e');
+	});
+});

--- a/shared/utils/workspace-scope.ts
+++ b/shared/utils/workspace-scope.ts
@@ -1,0 +1,57 @@
+/**
+ * Workspace scope keys.
+ *
+ * Terminal sessions and preview tabs are keyed per workspace, not per project:
+ * a worktree exists so its work stays separate, and sharing those keys with the
+ * main tree would leak one task's shells and tabs into another's.
+ *
+ * Access is always decided on the project id, so the key stays parseable back
+ * to it rather than becoming an opaque identifier of its own.
+ */
+
+/** Separator that cannot appear in a UUID, so parsing is unambiguous. */
+const SCOPE_SEPARATOR = '~';
+
+/** Key for a workspace: the project itself, or one of its worktrees. */
+export function makeScopeKey(projectId: string, worktreeId?: string | null): string {
+	return worktreeId ? `${projectId}${SCOPE_SEPARATOR}${worktreeId}` : projectId;
+}
+
+export function parseScopeKey(scopeKey: string): { projectId: string; worktreeId: string | null } {
+	const index = scopeKey.indexOf(SCOPE_SEPARATOR);
+	if (index === -1) return { projectId: scopeKey, worktreeId: null };
+
+	return {
+		projectId: scopeKey.slice(0, index),
+		worktreeId: scopeKey.slice(index + SCOPE_SEPARATOR.length) || null
+	};
+}
+
+/** The project a scope key belongs to — what every access check runs against. */
+export function scopeProjectId(scopeKey: string): string {
+	return parseScopeKey(scopeKey).projectId;
+}
+
+/** Whether `scopeKey` is any workspace of `projectId` (the project or a worktree). */
+export function isScopeOfProject(scopeKey: string, projectId: string): boolean {
+	return parseScopeKey(scopeKey).projectId === projectId;
+}
+
+/**
+ * Short id-safe token that distinguishes one workspace from another.
+ *
+ * Ids generated per workspace (terminal sessions, preview tabs) are numbered
+ * from 1 inside their own scope, so two scopes of the same project mint the
+ * same id. Embedding this token is what keeps those numbers from colliding —
+ * a collision is not cosmetic: PtyKit refuses a session id held by another
+ * namespace, and the preview client matches events on tab id alone.
+ */
+export function scopeSlug(scopeKey: string): string {
+	const { projectId, worktreeId } = parseScopeKey(scopeKey);
+	const alphanumeric = (value: string) => value.replace(/[^a-zA-Z0-9]/g, '');
+
+	const head = alphanumeric(projectId).slice(0, 8);
+	if (!worktreeId) return head;
+	// `w` keeps the token alphanumeric, so it survives id sanitisation.
+	return `${head}w${alphanumeric(worktreeId).slice(0, 6)}`;
+}

--- a/shared/utils/ws-client.ts
+++ b/shared/utils/ws-client.ts
@@ -299,9 +299,11 @@ export class WSClient<TAPI extends { client: any; server: any }> {
 	private context: {
 		userId: string | null;
 		projectId: string | null;
+		worktreeId: string | null;
 	} = {
 		userId: null,
-		projectId: null
+		projectId: null,
+		worktreeId: null
 	};
 
 	/** Session token for re-authentication on reconnection */
@@ -775,7 +777,24 @@ export class WSClient<TAPI extends { client: any; server: any }> {
 		if (this.context.projectId === projectId) return;
 
 		this.context.projectId = projectId;
+		// A worktree belongs to one project, so it never survives the switch.
+		this.context.worktreeId = null;
 		debug.log('websocket', 'Context: project set to', projectId);
+
+		if (this.isConnected) {
+			await this.syncContext();
+		}
+	}
+
+	/**
+	 * Set the worktree this client is viewing (null = the main project tree).
+	 * Server-side scoping of terminals and preview tabs reads this.
+	 */
+	async setWorktree(worktreeId: string | null): Promise<void> {
+		if (this.context.worktreeId === worktreeId) return;
+
+		this.context.worktreeId = worktreeId;
+		debug.log('websocket', 'Context: worktree set to', worktreeId);
 
 		if (this.isConnected) {
 			await this.syncContext();
@@ -785,7 +804,7 @@ export class WSClient<TAPI extends { client: any; server: any }> {
 	/**
 	 * Get current context
 	 */
-	getContext(): { userId: string | null; projectId: string | null } {
+	getContext(): { userId: string | null; projectId: string | null; worktreeId: string | null } {
 		return { ...this.context };
 	}
 
@@ -862,15 +881,16 @@ export class WSClient<TAPI extends { client: any; server: any }> {
 			// Register response listener
 			unsubResponse = this.on('ws:set-context:response' as any, handleResponse);
 
-			// Send context sync request (only projectId — userId is set server-side by auth)
+			// Send context sync request (userId is set server-side by auth)
 			this.emit('ws:set-context' as any, {
 				requestId,
 				data: {
-					projectId: this.context.projectId
+					projectId: this.context.projectId,
+					worktreeId: this.context.worktreeId
 				}
 			} as any);
 
-			debug.log('websocket', 'Context sync sent: projectId=', this.context.projectId);
+			debug.log('websocket', 'Context sync sent: projectId=', this.context.projectId, 'worktreeId=', this.context.worktreeId);
 		});
 	}
 

--- a/shared/utils/ws-server.ts
+++ b/shared/utils/ws-server.ts
@@ -308,11 +308,13 @@ export class WSRouter<
 		this.httpRoutes.set('ws:set-context', {
 			action: 'ws:set-context',
 			dataSchema: t.Object({
-				projectId: t.Optional(t.Union([t.String(), t.Null()]))
+				projectId: t.Optional(t.Union([t.String(), t.Null()])),
+				worktreeId: t.Optional(t.Union([t.String(), t.Null()]))
 			}),
 			responseSchema: t.Object({
 				userId: t.Union([t.String(), t.Null()]),
-				projectId: t.Union([t.String(), t.Null()])
+				projectId: t.Union([t.String(), t.Null()]),
+				worktreeId: t.Union([t.String(), t.Null()])
 			}),
 			handler: async ({ conn, data }) => {
 				// Import ws server to update context
@@ -338,11 +340,25 @@ export class WSRouter<
 					wsServer.setProject(conn, data.projectId);
 				}
 
+				// Which tree this connection is viewing. Validated against the
+				// project so a client cannot point itself at another one's worktree.
+				if (data.worktreeId !== undefined) {
+					let worktreeId = data.worktreeId;
+					if (worktreeId !== null) {
+						const { worktreeQueries } = await import('$backend/database/queries');
+						const activeProjectId = wsServer.getConnectionState(conn)?.projectId ?? null;
+						const worktree = worktreeQueries.getById(worktreeId);
+						if (!worktree || worktree.project_id !== activeProjectId) worktreeId = null;
+					}
+					wsServer.setWorktree(conn, worktreeId);
+				}
+
 				// Read back from connectionState (single source of truth)
 				const state = wsServer.getConnectionState(conn);
 				return {
 					userId: state?.userId ?? null,
-					projectId: state?.projectId ?? null
+					projectId: state?.projectId ?? null,
+					worktreeId: state?.worktreeId ?? null
 				};
 			}
 		});


### PR DESCRIPTION
## Summary

Adds worktrees — isolated copies of a project that chat sessions run in, so
several tasks can proceed in parallel without touching each other's files.

The isolation is Clopen-native rather than `git worktree`-based. It works on
any project, git or not, and reuses the Checkpoints engine: the blob store
holds the merge base, and landing work back on Main is the existing restore
flow pointed the other way.

## Why

Two tasks at once meant one shared tree. An agent's edits landed on top of
whatever else was in flight, and there was no way to hand a task its own copy.

## Changes

**Isolation** — migration 070 adds `worktrees` and `chat_sessions.worktree_id`.
Creating a worktree clones the tree with `COPYFILE_FICLONE`: near-instant on
APFS/btrfs/reflink-XFS, no extra disk until files change, and it carries `.git`
and dependencies so the copy runs immediately. Where reflink is unavailable it
falls back to tracked files plus `.git` and reports which mode it used.

**Apply / Sync** — three-way merge against the base tree recorded at clone time.
Files only one side changed transfer silently; files both sides changed are
merged line-by-line through `git merge-file` when that is clean, and surfaced
for a decision otherwise. Both directions re-base afterwards, so a transfer
never re-proposes what the user already declined.

**Root resolution** — the session decides which tree it runs in: chat streaming
and snapshot restore resolve the root from the session id instead of trusting
the client's `projectPath`. On the client one path override on `currentProject`
makes Files, Git, Terminal and Preview follow the active session.

Handlers that accept a root from the client (`files:list-tree`, the three search
handlers, `files:read-file-at`, and all 55 git handlers) previously validated it
and then operated on `project.path`. `requireWorkspaceRootAccess` and
`requireProjectWorkspace` return the requested root, so they cannot silently
fall back to the main tree.

**Per-workspace state** — a scope key (`projectId` or `projectId~worktreeId`)
separates what belongs to a tree rather than a project: PtyKit namespaces,
preview services, file watchers, the Files panel's persisted state including
unsaved buffers, and the Git panel's view slice, commit draft and operation
flags. Ids minted inside a scope carry it too, since terminal sessions and
preview tabs both number from 1 per workspace and would otherwise collide.

**Panel resets** are keyed on the workspace rather than the project, so
switching trees reloads Files, Git, Terminal and Preview in place.

**UI** — a worktree switcher in the navigator with each tree's actions inline
(apply, sync, rename, delete), a create dialog, and a two-phase transfer dialog
with conflict resolution.

## Notes

Worktrees live in `~/.clopen/worktrees/<projectId>/<slug>`, outside the project
so they are not picked up as nested repos or walked by the file watcher. They
are removed with the project via the cleanup registry, and deleting one also
reaps its shells and browser tabs.

A terminal tab opened in one tree keeps its original cwd — switching trees does
not relocate a live shell. Two worktrees running dev servers concurrently will
still contend for a port.

Verified against a scratch repo: reflink clone carried `node_modules` and
`.git` with distinct inodes, a both-sides edit auto-merged line-level, a
genuinely conflicting edit was flagged and the "keep Main" choice honoured, and
a worktree-only file transferred cleanly.

`bun run check` clean · `bun run lint` clean · `bun run test` 893 pass / 0 fail
(35 new).