### PR TITLE
fix(worktrees): keep the active tree on refresh and make rows clickable

### DIFF
--- a/frontend/components/worktree/WorktreeSwitcher.svelte
+++ b/frontend/components/worktree/WorktreeSwitcher.svelte
@@ -141,11 +141,11 @@
 		}
 	}
 
-	/** Tooltip spells out what the counts mean; the row itself has no space for it. */
-	function summaryTitleFor(worktree: WorktreeSummary): string {
+	/** Row tooltip: the path, plus what the pending count actually means. */
+	function rowTitleFor(worktree: WorktreeSummary): string {
 		const pending = pendingByWorktree[worktree.id];
 		if (pending === undefined) return worktree.path;
-		return `${pending} file${pending === 1 ? '' : 's'} differ from Main and would be transferred by "Apply to Main"`;
+		return `${worktree.path}\n${pending} file${pending === 1 ? '' : 's'} differ from Main and would be transferred by "Apply to Main"`;
 	}
 
 	function summaryFor(worktree: WorktreeSummary): string {
@@ -233,10 +233,22 @@
 
 					{#each worktrees as worktree (worktree.id)}
 						{@const isActive = worktreeState.activeId === worktree.id}
-						<div class="group px-3 py-2 transition-colors duration-150 hover:bg-violet-500/5">
+						<div class="group relative px-3 py-2 transition-colors duration-150 hover:bg-violet-500/5">
+							{#if renamingId !== worktree.id}
+								<!-- Overlay carries the whole row's click: the row itself cannot be a
+								     button because it already holds the action buttons. -->
+								<button
+									type="button"
+									class="absolute inset-0 bg-transparent border-none cursor-pointer focus-visible:outline-none focus-visible:bg-violet-500/10"
+									title={rowTitleFor(worktree)}
+									aria-label="Switch to {worktree.name}"
+									onclick={() => selectContext(worktree.id)}
+								></button>
+							{/if}
+
 							<!-- Actions share the name's line; the summary gets the row to itself. -->
 							<div class="flex items-center gap-2.5">
-								<div class="relative shrink-0">
+								<div class="relative shrink-0 pointer-events-none">
 									<Icon
 										name="lucide:git-fork"
 										class="w-4 h-4 {isActive ? 'text-amber-600 dark:text-amber-400' : 'text-slate-500'}"
@@ -257,22 +269,18 @@
 										class="flex-1 min-w-0 px-2 py-1 bg-white dark:bg-slate-900 border border-violet-500/50 rounded text-sm text-slate-900 dark:text-slate-100 outline-none"
 									/>
 								{:else}
-									<button
-										type="button"
-										class="flex items-center gap-1.5 min-w-0 flex-1 bg-transparent border-none text-left cursor-pointer p-0"
-										title={worktree.path}
-										onclick={() => selectContext(worktree.id)}
-									>
+									<span class="flex items-center gap-1.5 min-w-0 flex-1">
 										<span class="text-sm font-medium text-slate-800 dark:text-slate-200 truncate">
 											{worktree.name}
 										</span>
 										{#if isActive}
 											<Icon name="lucide:check" class="w-3.5 h-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
 										{/if}
-									</button>
+									</span>
 
-									<!-- Dimmed rather than hidden: taps have no hover to reveal them. -->
-									<div class="flex items-center gap-0.5 shrink-0 opacity-60 transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100">
+									<!-- Above the overlay so they keep their own clicks; dimmed rather
+								     than hidden, since taps have no hover to reveal them. -->
+									<div class="relative z-10 flex items-center gap-0.5 shrink-0 opacity-60 transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100">
 										<button
 											type="button"
 											class="{actionButtonClass} hover:bg-violet-500/10 hover:text-violet-600"
@@ -313,10 +321,7 @@
 								{/if}
 							</div>
 
-							<span
-								class="block pl-6.5 text-xs text-slate-500 dark:text-slate-500 truncate"
-								title={summaryTitleFor(worktree)}
-							>
+							<span class="block pl-6.5 text-xs text-slate-500 dark:text-slate-500 truncate">
 								{summaryFor(worktree)}
 							</span>
 						</div>

--- a/frontend/stores/core/sessions.svelte.ts
+++ b/frontend/stores/core/sessions.svelte.ts
@@ -389,18 +389,13 @@ export async function loadSessions() {
 						}
 
 						debug.log('session', 'Auto-restoring session for project:', targetSession.id);
-						// Load messages BEFORE setting session to avoid race condition:
-						// Setting session triggers $effect → catchupActiveStream (async),
-						// but loadMessagesForSession replaces sessionState.messages entirely,
-						// wiping out any stream_event injected by catchup.
+						// Messages first: adopting the session triggers catchupActiveStream,
+						// and loadMessagesForSession would overwrite what it injected.
 						await loadMessagesForSession(targetSession.id);
-						sessionState.currentSession = targetSession;
-						// Clear unread status — user is actively viewing this session
-						markSessionRead(targetSession.id);
-						// Join chat session room so we receive session-scoped events
-						// (stream, input sync, edit mode, model sync).
-						// Critical after refresh — without it, connection misses all events.
-						ws.emit('chat:join-session', { chatSessionId: targetSession.id });
+						// Adopt via setCurrentSession, not a direct assignment: it re-points the
+						// workspace at the session's tree, joins the chat room and clears unread.
+						// Assigning skipped all three, so a refresh in a worktree returned to Main.
+						await setCurrentSession(targetSession, true);
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
Two worktree fixes: refreshing the browser inside a worktree no longer drops the workspace back to Main, and the whole worktree row switches trees instead of just its name.

## Why
**Refresh.** The active tree is derived state, not stored state — `syncWorktreeContextFromSession` is what sets `worktreeState.activeId`, applies the project root override so Files/Git/Terminal/Preview follow the worktree path, and sends `ws.setWorktree` so the server scopes terminals and preview tabs to that tree.

Only `setCurrentSession` calls it. The auto-restore branch in `loadSessions` — the path a refresh takes — assigned `sessionState.currentSession` directly, so all three were skipped and `activeId` stayed at its initial `null`. The restored session's `worktree_id` was correct throughout; only the workspace around it was wrong. Project switching was never affected: `restoreSessionForProject` already goes through `setCurrentSession`.

**Click target.** Once the action buttons moved inline onto the name's line (#522), the row could no longer be a `<button>` — a button cannot contain buttons — so the click target shrank to the label alone, while the Main row directly above stayed clickable across its full width.

## Changes
- `sessions.svelte.ts`: boot restore adopts the session via `setCurrentSession(session, true)` instead of assigning the field, dropping the now-duplicated `markSessionRead` and `chat:join-session` calls it covers
- `WorktreeSwitcher.svelte`: transparent `absolute inset-0` button covers the row and carries the switch click
- `WorktreeSwitcher.svelte`: action group raised to `relative z-10` so it keeps its own clicks; icon wrapper set to `pointer-events-none` so it stops swallowing clicks over its square
- `WorktreeSwitcher.svelte`: the pending-count explanation moved from the summary line's tooltip to the row tooltip, since the overlay covers the summary

## Notes
`skipLoadMessages` is what makes the restore change safe: messages still load before the session is adopted, preserving the ordering that keeps `loadMessagesForSession` from overwriting what `catchupActiveStream` injects.

Two side effects of routing through the shared path, both wanted. Boot restore now also runs `syncGlobalStateFromSession`, which it had been skipping — that is the guard against one session's `isWaitingInput` leaking into another view. And since `loadWorktrees` seeds `lastAppliedScope` to the main tree, restoring a worktree session now triggers `refreshRootDependentPanels`, re-keying terminals and preview onto that tree. Cost is one extra `sessions:get` round-trip at boot, behind the loading screen.

The click overlay is a real `<button>` with `aria-label="Switch to <name>"` and a `focus-visible` background, so keyboard access is unchanged. It is skipped while a tree is being renamed, or it would sit over the input.

No regression test for the refresh fix: the session and project stores have no test harness today (only pure utils under `frontend/utils` are covered), and mocking WS plus runes for this is out of proportion to the change.

## Test plan
- [x] `bun run check` — 0 errors
- [x] `bun run lint` — clean (one pre-existing unrelated warning)
- [x] `bun run test` — 893 pass, 0 fail
- [x] Manual: enter a worktree, refresh — switcher still shows that tree, Files/Terminal/Preview still point at its path
- [x] Manual: refresh on Main — still Main, no regression
- [x] Manual: refresh in a worktree with an open terminal — it comes back scoped to the worktree, not the project root
- [x] Manual: click the icon, name, summary and empty space — each switches to that tree
- [x] Manual: the four action buttons still fire their own actions, not a switch; rename still receives clicks and typing