### PR TITLE
feat(worktrees): compact worktree rows and show per-tree status

### DIFF
--- a/backend/project/status-manager.ts
+++ b/backend/project/status-manager.ts
@@ -5,6 +5,7 @@
 
 import { streamManager, type StreamState } from '../chat/stream-manager.js';
 import { ws } from '../utils/ws.js';
+import { sessionQueries } from '../database/queries/session-queries.js';
 import type { UnifiedMessage } from '$shared/types/unified';
 import { isWaitingForInteractiveInput } from '$shared/utils/interactive-input';
 
@@ -23,6 +24,21 @@ function detectStreamWaitingInput(stream: StreamState): boolean {
     .filter((msg): msg is UnifiedMessage => Boolean(msg));
 
   return isWaitingForInteractiveInput(messages);
+}
+
+/**
+ * Which tree a stream runs in (null = the main project tree).
+ * Resolved from the session rather than the stream, because a stream never
+ * carries the worktree it was started in — and the callers need it to tell
+ * apart "this project is busy" from "this worktree is busy".
+ */
+function resolveStreamWorktreeId(chatSessionId: string, memo: Map<string, string | null>): string | null {
+  const cached = memo.get(chatSessionId);
+  if (cached !== undefined) return cached;
+
+  const worktreeId = sessionQueries.getById(chatSessionId)?.worktree_id ?? null;
+  memo.set(chatSessionId, worktreeId);
+  return worktreeId;
 }
 
 // Store active users per project (shared with main endpoint)
