### PR TITLE
feat(history): show which worktree each session ran in

### DIFF
--- a/frontend/components/history/HistoryModal.svelte
+++ b/frontend/components/history/HistoryModal.svelte
@@ -14,6 +14,7 @@
 	import { userStore } from '$frontend/stores/features/user.svelte';
 	import { debug } from '$shared/utils/logger';
 	import { modelStore } from '$frontend/stores/features/models.svelte';
+	import { worktreeById } from '$frontend/stores/features/worktrees.svelte';
 	import { parseSnippet } from '$frontend/utils/fts-snippet';
 
 	interface Props {
@@ -525,6 +526,11 @@
 					{@const summary = session.head_summary || 'No messages yet'}
 					{@const deepSnippet = deepSearchResults?.get(session.id)}
 					{@const userCount = session.user_count ?? 0}
+					<!-- Only a worktree is labelled — no label means the main tree, which is
+					     where most sessions live. A worktree deleted since the session ran
+					     leaves a dangling id, and the server resolves that to the main tree,
+					     so the lookup missing is the right answer rather than a gap. -->
+					{@const sessionWorktree = worktreeById(session.worktree_id)}
 					<div
 						class="flex items-center gap-2 w-full p-3 bg-transparent border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-slate-100 text-sm text-left transition-all duration-150
 							{isActive
@@ -571,6 +577,16 @@
 									{/if}
 								</div>
 								<div class="flex items-center gap-2 mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+									{#if sessionWorktree}
+										<span
+											class="flex items-center gap-1 min-w-0 max-w-32 text-amber-600 dark:text-amber-400"
+											title="Worktree: {sessionWorktree.name}"
+										>
+											<Icon name="lucide:git-fork" class="w-3 h-3 shrink-0" />
+											<span class="truncate">{sessionWorktree.name}</span>
+										</span>
+										<span>·</span>
+									{/if}
 									<span class="flex items-center gap-1 flex-none">
 										<Icon name="lucide:messages-square" class="w-3 h-3" />
 										{userCount}


### PR DESCRIPTION
## Summary
Sessions that ran in a worktree are now labelled with its name in the Sessions modal. Main-tree sessions stay unlabelled.

## Why
Worktrees (#519) let several sessions run in isolated copies of the project, but the Sessions modal lists them all together with no indication of where each one lives. Resuming a session switches the workspace to its tree, so which tree it belongs to is exactly what you need to know before clicking.

## Changes
- `frontend/components/history/HistoryModal.svelte`: add a `git-fork` + worktree-name label to the meta row of sessions bound to a worktree, matching the icon and colour language of `WorktreeSwitcher`
- The main tree is deliberately unlabelled — absence of the label is what says "main"
- Sessions whose worktree has since been deleted fall into the unlabelled case, mirroring `resolveWorktreeRoot()`'s fallback so the label cannot disagree with where the session actually runs

No backend changes: `sessions:list` already serialises `worktree_id`, and the worktree list stays current through the existing `worktrees:changed` event.

## Test plan
- `bun run check` — 0 errors
- `bun run lint` — clean (the one warning is pre-existing, in `AboutDeviceSettings.svelte`)
- Manual: sessions started in a worktree show its name; main-tree sessions show nothing extra; deleting a worktree drops the label from its sessions

## Follow-ups
Filtering the list by tree would pair well with this, but it is a separate change — this PR only makes the tree visible.