@@ -57,6 +73,7 @@ export async function getProjectStatusData(projectId?: string) {
 
     // Get per-chat-session user presence from WS rooms
     const chatSessionUsers = ws.getProjectChatSessions(projectId);
+    const worktreeMemo = new Map<string, string | null>();
 
     return {
       projectId,
@@ -69,6 +86,7 @@ export async function getProjectStatusData(projectId?: string) {
       streams: allProjectStreams.map(s => ({
         streamId: s.streamId,
         chatSessionId: s.chatSessionId,
+        worktreeId: resolveStreamWorktreeId(s.chatSessionId, worktreeMemo),
         status: s.status,
         startedAt: s.startedAt,
         messagesCount: s.messages.length,
@@ -91,6 +109,7 @@ export async function getProjectStatusData(projectId?: string) {
     
     // Get all active streams grouped by project
     const allStreams = streamManager.getAllStreams();
+    const worktreeMemo = new Map<string, string | null>();
     allStreams.forEach(stream => {
       if (stream.projectId) {
         if (!allProjects.has(stream.projectId)) {
@@ -111,6 +130,7 @@ export async function getProjectStatusData(projectId?: string) {
         projectData.streams.push({
           streamId: stream.streamId,
           chatSessionId: stream.chatSessionId,
+          worktreeId: resolveStreamWorktreeId(stream.chatSessionId, worktreeMemo),
           status: stream.status,
           startedAt: stream.startedAt,
           messagesCount: stream.messages.length,

--- a/frontend/components/worktree/WorktreeSwitcher.svelte
+++ b/frontend/components/worktree/WorktreeSwitcher.svelte
@@ -9,6 +9,7 @@
 	import Icon from '$frontend/components/common/display/Icon.svelte';
 	import { clickOutside } from '$frontend/utils/click-outside';
 	import { projectState } from '$frontend/stores/core/projects.svelte';
+	import { getWorktreeStatusColor } from '$frontend/stores/core/presence.svelte';
 	import { showConfirm } from '$frontend/stores/ui/dialog.svelte';
 	import { addNotification } from '$frontend/stores/ui/notification.svelte';
 	import {
@@ -44,6 +45,7 @@
 	let renameValue = $state('');
 
 	const hasProject = $derived(projectState.currentProject !== null);
+	const projectId = $derived(projectState.currentProject?.id ?? '');
 	const contextName = $derived(activeContextName());
 	const inWorktree = $derived(isInWorktree());
 	const worktrees = $derived(worktreeState.worktrees);
@@ -139,6 +141,13 @@
 		}
 	}
 
+	/** Tooltip spells out what the counts mean; the row itself has no space for it. */
+	function summaryTitleFor(worktree: WorktreeSummary): string {
+		const pending = pendingByWorktree[worktree.id];
+		if (pending === undefined) return worktree.path;
+		return `${pending} file${pending === 1 ? '' : 's'} differ from Main and would be transferred by "Apply to Main"`;
+	}
+
 	function summaryFor(worktree: WorktreeSummary): string {
 		const parts = [`${worktree.sessionCount} chat${worktree.sessionCount === 1 ? '' : 's'}`];
 		const pending = pendingByWorktree[worktree.id];
@@ -148,7 +157,11 @@
 	}
 
 	const actionButtonClass =
-		'flex items-center justify-center w-6 h-6 rounded-md text-slate-500 transition-colors duration-150';
+		'flex items-center justify-center w-5 h-5 rounded text-slate-500 transition-colors duration-150';
+
+	/** Same dot as the project list, so a busy tree reads the same as a busy project. */
+	const statusDotClass =
+		'absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-white dark:border-slate-800';
 </script>
 
 {#if hasProject}
@@ -200,27 +213,36 @@
 
 					<button
 						type="button"
-						class="flex items-center gap-3 w-full px-3 py-2.5 bg-transparent border-none text-left cursor-pointer transition-all duration-150 hover:bg-violet-500/10"
+						class="flex items-center gap-2.5 w-full px-3 py-2.5 bg-transparent border-none text-left cursor-pointer transition-all duration-150 hover:bg-violet-500/10"
 						onclick={() => selectContext(null)}
 					>
-						<Icon name="lucide:folder" class="w-4 h-4 shrink-0 {inWorktree ? 'text-slate-500' : 'text-violet-600 dark:text-violet-400'}" />
+						<div class="relative shrink-0">
+							<Icon name="lucide:folder" class="w-4 h-4 {inWorktree ? 'text-slate-500' : 'text-violet-600 dark:text-violet-400'}" />
+							<span class="{statusDotClass} {getWorktreeStatusColor(projectId, null)}"></span>
+						</div>
 						<div class="flex flex-col min-w-0 flex-1">
-							<span class="text-sm font-medium text-slate-800 dark:text-slate-200">Main</span>
+							<span class="flex items-center gap-1.5">
+								<span class="text-sm font-medium text-slate-800 dark:text-slate-200">Main</span>
+								{#if !inWorktree}
+									<Icon name="lucide:check" class="w-3.5 h-3.5 shrink-0 text-violet-600 dark:text-violet-400" />
+								{/if}
+							</span>
 							<span class="text-xs text-slate-500 dark:text-slate-500 truncate">The project itself</span>
 						</div>
-						{#if !inWorktree}
-							<Icon name="lucide:check" class="w-4 h-4 shrink-0 text-violet-600 dark:text-violet-400" />
-						{/if}
 					</button>
 
 					{#each worktrees as worktree (worktree.id)}
 						{@const isActive = worktreeState.activeId === worktree.id}
-						<div class="px-3 py-2 transition-colors duration-150 hover:bg-violet-500/5">
-							<div class="flex items-center gap-3">
-								<Icon
-									name="lucide:git-fork"
-									class="w-4 h-4 shrink-0 {isActive ? 'text-amber-600 dark:text-amber-400' : 'text-slate-500'}"
-								/>
+						<div class="group px-3 py-2 transition-colors duration-150 hover:bg-violet-500/5">
+							<!-- Actions share the name's line; the summary gets the row to itself. -->
+							<div class="flex items-center gap-2.5">
+								<div class="relative shrink-0">
+									<Icon
+										name="lucide:git-fork"
+										class="w-4 h-4 {isActive ? 'text-amber-600 dark:text-amber-400' : 'text-slate-500'}"
+									/>
+									<span class="{statusDotClass} {getWorktreeStatusColor(projectId, worktree.id)}"></span>
+								</div>
 
 								{#if renamingId === worktree.id}
 									<!-- svelte-ignore a11y_autofocus -->
@@ -237,64 +259,66 @@
 								{:else}
 									<button
 										type="button"
-										class="flex flex-col min-w-0 flex-1 bg-transparent border-none text-left cursor-pointer p-0"
+										class="flex items-center gap-1.5 min-w-0 flex-1 bg-transparent border-none text-left cursor-pointer p-0"
 										title={worktree.path}
 										onclick={() => selectContext(worktree.id)}
 									>
-										<span class="text-sm font-medium text-slate-800 dark:text-slate-200 truncate w-full">
+										<span class="text-sm font-medium text-slate-800 dark:text-slate-200 truncate">
 											{worktree.name}
 										</span>
-										<span class="text-xs text-slate-500 dark:text-slate-500 truncate w-full">
-											{summaryFor(worktree)}
-										</span>
+										{#if isActive}
+											<Icon name="lucide:check" class="w-3.5 h-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+										{/if}
 									</button>
 
-									{#if isActive}
-										<Icon name="lucide:check" class="w-4 h-4 shrink-0 text-amber-600 dark:text-amber-400" />
-									{/if}
+									<!-- Dimmed rather than hidden: taps have no hover to reveal them. -->
+									<div class="flex items-center gap-0.5 shrink-0 opacity-60 transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100">
+										<button
+											type="button"
+											class="{actionButtonClass} hover:bg-violet-500/10 hover:text-violet-600"
+											title="Apply to Main"
+											aria-label="Apply to Main"
+											onclick={() => startTransfer(worktree, 'apply')}
+										>
+											<Icon name="lucide:arrow-up-from-line" class="w-3.5 h-3.5" />
+										</button>
+										<button
+											type="button"
+											class="{actionButtonClass} hover:bg-violet-500/10 hover:text-violet-600"
+											title="Sync from Main"
+											aria-label="Sync from Main"
+											onclick={() => startTransfer(worktree, 'sync')}
+										>
+											<Icon name="lucide:arrow-down-to-line" class="w-3.5 h-3.5" />
+										</button>
+										<button
+											type="button"
+											class="{actionButtonClass} hover:bg-violet-500/10 hover:text-violet-600"
+											title="Rename"
+											aria-label="Rename"
+											onclick={() => startRename(worktree)}
+										>
+											<Icon name="lucide:pencil" class="w-3.5 h-3.5" />
+										</button>
+										<button
+											type="button"
+											class="{actionButtonClass} hover:bg-red-500/10 hover:text-red-500"
+											title="Delete"
+											aria-label="Delete"
+											onclick={() => remove(worktree)}
+										>
+											<Icon name="lucide:trash-2" class="w-3.5 h-3.5" />
+										</button>
+									</div>
 								{/if}
 							</div>
 
-							{#if renamingId !== worktree.id}
-								<div class="flex items-center gap-1 mt-1.5 pl-7">
-									<button
-										type="button"
-										class="{actionButtonClass} hover:bg-violet-500/10 hover:text-violet-600"
-										title="Apply to Main"
-										aria-label="Apply to Main"
-										onclick={() => startTransfer(worktree, 'apply')}
-									>
-										<Icon name="lucide:arrow-up-from-line" class="w-3.5 h-3.5" />
-									</button>
-									<button
-										type="button"
-										class="{actionButtonClass} hover:bg-violet-500/10 hover:text-violet-600"
-										title="Sync from Main"
-										aria-label="Sync from Main"
-										onclick={() => startTransfer(worktree, 'sync')}
-									>
-										<Icon name="lucide:arrow-down-to-line" class="w-3.5 h-3.5" />
-									</button>
-									<button
-										type="button"
-										class="{actionButtonClass} hover:bg-violet-500/10 hover:text-violet-600"
-										title="Rename"
-										aria-label="Rename"
-										onclick={() => startRename(worktree)}
-									>
-										<Icon name="lucide:pencil" class="w-3.5 h-3.5" />
-									</button>
-									<button
-										type="button"
-										class="{actionButtonClass} hover:bg-red-500/10 hover:text-red-500"
-										title="Delete"
-										aria-label="Delete"
-										onclick={() => remove(worktree)}
-									>
-										<Icon name="lucide:trash-2" class="w-3.5 h-3.5" />
-									</button>
-								</div>
-							{/if}
+							<span
+								class="block pl-6.5 text-xs text-slate-500 dark:text-slate-500 truncate"
+								title={summaryTitleFor(worktree)}
+							>
+								{summaryFor(worktree)}
+							</span>
 						</div>
 					{/each}
 

--- a/frontend/services/project/status.service.ts
+++ b/frontend/services/project/status.service.ts
@@ -18,6 +18,8 @@ export interface ProjectStatus {
   streams: {
     streamId: string;
     chatSessionId: string;
+    /** Worktree the stream runs in; null = the main project tree. */
+    worktreeId?: string | null;
     status: string;
     startedAt: string;
     messagesCount: number;

--- a/frontend/stores/core/presence.svelte.ts
+++ b/frontend/stores/core/presence.svelte.ts
@@ -126,3 +126,43 @@ export function getProjectStatusColor(projectId: string): string {
 	return 'bg-slate-500/30';
 }
 
+/**
+ * Which tree a chat session belongs to (null = the main project tree).
+ * Presence wins over the local session list: a session started in another tab
+ * reaches presence before it reaches `sessionState.sessions`.
+ */
+function sessionWorktreeId(chatSessionId: string, status: ProjectStatus | undefined): string | null {
+	const stream = status?.streams?.find((s: any) => s.chatSessionId === chatSessionId);
+	if (stream && stream.worktreeId !== undefined) return stream.worktreeId ?? null;
+
+	return sessionState.sessions.find((s) => s.id === chatSessionId)?.worktree_id ?? null;
+}
+
+/**
+ * Same indicator as {@link getProjectStatusColor}, narrowed to one tree, so the
+ * worktree list can show which tree is busy instead of only that the project is.
+ * `worktreeId` of null means the main project tree.
+ */
+export function getWorktreeStatusColor(projectId: string, worktreeId: string | null): string {
+	const status = presenceState.statuses.get(projectId);
+	const inTree = (id: string | null | undefined) => (id ?? null) === worktreeId;
+
+	const activeStreams =
+		status?.streams?.filter((s: any) => s.status === 'active' && inTree(s.worktreeId)) ?? [];
+
+	if (activeStreams.length > 0) {
+		const hasProcessing = activeStreams.some((s: any) =>
+			!s.isWaitingInput && !appState.sessionStates[s.chatSessionId]?.isWaitingInput
+		);
+		return hasProcessing ? 'bg-emerald-500' : 'bg-amber-500';
+	}
+
+	const currentSessionId = sessionState.currentSession?.id;
+	for (const [sessionId, unreadProjectId] of appState.unreadSessions.entries()) {
+		if (unreadProjectId !== projectId || sessionId === currentSessionId) continue;
+		if (inTree(sessionWorktreeId(sessionId, status))) return 'bg-blue-500';
+	}
+
+	return 'bg-slate-500/30';
+}
+


### PR DESCRIPTION
## Summary
Give each worktree's action buttons the name's line, move the summary to its own full-width line, and add the project status dot — green/amber/blue/gray — to every row in the worktree switcher.

## Why
The switcher grew a line taller per tree than it needed to: name, summary, then a separate action strip indented underneath. It also gave no signal about what was happening inside each tree, which is the whole point of running several in parallel — you could not tell a busy worktree from an idle one without switching into it.

The existing project dot could not be reused as-is: `getProjectStatusColor` is project-wide, so a single active stream anywhere would light up every tree identically.

## Changes
- `WorktreeSwitcher.svelte`: actions moved onto the name's line, sized to `w-5 h-5`; rows drop from three lines to two
- `WorktreeSwitcher.svelte`: summary moved to its own line, indented under the name, so the buttons no longer clip it
- `WorktreeSwitcher.svelte`: active-tree check sits beside the name in both the Main and worktree rows
- `WorktreeSwitcher.svelte`: status dot added to the Main row and every worktree row, plus a tooltip explaining what the pending count means
- `presence.svelte.ts`: new `getWorktreeStatusColor(projectId, worktreeId)` — same priority as the project dot, filtered to one tree (`null` = main)
- `status-manager.ts`: presence stream entries now carry `worktreeId`, resolved from the session and memoized per call
- `status.service.ts`: `ProjectStatus.streams[].worktreeId` added to the client type

## Notes
Actions are dimmed to `opacity-60` and brighten on hover/focus rather than being hidden behind `group-hover`, because the switcher also renders from `MobileNavigator` where there is no hover state to reveal them.

Unread (blue) resolves a session's tree from presence first and falls back to the local session list, since a session started in another tab reaches presence before it reaches `sessionState.sessions`.

## Test plan
- [x] `bun run check` — 0 errors
- [x] `bun run lint` — clean (one pre-existing unrelated warning)
- [x] `bun run test` — 893 pass, 0 fail
- [x] Manual UI check: dot turns green while a worktree session streams, amber when it waits for input, and stays gray on the other trees