### PR TITLE
fix(git): honour branch upstream on push and add operation continue

### DIFF
--- a/backend/git/conflict-state.test.ts
+++ b/backend/git/conflict-state.test.ts
@@ -1,0 +1,396 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile, readFile, unlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execGit } from './git-executor';
+import { gitService } from './git-service';
+import { parseConflictMarkers, parseReflog, parseUnmergedStages } from './git-parser';
+
+/**
+ * Covers the conflict states the panel used to mishandle: paths with no working
+ * -tree file (which were silently dropped), binary conflicts (decoded as UTF-8),
+ * and in-progress operations that had no "continue" at all.
+ */
+
+let repo: string;
+
+async function git(...args: string[]) {
+	return execGit(args, repo);
+}
+
+async function gitOk(...args: string[]) {
+	const result = await git(...args);
+	if (result.exitCode !== 0) throw new Error(`git ${args.join(' ')}: ${result.stderr}`);
+	return result.stdout;
+}
+
+async function commitAll(message: string) {
+	await gitOk('add', '-A');
+	await gitOk('commit', '-m', message);
+}
+
+beforeEach(async () => {
+	repo = await mkdtemp(path.join(tmpdir(), 'clopen-conflict-'));
+	await gitOk('init', '-b', 'main', '.');
+	await gitOk('config', 'user.email', 'test@example.com');
+	await gitOk('config', 'user.name', 'Test');
+	await gitOk('config', 'commit.gpgsign', 'false');
+	await writeFile(path.join(repo, 'base.txt'), 'base\n');
+	await commitAll('init');
+});
+
+afterEach(async () => {
+	await rm(repo, { recursive: true, force: true });
+});
+
+/** Create a both-modified conflict on `file.txt` by merging `feature` into main. */
+async function makeBothModifiedConflict() {
+	await writeFile(path.join(repo, 'file.txt'), 'one\ntwo\nthree\n');
+	await commitAll('add file');
+
+	await gitOk('checkout', '-b', 'feature');
+	await writeFile(path.join(repo, 'file.txt'), 'one\nfeature\nthree\n');
+	await commitAll('feature edit');
+
+	await gitOk('checkout', 'main');
+	await writeFile(path.join(repo, 'file.txt'), 'one\nmain\nthree\n');
+	await commitAll('main edit');
+
+	// Expected to fail with a conflict.
+	await git('merge', 'feature');
+}
+
+describe('parseConflictMarkers', () => {
+	test('parses a plain conflict', () => {
+		const markers = parseConflictMarkers(
+			['a', '<<<<<<< HEAD', 'ours', '=======', 'theirs', '>>>>>>> feature', 'b'].join('\n')
+		);
+		expect(markers).toHaveLength(1);
+		expect(markers[0].ourContent).toBe('ours');
+		expect(markers[0].theirContent).toBe('theirs');
+		expect(markers[0].ourStart).toBe(1);
+	});
+
+	test('captures the merge base from diff3-style markers', () => {
+		const markers = parseConflictMarkers(
+			[
+				'<<<<<<< HEAD',
+				'ours',
+				'||||||| base',
+				'original',
+				'=======',
+				'theirs',
+				'>>>>>>> feature'
+			].join('\n')
+		);
+		expect(markers[0].baseContent).toBe('original');
+		expect(markers[0].ourContent).toBe('ours');
+	});
+
+	test('ignores dividers that merely start with the same character', () => {
+		// Eight arrows is an ASCII divider, not a marker. The old `startsWith`
+		// check treated it as one and reported a phantom conflict.
+		const markers = parseConflictMarkers(
+			['<<<<<<<<<<<<<<<<', 'text', '================', 'more', '>>>>>>>>>>>>>>>>'].join('\n')
+		);
+		expect(markers).toHaveLength(0);
+	});
+
+	test('ignores an opener with no separator', () => {
+		expect(parseConflictMarkers(['<<<<<<< HEAD', 'orphan', 'text'].join('\n'))).toHaveLength(0);
+	});
+
+	test('recovers when a second opener appears before the first closes', () => {
+		const markers = parseConflictMarkers(
+			[
+				'<<<<<<< stray',
+				'noise',
+				'<<<<<<< HEAD',
+				'ours',
+				'=======',
+				'theirs',
+				'>>>>>>> feature'
+			].join('\n')
+		);
+		expect(markers).toHaveLength(1);
+		expect(markers[0].ourContent).toBe('ours');
+	});
+});
+
+describe('parseUnmergedStages', () => {
+	test('groups stages per path', () => {
+		// `\x00`, not `\0`: in a JS string `\0` followed by a digit is a legacy
+		// octal escape, so `\0100644` would be one character, not NUL + "100644".
+		const output = [
+			'100644 aaa 1\tsrc/a.ts',
+			'100644 bbb 2\tsrc/a.ts',
+			'100644 ccc 3\tsrc/a.ts',
+			'100644 ddd 3\tsrc/b.ts',
+			''
+		].join('\x00');
+		const stages = parseUnmergedStages(output);
+		expect([...(stages.get('src/a.ts') ?? [])].sort()).toEqual([1, 2, 3]);
+		expect([...(stages.get('src/b.ts') ?? [])]).toEqual([3]);
+	});
+});
+
+describe('parseReflog', () => {
+	test('splits the action from the subject', () => {
+		const entries = parseReflog(
+			'abc123|||abc123|||HEAD@{0}|||rebase (finish): returning to refs/heads/main|||2026-01-01T00:00:00Z'
+		);
+		expect(entries[0].action).toBe('rebase (finish)');
+		expect(entries[0].subject).toBe('returning to refs/heads/main');
+		expect(entries[0].selector).toBe('HEAD@{0}');
+	});
+
+	test('tolerates a subject with no action prefix', () => {
+		const entries = parseReflog('abc|||abc|||HEAD@{1}|||something|||2026-01-01T00:00:00Z');
+		expect(entries[0].action).toBe('something');
+		expect(entries[0].subject).toBe('');
+	});
+});
+
+describe('getConflictFiles', () => {
+	test('reports a both-modified conflict with markers', async () => {
+		await makeBothModifiedConflict();
+
+		const conflicts = await gitService.getConflictFiles(repo);
+		expect(conflicts).toHaveLength(1);
+		expect(conflicts[0].path).toBe('file.txt');
+		expect(conflicts[0].kind).toBe('both-modified');
+		expect(conflicts[0].contentOmitted).toBe(false);
+		expect(conflicts[0].markers).toHaveLength(1);
+	});
+
+	test('keeps a delete/modify conflict instead of dropping it', async () => {
+		await writeFile(path.join(repo, 'gone.txt'), 'content\n');
+		await commitAll('add gone');
+
+		await gitOk('checkout', '-b', 'feature');
+		await writeFile(path.join(repo, 'gone.txt'), 'changed\n');
+		await commitAll('modify');
+
+		await gitOk('checkout', 'main');
+		await unlink(path.join(repo, 'gone.txt'));
+		await commitAll('delete');
+
+		await git('merge', 'feature');
+
+		const conflicts = await gitService.getConflictFiles(repo);
+		expect(conflicts.map(c => c.path)).toContain('gone.txt');
+		// Deleted on our side, modified on theirs — no markers to walk.
+		expect(conflicts[0].kind).toBe('deleted-by-us');
+		expect(conflicts[0].markers).toHaveLength(0);
+	});
+
+	test('flags a binary conflict rather than decoding it as text', async () => {
+		const binary = (a: number) => Buffer.from([0x00, 0x01, a, 0xff, 0x00]);
+		await writeFile(path.join(repo, 'blob.bin'), binary(0x10));
+		await commitAll('add blob');
+
+		await gitOk('checkout', '-b', 'feature');
+		await writeFile(path.join(repo, 'blob.bin'), binary(0x20));
+		await commitAll('feature blob');
+
+		await gitOk('checkout', 'main');
+		await writeFile(path.join(repo, 'blob.bin'), binary(0x30));
+		await commitAll('main blob');
+
+		await git('merge', 'feature');
+
+		const conflicts = await gitService.getConflictFiles(repo);
+		const blob = conflicts.find(c => c.path === 'blob.bin');
+		expect(blob).toBeDefined();
+		expect(blob?.contentOmitted).toBe(true);
+		expect(blob?.omitReason).toBe('binary');
+		expect(blob?.content).toBe('');
+	});
+});
+
+describe('resolveConflict', () => {
+	test('refuses to stage content that still has markers', async () => {
+		await makeBothModifiedConflict();
+		const withMarkers = await readFile(path.join(repo, 'file.txt'), 'utf-8');
+
+		await expect(
+			gitService.resolveConflict(repo, 'file.txt', 'custom', withMarkers)
+		).rejects.toThrow(/conflict markers/i);
+
+		// Still unmerged — the guard must not half-apply.
+		expect(await gitService.getUnmergedPaths(repo)).toEqual(['file.txt']);
+	});
+
+	test('"ours" takes our side and stages it', async () => {
+		await makeBothModifiedConflict();
+		await gitService.resolveConflict(repo, 'file.txt', 'ours');
+
+		expect(await readFile(path.join(repo, 'file.txt'), 'utf-8')).toBe('one\nmain\nthree\n');
+		expect(await gitService.getUnmergedPaths(repo)).toEqual([]);
+	});
+
+	test('"ours" resolves as a deletion when our side deleted the path', async () => {
+		await writeFile(path.join(repo, 'gone.txt'), 'content\n');
+		await commitAll('add gone');
+		await gitOk('checkout', '-b', 'feature');
+		await writeFile(path.join(repo, 'gone.txt'), 'changed\n');
+		await commitAll('modify');
+		await gitOk('checkout', 'main');
+		await unlink(path.join(repo, 'gone.txt'));
+		await commitAll('delete');
+		await git('merge', 'feature');
+
+		// `git checkout --ours` cannot work here; the answer git wants is `rm`.
+		await gitService.resolveConflict(repo, 'gone.txt', 'ours');
+		expect(await gitService.getUnmergedPaths(repo)).toEqual([]);
+	});
+
+	test('"reset" puts the markers back', async () => {
+		await makeBothModifiedConflict();
+		await writeFile(path.join(repo, 'file.txt'), 'one\nresolved\nthree\n');
+		await gitService.resolveConflict(repo, 'file.txt', 'reset');
+
+		const restored = await readFile(path.join(repo, 'file.txt'), 'utf-8');
+		expect(restored).toContain('<<<<<<<');
+		expect(await gitService.getUnmergedPaths(repo)).toEqual(['file.txt']);
+	});
+});
+
+describe('stageAll', () => {
+	test('refuses while a conflicted file still has markers', async () => {
+		await makeBothModifiedConflict();
+		await expect(gitService.stageAll(repo)).rejects.toThrow(/conflict markers/i);
+	});
+
+	test('proceeds once the markers are gone', async () => {
+		await makeBothModifiedConflict();
+		await writeFile(path.join(repo, 'file.txt'), 'one\nresolved\nthree\n');
+		await gitService.stageAll(repo);
+		expect(await gitService.getUnmergedPaths(repo)).toEqual([]);
+	});
+});
+
+describe('getOperationState', () => {
+	test('is idle in a clean repo', async () => {
+		const state = await gitService.getOperationState(repo);
+		expect(state.operation).toBeNull();
+		expect(state.canContinue).toBe(false);
+		expect(state.unmergedCount).toBe(0);
+	});
+
+	test('describes a merge and names both sides', async () => {
+		await makeBothModifiedConflict();
+
+		const state = await gitService.getOperationState(repo);
+		expect(state.operation).toBe('merge');
+		expect(state.oursLabel).toBe('main');
+		expect(state.theirsLabel).toBe('feature');
+		expect(state.unmergedCount).toBe(1);
+		// Blocked until the conflict is staged.
+		expect(state.canContinue).toBe(false);
+	});
+
+	test('allows continue once every path is resolved', async () => {
+		await makeBothModifiedConflict();
+		await gitService.resolveConflict(repo, 'file.txt', 'ours');
+
+		const state = await gitService.getOperationState(repo);
+		expect(state.canContinue).toBe(true);
+	});
+
+	test('reports rebase progress with the sides inverted', async () => {
+		await writeFile(path.join(repo, 'file.txt'), 'one\ntwo\n');
+		await commitAll('add file');
+
+		await gitOk('checkout', '-b', 'feature');
+		await writeFile(path.join(repo, 'file.txt'), 'one\nfeature\n');
+		await commitAll('feature edit');
+
+		await gitOk('checkout', 'main');
+		await writeFile(path.join(repo, 'file.txt'), 'one\nmain\n');
+		await commitAll('main edit');
+
+		await gitOk('checkout', 'feature');
+		await git('rebase', 'main');
+
+		const state = await gitService.getOperationState(repo);
+		expect(state.operation).toBe('rebase');
+		// During a rebase "ours" is the branch being rebased ONTO.
+		expect(state.oursLabel).toBe('main');
+		expect(state.theirsLabel).toContain('feature');
+		expect(state.canSkip).toBe(true);
+		expect(state.total).toBe(1);
+	});
+
+	test('flags unmerged paths with no sentinel as a stash conflict', async () => {
+		await writeFile(path.join(repo, 'file.txt'), 'one\n');
+		await commitAll('add file');
+
+		await writeFile(path.join(repo, 'file.txt'), 'stashed\n');
+		await gitOk('stash', 'push', '-m', 'wip');
+		await writeFile(path.join(repo, 'file.txt'), 'other\n');
+		await commitAll('conflicting edit');
+		await git('stash', 'pop');
+
+		const state = await gitService.getOperationState(repo);
+		expect(state.operation).toBeNull();
+		expect(state.stashConflict).toBe(true);
+		expect(state.unmergedCount).toBeGreaterThan(0);
+	});
+});
+
+describe('continueOperation', () => {
+	test('refuses while paths are still unmerged', async () => {
+		await makeBothModifiedConflict();
+		await expect(gitService.continueOperation(repo)).rejects.toThrow(/still unmerged/i);
+	});
+
+	test('finishes a merge once the conflict is staged', async () => {
+		await makeBothModifiedConflict();
+		await gitService.resolveConflict(repo, 'file.txt', 'ours');
+
+		const result = await gitService.continueOperation(repo);
+		expect(result.success).toBe(true);
+
+		const state = await gitService.getOperationState(repo);
+		expect(state.operation).toBeNull();
+	});
+
+	test('finishes a rebase, leaving the branch on top of the upstream', async () => {
+		await writeFile(path.join(repo, 'file.txt'), 'one\ntwo\n');
+		await commitAll('add file');
+		await gitOk('checkout', '-b', 'feature');
+		await writeFile(path.join(repo, 'file.txt'), 'one\nfeature\n');
+		await commitAll('feature edit');
+		await gitOk('checkout', 'main');
+		await writeFile(path.join(repo, 'file.txt'), 'one\nmain\n');
+		await commitAll('main edit');
+		await gitOk('checkout', 'feature');
+		await git('rebase', 'main');
+
+		await gitService.resolveConflict(repo, 'file.txt', 'theirs');
+		const result = await gitService.continueOperation(repo);
+		expect(result.success).toBe(true);
+
+		const state = await gitService.getOperationState(repo);
+		expect(state.operation).toBeNull();
+		const branch = (await gitOk('branch', '--show-current')).trim();
+		expect(branch).toBe('feature');
+	});
+
+	test('reports there is nothing to continue', async () => {
+		await expect(gitService.continueOperation(repo)).rejects.toThrow(/no operation/i);
+	});
+});
+
+describe('getReflog', () => {
+	test('lists recent HEAD movements', async () => {
+		await writeFile(path.join(repo, 'a.txt'), 'a\n');
+		await commitAll('second');
+
+		const entries = await gitService.getReflog(repo, 10);
+		expect(entries.length).toBeGreaterThan(0);
+		expect(entries[0].selector).toBe('HEAD@{0}');
+		expect(entries[0].action).toContain('commit');
+	});
+});

--- a/backend/git/git-executor.ts
+++ b/backend/git/git-executor.ts
@@ -62,6 +62,12 @@ export async function execGit(
 			// actually changing. Commands that genuinely need the index lock (commit,
 			// add, checkout) still take it; only the optional refresh is suppressed.
 			GIT_OPTIONAL_LOCKS: '0',
+			// `rebase --continue`, `merge --continue` and friends open $EDITOR for the
+			// commit message. With no TTY that call blocks until our timeout kills it,
+			// so point both editors at `true`: it exits 0 immediately and git keeps
+			// the message git already prepared.
+			GIT_EDITOR: 'true',
+			GIT_SEQUENCE_EDITOR: 'true',
 			// Use English output for consistent parsing
 			LANG: 'en_US.UTF-8',
 			LC_ALL: 'en_US.UTF-8'

--- a/backend/git/git-parser.ts
+++ b/backend/git/git-parser.ts
@@ -14,7 +14,8 @@ import type {
 	GitCommit,
 	GitRemote,
 	GitStashEntry,
-	GitConflictMarker
+	GitConflictMarker,
+	GitReflogEntry
 } from '$shared/types/git';
 
 /**
@@ -120,10 +121,15 @@ export function parseBranches(localOutput: string, remoteOutput: string): GitBra
 	// Parse local branches
 	const localLines = localOutput.split('\n').filter(Boolean);
 	for (const line of localLines) {
-		const dateSep = line.lastIndexOf('|');
+		// The upstream is appended after a 0x1F unit separator rather than another
+		// `|`, because the subject in the middle of the line can contain `|` and
+		// the legacy fields are still split positionally.
+		const [legacy, upstreamField = ''] = line.split('\x1f');
+
+		const dateSep = legacy.lastIndexOf('|');
 		if (dateSep === -1) continue;
-		const lastCommitDate = line.substring(dateSep + 1);
-		const head = line.substring(0, dateSep);
+		const lastCommitDate = legacy.substring(dateSep + 1);
+		const head = legacy.substring(0, dateSep);
 
 		// head = "<*>|<name>|<hash>|<subject>"
 		const parts = head.split('|', 4);
@@ -135,7 +141,7 @@ export function parseBranches(localOutput: string, remoteOutput: string): GitBra
 
 		if (isCurrent) current = name;
 
-		local.push({
+		const branch: GitBranch = {
 			name,
 			isCurrent,
 			isRemote: false,
@@ -144,7 +150,10 @@ export function parseBranches(localOutput: string, remoteOutput: string): GitBra
 			lastCommit,
 			lastCommitMessage,
 			lastCommitDate
-		} as GitBranch);
+		};
+		if (upstreamField.trim()) branch.upstream = upstreamField.trim();
+
+		local.push(branch);
 	}
 
 	// Parse remote branches
@@ -394,58 +403,145 @@ export function parseStashList(output: string): GitStashEntry[] {
 /**
  * Parse conflict markers from file content
  */
+/**
+ * Conflict markers are exactly seven repeated characters followed by a space or
+ * the end of the line. Matching a bare `startsWith('<<<<<<<')` also fires on
+ * ordinary content — an eight-arrow ASCII divider, a diff quoted inside a
+ * markdown file — and turns a clean file into a phantom conflict.
+ */
+const MARKER_OURS = /^<{7}(?:[ \t\r]|$)/;
+const MARKER_BASE = /^\|{7}(?:[ \t\r]|$)/;
+const MARKER_SEP = /^={7}(?:[ \t\r]|$)/;
+const MARKER_THEIRS = /^>{7}(?:[ \t\r]|$)/;
+
+/**
+ * True when the text still contains an unresolved conflict block. Used as a
+ * guard before staging: `git add` happily records a file that still has markers
+ * in it, which silently commits `<<<<<<<` into the tree.
+ */
+export function hasConflictMarkers(content: string): boolean {
+	return parseConflictMarkers(content).length > 0;
+}
+
 export function parseConflictMarkers(content: string): GitConflictMarker[] {
 	const markers: GitConflictMarker[] = [];
 	const lines = content.split('\n');
 
 	let i = 0;
 	while (i < lines.length) {
-		if (lines[i].startsWith('<<<<<<<')) {
-			const ourStart = i;
-			let baseStart: number | undefined;
-			let separatorIndex = -1;
-			let theirEnd = -1;
-
-			// Find the rest of the conflict
-			let j = i + 1;
-			while (j < lines.length) {
-				if (lines[j].startsWith('|||||||')) {
-					baseStart = j;
-				} else if (lines[j].startsWith('=======')) {
-					separatorIndex = j;
-				} else if (lines[j].startsWith('>>>>>>>')) {
-					theirEnd = j;
-					break;
-				}
-				j++;
-			}
-
-			if (separatorIndex >= 0 && theirEnd >= 0) {
-				const ourContentStart = ourStart + 1;
-				const ourContentEnd = baseStart !== undefined ? baseStart : separatorIndex;
-				const theirContentStart = separatorIndex + 1;
-
-				const marker: GitConflictMarker = {
-					ourStart,
-					ourEnd: separatorIndex,
-					theirStart: separatorIndex,
-					theirEnd,
-					ourContent: lines.slice(ourContentStart, ourContentEnd).join('\n'),
-					theirContent: lines.slice(theirContentStart, theirEnd).join('\n')
-				};
-
-				if (baseStart !== undefined) {
-					marker.baseStart = baseStart;
-					marker.baseContent = lines.slice(baseStart + 1, separatorIndex).join('\n');
-				}
-
-				markers.push(marker);
-				i = theirEnd + 1;
-				continue;
-			}
+		if (!MARKER_OURS.test(lines[i])) {
+			i++;
+			continue;
 		}
-		i++;
+
+		const ourStart = i;
+		let baseStart: number | undefined;
+		let separatorIndex = -1;
+		let theirEnd = -1;
+		let restartAt = -1;
+
+		let j = i + 1;
+		while (j < lines.length) {
+			const line = lines[j];
+			if (MARKER_OURS.test(line)) {
+				// A second opener before this one closed means the first was never a
+				// real conflict. Drop it and re-scan from the opener we just found.
+				restartAt = j;
+				break;
+			}
+			if (MARKER_BASE.test(line)) baseStart = j;
+			else if (MARKER_SEP.test(line)) separatorIndex = j;
+			else if (MARKER_THEIRS.test(line)) {
+				theirEnd = j;
+				break;
+			}
+			j++;
+		}
+
+		if (restartAt >= 0) {
+			i = restartAt;
+			continue;
+		}
+
+		if (separatorIndex < 0 || theirEnd < 0) {
+			i = ourStart + 1;
+			continue;
+		}
+
+		const ourContentEnd = baseStart !== undefined ? baseStart : separatorIndex;
+		const marker: GitConflictMarker = {
+			ourStart,
+			ourEnd: separatorIndex,
+			theirStart: separatorIndex,
+			theirEnd,
+			ourContent: lines.slice(ourStart + 1, ourContentEnd).join('\n'),
+			theirContent: lines.slice(separatorIndex + 1, theirEnd).join('\n')
+		};
+
+		if (baseStart !== undefined) {
+			marker.baseStart = baseStart;
+			marker.baseContent = lines.slice(baseStart + 1, separatorIndex).join('\n');
+		}
+
+		markers.push(marker);
+		i = theirEnd + 1;
 	}
 
 	return markers;
+}
+
+/**
+ * Parse `git reflog --format=%H|||%h|||%gd|||%gs|||%cI`.
+ *
+ * `%gs` (the reflog subject) already carries both halves — "commit: fix thing",
+ * "rebase (finish): returning to refs/heads/main" — so we split on the first
+ * ": " to separate the action from the description.
+ */
+export function parseReflog(output: string): GitReflogEntry[] {
+	const SEPARATOR = '|||';
+	const entries: GitReflogEntry[] = [];
+
+	for (const line of output.split('\n')) {
+		if (!line.trim()) continue;
+		const parts = line.split(SEPARATOR);
+		if (parts.length < 5) continue;
+		const [hash, hashShort, selector, gs, date] = parts;
+		const colon = gs.indexOf(': ');
+		entries.push({
+			hash,
+			hashShort,
+			selector,
+			action: colon >= 0 ? gs.slice(0, colon) : gs,
+			subject: colon >= 0 ? gs.slice(colon + 2) : '',
+			date
+		});
+	}
+
+	return entries;
+}
+
+/**
+ * Parse `git ls-files -u -z`: one row per unmerged *stage* (1 = base, 2 = ours,
+ * 3 = theirs), so a path shows up two or three times. Which stages are present
+ * is what distinguishes a both-modified conflict from a delete/modify one, and
+ * unlike `git status` this never omits a path whose working-tree file is gone.
+ */
+export function parseUnmergedStages(output: string): Map<string, Set<number>> {
+	const stages = new Map<string, Set<number>>();
+
+	for (const row of output.split('\0')) {
+		if (!row.trim()) continue;
+		// "<mode> <sha> <stage>\t<path>"
+		const tab = row.indexOf('\t');
+		if (tab < 0) continue;
+		const meta = row.slice(0, tab).trim().split(/\s+/);
+		const path = row.slice(tab + 1);
+		const stage = Number(meta[2]);
+		if (!path || !Number.isInteger(stage)) continue;
+		const set = stages.get(path) ?? new Set<number>();
+		set.add(stage);
+		stages.set(path, set);
+	}
+
+	return stages;
 }

--- a/backend/git/git-service.ts
+++ b/backend/git/git-service.ts
@@ -14,7 +14,10 @@ import {
 	parseLog,
 	parseRemotes,
 	parseStashList,
-	parseConflictMarkers
+	parseConflictMarkers,
+	parseReflog,
+	parseUnmergedStages,
+	hasConflictMarkers
 } from './git-parser';
 import type {
 	GitStatus,
@@ -25,7 +28,12 @@ import type {
 	GitLogResult,
 	GitRemote,
 	GitStashEntry,
-	GitConflictFile
+	GitPushTarget,
+	GitConflictFile,
+	GitConflictKind,
+	GitConflictResolution,
+	GitOperationState,
+	GitReflogEntry
 } from '$shared/types/git';
 import { debug } from '$shared/utils/logger';
 import {
@@ -119,11 +127,46 @@ export class GitService {
 		}
 	}
 
+	/**
+	 * Stage everything. Git will happily record a conflicted file that still has
+	 * `<<<<<<<` in it as resolved, so we check first and refuse — committing the
+	 * markers is far more expensive to undo than this error is to read.
+	 */
 	async stageAll(cwd: string): Promise<void> {
+		const unresolved = await this.findFilesWithLeftoverMarkers(cwd);
+		if (unresolved.length > 0) {
+			const shown = unresolved.slice(0, 5).join(', ');
+			const rest = unresolved.length > 5 ? ` and ${unresolved.length - 5} more` : '';
+			throw new Error(
+				`Cannot stage everything: ${shown}${rest} still contain conflict markers. Resolve them first.`
+			);
+		}
 		const result = await execGit(['add', '-A'], cwd);
 		if (result.exitCode !== 0) {
 			throw new Error(`git add -A failed: ${result.stderr}`);
 		}
+	}
+
+	/** Unmerged paths whose working-tree text still has conflict markers in it. */
+	private async findFilesWithLeftoverMarkers(cwd: string): Promise<string[]> {
+		const unmerged = await this.getUnmergedPaths(cwd);
+		if (unmerged.length === 0) return [];
+
+		const { readFile } = await import('node:fs/promises');
+		const { join } = await import('node:path');
+		const offenders: string[] = [];
+
+		for (const filePath of unmerged) {
+			try {
+				const buffer = await readFile(join(cwd, filePath));
+				if (buffer.subarray(0, 8000).includes(0)) continue;
+				if (hasConflictMarkers(buffer.toString('utf-8'))) offenders.push(filePath);
+			} catch {
+				// Missing file (both-deleted) has no markers to leave behind.
+			}
+		}
+
+		return offenders;
 	}
 
 	async unstageFile(cwd: string, filePath: string): Promise<void> {
@@ -169,9 +212,27 @@ export class GitService {
 		}
 	}
 
+	/**
+	 * Discard every working-tree change.
+	 *
+	 * Refused during a conflict: `git checkout -- .` cannot restore an unmerged
+	 * path, so it would half-succeed — wiping the unrelated edits while leaving
+	 * the conflict in place — and the old code ignored both exit codes, so that
+	 * partial result was invisible. Unwinding a merge is `abortOperation`'s job.
+	 */
 	async discardAll(cwd: string): Promise<void> {
+		const unmerged = await this.getUnmergedPaths(cwd);
+		if (unmerged.length > 0) {
+			throw new Error(
+				'Cannot discard everything while a merge is unresolved. Abort the operation instead, or resolve the conflicts first.'
+			);
+		}
+
 		// Restore tracked files
-		await execGit(['checkout', '--', '.'], cwd);
+		const restore = await execGit(['checkout', '--', '.'], cwd);
+		if (restore.exitCode !== 0 && restore.stderr.trim()) {
+			throw new Error(`git checkout failed: ${restore.stderr.trim()}`);
+		}
 		// Remove untracked files
 		await execGit(['clean', '-fd'], cwd);
 	}
@@ -297,7 +358,10 @@ export class GitService {
 		// where `HEAD` is `*` for the current branch and ` ` for others.
 		// `iso-date` is strict ISO 8601 so it can't collide with the `|`
 		// separators — the parser uses `lastIndexOf('|')` to extract it.
-		const localFmt = '%(HEAD)|%(refname:short)|%(objectname:short)|%(subject)|%(committerdate:iso8601)';
+		// `%1f` emits a literal 0x1F, which separates the upstream from the legacy
+		// pipe-delimited fields without colliding with a `|` inside a subject.
+		const localFmt =
+			'%(HEAD)|%(refname:short)|%(objectname:short)|%(subject)|%(committerdate:iso8601)%1f%(upstream:short)';
 		const remoteFmt = '%(refname:short)|%(objectname:short)|%(subject)|%(committerdate:iso8601)';
 		const [localResult, remoteResult, headRef] = await Promise.all([
 			execGit(['for-each-ref', `--format=${localFmt}`, 'refs/heads/'], cwd),
@@ -334,10 +398,35 @@ export class GitService {
 		branchInfo.current = headName;
 		for (const b of branchInfo.local) b.isCurrent = b.name === headName;
 
-		// Get ahead/behind for current branch relative to the SELECTED remote
-		if (branchInfo.current && selectedRemote) {
+		// Fill in upstreams that git cannot name. `gh pr checkout` on a fork PR
+		// writes the fork's URL into `branch.<name>.remote`, and a URL has no
+		// remote-tracking ref, so `%(upstream:short)` comes back empty even though
+		// the branch is very much tracking something.
+		for (const localBranch of branchInfo.local) {
+			if (localBranch.upstream) continue;
+			const configured = await this.readBranchTracking(cwd, localBranch.name);
+			if (configured) localBranch.upstream = `${configured.remote}/${configured.remoteBranch}`;
+		}
+
+		// Ahead/behind belongs against the branch's REAL upstream. Measuring it
+		// against `<selectedRemote>/<same name>` reported 0/0 whenever the branch
+		// tracked a differently-named branch or a different remote — which is
+		// exactly the fork-PR case.
+		const currentUpstream = branchInfo.local.find(b => b.isCurrent)?.upstream;
+		const trackingRef = currentUpstream
+			? // Tracks something. Use it when it resolves locally; when it does not —
+				// a URL upstream has no local ref — report nothing rather than compare
+				// against an unrelated same-named branch on the selected remote.
+				(await this.hasRef(cwd, currentUpstream))
+				? currentUpstream
+				: null
+			: selectedRemote
+				? `${selectedRemote}/${branchInfo.current}`
+				: null;
+
+		if (branchInfo.current && trackingRef) {
 			try {
-				const remoteRef = `${selectedRemote}/${branchInfo.current}`;
+				const remoteRef = trackingRef;
 				const abResult = await execGit(
 					['rev-list', '--left-right', '--count', `${branchInfo.current}...${remoteRef}`],
 					cwd
@@ -455,12 +544,27 @@ export class GitService {
 		}
 	}
 
-	async mergeBranch(cwd: string, branchName: string, noFastForward = false): Promise<{ success: boolean; message: string }> {
+	/**
+	 * Merge `branchName` into the current branch.
+	 *
+	 * The three mode flags are mutually exclusive in git, so the caller picks one:
+	 * `--no-ff` always records a merge commit, `--squash` collapses the branch into
+	 * staged changes without committing, `--ff-only` refuses anything that is not a
+	 * fast-forward.
+	 */
+	async mergeBranch(
+		cwd: string,
+		branchName: string,
+		options: { noFastForward?: boolean; squash?: boolean; ffOnly?: boolean } | boolean = false
+	): Promise<{ success: boolean; message: string }> {
 		assertSafeGitRevish(branchName, 'merge branch');
+		const opts = typeof options === 'boolean' ? { noFastForward: options } : options;
 		const args = ['merge'];
-		if (noFastForward) args.push('--no-ff');
+		if (opts.squash) args.push('--squash');
+		else if (opts.ffOnly) args.push('--ff-only');
+		else if (opts.noFastForward) args.push('--no-ff');
 		args.push(branchName);
-		const result = await execGit(args, cwd);
+		const result = await execGit(args, cwd, 120000);
 		return {
 			success: result.exitCode === 0,
 			message: result.exitCode === 0 ? result.stdout : result.stderr
@@ -533,15 +637,28 @@ export class GitService {
 		return result.stderr || result.stdout; // git fetch outputs to stderr
 	}
 
+	/**
+	 * Pull the current branch.
+	 *
+	 * Mirrors `push`: naming `<selectedRemote> <localName>` explicitly pulled from
+	 * the wrong place whenever the branch tracked a different remote or a
+	 * differently-named branch, which is the normal state of a fork PR under
+	 * review. A tracked branch pulls from its own upstream.
+	 */
 	async pull(cwd: string, remote = 'origin', branch?: string, rebase = false): Promise<{ success: boolean; message: string }> {
-		assertSafeGitRemoteName(remote);
 		const args = ['pull'];
 		if (rebase) args.push('--rebase');
-		args.push(remote);
-		if (branch) {
-			assertSafeGitRevish(branch, 'pull branch');
-			args.push(branch);
+
+		const target = await this.getPushTarget(cwd, branch);
+		if (!target.hasUpstream) {
+			assertSafeGitRemoteName(remote);
+			args.push(remote);
+			if (branch) {
+				assertSafeGitRevish(branch, 'pull branch');
+				args.push(branch);
+			}
 		}
+
 		const result = await execGit(args, cwd, 60000);
 		return {
 			success: result.exitCode === 0,
@@ -564,10 +681,130 @@ export class GitService {
 		if (!(await this.hasCommits(cwd))) {
 			return { success: false, message: 'This branch has no commits yet, so there is nothing to push.' };
 		}
+		// `--force-with-lease` compares against the remote-tracking ref. A branch
+		// that tracks a bare URL — a fork PR checked out for review — has no such
+		// ref, so git refuses with a bare "stale info" that explains nothing.
+		if (/stale info/i.test(result.stderr)) {
+			return {
+				success: false,
+				message:
+					'Force push with lease needs a remote-tracking ref to compare against, and this branch does not have one (it tracks a URL rather than a named remote). Fetch the branch first, or use a plain force push.'
+			};
+		}
 		return { success: false, message: result.stderr };
 	}
 
-	async push(cwd: string, remote = 'origin', branch?: string, force = false): Promise<{ success: boolean; message: string }> {
+	/** Read a single git config value, or null when it is unset. */
+	private async readConfig(cwd: string, key: string): Promise<string | null> {
+		const result = await execGit(['config', '--get', key], cwd, { okExitCodes: [1] });
+		const value = result.stdout.trim();
+		return result.exitCode === 0 && value ? value : null;
+	}
+
+	/** True when `ref` resolves in this repo. */
+	private async hasRef(cwd: string, ref: string): Promise<boolean> {
+		if (!/^[^\0\n\r]+$/.test(ref) || ref.startsWith('-')) return false;
+		const result = await execGit(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], cwd, {
+			okExitCodes: [1]
+		});
+		return result.exitCode === 0;
+	}
+
+	/**
+	 * The tracking configuration recorded for a branch, straight from git config.
+	 *
+	 * Read from config rather than from `@{upstream}` on purpose: when
+	 * `branch.<name>.remote` holds a URL instead of a remote name — which is what
+	 * `gh pr checkout` writes for a fork PR — every ref-based lookup fails with
+	 * "not stored as a remote-tracking branch", even though the branch does track
+	 * something and a plain `git push` sends it to exactly the right place.
+	 */
+	private async readBranchTracking(
+		cwd: string,
+		branch: string
+	): Promise<{ remote: string; remoteBranch: string } | null> {
+		assertSafeGitRevish(branch, 'branch name');
+		const remote = await this.readConfig(cwd, `branch.${branch}.remote`);
+		const merge = await this.readConfig(cwd, `branch.${branch}.merge`);
+		if (!remote || !merge) return null;
+		return { remote, remoteBranch: merge.replace(/^refs\/heads\//, '') };
+	}
+
+	/** A remote name is a configured remote; anything else we treat as a URL. */
+	private async isConfiguredRemote(cwd: string, name: string): Promise<boolean> {
+		const result = await execGit(['remote'], cwd);
+		return result.stdout.split('\n').map(r => r.trim()).includes(name);
+	}
+
+	/**
+	 * Resolve where a push would actually land, following git's own precedence:
+	 * `branch.<name>.pushRemote` > `remote.pushDefault` > `branch.<name>.remote`.
+	 *
+	 * Used for display and to decide whether a push needs `-u`; the push itself
+	 * still delegates to git so nothing here can drift from what git does.
+	 */
+	async getPushTarget(cwd: string, branch?: string): Promise<GitPushTarget> {
+		const current = branch ?? (await execGit(['branch', '--show-current'], cwd)).stdout.trim();
+		const fallback: GitPushTarget = {
+			remote: 'origin',
+			remoteBranch: current,
+			hasUpstream: false,
+			isUrl: false,
+			branch: current
+		};
+		if (!current) return fallback;
+
+		const tracking = await this.readBranchTracking(cwd, current);
+		const pushRemote =
+			(await this.readConfig(cwd, `branch.${current}.pushRemote`)) ??
+			(await this.readConfig(cwd, 'remote.pushDefault')) ??
+			tracking?.remote ??
+			null;
+
+		if (!pushRemote) return fallback;
+
+		return {
+			remote: pushRemote,
+			// When pushing to a different remote than the branch fetches from, git's
+			// default `push.default=simple` uses the local name; otherwise it uses
+			// the configured merge ref.
+			remoteBranch:
+				tracking && pushRemote === tracking.remote ? tracking.remoteBranch : current,
+			hasUpstream: Boolean(tracking),
+			isUrl: !(await this.isConfiguredRemote(cwd, pushRemote)),
+			branch: current
+		};
+	}
+
+	/**
+	 * Push the current branch.
+	 *
+	 * When the branch already tracks something we run a bare `git push` and let
+	 * git resolve the destination. Naming a remote and a branch explicitly — which
+	 * this used to do unconditionally, with `-u` — sent a fork PR's review commits
+	 * into the main repository as a brand-new branch, and the `-u` then rewrote
+	 * the branch's remote so every subsequent push went there too.
+	 *
+	 * `remote`/`branch` are only used for the genuinely untracked case (the first
+	 * push of a new local branch), where a destination has to be chosen and `-u`
+	 * is what the user wants.
+	 */
+	async push(
+		cwd: string,
+		remote = 'origin',
+		branch?: string,
+		force = false,
+		options: { useUpstream?: boolean } = {}
+	): Promise<{ success: boolean; message: string }> {
+		const { useUpstream = true } = options;
+		const target = await this.getPushTarget(cwd, branch);
+
+		if (useUpstream && target.hasUpstream) {
+			const args = ['push'];
+			if (force) args.push('--force-with-lease');
+			return this.describePushResult(cwd, await execGit(args, cwd, 60000));
+		}
+
 		assertSafeGitRemoteName(remote);
 		const args = ['push', remote];
 		if (branch) {
@@ -575,9 +812,38 @@ export class GitService {
 			args.push(branch);
 		}
 		if (force) args.push('--force-with-lease');
-		// Set upstream if needed
+		// Only safe here: the branch tracks nothing, so there is no upstream to
+		// overwrite and recording one is the point of a first push.
 		args.push('-u');
 		return this.describePushResult(cwd, await execGit(args, cwd, 60000));
+	}
+
+	/** Point a branch at a different upstream — the way back from a wrong push. */
+	async setUpstream(
+		cwd: string,
+		branch: string,
+		remote: string,
+		remoteBranch?: string
+	): Promise<void> {
+		assertSafeGitRevish(branch, 'branch name');
+		assertSafeGitRemoteName(remote);
+		const target = remoteBranch ?? branch;
+		assertSafeGitRevish(target, 'upstream branch');
+		const result = await execGit(
+			['branch', `--set-upstream-to=${remote}/${target}`, branch],
+			cwd
+		);
+		if (result.exitCode !== 0) {
+			throw new Error(`Could not set upstream: ${result.stderr.trim() || 'unknown error'}`);
+		}
+	}
+
+	async unsetUpstream(cwd: string, branch: string): Promise<void> {
+		assertSafeGitRevish(branch, 'branch name');
+		const result = await execGit(['branch', '--unset-upstream', branch], cwd);
+		if (result.exitCode !== 0) {
+			throw new Error(`Could not clear upstream: ${result.stderr.trim() || 'unknown error'}`);
+		}
 	}
 
 	/**
@@ -593,20 +859,36 @@ export class GitService {
 		remote = 'origin',
 		branch?: string
 	): Promise<{ success: boolean; message: string }> {
+		// `--tags` is about the tag namespace, not this branch, so it always needs
+		// an explicit remote.
+		if (mode === 'all-tags') {
+			assertSafeGitRemoteName(remote);
+			return this.describePushResult(
+				cwd,
+				await execGit(['push', remote, '--tags'], cwd, 60000)
+			);
+		}
+
+		const flag =
+			mode === 'with-tags'
+				? '--follow-tags'
+				: mode === 'force-lease'
+					? '--force-with-lease'
+					: '--force';
+
+		// Same rule as `push`: a tracked branch goes where git says it goes.
+		const target = await this.getPushTarget(cwd, branch);
+		if (target.hasUpstream) {
+			return this.describePushResult(cwd, await execGit(['push', flag], cwd, 60000));
+		}
+
 		assertSafeGitRemoteName(remote);
 		const args = ['push', remote];
-		if (mode === 'all-tags') {
-			args.push('--tags');
-		} else {
-			if (branch) {
-				assertSafeGitRevish(branch, 'push branch');
-				args.push(branch);
-			}
-			if (mode === 'with-tags') args.push('--follow-tags');
-			else if (mode === 'force-lease') args.push('--force-with-lease');
-			else if (mode === 'force') args.push('--force');
-			args.push('-u');
+		if (branch) {
+			assertSafeGitRevish(branch, 'push branch');
+			args.push(branch);
 		}
+		args.push(flag, '-u');
 		return this.describePushResult(cwd, await execGit(args, cwd, 60000));
 	}
 
@@ -716,6 +998,30 @@ export class GitService {
 		return { success: true, hasConflicts: false, message: result.stdout };
 	}
 
+	/**
+	 * Like `stashPop`, but leaves the entry in the stash list. Preferred when the
+	 * changes might not apply cleanly: a conflicted `pop` is easy to abort into a
+	 * state where the work looks lost, whereas `apply` always keeps a copy.
+	 */
+	async stashApply(
+		cwd: string,
+		index = 0
+	): Promise<{ success: boolean; hasConflicts: boolean; message: string }> {
+		if (!Number.isInteger(index) || index < 0) {
+			throw new Error('Invalid stash index');
+		}
+		const result = await execGit(['stash', 'apply', `stash@{${index}}`], cwd);
+		const combined = `${result.stdout}\n${result.stderr}`;
+		const hasConflicts = /CONFLICT \(/.test(combined) || /needs merge/.test(combined);
+		if (result.exitCode !== 0) {
+			if (hasConflicts) {
+				return { success: false, hasConflicts: true, message: result.stderr || result.stdout };
+			}
+			throw new Error(`git stash apply failed: ${result.stderr}`);
+		}
+		return { success: true, hasConflicts: false, message: result.stdout };
+	}
+
 	async stashDrop(cwd: string, index = 0): Promise<void> {
 		if (!Number.isInteger(index) || index < 0) {
 			throw new Error('Invalid stash index');
@@ -808,54 +1114,184 @@ export class GitService {
 	// Conflict Resolution
 	// ============================================
 
+	/**
+	 * Working-tree text above this size is not shipped to the client. A conflicted
+	 * minified bundle can be tens of megabytes; reading it, holding it as a JS
+	 * string and pushing it down the WebSocket stalls the panel for no benefit,
+	 * since nobody resolves a 20 MB file marker-by-marker anyway.
+	 */
+	private static readonly MAX_CONFLICT_CONTENT_BYTES = 2 * 1024 * 1024;
+
+	/**
+	 * Classify a conflict from the stages present in the index. Git records up to
+	 * three: 1 = merge base, 2 = ours, 3 = theirs. A missing stage means that side
+	 * deleted (or never had) the path.
+	 */
+	private conflictKindFromStages(stages: Set<number>): GitConflictKind {
+		const base = stages.has(1);
+		const ours = stages.has(2);
+		const theirs = stages.has(3);
+
+		if (ours && theirs) return base ? 'both-modified' : 'both-added';
+		if (ours && !theirs) return base ? 'deleted-by-them' : 'added-by-us';
+		if (!ours && theirs) return base ? 'deleted-by-us' : 'added-by-them';
+		return 'both-deleted';
+	}
+
+	/**
+	 * List every unmerged path with enough context for the resolver to render it.
+	 *
+	 * The source of truth is `git ls-files -u`, not the working tree. Reading files
+	 * first (and dropping the ones that throw) silently hid whole classes of
+	 * conflict: both-deleted has no file on disk at all, so those paths vanished
+	 * from the UI while git still refused to continue.
+	 */
 	async getConflictFiles(cwd: string): Promise<GitConflictFile[]> {
-		const status = await this.getStatus(cwd);
+		const result = await execGit(['ls-files', '-u', '-z'], cwd);
+		if (result.exitCode !== 0) {
+			throw new Error(`git ls-files -u failed: ${result.stderr}`);
+		}
+
+		const stages = parseUnmergedStages(result.stdout);
+		const { readFile, stat } = await import('node:fs/promises');
+		const { join } = await import('node:path');
 		const conflicts: GitConflictFile[] = [];
 
-		for (const file of status.conflicted) {
+		for (const [filePath, fileStages] of stages) {
+			const kind = this.conflictKindFromStages(fileStages);
+			const entry: GitConflictFile = {
+				path: filePath,
+				content: '',
+				markers: [],
+				kind,
+				contentOmitted: true
+			};
+
 			try {
-				const { readFile } = await import('node:fs/promises');
-				const { join } = await import('node:path');
-				const content = await readFile(join(cwd, file.path), 'utf-8');
-				const markers = parseConflictMarkers(content);
-				conflicts.push({ path: file.path, content, markers });
-			} catch (err) {
-				debug.error('git', `Failed to read conflict file: ${file.path}`, err);
+				const info = await stat(join(cwd, filePath));
+				entry.size = info.size;
+				if (info.size > GitService.MAX_CONFLICT_CONTENT_BYTES) {
+					entry.omitReason = 'too-large';
+				} else {
+					const buffer = await readFile(join(cwd, filePath));
+					// A NUL in the head is git's own binary heuristic. Decoding such a
+					// file as UTF-8 produces replacement characters, and writing that
+					// back as a "resolution" would corrupt it.
+					if (buffer.subarray(0, 8000).includes(0)) {
+						entry.omitReason = 'binary';
+					} else {
+						entry.content = buffer.toString('utf-8');
+						entry.markers = parseConflictMarkers(entry.content);
+						entry.contentOmitted = false;
+					}
+				}
+			} catch {
+				// No working-tree file: both-deleted, or deleted-by-us before the user
+				// restored it. Still a conflict git needs an answer for.
+				entry.omitReason = 'missing';
 			}
+
+			conflicts.push(entry);
 		}
 
 		return conflicts;
 	}
 
+	/**
+	 * Apply one resolution to one conflicted path and stage the result.
+	 *
+	 * `ours`/`theirs` need the file to have that stage — `git checkout --ours` on a
+	 * path the other side deleted fails with an opaque "does not have our version",
+	 * so we translate those into the keep/delete answer git actually wants.
+	 */
 	async resolveConflict(
 		cwd: string,
 		filePath: string,
-		resolution: 'ours' | 'theirs' | 'custom',
+		resolution: GitConflictResolution,
 		customContent?: string
 	): Promise<void> {
 		assertSafeGitPathOperand(filePath, 'conflict path');
-		if (resolution === 'custom' && customContent !== undefined) {
-			// Write custom content
-			const { writeFile } = await import('node:fs/promises');
-			const { join } = await import('node:path');
-			await writeFile(join(cwd, filePath), customContent, 'utf-8');
-		} else if (resolution === 'ours') {
-			await execGit(['checkout', '--ours', '--', filePath], cwd);
-		} else if (resolution === 'theirs') {
-			await execGit(['checkout', '--theirs', '--', filePath], cwd);
+		const { writeFile, readFile } = await import('node:fs/promises');
+		const { join } = await import('node:path');
+		const absolute = join(cwd, filePath);
+
+		if (resolution === 'reset') {
+			// Re-materialize the conflict so the user can start over.
+			const reset = await execGit(['checkout', '--merge', '--', filePath], cwd);
+			if (reset.exitCode !== 0) {
+				throw new Error(`git checkout --merge failed: ${reset.stderr}`);
+			}
+			return;
 		}
 
-		// Stage the resolved file
+		if (resolution === 'delete') {
+			const removed = await execGit(['rm', '-f', '--', filePath], cwd);
+			if (removed.exitCode !== 0) {
+				throw new Error(`git rm failed: ${removed.stderr}`);
+			}
+			return;
+		}
+
+		if (resolution === 'custom') {
+			if (customContent === undefined) {
+				throw new Error('A custom resolution needs the resolved file content');
+			}
+			this.assertNoLeftoverMarkers(customContent, filePath);
+			await writeFile(absolute, customContent, 'utf-8');
+		} else if (resolution === 'ours' || resolution === 'theirs') {
+			const stages = parseUnmergedStages(
+				(await execGit(['ls-files', '-u', '-z', '--', filePath], cwd)).stdout
+			);
+			const present = stages.get(filePath) ?? new Set<number>();
+			const wanted = resolution === 'ours' ? 2 : 3;
+			if (!present.has(wanted)) {
+				// That side deleted the path — "take ours" means "stay deleted".
+				const removed = await execGit(['rm', '-f', '--', filePath], cwd);
+				if (removed.exitCode !== 0) {
+					throw new Error(`git rm failed: ${removed.stderr}`);
+				}
+				return;
+			}
+			const flag = resolution === 'ours' ? '--ours' : '--theirs';
+			const checkout = await execGit(['checkout', flag, '--', filePath], cwd);
+			if (checkout.exitCode !== 0) {
+				throw new Error(`git checkout ${flag} failed: ${checkout.stderr}`);
+			}
+		} else if (resolution === 'keep') {
+			// Keep whatever is on disk — but not if it still has markers in it.
+			try {
+				const buffer = await readFile(absolute);
+				if (!buffer.subarray(0, 8000).includes(0)) {
+					this.assertNoLeftoverMarkers(buffer.toString('utf-8'), filePath);
+				}
+			} catch (err) {
+				if (err instanceof Error && err.message.includes('conflict marker')) throw err;
+				throw new Error(`Cannot keep "${filePath}": the file is not in the working tree`);
+			}
+		}
+
 		await this.stageFile(cwd, filePath);
 	}
 
 	/**
-	 * Aborts the in-progress conflict-producing operation: merge, cherry-pick,
-	 * revert, rebase, or a stash pop that left unmerged paths. We detect the
-	 * type via `.git/*_HEAD` sentinel files and pick the matching abort command.
-	 * For stash conflicts (no sentinel) we fall back to `git reset --merge`,
-	 * which unwinds the unmerged paths while keeping unrelated local edits.
+	 * Refuse to stage text that still contains `<<<<<<<`. Git does not check this,
+	 * so without the guard a half-finished resolution commits the markers.
 	 */
+	private assertNoLeftoverMarkers(content: string, filePath: string): void {
+		if (hasConflictMarkers(content)) {
+			throw new Error(
+				`"${filePath}" still contains conflict markers. Remove every <<<<<<< / ======= / >>>>>>> block before staging it.`
+			);
+		}
+	}
+
+	/** Paths git still considers unmerged. */
+	async getUnmergedPaths(cwd: string): Promise<string[]> {
+		const result = await execGit(['diff', '--name-only', '--diff-filter=U', '-z'], cwd);
+		if (result.exitCode !== 0) return [];
+		return result.stdout.split('\0').filter(Boolean);
+	}
+
 	/** Resolve the absolute git dir for a working tree (handles worktrees/.git files). */
 	private async resolveGitDir(cwd: string): Promise<string> {
 		const { join } = await import('node:path');
@@ -883,7 +1319,177 @@ export class GitService {
 		return null;
 	}
 
-	async abortMerge(cwd: string): Promise<void> {
+	/** Short subject of a revision, or an empty string when it cannot be read. */
+	private async subjectOf(cwd: string, rev: string): Promise<string> {
+		const result = await execGit(['log', '-1', '--format=%s', rev], cwd);
+		return result.exitCode === 0 ? result.stdout.trim() : '';
+	}
+
+	/** Best human name for a commit-ish: a branch name if one points at it, else a short hash. */
+	private async describeRef(cwd: string, rev: string): Promise<string> {
+		const named = await execGit(
+			['name-rev', '--name-only', '--refs=refs/heads/*', '--refs=refs/remotes/*', rev],
+			cwd
+		);
+		const name = named.stdout.trim();
+		if (named.exitCode === 0 && name && name !== 'undefined') {
+			return name.replace(/^remotes\//, '');
+		}
+		const short = await execGit(['rev-parse', '--short', rev], cwd);
+		return short.exitCode === 0 ? short.stdout.trim() : rev;
+	}
+
+	/**
+	 * Everything the UI needs to describe and finish an in-progress operation.
+	 *
+	 * The `ours`/`theirs` labels matter more than they look: during a rebase git
+	 * replays your commit on top of the upstream, so `--ours` is the upstream and
+	 * `--theirs` is your own work — inverted relative to a merge. Surfacing the
+	 * raw words without the branch names is what makes people pick the wrong side.
+	 */
+	async getOperationState(cwd: string): Promise<GitOperationState> {
+		const { existsSync, readFileSync } = await import('node:fs');
+		const { join } = await import('node:path');
+		const gitDir = await this.resolveGitDir(cwd);
+		const readTrimmed = (...parts: string[]): string => {
+			const target = join(gitDir, ...parts);
+			try {
+				return existsSync(target) ? readFileSync(target, 'utf-8').trim() : '';
+			} catch {
+				return '';
+			}
+		};
+
+		const operation = await this.detectGitOperation(cwd);
+		const unmerged = await this.getUnmergedPaths(cwd);
+		const state: GitOperationState = {
+			operation,
+			oursLabel: 'ours',
+			theirsLabel: 'theirs',
+			unmergedCount: unmerged.length,
+			canContinue: false,
+			canSkip: false,
+			stashConflict: false
+		};
+
+		const currentBranch = (await execGit(['branch', '--show-current'], cwd)).stdout.trim();
+
+		if (operation === 'rebase') {
+			// Interactive/merge-backend rebases use rebase-merge; `git am`-style ones
+			// use rebase-apply. They spell the same counters differently.
+			const isMerge = existsSync(join(gitDir, 'rebase-merge'));
+			const dir = isMerge ? 'rebase-merge' : 'rebase-apply';
+			const step = Number(readTrimmed(dir, isMerge ? 'msgnum' : 'next'));
+			const total = Number(readTrimmed(dir, isMerge ? 'end' : 'last'));
+			if (Number.isInteger(step) && step > 0) state.step = step;
+			if (Number.isInteger(total) && total > 0) state.total = total;
+
+			const headName = readTrimmed(dir, 'head-name').replace(/^refs\/heads\//, '');
+			const onto = readTrimmed(dir, 'onto');
+			state.oursLabel = onto ? await this.describeRef(cwd, onto) : 'upstream';
+			state.theirsLabel = headName ? `your commit (${headName})` : 'your commit';
+
+			const stopped = readTrimmed(dir, 'stopped-sha') || readTrimmed(dir, 'original-commit');
+			if (stopped) state.currentCommit = await this.subjectOf(cwd, stopped);
+			state.canSkip = true;
+		} else if (operation === 'merge') {
+			state.oursLabel = currentBranch || 'current branch';
+			state.theirsLabel = await this.describeRef(cwd, 'MERGE_HEAD');
+			state.currentCommit = await this.subjectOf(cwd, 'MERGE_HEAD');
+		} else if (operation === 'cherry-pick' || operation === 'revert') {
+			const head = operation === 'cherry-pick' ? 'CHERRY_PICK_HEAD' : 'REVERT_HEAD';
+			state.oursLabel = currentBranch || 'current branch';
+			state.theirsLabel = await this.describeRef(cwd, head);
+			state.currentCommit = await this.subjectOf(cwd, head);
+			state.canSkip = true;
+		} else if (operation === null && unmerged.length > 0) {
+			// Unmerged paths with no sentinel: a stash pop/apply that conflicted.
+			state.stashConflict = true;
+			state.oursLabel = currentBranch || 'working tree';
+			state.theirsLabel = 'stashed changes';
+		}
+
+		// Bisect never has a "continue"; everything else is finishable once the
+		// index is clean.
+		state.canContinue =
+			operation !== null && operation !== 'bisect' && unmerged.length === 0;
+
+		return state;
+	}
+
+	/**
+	 * Finish the in-progress operation. Returns the git output instead of throwing
+	 * on failure, because the common failures here are instructions rather than
+	 * errors — "nothing to commit, use --skip" is something the user must read.
+	 */
+	async continueOperation(cwd: string): Promise<{ success: boolean; message: string }> {
+		const operation = await this.detectGitOperation(cwd);
+		const unmerged = await this.getUnmergedPaths(cwd);
+		if (unmerged.length > 0) {
+			throw new Error(
+				`${unmerged.length} file${unmerged.length === 1 ? ' is' : 's are'} still unmerged. Resolve and stage them first.`
+			);
+		}
+
+		let args: string[];
+		switch (operation) {
+			case 'rebase':
+				args = ['rebase', '--continue'];
+				break;
+			case 'merge':
+				args = ['merge', '--continue'];
+				break;
+			case 'cherry-pick':
+				args = ['cherry-pick', '--continue'];
+				break;
+			case 'revert':
+				args = ['revert', '--continue'];
+				break;
+			default:
+				throw new Error('There is no operation to continue.');
+		}
+
+		const result = await execGit(args, cwd, 120000);
+		return {
+			success: result.exitCode === 0,
+			message: (result.exitCode === 0 ? result.stdout : result.stderr).trim()
+		};
+	}
+
+	/** Drop the commit git is currently stuck on and move to the next one. */
+	async skipOperation(cwd: string): Promise<{ success: boolean; message: string }> {
+		const operation = await this.detectGitOperation(cwd);
+		let args: string[];
+		switch (operation) {
+			case 'rebase':
+				args = ['rebase', '--skip'];
+				break;
+			case 'cherry-pick':
+				args = ['cherry-pick', '--skip'];
+				break;
+			case 'revert':
+				args = ['revert', '--skip'];
+				break;
+			default:
+				throw new Error('This operation cannot be skipped.');
+		}
+
+		const result = await execGit(args, cwd, 120000);
+		return {
+			success: result.exitCode === 0,
+			message: (result.exitCode === 0 ? result.stdout : result.stderr).trim()
+		};
+	}
+
+	/**
+	 * Aborts the in-progress conflict-producing operation: merge, cherry-pick,
+	 * revert, rebase, or a stash pop that left unmerged paths. We detect the
+	 * type via `.git/*_HEAD` sentinel files and pick the matching abort command.
+	 * For stash conflicts (no sentinel) we fall back to `git reset --merge`,
+	 * which unwinds the unmerged paths while keeping unrelated local edits — the
+	 * stash entry itself survives a failed pop, so nothing is actually lost.
+	 */
+	async abortOperation(cwd: string): Promise<void> {
 		const { existsSync } = await import('node:fs');
 		const { join } = await import('node:path');
 
@@ -897,19 +1503,83 @@ export class GitService {
 		else if (has('rebase-merge') || has('rebase-apply')) args = ['rebase', '--abort'];
 
 		if (args) {
-			const result = await execGit(args, cwd);
+			const result = await execGit(args, cwd, 120000);
 			if (result.exitCode !== 0) {
 				throw new Error(`git ${args.join(' ')} failed: ${result.stderr}`);
 			}
 			return;
 		}
 
-		// No standard in-progress operation — likely a stash pop conflict. Use
-		// `git reset --merge` to unwind unmerged paths safely.
 		const reset = await execGit(['reset', '--merge'], cwd);
 		if (reset.exitCode !== 0) {
 			throw new Error(`git reset --merge failed: ${reset.stderr}`);
 		}
+	}
+
+	/** Back-compat alias — the panel called this before rebase/cherry-pick were handled. */
+	async abortMerge(cwd: string): Promise<void> {
+		return this.abortOperation(cwd);
+	}
+
+	/**
+	 * Rebase the current branch onto `upstream`.
+	 *
+	 * `--autostash` is on by default: without it git refuses to start whenever the
+	 * working tree is dirty, which from the panel just looks like the button not
+	 * working.
+	 */
+	async rebaseOnto(
+		cwd: string,
+		upstream: string,
+		autostash = true
+	): Promise<{ success: boolean; hasConflicts: boolean; message: string }> {
+		assertSafeGitRevish(upstream, 'rebase upstream');
+		const args = ['rebase'];
+		if (autostash) args.push('--autostash');
+		args.push(upstream);
+
+		const result = await execGit(args, cwd, 120000);
+		const combined = `${result.stdout}\n${result.stderr}`;
+		const hasConflicts = /CONFLICT \(/.test(combined) || /could not apply/i.test(combined);
+		if (result.exitCode !== 0 && !hasConflicts) {
+			throw new Error(`git rebase failed: ${result.stderr || result.stdout}`);
+		}
+		return {
+			success: result.exitCode === 0,
+			hasConflicts,
+			message: (result.exitCode === 0 ? result.stdout : result.stderr || result.stdout).trim()
+		};
+	}
+
+	/** Restore the HEAD position recorded before the last checkout. */
+	async returnToBranch(cwd: string, branch?: string): Promise<void> {
+		if (branch) {
+			await this.switchBranch(cwd, branch);
+			return;
+		}
+		// `-` is git's own "previous checkout" shorthand, which is exactly what the
+		// user wants after inspecting a commit from the history view.
+		const result = await execGit(['checkout', '-'], cwd);
+		if (result.exitCode !== 0) {
+			throw new Error(
+				`Could not return to the previous branch: ${result.stderr.trim() || 'no previous checkout recorded'}`
+			);
+		}
+	}
+
+	/** Read the repo's undo journal — the only way back from a bad reset or rebase. */
+	async getReflog(cwd: string, limit = 100): Promise<GitReflogEntry[]> {
+		const SEPARATOR = '|||';
+		const format = `%H${SEPARATOR}%h${SEPARATOR}%gd${SEPARATOR}%gs${SEPARATOR}%cI`;
+		const result = await execGit(
+			['reflog', `--format=${format}`, `--max-count=${Math.max(1, Math.min(limit, 500))}`],
+			cwd
+		);
+		if (result.exitCode !== 0) {
+			if (!(await this.hasCommits(cwd))) return [];
+			throw new Error(`git reflog failed: ${result.stderr}`);
+		}
+		return parseReflog(result.stdout);
 	}
 
 	// ============================================

--- a/backend/git/push-target.test.ts
+++ b/backend/git/push-target.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execGit } from './git-executor';
+import { gitService } from './git-service';
+
+/**
+ * Reviewing a pull request from a fork is the case that broke.
+ *
+ * `gh pr checkout` records the contributor's repository in
+ * `branch.<name>.remote` — often as a bare URL — and their branch name in
+ * `branch.<name>.merge`. The panel ignored both and ran
+ * `git push <selectedRemote> <localName> -u`, which pushed the review commits
+ * into the maintainer's own repository as a new branch and then rewrote the
+ * branch's remote so every later push went there too.
+ */
+
+let workspace: string;
+/** Bare repo standing in for the maintainer's repository. */
+let upstream: string;
+/** Bare repo standing in for the contributor's fork. */
+let fork: string;
+/** Working clone, with `origin` pointing at `upstream`. */
+let work: string;
+
+async function git(cwd: string, ...args: string[]) {
+	const result = await execGit(args, cwd);
+	if (result.exitCode !== 0) throw new Error(`git ${args.join(' ')}: ${result.stderr}`);
+	return result.stdout;
+}
+
+async function branchesOf(bareRepo: string): Promise<string[]> {
+	const out = await git(bareRepo, 'for-each-ref', '--format=%(refname:short)', 'refs/heads/');
+	return out.split('\n').map(l => l.trim()).filter(Boolean).sort();
+}
+
+async function identify(repo: string) {
+	await git(repo, 'config', 'user.email', 'test@example.com');
+	await git(repo, 'config', 'user.name', 'Test');
+	await git(repo, 'config', 'commit.gpgsign', 'false');
+}
+
+beforeEach(async () => {
+	workspace = await mkdtemp(path.join(tmpdir(), 'clopen-push-'));
+	upstream = path.join(workspace, 'upstream.git');
+	fork = path.join(workspace, 'fork.git');
+	work = path.join(workspace, 'work');
+
+	await git(workspace, 'init', '--bare', '-b', 'main', upstream);
+
+	// Seed `main` in the upstream repo.
+	const seed = path.join(workspace, 'seed');
+	await git(workspace, 'clone', '-q', upstream, seed);
+	await identify(seed);
+	await writeFile(path.join(seed, 'a.txt'), 'a\n');
+	await git(seed, 'add', '-A');
+	await git(seed, 'commit', '-m', 'init');
+	await git(seed, 'push', 'origin', 'main');
+
+	// The fork starts as a copy of upstream and gains the contributor's branch.
+	await git(workspace, 'clone', '--bare', '-q', upstream, fork);
+	const forkWork = path.join(workspace, 'forkwork');
+	await git(workspace, 'clone', '-q', fork, forkWork);
+	await identify(forkWork);
+	await git(forkWork, 'checkout', '-b', 'their-branch');
+	await writeFile(path.join(forkWork, 'contrib.txt'), 'contribution\n');
+	await git(forkWork, 'add', '-A');
+	await git(forkWork, 'commit', '-m', 'contribution');
+	await git(forkWork, 'push', 'origin', 'their-branch');
+
+	// The maintainer's clone.
+	await git(workspace, 'clone', '-q', upstream, work);
+	await identify(work);
+});
+
+afterEach(async () => {
+	await rm(workspace, { recursive: true, force: true });
+});
+
+/** Reproduce what `gh pr checkout` leaves behind for a fork PR. */
+async function checkoutForkPr(localName = 'their-branch') {
+	await git(work, 'fetch', fork, 'their-branch');
+	await git(work, 'checkout', '-b', localName, 'FETCH_HEAD');
+	await git(work, 'config', `branch.${localName}.remote`, fork);
+	await git(work, 'config', `branch.${localName}.merge`, 'refs/heads/their-branch');
+}
+
+describe('getPushTarget', () => {
+	test('reports no upstream for a fresh local branch', async () => {
+		await git(work, 'checkout', '-b', 'brand-new');
+		const target = await gitService.getPushTarget(work);
+		expect(target.branch).toBe('brand-new');
+		expect(target.hasUpstream).toBe(false);
+	});
+
+	test('reports the tracking branch of a normal clone', async () => {
+		const target = await gitService.getPushTarget(work);
+		expect(target.hasUpstream).toBe(true);
+		expect(target.remote).toBe('origin');
+		expect(target.remoteBranch).toBe('main');
+		expect(target.isUrl).toBe(false);
+	});
+
+	test('resolves a fork PR to the fork, not to origin', async () => {
+		await checkoutForkPr();
+
+		const target = await gitService.getPushTarget(work);
+		expect(target.hasUpstream).toBe(true);
+		expect(target.remote).toBe(fork);
+		expect(target.remoteBranch).toBe('their-branch');
+		expect(target.isUrl).toBe(true);
+	});
+
+	test('keeps the remote branch name when the local branch was renamed', async () => {
+		// gh renames the local branch when the name would collide.
+		await checkoutForkPr('contributor-their-branch');
+
+		const target = await gitService.getPushTarget(work);
+		expect(target.branch).toBe('contributor-their-branch');
+		expect(target.remoteBranch).toBe('their-branch');
+	});
+
+	test('honours branch.<name>.pushRemote over branch.<name>.remote', async () => {
+		await git(work, 'remote', 'add', 'fork', fork);
+		await git(work, 'config', 'branch.main.pushRemote', 'fork');
+
+		const target = await gitService.getPushTarget(work);
+		expect(target.remote).toBe('fork');
+		expect(target.isUrl).toBe(false);
+	});
+});
+
+describe('push — fork pull request under review', () => {
+	test('sends the review commit to the fork and leaves origin untouched', async () => {
+		await checkoutForkPr();
+		await writeFile(path.join(work, 'review.txt'), 'review fix\n');
+		await git(work, 'add', '-A');
+		await git(work, 'commit', '-m', 'review fix');
+
+		// `remote` here is what the panel's dropdown would have supplied.
+		const result = await gitService.push(work, 'origin', 'their-branch');
+		expect(result.success).toBe(true);
+
+		// The fix landed on the contributor's branch...
+		const forkHead = await git(fork, 'log', '-1', '--format=%s', 'their-branch');
+		expect(forkHead.trim()).toBe('review fix');
+
+		// ...and the maintainer's repository gained nothing.
+		expect(await branchesOf(upstream)).toEqual(['main']);
+	});
+
+	test('does not rewrite the branch\'s configured remote', async () => {
+		await checkoutForkPr();
+		await writeFile(path.join(work, 'review.txt'), 'review fix\n');
+		await git(work, 'add', '-A');
+		await git(work, 'commit', '-m', 'review fix');
+
+		await gitService.push(work, 'origin', 'their-branch');
+
+		// The old `-u` replaced this with "origin", so every later push — including
+		// a manual `git push` — silently went to the wrong repository.
+		const configured = (await git(work, 'config', '--get', 'branch.their-branch.remote')).trim();
+		expect(configured).toBe(fork);
+		const merge = (await git(work, 'config', '--get', 'branch.their-branch.merge')).trim();
+		expect(merge).toBe('refs/heads/their-branch');
+	});
+
+	test('force push targets the fork rather than origin', async () => {
+		await checkoutForkPr();
+		await writeFile(path.join(work, 'review.txt'), 'review fix\n');
+		await git(work, 'add', '-A');
+		await git(work, 'commit', '-m', 'review fix');
+
+		const result = await gitService.pushAdvanced(work, 'force', 'origin', 'their-branch');
+		expect(result.success).toBe(true);
+
+		const forkHead = await git(fork, 'log', '-1', '--format=%s', 'their-branch');
+		expect(forkHead.trim()).toBe('review fix');
+		expect(await branchesOf(upstream)).toEqual(['main']);
+	});
+
+	test('explains why --force-with-lease cannot work against a URL upstream', async () => {
+		await checkoutForkPr();
+		await writeFile(path.join(work, 'review.txt'), 'review fix\n');
+		await git(work, 'add', '-A');
+		await git(work, 'commit', '-m', 'review fix');
+
+		// There is no remote-tracking ref for the lease to compare against, so git
+		// refuses with a bare "stale info". Say what that means instead.
+		const result = await gitService.pushAdvanced(work, 'force-lease', 'origin', 'their-branch');
+		expect(result.success).toBe(false);
+		expect(result.message).toMatch(/remote-tracking ref/i);
+		expect(await branchesOf(upstream)).toEqual(['main']);
+	});
+});
+
+describe('push — branch with no upstream', () => {
+	test('still creates the branch on the chosen remote and records it', async () => {
+		await git(work, 'checkout', '-b', 'feature/new');
+		await writeFile(path.join(work, 'f.txt'), 'f\n');
+		await git(work, 'add', '-A');
+		await git(work, 'commit', '-m', 'new work');
+
+		const result = await gitService.push(work, 'origin', 'feature/new');
+		expect(result.success).toBe(true);
+		expect(await branchesOf(upstream)).toEqual(['feature/new', 'main']);
+
+		// `-u` is correct here: there was no upstream to overwrite.
+		const target = await gitService.getPushTarget(work);
+		expect(target.hasUpstream).toBe(true);
+		expect(target.remote).toBe('origin');
+	});
+});
+
+describe('getBranches', () => {
+	test('exposes the upstream of a normal tracking branch', async () => {
+		const info = await gitService.getBranches(work, 'origin');
+		expect(info.local.find(b => b.name === 'main')?.upstream).toBe('origin/main');
+	});
+
+	test('exposes a URL upstream that git itself cannot name', async () => {
+		await checkoutForkPr();
+		const info = await gitService.getBranches(work, 'origin');
+		const branch = info.local.find(b => b.name === 'their-branch');
+		expect(branch?.upstream).toBe(`${fork}/their-branch`);
+	});
+
+	test('counts ahead against the real upstream, not <selected remote>/<name>', async () => {
+		await git(work, 'checkout', '-b', 'renamed-locally', 'main');
+		await git(work, 'branch', '--set-upstream-to=origin/main', 'renamed-locally');
+		await writeFile(path.join(work, 'x.txt'), 'x\n');
+		await git(work, 'add', '-A');
+		await git(work, 'commit', '-m', 'local work');
+
+		// `origin/renamed-locally` does not exist; the old code compared against it
+		// and reported nothing to push.
+		const info = await gitService.getBranches(work, 'origin');
+		expect(info.ahead).toBe(1);
+	});
+});
+
+describe('setUpstream / unsetUpstream', () => {
+	test('repoints a branch at a different remote branch', async () => {
+		await git(work, 'checkout', '-b', 'wip', 'main');
+		await gitService.setUpstream(work, 'wip', 'origin', 'main');
+
+		const target = await gitService.getPushTarget(work, 'wip');
+		expect(target.remote).toBe('origin');
+		expect(target.remoteBranch).toBe('main');
+	});
+
+	test('clears tracking so the next push has to choose', async () => {
+		await gitService.unsetUpstream(work, 'main');
+		const target = await gitService.getPushTarget(work, 'main');
+		expect(target.hasUpstream).toBe(false);
+	});
+
+	test('reports a remote-tracking ref that does not exist', async () => {
+		await expect(gitService.setUpstream(work, 'main', 'origin', 'nope')).rejects.toThrow(
+			/could not set upstream/i
+		);
+	});
+});

--- a/backend/ws/git/branch-name.ts
+++ b/backend/ws/git/branch-name.ts
@@ -7,6 +7,7 @@
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
 import { execGit } from '../../git/git-executor';
+import { buildBudgetedStagedDiff, BRANCH_NAME_BUDGET } from './diff-budget';
 import { initializeEngine } from '../../engine';
 import { resolveGenerationTarget } from '../../engine/resolve-model';
 import type { EngineType } from '$shared/types/unified';
@@ -147,10 +148,10 @@ export const branchNameHandler = createRouter()
 		const { root } = requireProjectWorkspace(conn, data.projectId);
 		const cwd = resolveRepoCwd(root, data.repoPath);
 
-		const diffResult = await execGit(['diff', '--cached'], cwd);
-		const rawDiff = diffResult.stdout;
-
-		if (!rawDiff.trim()) {
+		// A branch name is a topic, not a description — the file list carries nearly
+		// all the signal, so this budget is much tighter than the commit-message one.
+		const diff = await buildBudgetedStagedDiff(cwd, BRANCH_NAME_BUDGET);
+		if (diff.isEmpty) {
 			throw new Error('No staged changes to generate a branch name for');
 		}
 
@@ -167,7 +168,7 @@ export const branchNameHandler = createRouter()
 		const separator = normalizeBranchSeparator(data.branchSeparator);
 		const instructions = createBranchNameInstructions(currentBranch, prefix, separator);
 		const extra = data.customPrompt?.trim();
-		const prompt = `${instructions}${extra ? `\n\nAdditional constraints:\n${extra}` : ''}\n\nGit diff:\n${rawDiff}`;
+		const prompt = `${instructions}${extra ? `\n\nAdditional constraints:\n${extra}` : ''}\n\n${diff.text}`;
 
 		// The caller's providerSlug/account can be stale (see resolve-model.ts).
 		const target = await resolveGenerationTarget(engine, data.modelId, data.providerSlug);

--- a/backend/ws/git/branch.ts
+++ b/backend/ws/git/branch.ts
@@ -158,6 +158,10 @@ export const branchHandler = createRouter()
 			projectId: t.String(),
 			branchName: t.String(),
 			noFastForward: t.Optional(t.Boolean()),
+			/** Collapse the branch into staged changes without committing. */
+			squash: t.Optional(t.Boolean()),
+			/** Refuse the merge unless it is a fast-forward. */
+			ffOnly: t.Optional(t.Boolean()),
 			repoPath: t.Optional(t.String())
 		}),
 		response: t.Object({
@@ -167,5 +171,43 @@ export const branchHandler = createRouter()
 	}, async ({ data, conn }) => {
 		const { root } = requireProjectWorkspace(conn, data.projectId);
 		const cwd = resolveRepoCwd(root, data.repoPath);
-		return await gitService.mergeBranch(cwd, data.branchName, data.noFastForward ?? false);
+		return await gitService.mergeBranch(cwd, data.branchName, {
+			noFastForward: data.noFastForward ?? false,
+			squash: data.squash ?? false,
+			ffOnly: data.ffOnly ?? false
+		});
+	})
+
+	.http('git:rebase', {
+		data: t.Object({
+			projectId: t.String(),
+			upstream: t.String({ minLength: 1 }),
+			/** Stash and restore local changes around the rebase. Defaults to true. */
+			autostash: t.Optional(t.Boolean()),
+			repoPath: t.Optional(t.String())
+		}),
+		response: t.Object({
+			success: t.Boolean(),
+			hasConflicts: t.Boolean(),
+			message: t.String()
+		})
+	}, async ({ data, conn }) => {
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
+		return await gitService.rebaseOnto(cwd, data.upstream, data.autostash ?? true);
+	})
+
+	.http('git:return-to-branch', {
+		data: t.Object({
+			projectId: t.String(),
+			/** Explicit target; omit to use git's own "previous checkout" shorthand. */
+			branch: t.Optional(t.String()),
+			repoPath: t.Optional(t.String())
+		}),
+		response: t.Object({ ok: t.Boolean() })
+	}, async ({ data, conn }) => {
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
+		await gitService.returnToBranch(cwd, data.branch);
+		return { ok: true };
 	});

--- a/backend/ws/git/commit-message.ts
+++ b/backend/ws/git/commit-message.ts
@@ -6,7 +6,7 @@
 
 import { t } from 'elysia';
 import { createRouter } from '$shared/utils/ws-server';
-import { execGit } from '../../git/git-executor';
+import { buildBudgetedStagedDiff, COMMIT_MESSAGE_BUDGET } from './diff-budget';
 import { initializeEngine } from '../../engine';
 import { resolveGenerationTarget } from '../../engine/resolve-model';
 import type { EngineType } from '$shared/types/unified';
@@ -77,11 +77,9 @@ export const commitMessageHandler = createRouter()
 		const { root } = requireProjectWorkspace(conn, data.projectId);
 		const cwd = resolveRepoCwd(root, data.repoPath);
 
-		// Get raw staged diff text
-		const diffResult = await execGit(['diff', '--cached'], cwd);
-		const rawDiff = diffResult.stdout;
-
-		if (!rawDiff.trim()) {
+		// A budgeted view of the staged change, not the raw diff — see diff-budget.ts.
+		const diff = await buildBudgetedStagedDiff(cwd, COMMIT_MESSAGE_BUDGET);
+		if (diff.isEmpty) {
 			throw new Error('No staged changes to generate a commit message for');
 		}
 
@@ -96,16 +94,21 @@ export const commitMessageHandler = createRouter()
 			? 'Generate a multi-line conventional commit message with type, scope, subject, AND body fields. The body should explain WHY the change was made.'
 			: 'Generate a single-line conventional commit message with type, optional scope, and subject. Leave body empty.';
 
-		const defaultPrompt = `Analyze the following git diff and generate a conventional commit message.
+		// When the diff was sampled, say so: without this the model describes only
+		// the files it happened to see and writes a subject that misses the change.
+		const coverageNote = diff.truncated
+			? '\n- The diff below is a sample. Describe the change as a whole using the file list, not just the visible hunks.'
+			: '';
+
+		const defaultPrompt = `Analyze the following staged git change and generate a conventional commit message.
 
 Rules:
 - type: one of feat, fix, refactor, docs, test, chore, style, perf, ci, build
 - scope: optional, the area of the codebase affected (e.g., git, settings, engine)
 - subject: imperative mood, lowercase, no period at end, max 72 characters
-- ${formatInstruction}
+- ${formatInstruction}${coverageNote}
 
-Git diff:
-${rawDiff}`;
+${diff.text}`;
 
 		const extra = data.customPrompt?.trim();
 		const prompt = extra

--- a/backend/ws/git/conflict.ts
+++ b/backend/ws/git/conflict.ts
@@ -22,6 +22,38 @@ function resolveRepoCwd(projectPath: string, repoPath: string | undefined): stri
 	return resolved;
 }
 
+const ConflictKindSchema = t.Union([
+	t.Literal('both-modified'),
+	t.Literal('both-added'),
+	t.Literal('added-by-us'),
+	t.Literal('added-by-them'),
+	t.Literal('deleted-by-us'),
+	t.Literal('deleted-by-them'),
+	t.Literal('both-deleted')
+]);
+
+const OperationSchema = t.Union([
+	t.Literal('rebase'),
+	t.Literal('merge'),
+	t.Literal('cherry-pick'),
+	t.Literal('revert'),
+	t.Literal('bisect'),
+	t.Null()
+]);
+
+const OperationStateSchema = t.Object({
+	operation: OperationSchema,
+	step: t.Optional(t.Number()),
+	total: t.Optional(t.Number()),
+	oursLabel: t.String(),
+	theirsLabel: t.String(),
+	currentCommit: t.Optional(t.String()),
+	unmergedCount: t.Number(),
+	canContinue: t.Boolean(),
+	canSkip: t.Boolean(),
+	stashConflict: t.Boolean()
+});
+
 const ConflictMarkerSchema = t.Object({
 	ourStart: t.Number(),
 	ourEnd: t.Number(),
@@ -42,7 +74,15 @@ export const conflictHandler = createRouter()
 		response: t.Array(t.Object({
 			path: t.String(),
 			content: t.String(),
-			markers: t.Array(ConflictMarkerSchema)
+			markers: t.Array(ConflictMarkerSchema),
+			kind: ConflictKindSchema,
+			contentOmitted: t.Boolean(),
+			omitReason: t.Optional(t.Union([
+				t.Literal('binary'),
+				t.Literal('missing'),
+				t.Literal('too-large')
+			])),
+			size: t.Optional(t.Number())
 		}))
 	}, async ({ data, conn }) => {
 		const { root } = requireProjectWorkspace(conn, data.projectId);
@@ -75,7 +115,14 @@ export const conflictHandler = createRouter()
 		data: t.Object({
 			projectId: t.String(),
 			filePath: t.String(),
-			resolution: t.Union([t.Literal('ours'), t.Literal('theirs'), t.Literal('custom')]),
+			resolution: t.Union([
+				t.Literal('ours'),
+				t.Literal('theirs'),
+				t.Literal('custom'),
+				t.Literal('keep'),
+				t.Literal('delete'),
+				t.Literal('reset')
+			]),
 			customContent: t.Optional(t.String())
 		}),
 		response: t.Object({ ok: t.Boolean() })
@@ -93,6 +140,62 @@ export const conflictHandler = createRouter()
 		return { ok: true };
 	})
 
+	/**
+	 * Everything needed to describe (and finish) an in-progress merge/rebase.
+	 * Scoped to one repo: a project with nested repos can be mid-rebase in a
+	 * sub-repo while the outer tree is clean, so the caller passes `repoPath`
+	 * rather than us guessing from whichever conflict happens to be first.
+	 */
+	.http('git:operation-state', {
+		data: t.Object({
+			projectId: t.String(),
+			repoPath: t.Optional(t.String())
+		}),
+		response: OperationStateSchema
+	}, async ({ data, conn }) => {
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath) ?? root;
+		return await gitService.getOperationState(cwd);
+	})
+
+	.http('git:continue-operation', {
+		data: t.Object({
+			projectId: t.String(),
+			repoPath: t.Optional(t.String())
+		}),
+		response: t.Object({ success: t.Boolean(), message: t.String() })
+	}, async ({ data, conn }) => {
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath) ?? root;
+		return await gitService.continueOperation(cwd);
+	})
+
+	.http('git:skip-operation', {
+		data: t.Object({
+			projectId: t.String(),
+			repoPath: t.Optional(t.String())
+		}),
+		response: t.Object({ success: t.Boolean(), message: t.String() })
+	}, async ({ data, conn }) => {
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath) ?? root;
+		return await gitService.skipOperation(cwd);
+	})
+
+	.http('git:abort-operation', {
+		data: t.Object({
+			projectId: t.String(),
+			repoPath: t.Optional(t.String())
+		}),
+		response: t.Object({ ok: t.Boolean() })
+	}, async ({ data, conn }) => {
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath) ?? root;
+		await gitService.abortOperation(cwd);
+		return { ok: true };
+	})
+
+	/** Retained under the old name so existing clients keep working. */
 	.http('git:abort-merge', {
 		data: t.Object({
 			projectId: t.String(),
@@ -102,6 +205,6 @@ export const conflictHandler = createRouter()
 	}, async ({ data, conn }) => {
 		const { root } = requireProjectWorkspace(conn, data.projectId);
 		const cwd = resolveRepoCwd(root, data.repoPath) ?? root;
-		await gitService.abortMerge(cwd);
+		await gitService.abortOperation(cwd);
 		return { ok: true };
 	});

--- a/backend/ws/git/diff-budget.test.ts
+++ b/backend/ws/git/diff-budget.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execGit } from '../../git/git-executor';
+import { buildBudgetedStagedDiff, COMMIT_MESSAGE_BUDGET, type DiffBudget } from './diff-budget';
+
+/**
+ * The AI generators used to inline the raw `git diff --cached` output, which had
+ * no upper bound at all. These assert the replacement stays inside its budget
+ * while still describing the whole change.
+ */
+
+let repo: string;
+
+async function git(...args: string[]) {
+	const result = await execGit(args, repo);
+	if (result.exitCode !== 0) throw new Error(`git ${args.join(' ')}: ${result.stderr}`);
+	return result.stdout;
+}
+
+const TINY_BUDGET: DiffBudget = {
+	perFileBytes: 400,
+	totalBytes: 900,
+	maxFiles: 3,
+	contextLines: 1
+};
+
+beforeEach(async () => {
+	repo = await mkdtemp(path.join(tmpdir(), 'clopen-diffbudget-'));
+	await git('init', '-b', 'main', '.');
+	await git('config', 'user.email', 'test@example.com');
+	await git('config', 'user.name', 'Test');
+	await git('config', 'commit.gpgsign', 'false');
+});
+
+afterEach(async () => {
+	await rm(repo, { recursive: true, force: true });
+});
+
+describe('buildBudgetedStagedDiff', () => {
+	test('reports an empty staging area', async () => {
+		const result = await buildBudgetedStagedDiff(repo, COMMIT_MESSAGE_BUDGET);
+		expect(result.isEmpty).toBe(true);
+		expect(result.text).toBe('');
+	});
+
+	test('includes the stat header and the patch for a small change', async () => {
+		await writeFile(path.join(repo, 'a.ts'), 'export const a = 1;\n');
+		await git('add', '-A');
+
+		const result = await buildBudgetedStagedDiff(repo, COMMIT_MESSAGE_BUDGET);
+		expect(result.isEmpty).toBe(false);
+		expect(result.truncated).toBe(false);
+		expect(result.text).toContain('Files changed:');
+		expect(result.text).toContain('a.ts');
+		expect(result.text).toContain('export const a = 1;');
+	});
+
+	test('skips lockfiles and generated output but still names them', async () => {
+		await writeFile(path.join(repo, 'bun.lock'), 'x'.repeat(50_000));
+		await mkdir(path.join(repo, 'dist'), { recursive: true });
+		await writeFile(path.join(repo, 'dist', 'bundle.js'), 'y'.repeat(50_000));
+		await writeFile(path.join(repo, 'src.ts'), 'export const keep = true;\n');
+		await git('add', '-A');
+
+		const result = await buildBudgetedStagedDiff(repo, COMMIT_MESSAGE_BUDGET);
+		expect(result.text).toContain('Binary or generated files (diff omitted)');
+		expect(result.text).toContain('bun.lock');
+		expect(result.text).toContain('dist/bundle.js');
+		// The real source file still gets its patch.
+		expect(result.text).toContain('export const keep = true;');
+		// And none of the 100 KB of noise made it into the prompt.
+		expect(result.text).not.toContain('x'.repeat(200));
+		expect(result.text).not.toContain('y'.repeat(200));
+	});
+
+	test('omits a binary file from the patch body', async () => {
+		await writeFile(path.join(repo, 'image.dat'), Buffer.from([0, 1, 2, 0, 255, 0]));
+		await git('add', '-A');
+
+		const result = await buildBudgetedStagedDiff(repo, COMMIT_MESSAGE_BUDGET);
+		expect(result.text).toContain('Binary or generated files (diff omitted)');
+		expect(result.text).toContain('image.dat');
+	});
+
+	test('clips an oversized file and says so', async () => {
+		const big = Array.from({ length: 400 }, (_, i) => `line ${i}`).join('\n');
+		await writeFile(path.join(repo, 'big.ts'), `${big}\n`);
+		await git('add', '-A');
+
+		const result = await buildBudgetedStagedDiff(repo, TINY_BUDGET);
+		expect(result.truncated).toBe(true);
+		expect(result.text).toContain('… truncated');
+		expect(result.text).toContain('sampled');
+		// The whole point: the prompt stays near the budget, not the file size.
+		expect(result.text.length).toBeLessThan(TINY_BUDGET.totalBytes * 3);
+	});
+
+	test('stops opening files once the budget is spent, and reports the remainder', async () => {
+		for (let i = 0; i < 8; i++) {
+			const body = Array.from({ length: 60 }, (_, n) => `const v${i}_${n} = ${n};`).join('\n');
+			await writeFile(path.join(repo, `f${i}.ts`), `${body}\n`);
+		}
+		await git('add', '-A');
+
+		const result = await buildBudgetedStagedDiff(repo, TINY_BUDGET);
+		expect(result.truncated).toBe(true);
+		expect(result.text).toContain('were omitted');
+		// Every file is still visible in the stat header, so the model can
+		// describe the change as a whole.
+		expect(result.text).toContain('f7.ts');
+	});
+
+	test('handles a rename without losing the path', async () => {
+		await writeFile(path.join(repo, 'old.ts'), 'export const x = 1;\n');
+		await git('add', '-A');
+		await git('commit', '-m', 'init');
+		await git('mv', 'old.ts', 'new.ts');
+
+		const result = await buildBudgetedStagedDiff(repo, COMMIT_MESSAGE_BUDGET);
+		expect(result.isEmpty).toBe(false);
+		expect(result.text).toContain('new.ts');
+	});
+});

--- a/backend/ws/git/diff-budget.ts
+++ b/backend/ws/git/diff-budget.ts
@@ -1,0 +1,220 @@
+/**
+ * Budgeted staged-diff builder for the AI generators.
+ *
+ * The commit-message and branch-name handlers used to inline the raw output of
+ * `git diff --cached` into the prompt. That has no upper bound: a lockfile
+ * refresh or a vendored bundle turns one "generate commit message" click into
+ * hundreds of thousands of tokens, and on strict-context models it fails
+ * outright instead of degrading.
+ *
+ * This builds the same information under a hard budget: the `--stat` header
+ * always survives (it is small and describes the *whole* change), noisy paths
+ * are skipped by name, and the patch body is filled file by file until the
+ * budget runs out. Truncation is announced in the text so the model knows it is
+ * looking at a sample rather than the complete change.
+ */
+
+import { execGit } from '../../git/git-executor';
+import { assertSafeGitPathOperand } from '../../git/git-spawn-validation';
+
+export interface DiffBudget {
+	/** Max bytes of patch text kept for any single file. */
+	perFileBytes: number;
+	/** Max bytes of patch text across all files. */
+	totalBytes: number;
+	/** Max number of files we spawn a `git diff` for. */
+	maxFiles: number;
+	/** Lines of surrounding context per hunk. */
+	contextLines: number;
+}
+
+/**
+ * Budget for commit messages. Big enough that a normal feature change arrives
+ * whole, small enough that a lockfile-sized diff cannot blow up the request.
+ */
+export const COMMIT_MESSAGE_BUDGET: DiffBudget = {
+	perFileBytes: 6 * 1024,
+	totalBytes: 24 * 1024,
+	maxFiles: 40,
+	contextLines: 3
+};
+
+/**
+ * Budget for branch names. A branch name is one to three words about the *topic*
+ * of the change, so the file list carries almost all the signal and the patch is
+ * only there to disambiguate.
+ */
+export const BRANCH_NAME_BUDGET: DiffBudget = {
+	perFileBytes: 2 * 1024,
+	totalBytes: 4 * 1024,
+	maxFiles: 15,
+	contextLines: 0
+};
+
+/**
+ * Paths whose diff is machine-generated: enormous, uninformative, and the single
+ * biggest source of wasted context. They still appear in the `--stat` header, so
+ * the model can see they changed.
+ */
+const GENERATED_PATH_PATTERNS: RegExp[] = [
+	/(^|\/)(bun\.lock|bun\.lockb|package-lock\.json|yarn\.lock|pnpm-lock\.yaml)$/,
+	/(^|\/)(Cargo\.lock|composer\.lock|Gemfile\.lock|poetry\.lock|go\.sum)$/,
+	/(^|\/)(dist|build|out|vendor|node_modules|coverage)\//,
+	/\.(min\.js|min\.css|map|snap)$/,
+	/(^|\/)__snapshots__\//
+];
+
+function isGeneratedPath(filePath: string): boolean {
+	return GENERATED_PATH_PATTERNS.some(pattern => pattern.test(filePath));
+}
+
+interface NumstatEntry {
+	path: string;
+	isBinary: boolean;
+}
+
+/**
+ * `git diff --cached --numstat -z` emits `adds\tdels\tpath\0`, with `-` counts
+ * for binary files. Renames add two extra NUL-separated path fields after an
+ * empty path slot, which is why the parser advances through the stream rather
+ * than splitting it into fixed records.
+ */
+function parseNumstat(output: string): NumstatEntry[] {
+	const entries: NumstatEntry[] = [];
+	const fields = output.split('\0');
+
+	for (let i = 0; i < fields.length; i++) {
+		const field = fields[i];
+		if (!field.trim()) continue;
+		const parts = field.split('\t');
+		if (parts.length < 3) continue;
+
+		const [adds, dels, rawPath] = parts;
+		let filePath = rawPath;
+		if (filePath === '') {
+			// Rename/copy: the old and new paths follow as their own fields.
+			const newPath = fields[i + 2];
+			if (newPath) filePath = newPath;
+			i += 2;
+		}
+		if (!filePath) continue;
+
+		entries.push({ path: filePath, isBinary: adds === '-' && dels === '-' });
+	}
+
+	return entries;
+}
+
+function truncate(text: string, limit: number): { text: string; truncated: boolean } {
+	if (text.length <= limit) return { text, truncated: false };
+	const clipped = text.slice(0, limit);
+	// Cut on a line boundary so the model never sees half a diff line.
+	const lastNewline = clipped.lastIndexOf('\n');
+	const body = lastNewline > 0 ? clipped.slice(0, lastNewline) : clipped;
+	const droppedLines = text.slice(body.length).split('\n').length;
+	return {
+		text: `${body}\n… truncated, ${droppedLines} more line${droppedLines === 1 ? '' : 's'} in this file`,
+		truncated: true
+	};
+}
+
+export interface BudgetedDiff {
+	/** The rendered prompt section, ready to append. */
+	text: string;
+	/** True when any file's patch was clipped or dropped. */
+	truncated: boolean;
+	/** True when there is nothing staged at all. */
+	isEmpty: boolean;
+}
+
+/**
+ * Build the staged-diff section of an AI prompt under `budget`.
+ *
+ * We deliberately spawn one `git diff` per file rather than one for everything:
+ * it lets us stop as soon as the budget is spent, so a 200 MB staged blob is
+ * never read into memory in the first place.
+ */
+export async function buildBudgetedStagedDiff(
+	cwd: string,
+	budget: DiffBudget
+): Promise<BudgetedDiff> {
+	const numstat = await execGit(['diff', '--cached', '--numstat', '-z', '-M'], cwd);
+	const entries = parseNumstat(numstat.stdout);
+
+	if (entries.length === 0) {
+		return { text: '', truncated: false, isEmpty: true };
+	}
+
+	const statResult = await execGit(['diff', '--cached', '--stat=200', '-M'], cwd);
+	const stat = statResult.stdout.trim();
+
+	const skipped: string[] = [];
+	const candidates: string[] = [];
+	for (const entry of entries) {
+		if (entry.isBinary || isGeneratedPath(entry.path)) {
+			skipped.push(entry.path);
+			continue;
+		}
+		candidates.push(entry.path);
+	}
+
+	const patches: string[] = [];
+	let used = 0;
+	let truncated = false;
+	let filesOmitted = 0;
+
+	for (const [index, filePath] of candidates.entries()) {
+		if (index >= budget.maxFiles || used >= budget.totalBytes) {
+			filesOmitted = candidates.length - index;
+			truncated = true;
+			break;
+		}
+
+		try {
+			assertSafeGitPathOperand(filePath, 'diff path');
+		} catch {
+			skipped.push(filePath);
+			continue;
+		}
+
+		const result = await execGit(
+			[
+				'diff',
+				'--cached',
+				'--no-color',
+				`--unified=${budget.contextLines}`,
+				'-M',
+				'--',
+				filePath
+			],
+			cwd
+		);
+		if (result.exitCode !== 0 || !result.stdout.trim()) continue;
+
+		const remaining = budget.totalBytes - used;
+		const limit = Math.min(budget.perFileBytes, remaining);
+		const clipped = truncate(result.stdout.trimEnd(), limit);
+		if (clipped.truncated) truncated = true;
+		patches.push(clipped.text);
+		used += clipped.text.length;
+	}
+
+	const sections: string[] = [];
+	if (stat) sections.push(`Files changed:\n${stat}`);
+	if (skipped.length > 0) {
+		const shown = skipped.slice(0, 10).join(', ');
+		const rest = skipped.length > 10 ? `, and ${skipped.length - 10} more` : '';
+		sections.push(`Binary or generated files (diff omitted): ${shown}${rest}`);
+	}
+	if (patches.length > 0) {
+		const header = truncated
+			? 'Staged diff (sampled — some files or lines were omitted to fit context):'
+			: 'Staged diff:';
+		sections.push(`${header}\n${patches.join('\n')}`);
+	}
+	if (filesOmitted > 0) {
+		sections.push(`${filesOmitted} further changed file(s) were omitted; see the file list above.`);
+	}
+
+	return { text: sections.join('\n\n'), truncated, isEmpty: false };
+}

--- a/backend/ws/git/log.ts
+++ b/backend/ws/git/log.ts
@@ -59,4 +59,29 @@ export const logHandler = createRouter()
 			data.branch,
 			data.allBranches ?? false
 		);
+	})
+
+	/**
+	 * The repo's undo journal. Unlike `git log` this still lists commits that a
+	 * reset, a branch delete or a rebase orphaned, so it is the recovery path for
+	 * every destructive action the panel offers.
+	 */
+	.http('git:reflog', {
+		data: t.Object({
+			projectId: t.String(),
+			limit: t.Optional(t.Number()),
+			repoPath: t.Optional(t.String())
+		}),
+		response: t.Array(t.Object({
+			hash: t.String(),
+			hashShort: t.String(),
+			selector: t.String(),
+			action: t.String(),
+			subject: t.String(),
+			date: t.String()
+		}))
+	}, async ({ data, conn }) => {
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
+		return await gitService.getReflog(cwd, data.limit ?? 100);
 	});

--- a/backend/ws/git/remote.ts
+++ b/backend/ws/git/remote.ts
@@ -120,6 +120,11 @@ export const remoteHandler = createRouter()
 			remote: t.Optional(t.String()),
 			branch: t.Optional(t.String()),
 			force: t.Optional(t.Boolean()),
+			/**
+			 * Follow the branch's own upstream instead of `remote`. Default true —
+			 * only set false for a deliberate "push this somewhere else" action.
+			 */
+			useUpstream: t.Optional(t.Boolean()),
 			repoPath: t.Optional(t.String())
 		}),
 		response: t.Object({
@@ -129,7 +134,59 @@ export const remoteHandler = createRouter()
 	}, async ({ data, conn }) => {
 		const { root } = requireProjectWorkspace(conn, data.projectId);
 		const cwd = resolveRepoCwd(root, data.repoPath);
-		return await gitService.push(cwd, data.remote, data.branch, data.force);
+		return await gitService.push(cwd, data.remote, data.branch, data.force, {
+			useUpstream: data.useUpstream ?? true
+		});
+	})
+
+	/** Where a push would actually land — drives the Push button's label. */
+	.http('git:push-target', {
+		data: t.Object({
+			projectId: t.String(),
+			branch: t.Optional(t.String()),
+			repoPath: t.Optional(t.String())
+		}),
+		response: t.Object({
+			remote: t.String(),
+			remoteBranch: t.String(),
+			hasUpstream: t.Boolean(),
+			isUrl: t.Boolean(),
+			branch: t.String()
+		})
+	}, async ({ data, conn }) => {
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
+		return await gitService.getPushTarget(cwd, data.branch);
+	})
+
+	.http('git:set-upstream', {
+		data: t.Object({
+			projectId: t.String(),
+			branch: t.String({ minLength: 1 }),
+			remote: t.String({ minLength: 1 }),
+			remoteBranch: t.Optional(t.String()),
+			repoPath: t.Optional(t.String())
+		}),
+		response: t.Object({ ok: t.Boolean() })
+	}, async ({ data, conn }) => {
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
+		await gitService.setUpstream(cwd, data.branch, data.remote, data.remoteBranch);
+		return { ok: true };
+	})
+
+	.http('git:unset-upstream', {
+		data: t.Object({
+			projectId: t.String(),
+			branch: t.String({ minLength: 1 }),
+			repoPath: t.Optional(t.String())
+		}),
+		response: t.Object({ ok: t.Boolean() })
+	}, async ({ data, conn }) => {
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
+		await gitService.unsetUpstream(cwd, data.branch);
+		return { ok: true };
 	})
 
 	.http('git:add-remote', {
@@ -271,6 +328,23 @@ export const remoteHandler = createRouter()
 		const { root } = requireProjectWorkspace(conn, data.projectId);
 		const cwd = resolveRepoCwd(root, data.repoPath);
 		return await gitService.stashPop(cwd, data.index);
+	})
+
+	.http('git:stash-apply', {
+		data: t.Object({
+			projectId: t.String(),
+			index: t.Optional(t.Number()),
+			repoPath: t.Optional(t.String())
+		}),
+		response: t.Object({
+			success: t.Boolean(),
+			hasConflicts: t.Boolean(),
+			message: t.String()
+		})
+	}, async ({ data, conn }) => {
+		const { root } = requireProjectWorkspace(conn, data.projectId);
+		const cwd = resolveRepoCwd(root, data.repoPath);
+		return await gitService.stashApply(cwd, data.index);
 	})
 
 	.http('git:stash-drop', {

--- a/frontend/components/git/CommitForm.svelte
+++ b/frontend/components/git/CommitForm.svelte
@@ -33,6 +33,12 @@
 		isMoreBusy?: boolean;
 		/** Repo is detached / mid-operation (rebase, merge, …) — block branch-targeted actions */
 		repoBusy?: boolean;
+		/**
+		 * Where a push will actually land, e.g. `contributor/clopen/their-branch`.
+		 * Shown in the tooltip because the destination is decided by the branch's
+		 * own config, not by the panel's remote dropdown.
+		 */
+		pushDestination?: string;
 		/** Human-readable reason shown in disabled button tooltips */
 		repoBusyReason?: string;
 		/** Absolute path to a nested repo; when set, actions operate inside that repo. */
@@ -62,6 +68,7 @@
 		isMoreBusy = false,
 		repoBusy = false,
 		repoBusyReason = '',
+		pushDestination = '',
 		repoPath,
 		onCreateBranch,
 		onPush,
@@ -78,7 +85,6 @@
 	const showSyncActions = $derived(Boolean(onPush || onPull));
 
 	// Branch operand shown in the sync-button tooltips (omitted when unknown).
-	const branchRef = $derived(currentBranch ? ` ${currentBranch}` : '');
 
 	// The commit message draft is per-project and lives in the git workspace
 	// store so it survives remounts and is isolated/restored per project.
@@ -455,7 +461,11 @@
 					class="relative flex items-center justify-center w-8 h-7 bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-700 rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-violet-600 dark:hover:text-violet-400 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-white dark:disabled:hover:bg-slate-800/80 disabled:hover:text-slate-500 flex-shrink-0"
 					onclick={onPush}
 					disabled={isPushing || !hasRemotes || !onPush || repoBusy}
-					title={repoBusy ? repoBusyReason : hasRemotes ? `Push${branchAhead > 0 ? ` (${branchAhead} ahead)` : ''} — git push -u ${selectedRemote}${branchRef}` : 'No remote configured'}
+					title={repoBusy
+						? repoBusyReason
+						: hasRemotes
+							? `Push${branchAhead > 0 ? ` (${branchAhead} ahead)` : ''}${pushDestination ? ` → ${pushDestination}` : ''}`
+							: 'No remote configured'}
 				>
 					{#if isPushing}
 						<div class="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin flex-shrink-0"></div>
@@ -473,7 +483,11 @@
 					class="relative flex items-center justify-center w-8 h-7 bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-700 rounded-md text-slate-500 cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:text-violet-600 dark:hover:text-violet-400 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-white dark:disabled:hover:bg-slate-800/80 disabled:hover:text-slate-500 flex-shrink-0"
 					onclick={onPull}
 					disabled={isPulling || !hasRemotes || !onPull || repoBusy}
-					title={repoBusy ? repoBusyReason : hasRemotes ? `Pull${branchBehind > 0 ? ` (${branchBehind} behind)` : ''} — git pull ${selectedRemote}${branchRef}` : 'No remote configured'}
+					title={repoBusy
+						? repoBusyReason
+						: hasRemotes
+							? `Pull${branchBehind > 0 ? ` (${branchBehind} behind)` : ''}${pushDestination ? ` ← ${pushDestination}` : ''}`
+							: 'No remote configured'}
 				>
 					{#if isPulling}
 						<div class="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin flex-shrink-0"></div>

--- a/frontend/components/git/ConflictResolver.svelte
+++ b/frontend/components/git/ConflictResolver.svelte
@@ -1,14 +1,24 @@
 <script lang="ts">
 	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import { clickOutside } from '$frontend/utils/click-outside';
 	import Modal from '$frontend/components/common/overlay/Modal.svelte';
 	import MonacoDiffEditor from '$frontend/components/common/editor/MonacoDiffEditor.svelte';
 	import MonacoCodeEditor from '$frontend/components/common/editor/MonacoCodeEditor.svelte';
 	import { detectLanguageFromFilename } from '$frontend/components/common/editor/monaco-languages';
 	import { getFileIcon } from '$frontend/utils/file-icon-mappings';
 	import type { IconName } from '$shared/types/ui/icons';
-	import type { GitConflictFile, GitConflictMarker } from '$shared/types/git';
+	import type {
+		GitConflictFile,
+		GitConflictMarker,
+		GitConflictResolution,
+		GitOperationState
+	} from '$shared/types/git';
 
+	/** Per-marker pick inside the guided editor — narrower than a file resolution. */
 	type Resolution = 'ours' | 'theirs' | 'both';
+
+	/** Which two sides the diff editor compares. */
+	type CompareMode = 'ours-theirs' | 'base-ours' | 'base-theirs';
 
 	interface MarkerState {
 		resolution: Resolution | null;
@@ -19,7 +29,13 @@
 		conflictFiles: GitConflictFile[];
 		isLoading: boolean;
 		initialPath?: string | null;
-		onResolve: (filePath: string, resolution: 'ours' | 'theirs' | 'custom', customContent?: string) => void;
+		onResolve: (filePath: string, resolution: GitConflictResolution, customContent?: string) => void;
+		/**
+		 * The in-progress operation, used to name the two sides. Without it the
+		 * resolver can only say "ours"/"theirs", which is actively misleading
+		 * during a rebase where those words swap meaning.
+		 */
+		operation?: GitOperationState | null;
 		onResolveWithAI: (filePath: string) => void;
 		onResolveAllWithAI: () => void;
 		onAbortMerge: () => void;
@@ -39,6 +55,7 @@
 		isLoading,
 		initialPath = null,
 		onResolve,
+		operation = null,
 		onResolveWithAI,
 		onResolveAllWithAI,
 		onAbortMerge,
@@ -51,7 +68,9 @@
 	let currentMarkerIndex = $state(0);
 	let manualContent = $state('');
 	let showMoreMenu = $state(false);
+	let showFileMenu = $state(false);
 	let markerStatesMap = $state<Record<string, MarkerState[]>>({});
+	let compareMode = $state<CompareMode>('ours-theirs');
 	let isWideViewport = $state(true);
 	let prevOpen = $state(false);
 
@@ -89,6 +108,189 @@
 	);
 
 	const allResolved = $derived(totalMarkers > 0 && resolvedCount === totalMarkers);
+
+	// Name the two sides. A rebase replays your commits onto the upstream, so git's
+	// `--ours` is the branch you are rebasing ONTO and `--theirs` is your own work —
+	// the opposite of a merge. Showing the bare words is how people pick backwards.
+	const oursLabel = $derived(operation?.oursLabel || 'HEAD');
+	const theirsLabel = $derived(operation?.theirsLabel || 'incoming');
+	const isRebase = $derived(operation?.operation === 'rebase');
+
+	const headerTitle = $derived(
+		operation?.operation === 'rebase'
+			? 'Rebase Conflicts'
+			: operation?.operation === 'cherry-pick'
+				? 'Cherry-pick Conflicts'
+				: operation?.operation === 'revert'
+					? 'Revert Conflicts'
+					: operation?.stashConflict
+						? 'Stash Conflicts'
+						: 'Merge Conflicts'
+	);
+
+	/**
+	 * Only both-modified / both-added conflicts carry inline markers. Everything
+	 * else is an add/delete disagreement (or a binary blob) where there is nothing
+	 * to edit — those need the structural pane instead of the guided editor.
+	 */
+	function isEditable(file: GitConflictFile): boolean {
+		return !file.contentOmitted && file.markers.length > 0;
+	}
+
+	const selectedIsEditable = $derived(Boolean(selectedFile && isEditable(selectedFile)));
+
+	/** True when each side still has a version of the file (vs. deleted it). */
+	function sidesPresent(file: GitConflictFile): { ours: boolean; theirs: boolean } {
+		switch (file.kind) {
+			case 'both-modified':
+			case 'both-added':
+				return { ours: true, theirs: true };
+			case 'added-by-us':
+			case 'deleted-by-them':
+				return { ours: true, theirs: false };
+			case 'added-by-them':
+			case 'deleted-by-us':
+				return { ours: false, theirs: true };
+			case 'both-deleted':
+				return { ours: false, theirs: false };
+		}
+	}
+
+	/** One-line explanation of what the two sides actually did to this path. */
+	function describeKind(file: GitConflictFile): string {
+		switch (file.kind) {
+			case 'both-modified':
+				return `Modified on both ${oursLabel} and ${theirsLabel}.`;
+			case 'both-added':
+				return `Added independently on ${oursLabel} and ${theirsLabel}.`;
+			case 'added-by-us':
+				return `Added on ${oursLabel} only — ${theirsLabel} has no such file.`;
+			case 'added-by-them':
+				return `Added on ${theirsLabel} only — ${oursLabel} has no such file.`;
+			case 'deleted-by-us':
+				return `Deleted on ${oursLabel}, but modified on ${theirsLabel}.`;
+			case 'deleted-by-them':
+				return `Modified on ${oursLabel}, but deleted on ${theirsLabel}.`;
+			case 'both-deleted':
+				return 'Deleted on both sides, with conflicting history.';
+		}
+	}
+
+	/** Why the text is missing, when it is. */
+	function describeOmission(file: GitConflictFile): string {
+		switch (file.omitReason) {
+			case 'binary':
+				return 'This is a binary file, so there is no text to merge — pick one side.';
+			case 'missing':
+				return 'There is no file in the working tree to edit.';
+			case 'too-large':
+				return 'This file is too large to open in the editor — pick one side, or resolve it outside Clopen.';
+			default:
+				return '';
+		}
+	}
+
+	interface StructuralAction {
+		id: GitConflictResolution;
+		label: string;
+		hint: string;
+		tone: 'ours' | 'theirs' | 'neutral' | 'danger';
+	}
+
+	/**
+	 * The answers git will accept for a conflict with no markers. "Use ours" on a
+	 * path the other side deleted still resolves — it just resolves as a deletion,
+	 * which the hint spells out so the button is never a surprise.
+	 */
+	function structuralActions(file: GitConflictFile): StructuralAction[] {
+		const sides = sidesPresent(file);
+		const actions: StructuralAction[] = [
+			{
+				id: 'ours',
+				label: `Use ${oursLabel}`,
+				hint: sides.ours ? 'Keep this side\u2019s version of the file' : 'Resolve as deleted',
+				tone: 'ours'
+			},
+			{
+				id: 'theirs',
+				label: `Use ${theirsLabel}`,
+				hint: sides.theirs ? 'Keep this side\u2019s version of the file' : 'Resolve as deleted',
+				tone: 'theirs'
+			}
+		];
+
+		if (file.omitReason !== 'missing') {
+			actions.push({
+				id: 'keep',
+				label: 'Keep working file',
+				hint: 'Stage the file exactly as it is on disk right now',
+				tone: 'neutral'
+			});
+		}
+
+		actions.push({
+			id: 'delete',
+			label: 'Delete file',
+			hint: 'Resolve the conflict by removing the file',
+			tone: 'danger'
+		});
+
+		return actions;
+	}
+
+	/** Short status chip for the file list. */
+	function fileChip(file: GitConflictFile): { text: string; complete: boolean } {
+		if (!isEditable(file)) {
+			if (file.omitReason === 'binary') return { text: 'bin', complete: false };
+			if (file.omitReason === 'too-large') return { text: 'big', complete: false };
+			if (file.kind === 'both-deleted') return { text: 'del', complete: false };
+			if (file.kind === 'deleted-by-us' || file.kind === 'deleted-by-them') {
+				return { text: 'del', complete: false };
+			}
+			return { text: 'add', complete: false };
+		}
+		const stats = getFileStats(file.path);
+		return {
+			text: `${stats.resolved}/${stats.total}`,
+			complete: stats.total > 0 && stats.resolved === stats.total
+		};
+	}
+
+	/**
+	 * Base content only exists when the repo writes diff3-style markers
+	 * (`merge.conflictStyle`), so the comparison switcher is hidden otherwise.
+	 */
+	const abortLabel = $derived(
+		operation?.operation === 'rebase'
+			? 'Abort Rebase'
+			: operation?.operation === 'cherry-pick'
+				? 'Abort Cherry-pick'
+				: operation?.operation === 'revert'
+					? 'Abort Revert'
+					: operation?.stashConflict
+						? 'Reset Working Tree'
+						: 'Abort Merge'
+	);
+
+	const hasBase = $derived(currentMarker?.baseContent !== undefined);
+
+	const comparison = $derived.by(() => {
+		const marker = currentMarker;
+		if (!marker) return null;
+		const base = marker.baseContent ?? '';
+		if (compareMode === 'base-ours' && marker.baseContent !== undefined) {
+			return { original: base, modified: marker.ourContent, left: 'base', right: oursLabel };
+		}
+		if (compareMode === 'base-theirs' && marker.baseContent !== undefined) {
+			return { original: base, modified: marker.theirContent, left: 'base', right: theirsLabel };
+		}
+		return {
+			original: marker.ourContent,
+			modified: marker.theirContent,
+			left: oursLabel,
+			right: theirsLabel
+		};
+	});
 
 	// On open, prefer the caller-provided initialPath; fall back to first file.
 	// We watch the open transition so re-opens from a different list entry land
@@ -128,6 +330,7 @@
 			currentMarkerIndex = 0;
 			manualContent = selectedFile.content;
 			editMode = 'guided';
+			compareMode = 'ours-theirs';
 		}
 	});
 
@@ -266,8 +469,15 @@
 	>
 		<div class="flex items-center gap-2 min-w-0">
 			<h2 class="text-sm md:text-base font-bold text-slate-900 dark:text-slate-100 truncate">
-				Merge Conflicts
+				{headerTitle}
 			</h2>
+			{#if operation?.step && operation.total}
+				<span
+					class="shrink-0 rounded px-1.5 py-0.5 text-3xs font-semibold bg-amber-500/20 text-amber-700 dark:text-amber-300"
+				>
+					{operation.step} / {operation.total}
+				</span>
+			{/if}
 		</div>
 		<div class="flex items-center gap-1 md:gap-2 shrink-0">
 			{#if conflictFiles.length > 0}
@@ -285,10 +495,10 @@
 					class="hidden md:flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-red-600 dark:text-red-400 bg-red-500/10 hover:bg-red-500/20 rounded-lg transition-colors cursor-pointer border-none"
 					onclick={onAbortMerge}
 					disabled={busy}
-					title="Abort the merge and discard all conflict resolutions"
+					title="Abort this operation and discard all conflict resolutions"
 				>
 					<Icon name="lucide:octagon-x" class="w-4 h-4" />
-					Abort Merge
+					{abortLabel}
 				</button>
 			{/if}
 			<!-- Mobile-only overflow menu -->
@@ -336,7 +546,7 @@
 							}}
 						>
 							<Icon name="lucide:octagon-x" class="w-4 h-4" />
-							Abort Merge
+							{abortLabel}
 						</button>
 					</div>
 				{/if}
@@ -351,6 +561,22 @@
 			</button>
 		</div>
 	</div>
+
+	{#if isRebase}
+		<!-- The single most useful sentence in this dialog. During a rebase git
+			replays your commits onto the upstream, so "ours" is the branch you are
+			rebasing onto and "theirs" is your own commit. -->
+		<div
+			class="flex items-start gap-2 px-3 py-1.5 md:px-4 border-b border-amber-500/30 bg-amber-500/10 text-3xs md:text-xs text-amber-800 dark:text-amber-200 shrink-0"
+		>
+			<Icon name="lucide:triangle-alert" class="w-3.5 h-3.5 mt-px shrink-0" />
+			<span class="min-w-0">
+				Rebase: the sides are swapped from a normal merge —
+				<strong class="font-semibold">ours = {oursLabel}</strong> (what you are rebasing onto) and
+				<strong class="font-semibold">theirs = {theirsLabel}</strong>.
+			</span>
+		</div>
+	{/if}
 
 	{#if isLoading}
 		<div class="flex-1 flex items-center justify-center">
@@ -371,9 +597,9 @@
 			class="md:hidden flex gap-1.5 px-3 py-2 border-b border-slate-200 dark:border-slate-800 overflow-x-auto shrink-0 bg-slate-50/50 dark:bg-slate-900/40"
 		>
 			{#each conflictFiles as file (file.path)}
-				{@const stats = getFileStats(file.path)}
+				{@const chip = fileChip(file)}
 				{@const isSelected = selectedPath === file.path}
-				{@const isComplete = stats.total > 0 && stats.resolved === stats.total}
+				{@const isComplete = chip.complete}
 				<button
 					type="button"
 					class="flex items-center gap-1.5 shrink-0 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors cursor-pointer border
@@ -397,7 +623,7 @@
 						{#if isComplete}
 							<Icon name="lucide:check" class="w-3 h-3" />
 						{:else}
-							{stats.resolved}/{stats.total}
+							{chip.text}
 						{/if}
 					</span>
 				</button>
@@ -410,9 +636,9 @@
 				class="hidden md:block w-56 lg:w-64 xl:w-72 border-r border-slate-200 dark:border-slate-800 overflow-y-auto shrink-0 bg-slate-50/50 dark:bg-slate-900/40 py-1"
 			>
 				{#each conflictFiles as file (file.path)}
-					{@const stats = getFileStats(file.path)}
+					{@const chip = fileChip(file)}
 					{@const isSelected = selectedPath === file.path}
-					{@const isComplete = stats.total > 0 && stats.resolved === stats.total}
+					{@const isComplete = chip.complete}
 					<button
 						type="button"
 						class="flex items-center gap-2 w-full px-3 py-2 text-left bg-transparent border-none cursor-pointer transition-colors
@@ -443,7 +669,7 @@
 							{#if isComplete}
 								<Icon name="lucide:check" class="w-3.5 h-3.5" />
 							{:else}
-								{stats.resolved}/{stats.total}
+								{chip.text}
 							{/if}
 						</span>
 					</button>
@@ -471,12 +697,12 @@
 							</span>
 						</div>
 						<div class="flex flex-wrap items-center gap-1.5 shrink-0">
-							{#if editMode === 'guided'}
+							{#if selectedIsEditable && editMode === 'guided'}
 								<button
 									type="button"
 									class="px-2 py-1 text-xs md:text-sm font-medium text-emerald-700 dark:text-emerald-300 bg-emerald-500/10 rounded-md hover:bg-emerald-500/20 transition-colors cursor-pointer border-none shrink-0"
 									onclick={applyAllOurs}
-									title="Mark every marker in this file as Ours (you still need to Stage)"
+									title="Mark every marker in this file as {oursLabel} (you still need to Stage)"
 								>
 									All Ours
 								</button>
@@ -484,11 +710,72 @@
 									type="button"
 									class="px-2 py-1 text-xs md:text-sm font-medium text-blue-700 dark:text-blue-300 bg-blue-500/10 rounded-md hover:bg-blue-500/20 transition-colors cursor-pointer border-none shrink-0"
 									onclick={applyAllTheirs}
-									title="Mark every marker in this file as Theirs (you still need to Stage)"
+									title="Mark every marker in this file as {theirsLabel} (you still need to Stage)"
 								>
 									All Theirs
 								</button>
 							{/if}
+
+							<!-- Whole-file answers. These call git directly
+								(`checkout --ours/--theirs`, `checkout --merge`) rather than
+								rewriting the text, so they also work on files the guided
+								editor cannot open. -->
+							<div class="relative shrink-0" use:clickOutside={() => (showFileMenu = false)}>
+								<button
+									type="button"
+									class="flex items-center gap-1 px-2 py-1 text-xs md:text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-200/60 dark:bg-slate-700/50 rounded-md hover:bg-slate-300/60 dark:hover:bg-slate-700 transition-colors cursor-pointer border-none"
+									onclick={() => (showFileMenu = !showFileMenu)}
+									aria-haspopup="menu"
+									aria-expanded={showFileMenu}
+									title="Whole-file actions"
+								>
+									<Icon name="lucide:file-cog" class="w-3.5 h-3.5" />
+									<span class="hidden md:inline">File</span>
+								</button>
+								{#if showFileMenu}
+									<div
+										class="absolute right-0 top-full mt-1 z-30 min-w-[240px] rounded-lg border border-slate-200 bg-white py-1 shadow-xl dark:border-slate-700 dark:bg-slate-800"
+										role="menu"
+									>
+										{#each structuralActions(selectedFile) as action (action.id)}
+											<button
+												type="button"
+												role="menuitem"
+												class="flex w-full flex-col items-start gap-0.5 border-none bg-transparent px-3 py-1.5 text-left transition-colors cursor-pointer
+													{action.tone === 'danger'
+													? 'text-red-600 hover:bg-red-500/10 dark:text-red-400'
+													: 'text-slate-700 hover:bg-violet-500/10 dark:text-slate-200'}"
+												onclick={() => {
+													showFileMenu = false;
+													onResolve(selectedFile.path, action.id);
+												}}
+												disabled={busy}
+											>
+												<span class="text-xs font-medium">{action.label}</span>
+												<span class="text-3xs text-slate-500 dark:text-slate-400">{action.hint}</span>
+											</button>
+										{/each}
+										<div class="my-1 h-px bg-slate-200 dark:bg-slate-700"></div>
+										<button
+											type="button"
+											role="menuitem"
+											class="flex w-full flex-col items-start gap-0.5 border-none bg-transparent px-3 py-1.5 text-left text-slate-700 transition-colors cursor-pointer hover:bg-violet-500/10 dark:text-slate-200"
+											onclick={() => {
+												showFileMenu = false;
+												onResolve(selectedFile.path, 'reset');
+											}}
+											disabled={busy}
+										>
+											<span class="text-xs font-medium">Reset to conflict</span>
+											<span class="text-3xs text-slate-500 dark:text-slate-400">
+												Put the conflict markers back and start over
+											</span>
+										</button>
+									</div>
+								{/if}
+							</div>
+
+							{#if selectedIsEditable}
 							<div
 								class="flex items-center gap-0.5 bg-slate-200/60 dark:bg-slate-700/50 rounded-lg p-0.5 shrink-0"
 							>
@@ -515,6 +802,7 @@
 									Manual
 								</button>
 							</div>
+							{/if}
 							<button
 								type="button"
 								class="flex items-center gap-1.5 px-2.5 py-1 text-xs md:text-sm font-medium text-white bg-violet-600 hover:bg-violet-700 rounded-md transition-colors cursor-pointer border-none shrink-0"
@@ -527,7 +815,81 @@
 						</div>
 					</div>
 
-					{#if editMode === 'guided'}
+					{#if !selectedIsEditable}
+						<!-- Structural conflict: git recorded a disagreement about whether
+							the file should exist (or it is binary/oversized), so there are no
+							markers to walk. These paths used to be dropped or shown as an
+							unresolvable 0/0 file with no way forward. -->
+						<div class="flex-1 overflow-y-auto p-4 md:p-6">
+							<div class="mx-auto max-w-xl">
+								<div class="flex items-start gap-3">
+									<Icon
+										name={selectedFile.omitReason === 'binary'
+											? 'lucide:binary'
+											: selectedFile.kind === 'both-deleted'
+												? 'lucide:file-x'
+												: 'lucide:file-question-mark'}
+										class="w-6 h-6 shrink-0 text-amber-600 dark:text-amber-400"
+									/>
+									<div class="min-w-0">
+										<h3 class="text-sm font-semibold text-slate-900 dark:text-slate-100">
+											Nothing to merge line by line
+										</h3>
+										<p class="mt-1 text-xs md:text-sm text-slate-600 dark:text-slate-300">
+											{describeKind(selectedFile)}
+										</p>
+										{#if describeOmission(selectedFile)}
+											<p class="mt-1 text-xs md:text-sm text-slate-500 dark:text-slate-400">
+												{describeOmission(selectedFile)}
+											</p>
+										{/if}
+									</div>
+								</div>
+
+								<div class="mt-5 flex flex-col gap-2">
+									{#each structuralActions(selectedFile) as action (action.id)}
+										<button
+											type="button"
+											class="flex w-full items-center justify-between gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50
+												{action.tone === 'ours'
+												? 'border-emerald-500/40 bg-emerald-500/10 hover:bg-emerald-500/20'
+												: action.tone === 'theirs'
+													? 'border-blue-500/40 bg-blue-500/10 hover:bg-blue-500/20'
+													: action.tone === 'danger'
+														? 'border-red-500/40 bg-red-500/10 hover:bg-red-500/20'
+														: 'border-slate-200 bg-slate-50 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800/50 dark:hover:bg-slate-800'}"
+											onclick={() => onResolve(selectedFile.path, action.id)}
+											disabled={busy}
+										>
+											<span class="min-w-0">
+												<span
+													class="block truncate text-sm font-semibold
+														{action.tone === 'ours'
+														? 'text-emerald-700 dark:text-emerald-300'
+														: action.tone === 'theirs'
+															? 'text-blue-700 dark:text-blue-300'
+															: action.tone === 'danger'
+																? 'text-red-600 dark:text-red-400'
+																: 'text-slate-700 dark:text-slate-200'}"
+												>
+													{action.label}
+												</span>
+												<span class="block truncate text-xs text-slate-500 dark:text-slate-400">
+													{action.hint}
+												</span>
+											</span>
+											<Icon name="lucide:chevron-right" class="w-4 h-4 shrink-0 text-slate-400" />
+										</button>
+									{/each}
+								</div>
+
+								<p class="mt-4 text-3xs text-slate-500 dark:text-slate-400">
+									Either answer stages the file, which is what git needs before the
+									operation can continue.
+								</p>
+							</div>
+						</div>
+					{:else if editMode === 'guided'}
 						<!-- Combined navigator + pick + stage row.
 							Layout: [prev next chips] | [Ours Theirs Both, Mark Resolved & Stage]
 							Pick + Stage live on the right so the user's eye flows naturally
@@ -597,7 +959,7 @@
 											? 'bg-emerald-600 border-emerald-600 text-white'
 											: 'bg-emerald-500/10 border-transparent text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/20'}"
 										onclick={() => setMarkerResolution(currentMarkerIndex, 'ours')}
-										title="Take ours for this marker"
+										title="Take {oursLabel} for this conflict (1)"
 									>
 										Ours
 									</button>
@@ -608,7 +970,7 @@
 											? 'bg-blue-600 border-blue-600 text-white'
 											: 'bg-blue-500/10 border-transparent text-blue-700 dark:text-blue-300 hover:bg-blue-500/20'}"
 										onclick={() => setMarkerResolution(currentMarkerIndex, 'theirs')}
-										title="Take theirs for this marker"
+										title="Take {theirsLabel} for this conflict (2)"
 									>
 										Theirs
 									</button>
@@ -652,13 +1014,17 @@
 										class="flex-1 px-3 md:px-4 py-1.5 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 flex items-center gap-1.5 md:gap-2"
 									>
 										<Icon name="lucide:arrow-left-to-line" class="w-3.5 h-3.5 md:w-4 md:h-4 shrink-0" />
-										<span class="truncate">Ours (HEAD)</span>
+										<span class="truncate" title="Ours — {comparison?.left ?? oursLabel}">
+											{comparison?.left ?? oursLabel}
+										</span>
 									</div>
 									<div
 										class="flex-1 px-3 md:px-4 py-1.5 bg-blue-500/10 text-blue-700 dark:text-blue-300 flex items-center gap-1.5 md:gap-2"
 									>
 										<Icon name="lucide:arrow-right-to-line" class="w-3.5 h-3.5 md:w-4 md:h-4 shrink-0" />
-										<span class="truncate">Theirs (incoming)</span>
+										<span class="truncate" title="Theirs — {comparison?.right ?? theirsLabel}">
+											{comparison?.right ?? theirsLabel}
+										</span>
 									</div>
 								</div>
 							{:else}
@@ -669,26 +1035,49 @@
 										class="flex-1 px-3 py-1 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 flex items-center gap-1"
 									>
 										<Icon name="lucide:minus" class="w-3 h-3 shrink-0" />
-										<span class="truncate">Ours (HEAD)</span>
+										<span class="truncate">{comparison?.left ?? oursLabel}</span>
 									</div>
 									<div
 										class="flex-1 px-3 py-1 bg-blue-500/10 text-blue-700 dark:text-blue-300 flex items-center gap-1"
 									>
 										<Icon name="lucide:plus" class="w-3 h-3 shrink-0" />
-										<span class="truncate">Theirs (incoming)</span>
+										<span class="truncate">{comparison?.right ?? theirsLabel}</span>
 									</div>
+								</div>
+							{/if}
+
+							{#if hasBase}
+								<!-- The merge base is only recorded when the repo writes diff3
+									markers. When it is there, comparing each side against the base
+									is what tells you which side actually changed a given line. -->
+								<div
+									class="flex items-center gap-1.5 px-3 py-1 md:px-4 border-b border-slate-200 dark:border-slate-800 shrink-0 overflow-x-auto"
+								>
+									<span class="text-3xs text-slate-500 dark:text-slate-400 shrink-0">Compare</span>
+									{#each [{ id: 'ours-theirs', label: 'Ours ↔ Theirs' }, { id: 'base-ours', label: `Base ↔ ${oursLabel}` }, { id: 'base-theirs', label: `Base ↔ ${theirsLabel}` }] as option (option.id)}
+										<button
+											type="button"
+											class="shrink-0 rounded-md px-2 py-0.5 text-3xs font-medium transition-colors cursor-pointer border-none
+												{compareMode === option.id
+												? 'bg-violet-600 text-white'
+												: 'bg-slate-200/60 text-slate-600 hover:bg-slate-300/60 dark:bg-slate-700/50 dark:text-slate-300 dark:hover:bg-slate-700'}"
+											onclick={() => (compareMode = option.id as CompareMode)}
+										>
+											{option.label}
+										</button>
+									{/each}
 								</div>
 							{/if}
 
 							<!-- Diff viewer for current marker -->
 							<div class="flex-1 overflow-hidden min-h-0">
-								{#key `${selectedFile.path}:${currentMarkerIndex}:${language}:${isWideViewport}`}
+								{#key `${selectedFile.path}:${currentMarkerIndex}:${compareMode}:${language}:${isWideViewport}`}
 									<MonacoDiffEditor
-										original={currentMarker.ourContent}
-										modified={currentMarker.theirContent}
+										original={comparison?.original ?? currentMarker.ourContent}
+										modified={comparison?.modified ?? currentMarker.theirContent}
 										{language}
-										originalPath={`ours/${selectedFile.path}`}
-										modifiedPath={`theirs/${selectedFile.path}`}
+										originalPath={`${comparison?.left ?? 'ours'}/${selectedFile.path}`}
+										modifiedPath={`${comparison?.right ?? 'theirs'}/${selectedFile.path}`}
 										readonly
 										renderSideBySide={isWideViewport}
 									/>

--- a/frontend/components/git/GitMoreMenu.svelte
+++ b/frontend/components/git/GitMoreMenu.svelte
@@ -7,6 +7,11 @@
 
 	export type GitMoreAction =
 		| 'merge-branch'
+		| 'rebase-onto'
+		| 'set-upstream'
+		| 'stash-apply'
+		| 'reflog'
+		| 'return-to-branch'
 		| 'push-follow-tags'
 		| 'push-all-tags'
 		| 'push-force-lease'
@@ -79,7 +84,13 @@
 		{
 			label: 'Branch',
 			items: [
-				{ id: 'merge-branch', label: 'Merge Branch', command: 'git merge', icon: 'lucide:git-merge' }
+				// One entry only: the merge modal already offers default / --no-ff /
+				// --squash, so listing the modes here as well would be two routes to
+				// the same choice.
+				{ id: 'merge-branch', label: 'Merge Branch', command: 'git merge', icon: 'lucide:git-merge' },
+				{ id: 'rebase-onto', label: 'Rebase onto Branch', hint: '--autostash', command: 'git rebase --autostash', icon: 'lucide:git-pull-request-arrow' },
+				{ id: 'return-to-branch', label: 'Return to Previous Branch', hint: 'checkout -', command: 'git checkout -', icon: 'lucide:corner-up-left' },
+				{ id: 'set-upstream', label: 'Branch Upstream…', hint: 'where it pushes', command: 'git branch --set-upstream-to', icon: 'lucide:git-compare-arrows' }
 			]
 		},
 		{
@@ -97,6 +108,13 @@
 				{ id: 'npm-patch', label: 'npm version patch', hint: 'x.x.+1', command: 'npm version patch', icon: 'lucide:package' },
 				{ id: 'npm-minor', label: 'npm version minor', hint: 'x.+1.0', command: 'npm version minor', icon: 'lucide:package' },
 				{ id: 'npm-major', label: 'npm version major', hint: '+1.0.0', command: 'npm version major', icon: 'lucide:package' }
+			]
+		},
+		{
+			label: 'Recovery',
+			items: [
+				{ id: 'stash-apply', label: 'Apply stash (keep entry)', hint: 'apply', command: 'git stash apply', icon: 'lucide:layers' },
+				{ id: 'reflog', label: 'Browse reflog', hint: 'recover commits', command: 'git reflog', icon: 'lucide:history' }
 			]
 		},
 		{

--- a/frontend/components/git/GitOperationBanner.svelte
+++ b/frontend/components/git/GitOperationBanner.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+	/**
+	 * Banner for an in-progress merge / rebase / cherry-pick / revert.
+	 *
+	 * The panel already knew about these states — it used them to grey out Push
+	 * and Pull — but never said so anywhere the user could see, so a stalled
+	 * rebase looked like broken buttons. This is also the only place that offers
+	 * "Continue": without it, resolving every conflict left the repo mid-rebase
+	 * with nothing to click but Abort.
+	 */
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import type { GitOperationState } from '$shared/types/git';
+	import type { IconName } from '$shared/types/ui/icons';
+
+	interface Props {
+		state: GitOperationState;
+		/** A continue/skip/abort is already running against this repo. */
+		busy?: boolean;
+		onContinue: () => void;
+		onSkip: () => void;
+		onAbort: () => void;
+		/** Opens the conflict resolver. Hidden when nothing is unmerged. */
+		onResolve?: () => void;
+		/** Repo label, shown only for nested repos so the banner is unambiguous. */
+		repoLabel?: string;
+	}
+
+	const { state, busy = false, onContinue, onSkip, onAbort, onResolve, repoLabel }: Props = $props();
+
+	const title = $derived.by(() => {
+		if (state.stashConflict) return 'Stash conflict';
+		switch (state.operation) {
+			case 'rebase': return 'Rebase in progress';
+			case 'merge': return 'Merge in progress';
+			case 'cherry-pick': return 'Cherry-pick in progress';
+			case 'revert': return 'Revert in progress';
+			case 'bisect': return 'Bisect in progress';
+			default: return 'Operation in progress';
+		}
+	});
+
+	const icon = $derived<IconName>(
+		state.operation === 'rebase'
+			? 'lucide:git-pull-request-arrow'
+			: state.operation === 'merge'
+				? 'lucide:git-merge'
+				: 'lucide:triangle-alert'
+	);
+
+	/**
+	 * The one sentence that prevents the most damage. During a rebase git replays
+	 * your commits onto the upstream, which swaps what `ours` and `theirs` mean
+	 * relative to a merge — so we spell both sides out by name rather than
+	 * printing the bare words.
+	 */
+	const sidesHint = $derived(
+		state.operation === 'bisect'
+			? ''
+			: `ours = ${state.oursLabel} · theirs = ${state.theirsLabel}`
+	);
+
+	const progress = $derived(
+		state.step && state.total ? `${state.step} / ${state.total}` : ''
+	);
+
+	const abortLabel = $derived(
+		state.stashConflict
+			? 'Reset'
+			: state.operation === 'merge'
+				? 'Abort merge'
+				: state.operation === 'rebase'
+					? 'Abort rebase'
+					: state.operation === 'cherry-pick'
+						? 'Abort cherry-pick'
+						: state.operation === 'revert'
+							? 'Abort revert'
+							: 'Abort'
+	);
+
+	const continueTitle = $derived(
+		state.unmergedCount > 0
+			? `Resolve and stage ${state.unmergedCount} file${state.unmergedCount === 1 ? '' : 's'} first`
+			: 'Finish this operation'
+	);
+</script>
+
+<div
+	class="mx-2 mb-2 rounded-lg border border-amber-400/50 bg-amber-500/10 dark:border-amber-500/40 dark:bg-amber-500/10"
+>
+	<div class="flex flex-wrap items-start gap-x-2 gap-y-1 px-2.5 py-2">
+		<Icon name={icon} class="w-4 h-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+		<div class="min-w-0 flex-1">
+			<div class="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+				<span class="text-xs font-semibold text-amber-800 dark:text-amber-200">{title}</span>
+				{#if progress}
+					<span
+						class="rounded px-1 py-px text-3xs font-semibold text-amber-800 dark:text-amber-200 bg-amber-500/20"
+					>
+						{progress}
+					</span>
+				{/if}
+				{#if repoLabel}
+					<span class="truncate text-3xs text-amber-700/80 dark:text-amber-300/80">in {repoLabel}</span>
+				{/if}
+			</div>
+
+			{#if state.currentCommit}
+				<p class="mt-0.5 truncate text-3xs text-amber-800/90 dark:text-amber-200/90" title={state.currentCommit}>
+					{state.currentCommit}
+				</p>
+			{/if}
+
+			{#if sidesHint}
+				<p class="mt-0.5 truncate text-3xs text-amber-700/80 dark:text-amber-300/80" title={sidesHint}>
+					{sidesHint}
+				</p>
+			{/if}
+
+			{#if state.unmergedCount > 0}
+				<button
+					type="button"
+					class="mt-1 inline-flex items-center gap-1 rounded-md border-none bg-amber-500/20 px-1.5 py-0.5 text-3xs font-medium text-amber-900 transition-colors hover:bg-amber-500/30 dark:text-amber-100 {onResolve ? 'cursor-pointer' : 'cursor-default'}"
+					onclick={onResolve}
+					disabled={!onResolve}
+				>
+					<Icon name="lucide:git-compare-arrows" class="w-3 h-3" />
+					{state.unmergedCount} unresolved file{state.unmergedCount === 1 ? '' : 's'}
+				</button>
+			{/if}
+		</div>
+
+		<div class="flex shrink-0 flex-wrap items-center gap-1">
+			{#if !state.stashConflict && state.operation !== 'bisect'}
+				<button
+					type="button"
+					class="flex items-center gap-1 rounded-md border-none px-2 py-1 text-3xs font-semibold transition-colors
+						{state.canContinue && !busy
+							? 'bg-emerald-600 text-white hover:bg-emerald-700 cursor-pointer'
+							: 'bg-slate-200 text-slate-400 dark:bg-slate-700 dark:text-slate-500 cursor-not-allowed'}"
+					onclick={onContinue}
+					disabled={!state.canContinue || busy}
+					title={continueTitle}
+				>
+					<Icon name="lucide:play" class="w-3 h-3" />
+					Continue
+				</button>
+			{/if}
+			{#if state.canSkip}
+				<button
+					type="button"
+					class="flex items-center gap-1 rounded-md border-none bg-white/70 px-2 py-1 text-3xs font-semibold text-amber-900 transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-800/70 dark:text-amber-100 dark:hover:bg-slate-800 cursor-pointer"
+					onclick={onSkip}
+					disabled={busy}
+					title="Drop the commit git is stuck on and move to the next one"
+				>
+					<Icon name="lucide:skip-forward" class="w-3 h-3" />
+					Skip
+				</button>
+			{/if}
+			<button
+				type="button"
+				class="flex items-center gap-1 rounded-md border-none bg-red-500/10 px-2 py-1 text-3xs font-semibold text-red-600 transition-colors hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400 cursor-pointer"
+				onclick={onAbort}
+				disabled={busy}
+				title={state.stashConflict
+					? 'Unwind the unmerged paths — the stash entry itself is kept'
+					: 'Undo this operation and return to the previous state'}
+			>
+				<Icon name="lucide:octagon-x" class="w-3 h-3" />
+				{abortLabel}
+			</button>
+		</div>
+	</div>
+</div>

--- a/frontend/components/git/GitReflogModal.svelte
+++ b/frontend/components/git/GitReflogModal.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+	/**
+	 * The repo's undo journal.
+	 *
+	 * `git log` only walks what is reachable from a ref, so a bad reset, a deleted
+	 * branch or an aborted rebase makes work look permanently gone. The reflog
+	 * still holds those commits, which makes this the recovery path for every
+	 * destructive action the panel offers.
+	 *
+	 * Recovery here is deliberately additive: you branch at the commit rather than
+	 * resetting onto it, so getting the wrong entry costs a stray branch instead of
+	 * the changes you were trying to save.
+	 */
+	import Icon from '$frontend/components/common/display/Icon.svelte';
+	import Modal from '$frontend/components/common/overlay/Modal.svelte';
+	import type { GitReflogEntry } from '$shared/types/git';
+	import type { IconName } from '$shared/types/ui/icons';
+
+	interface Props {
+		isOpen: boolean;
+		entries: GitReflogEntry[];
+		isLoading: boolean;
+		onClose: () => void;
+		onCreateBranch: (hash: string, name: string) => void;
+		onCheckout: (hash: string) => void;
+	}
+
+	const { isOpen, entries, isLoading, onClose, onCreateBranch, onCheckout }: Props = $props();
+
+	let query = $state('');
+	let branchingHash = $state<string | null>(null);
+	let branchName = $state('');
+
+	const filtered = $derived(
+		query.trim()
+			? entries.filter((entry) => {
+					const needle = query.trim().toLowerCase();
+					return (
+						entry.subject.toLowerCase().includes(needle) ||
+						entry.action.toLowerCase().includes(needle) ||
+						entry.selector.toLowerCase().includes(needle) ||
+						entry.hashShort.includes(needle)
+					);
+				})
+			: entries
+	);
+
+	/** A rough icon for the recorded action, so the list scans quickly. */
+	function actionIcon(action: string): IconName {
+		if (action.startsWith('rebase')) return 'lucide:git-pull-request-arrow';
+		if (action.startsWith('merge')) return 'lucide:git-merge';
+		if (action.startsWith('commit')) return 'lucide:git-commit-horizontal';
+		if (action.startsWith('reset')) return 'lucide:undo-2';
+		if (action.startsWith('checkout')) return 'lucide:git-branch';
+		if (action.startsWith('clone') || action.startsWith('pull')) return 'lucide:arrow-down-to-line';
+		return 'lucide:history';
+	}
+
+	function formatDate(iso: string): string {
+		const parsed = new Date(iso);
+		if (Number.isNaN(parsed.getTime())) return iso;
+		return parsed.toLocaleString(undefined, {
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit'
+		});
+	}
+
+	function startBranch(entry: GitReflogEntry) {
+		branchingHash = entry.hash;
+		branchName = `recover/${entry.hashShort}`;
+	}
+
+	function confirmBranch() {
+		if (!branchingHash || !branchName.trim()) return;
+		onCreateBranch(branchingHash, branchName.trim());
+		branchingHash = null;
+		branchName = '';
+	}
+</script>
+
+<Modal
+	{isOpen}
+	{onClose}
+	bare
+	closable
+	mobileFullscreen
+	className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-2xl w-full max-w-[95vw] md:max-w-[720px] h-[85vh] flex flex-col overflow-hidden"
+>
+	<div
+		class="flex items-center justify-between gap-2 border-b border-slate-200 px-3 py-2 md:px-4 dark:border-slate-800 shrink-0"
+	>
+		<div class="min-w-0">
+			<h2 class="truncate text-sm font-bold text-slate-900 md:text-base dark:text-slate-100">
+				Reflog
+			</h2>
+			<p class="truncate text-3xs text-slate-500 dark:text-slate-400">
+				Commits that resets, rebases and deleted branches left behind
+			</p>
+		</div>
+		<button
+			type="button"
+			class="flex cursor-pointer rounded-lg border-none bg-transparent p-1.5 text-slate-500 transition-colors hover:bg-violet-500/10 hover:text-slate-900 dark:hover:text-slate-100"
+			onclick={onClose}
+			aria-label="Close"
+		>
+			<Icon name="lucide:x" class="w-4 h-4 md:w-5 md:h-5" />
+		</button>
+	</div>
+
+	<div class="border-b border-slate-200 px-3 py-2 md:px-4 dark:border-slate-800 shrink-0">
+		<input
+			type="text"
+			bind:value={query}
+			placeholder="Filter by message, action or hash…"
+			class="w-full rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs text-slate-900 outline-none transition-colors placeholder:text-slate-400 focus:ring-1 focus:ring-violet-500 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-100"
+		/>
+	</div>
+
+	{#if isLoading}
+		<div class="flex flex-1 items-center justify-center">
+			<div
+				class="h-7 w-7 animate-spin rounded-full border-2 border-slate-200 border-t-violet-600 dark:border-slate-700"
+			></div>
+		</div>
+	{:else if filtered.length === 0}
+		<div class="flex flex-1 flex-col items-center justify-center gap-2 text-slate-500 dark:text-slate-400">
+			<Icon name="lucide:history" class="w-10 h-10 opacity-50" />
+			<p class="text-sm">{entries.length === 0 ? 'The reflog is empty.' : 'No entries match that filter.'}</p>
+		</div>
+	{:else}
+		<div class="min-h-0 flex-1 overflow-y-auto py-1">
+			{#each filtered as entry (entry.selector + entry.hash)}
+				<div
+					class="flex items-start gap-2.5 border-b border-slate-100 px-3 py-2 md:px-4 dark:border-slate-800/60"
+				>
+					<Icon
+						name={actionIcon(entry.action)}
+						class="mt-0.5 w-4 h-4 shrink-0 text-slate-400 dark:text-slate-500"
+					/>
+					<div class="min-w-0 flex-1">
+						<div class="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+							<code class="font-mono text-3xs text-violet-600 dark:text-violet-400">{entry.selector}</code>
+							<code class="font-mono text-3xs text-slate-500 dark:text-slate-400">{entry.hashShort}</code>
+							<span
+								class="rounded bg-slate-100 px-1 py-px text-3xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+							>
+								{entry.action}
+							</span>
+							<span class="text-3xs text-slate-400 dark:text-slate-500">{formatDate(entry.date)}</span>
+						</div>
+						<p class="mt-0.5 truncate text-xs text-slate-700 dark:text-slate-200" title={entry.subject}>
+							{entry.subject || '—'}
+						</p>
+
+						{#if branchingHash === entry.hash}
+							<div class="mt-1.5 flex items-center gap-1.5">
+								<input
+									type="text"
+									bind:value={branchName}
+									placeholder="branch name"
+									class="min-w-0 flex-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-xs outline-none focus:ring-1 focus:ring-violet-500 dark:border-slate-700 dark:bg-slate-800"
+									onkeydown={(e) => e.key === 'Enter' && confirmBranch()}
+								/>
+								<button
+									type="button"
+									class="shrink-0 cursor-pointer rounded-md border-none bg-violet-600 px-2 py-1 text-3xs font-semibold text-white transition-colors hover:bg-violet-700 disabled:cursor-not-allowed disabled:opacity-50"
+									onclick={confirmBranch}
+									disabled={!branchName.trim()}
+								>
+									Create
+								</button>
+								<button
+									type="button"
+									class="shrink-0 cursor-pointer rounded-md border-none bg-transparent px-1.5 py-1 text-3xs text-slate-500 transition-colors hover:text-slate-800 dark:hover:text-slate-200"
+									onclick={() => (branchingHash = null)}
+								>
+									Cancel
+								</button>
+							</div>
+						{/if}
+					</div>
+
+					{#if branchingHash !== entry.hash}
+						<div class="flex shrink-0 items-center gap-1">
+							<button
+								type="button"
+								class="flex cursor-pointer items-center gap-1 rounded-md border-none bg-violet-500/10 px-2 py-1 text-3xs font-medium text-violet-700 transition-colors hover:bg-violet-500/20 dark:text-violet-300"
+								onclick={() => startBranch(entry)}
+								title="Create a branch at this commit — the safe way to recover it"
+							>
+								<Icon name="lucide:git-branch-plus" class="w-3 h-3" />
+								Branch
+							</button>
+							<button
+								type="button"
+								class="flex cursor-pointer items-center gap-1 rounded-md border-none bg-transparent px-1.5 py-1 text-3xs font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+								onclick={() => onCheckout(entry.hash)}
+								title="Check this commit out to inspect it (detached HEAD)"
+							>
+								<Icon name="lucide:eye" class="w-3 h-3" />
+							</button>
+						</div>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	{/if}
+</Modal>

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -45,6 +45,10 @@
 		GitFileDiff,
 		GitCommit,
 		GitConflictFile,
+		GitConflictResolution,
+		GitPushTarget,
+		GitOperationState,
+		GitReflogEntry,
 		GitStashEntry,
 		GitTag,
 		GitRemote,
@@ -59,6 +63,8 @@
 	import GitLog from '$frontend/components/git/GitLog.svelte';
 	import CommitFileList from '$frontend/components/git/CommitFileList.svelte';
 	import ConflictResolver from '$frontend/components/git/ConflictResolver.svelte';
+	import GitOperationBanner from '$frontend/components/git/GitOperationBanner.svelte';
+	import GitReflogModal from '$frontend/components/git/GitReflogModal.svelte';
 
 	// Derived state
 	const hasActiveProject = $derived(projectState.currentProject !== null);
@@ -92,7 +98,7 @@
 	const repoBusy = $derived(Boolean(branchInfo?.detached || branchInfo?.operation));
 	const repoBusyReason = $derived(
 		branchInfo?.operation
-			? `A ${branchInfo.operation} is in progress — finish or abort it first.`
+			? `A ${branchInfo.operation} is in progress — use Continue or Abort in the banner above.`
 			: branchInfo?.detached
 				? 'HEAD is detached (no branch checked out).'
 				: ''
@@ -217,7 +223,12 @@
 	let viewMode = $state<'list' | 'diff'>('list');
 	let showMergeBranchModal = $state(false);
 	let mergeBranchName = $state('');
-	let mergeMode = $state<'default' | 'no-ff'>('default');
+	let mergeMode = $state<'default' | 'no-ff' | 'squash'>('default');
+	/**
+	 * The branch picker is identical for merge and rebase, so one modal serves
+	 * both; only the mode options and the final command differ.
+	 */
+	let mergeIntent = $state<'merge' | 'rebase'>('merge');
 	let showConflictResolver = $state(false);
 	let mergeRepoPath = $state<string | null>(null);
 	const mergeableBranches = $derived.by(() => {
@@ -1212,6 +1223,38 @@
 	let conflictFiles = $state<GitConflictFile[]>([]);
 	let isConflictLoading = $state(false);
 	let conflictInitialPath = $state<string | null>(null);
+	/**
+	 * In-progress merge/rebase/cherry-pick for the OUTER repo. Nested repos carry
+	 * their own state in `nestedOperations`, keyed by relPath — a project can be
+	 * mid-rebase in a sub-repo while the outer tree is perfectly clean.
+	 */
+	let operationState = $state<GitOperationState | null>(null);
+	let nestedOperations = $state<Record<string, GitOperationState>>({});
+	let isOperationBusy = $state(false);
+
+	/**
+	 * Operation state for the repo the resolver is focused on. A conflict inside a
+	 * sub-repo must be labelled with that sub-repo's rebase, not the outer one's.
+	 */
+	const resolverOperation = $derived.by(() => {
+		const focusedPath = conflictInitialPath || conflictFiles[0]?.path;
+		const nested = focusedPath
+			? branchInfo?.nested?.find((n) => focusedPath.startsWith(n.relPath + '/'))
+			: undefined;
+		return nested ? (nestedOperations[nested.relPath] ?? null) : operationState;
+	});
+
+	/**
+	 * Where a push actually lands, per git's own config. Shown on the Push button
+	 * so the destination is visible before the click rather than after it.
+	 */
+	let pushTarget = $state<GitPushTarget | null>(null);
+
+	// Reflog state
+	let showReflog = $state(false);
+	let reflogEntries = $state<GitReflogEntry[]>([]);
+	let reflogRepoPath = $state<string | null>(null);
+	let isReflogLoading = $state(false);
 
 	// ============================
 	// Staleness tracking
@@ -1371,6 +1414,8 @@
 			// Stash/Tags badge counts are correct immediately after a switch/refresh,
 			// not only once the user opens those views.
 			await Promise.all([loadStatus(), loadBranches(), loadRemotes(), loadStash(), loadTags(), loadContributors()]);
+			// Both depend on what `loadBranches` just produced.
+			await Promise.all([loadOperationState(), loadPushTarget()]);
 		} catch (err) {
 			debug.error('git', 'Failed to load git data:', err);
 		} finally {
@@ -1673,6 +1718,271 @@
 			debug.error('git', 'Failed to load conflicts:', err);
 		} finally {
 			isConflictLoading = false;
+		}
+	}
+
+	/**
+	 * Read the in-progress operation for the outer repo and every nested one.
+	 * Cheap enough to run on each status refresh: it is a handful of `.git` file
+	 * reads plus one `git diff --name-only`.
+	 */
+	async function loadOperationState() {
+		if (!projectId) return;
+		const requestProjectId = projectId;
+		try {
+			const outer = await ws.http('git:operation-state', { projectId });
+			if (requestProjectId !== projectId) return;
+			operationState = outer;
+		} catch (err) {
+			debug.error('git', 'Failed to load operation state:', err);
+			operationState = null;
+		}
+
+		const nested = branchInfo?.nested ?? [];
+		if (nested.length === 0) {
+			nestedOperations = {};
+			return;
+		}
+
+		const next: Record<string, GitOperationState> = {};
+		await Promise.all(
+			nested.map(async (repo) => {
+				try {
+					const state = await ws.http('git:operation-state', {
+						projectId,
+						repoPath: repo.path
+					});
+					if (state.operation || state.stashConflict) next[repo.relPath] = state;
+				} catch {
+					// A sub-repo we cannot read has nothing to show a banner for.
+				}
+			})
+		);
+		if (requestProjectId !== projectId) return;
+		nestedOperations = next;
+	}
+
+	async function loadPushTarget() {
+		if (!projectId) return;
+		const requestProjectId = projectId;
+		try {
+			const target = await ws.http('git:push-target', { projectId });
+			if (requestProjectId !== projectId) return;
+			pushTarget = target;
+		} catch (err) {
+			debug.error('git', 'Failed to resolve push target:', err);
+			pushTarget = null;
+		}
+	}
+
+	/** `owner/repo/branch` for a URL remote, `remote/branch` otherwise. */
+	function describePushTarget(target: GitPushTarget): string {
+		const remote = target.isUrl ? shortRemoteLabel(target.remote) : target.remote;
+		return `${remote}/${target.remoteBranch}`;
+	}
+
+	/**
+	 * Spelled out on the Push button. A branch under review often tracks somewhere
+	 * other than the panel's selected remote, and the destination is not something
+	 * the user should have to discover from the result.
+	 */
+	const pushDestinationLabel = $derived(
+		pushTarget
+			? pushTarget.hasUpstream
+				? describePushTarget(pushTarget)
+				: `${selectedRemote}/${pushTarget.branch} (new)`
+			: ''
+	);
+
+	/**
+	 * True when the push destination is not the obvious `<selected remote>/<same
+	 * name>`. That is the state that used to be invisible and cost the user a
+	 * stray branch in the main repository, so it gets a banner.
+	 */
+	const pushTargetDiffers = $derived.by(() => {
+		if (!pushTarget?.hasUpstream) return false;
+		return (
+			pushTarget.isUrl ||
+			pushTarget.remote !== selectedRemote ||
+			pushTarget.remoteBranch !== pushTarget.branch
+		);
+	});
+
+	// Upstream editor
+	let showUpstreamModal = $state(false);
+	let upstreamRemote = $state('');
+	let upstreamBranch = $state('');
+
+	function openUpstreamModal() {
+		if (!branchInfo?.current) return;
+		upstreamRemote =
+			pushTarget && !pushTarget.isUrl ? pushTarget.remote : (remotes[0]?.name ?? 'origin');
+		upstreamBranch = pushTarget?.remoteBranch || branchInfo.current;
+		showUpstreamModal = true;
+	}
+
+	async function saveUpstream() {
+		if (!projectId || !branchInfo?.current || !upstreamRemote.trim()) return;
+		try {
+			await ws.http('git:set-upstream', {
+				projectId,
+				branch: branchInfo.current,
+				remote: upstreamRemote.trim(),
+				remoteBranch: upstreamBranch.trim() || undefined
+			});
+			showUpstreamModal = false;
+			await Promise.all([loadBranches(), loadPushTarget()]);
+			showInfo('Upstream Updated', `${branchInfo.current} now tracks ${upstreamRemote}/${upstreamBranch}.`);
+		} catch (err) {
+			showError(
+				'Could Not Set Upstream',
+				err instanceof Error ? err.message : 'git rejected the upstream.'
+			);
+		}
+	}
+
+	function clearUpstream() {
+		if (!projectId || !branchInfo?.current) return;
+		const branch = branchInfo.current;
+		requestConfirm({
+			title: 'Clear Upstream',
+			message: `Stop "${branch}" from tracking anything? The next push will ask for a destination instead of using the current one.`,
+			type: 'warning',
+			confirmText: 'Clear',
+			onConfirm: async () => {
+				try {
+					await ws.http('git:unset-upstream', { projectId, branch });
+					showUpstreamModal = false;
+					await Promise.all([loadBranches(), loadPushTarget()]);
+					showInfo('Upstream Cleared', `${branch} no longer tracks a remote branch.`);
+				} catch (err) {
+					showError(
+						'Could Not Clear Upstream',
+						err instanceof Error ? err.message : 'git rejected the change.'
+					);
+				}
+			}
+		});
+	}
+
+	/** Absolute path of the nested repo a conflict path belongs to, if any. */
+	function nestedRepoPathFor(filePath: string): string | undefined {
+		return branchInfo?.nested?.find((n) => filePath.startsWith(n.relPath + '/'))?.path;
+	}
+
+	/**
+	 * Finish, skip or unwind the in-progress operation.
+	 *
+	 * These are the actions the panel was missing entirely: resolving every
+	 * conflict during a rebase used to leave the repo mid-rebase with Abort as the
+	 * only button, so the work had to be finished from a terminal.
+	 */
+	async function runOperationAction(
+		action: 'continue' | 'skip' | 'abort',
+		repoPath?: string
+	) {
+		if (!projectId || isOperationBusy) return;
+		isOperationBusy = true;
+		try {
+			if (action === 'abort') {
+				await ws.http('git:abort-operation', { projectId, ...(repoPath && { repoPath }) });
+				showConflictResolver = false;
+			} else {
+				const endpoint = action === 'continue' ? 'git:continue-operation' : 'git:skip-operation';
+				const result = await ws.http(endpoint, { projectId, ...(repoPath && { repoPath }) });
+				if (!result.success) {
+					// git's failure here is usually an instruction ("nothing to commit,
+					// use --skip"), so it belongs in front of the user verbatim.
+					showError(
+						action === 'continue' ? 'Could Not Continue' : 'Could Not Skip',
+						result.message || 'git refused the operation.'
+					);
+				}
+			}
+			await loadAll();
+			await loadConflicts();
+			await loadOperationState();
+			if (conflictFiles.length === 0) showConflictResolver = false;
+		} catch (err) {
+			debug.error('git', `Operation ${action} failed:`, err);
+			showError(
+				`Could Not ${action === 'continue' ? 'Continue' : action === 'skip' ? 'Skip' : 'Abort'}`,
+				err instanceof Error ? err.message : 'The git operation failed.'
+			);
+		} finally {
+			isOperationBusy = false;
+		}
+	}
+
+	function confirmAbortOperation(state: GitOperationState, repoPath?: string) {
+		const what = state.stashConflict
+			? 'reset the working tree'
+			: `abort the ${state.operation ?? 'operation'}`;
+		requestConfirm({
+			title: state.stashConflict ? 'Reset Working Tree' : `Abort ${state.operation ?? 'Operation'}`,
+			message: state.stashConflict
+				? 'Unwind the unmerged paths from the stash? Your stash entry is kept, so you can apply it again.'
+				: `Are you sure you want to ${what}? Every conflict resolution you have made will be discarded.`,
+			type: 'error',
+			confirmText: state.stashConflict ? 'Reset' : 'Abort',
+			onConfirm: () => void runOperationAction('abort', repoPath)
+		});
+	}
+
+	async function loadReflog(repoPath?: string) {
+		if (!projectId) return;
+		isReflogLoading = true;
+		try {
+			reflogEntries = await ws.http('git:reflog', {
+				projectId,
+				limit: 100,
+				...(repoPath && { repoPath })
+			});
+		} catch (err) {
+			debug.error('git', 'Failed to load reflog:', err);
+			showError('Reflog Failed', err instanceof Error ? err.message : 'Could not read the reflog.');
+		} finally {
+			isReflogLoading = false;
+		}
+	}
+
+	function openReflog(repoPath?: string) {
+		reflogRepoPath = repoPath ?? null;
+		showReflog = true;
+		void loadReflog(repoPath);
+	}
+
+	/**
+	 * Apply the newest stash without removing it. Offered from the More menu as
+	 * the low-risk counterpart to Pop; per-entry Apply lives in the Stash list.
+	 */
+	async function applyLatestStash(repoPath?: string) {
+		const entry = stashEntries.find((item) => (item.repoPath ?? undefined) === repoPath);
+		if (!entry) {
+			showError('No Stash', 'There is nothing in the stash to apply.');
+			return;
+		}
+		await handleStashRestore(entry, 'apply');
+	}
+
+	/** Recover an orphaned commit by branching at it — never by resetting onto it. */
+	async function createBranchAtCommit(hash: string, name: string) {
+		if (!projectId) return;
+		try {
+			await ws.http('git:create-branch', {
+				projectId,
+				name,
+				startPoint: hash,
+				...(reflogRepoPath && { repoPath: reflogRepoPath })
+			});
+			showReflog = false;
+			await loadAll();
+			showInfo('Branch Created', `${name} now points at ${hash.slice(0, 7)}.`);
+		} catch (err) {
+			showError(
+				'Create Branch Failed',
+				err instanceof Error ? err.message : 'Could not create the branch.'
+			);
 		}
 	}
 
@@ -2268,8 +2578,14 @@
 							};
 						}
 					} catch (readErr) {
+						// A conflict can exist with no working-tree file at all — both
+						// sides deleted the path, or one side did and the other edited it.
+						// An empty diff tab explains none of that, so hand the user to
+						// the resolver, which knows how to describe and resolve it.
 						debug.error('git', 'Failed to read conflicted file:', readErr);
-						diffResult = null;
+						closeTab(tabId);
+						openConflictResolver(file.path);
+						return;
 					}
 				}
 			} else if (status === '?') {
@@ -2560,14 +2876,48 @@
 		}
 	}
 
+	/**
+	 * Split an upstream like `origin/main` into its remote and branch halves.
+	 *
+	 * Matching against the configured remotes first matters: a remote name may
+	 * itself contain a slash, and `branch.<name>.remote` can hold a bare URL
+	 * (what `gh pr checkout` writes for a fork PR), where splitting on the first
+	 * `/` yields "https:".
+	 */
+	function splitUpstream(upstream: string): { remote: string; branch: string } {
+		const matched = remotes
+			.filter(remote => upstream.startsWith(remote.name + '/'))
+			.sort((a, b) => b.name.length - a.name.length)[0];
+		if (matched) {
+			return { remote: matched.name, branch: upstream.slice(matched.name.length + 1) };
+		}
+		// A URL upstream: everything up to the last slash is the remote.
+		const cut = upstream.lastIndexOf('/');
+		if (cut <= 0) return { remote: '', branch: upstream };
+		return { remote: upstream.slice(0, cut), branch: upstream.slice(cut + 1) };
+	}
+
+	/** Compact label for a remote that may be a full URL. */
+	function shortRemoteLabel(remote: string): string {
+		if (!/:\/\/|@/.test(remote)) return remote;
+		// git@github.com:owner/repo.git or https://github.com/owner/repo.git
+		const withoutSuffix = remote.replace(/\.git$/, '');
+		const parts = withoutSuffix.split(/[/:]/).filter(Boolean);
+		const owner = parts.length >= 2 ? parts[parts.length - 2] : '';
+		const repo = parts[parts.length - 1] ?? remote;
+		return owner ? `${owner}/${repo}` : repo;
+	}
+
 	function getBranchRemote(branch: GitBranch): string | null {
-		return branch.upstream?.split('/')[0] || remotes.find(remote => branch.upstream?.startsWith(remote.name + '/'))?.name || null;
+		if (!branch.upstream) return null;
+		return splitUpstream(branch.upstream).remote || null;
 	}
 
 	function getBranchRemoteName(branch: GitBranch): string | null {
 		if (!branch.upstream) return null;
-		const remoteName = getBranchRemote(branch);
-		return remoteName ? branch.upstream.slice(remoteName.length + 1) : branch.upstream;
+		const { remote, branch: remoteBranch } = splitUpstream(branch.upstream);
+		if (!remote) return remoteBranch;
+		return `${shortRemoteLabel(remote)}/${remoteBranch}`;
 	}
 
 	const BRANCH_COMMIT_PAGE_SIZE = 8;
@@ -2774,18 +3124,21 @@
 		});
 	}
 
-	async function openMergeBranchModal(repoPath?: string) {
+	async function openMergeBranchModal(repoPath?: string, intent: 'merge' | 'rebase' = 'merge') {
 		const isNested = Boolean(repoPath);
 		if (isNested) {
 			const nested = branchInfo?.nested?.find(n => n.path === repoPath);
 			if (!nested) return;
 			if (nested.info.operation || nested.info.detached) {
-				showError('Cannot Merge', nested.info.operation ? `A ${nested.info.operation} is in progress.` : 'HEAD is detached.');
+				showError(
+					intent === 'rebase' ? 'Cannot Rebase' : 'Cannot Merge',
+					nested.info.operation ? `A ${nested.info.operation} is in progress.` : 'HEAD is detached.'
+				);
 				return;
 			}
 			const latestMergeableBranches = nested.info.local.filter(branch => !branch.isCurrent) ?? [];
 			if (latestMergeableBranches.length === 0) {
-				showError('Merge Branch Unavailable', 'No other local branches are available to merge.');
+				showError('No Other Branches', 'No other local branches are available.');
 				return;
 			}
 			mergeRepoPath = repoPath ?? null;
@@ -2793,11 +3146,11 @@
 				?? latestMergeableBranches[0]?.name
 				?? '';
 		} else {
-			if (blockedWhileBusy('merge')) return;
+			if (blockedWhileBusy(intent)) return;
 			const latestBranchInfo = await loadBranches();
 			const latestMergeableBranches = latestBranchInfo?.local.filter(branch => !branch.isCurrent) ?? [];
 			if (latestMergeableBranches.length === 0) {
-				showError('Merge Branch Unavailable', 'No other local branches are available to merge.');
+				showError('No Other Branches', 'No other local branches are available.');
 				return;
 			}
 			mergeRepoPath = null;
@@ -2805,6 +3158,7 @@
 				?? latestMergeableBranches[0]?.name
 				?? '';
 		}
+		mergeIntent = intent;
 		mergeMode = 'default';
 		showMergeBranchModal = true;
 	}
@@ -2812,10 +3166,15 @@
 	function closeMergeBranchModal() {
 		showMergeBranchModal = false;
 		mergeMode = 'default';
+		mergeIntent = 'merge';
 		mergeRepoPath = null;
 	}
 
-	async function runMergeBranch(name: string, noFastForward = false, repoPath?: string) {
+	async function runMergeBranch(
+		name: string,
+		mode: 'default' | 'no-ff' | 'squash' = 'default',
+		repoPath?: string
+	) {
 		if (!projectId || !name) return;
 		const activeRepoPath = repoPath ?? mergeRepoPath ?? undefined;
 		const isNested = Boolean(activeRepoPath);
@@ -2828,7 +3187,8 @@
 				const result = await ws.http('git:merge-branch', {
 					projectId,
 					branchName: name,
-					noFastForward,
+					noFastForward: mode === 'no-ff',
+					squash: mode === 'squash',
 					...(activeRepoPath && { repoPath: activeRepoPath })
 				});
 				showMergeBranchModal = false;
@@ -2848,7 +3208,9 @@
 						: mergeTargetBranch;
 					showInfo(
 						'Merge Complete',
-						`Merged "${name}" into "${targetBranch}"${noFastForward ? ' with --no-ff' : ''}.`
+						mode === 'squash'
+							? `Squashed "${name}" into "${targetBranch}" — the changes are staged and still need a commit.`
+							: `Merged "${name}" into "${targetBranch}"${mode === 'no-ff' ? ' with --no-ff' : ''}.`
 					);
 				}
 			} catch (err) {
@@ -2865,7 +3227,7 @@
 			message: `Merge "${name}" into "${branchInfo?.current}"?`,
 			type: 'info',
 			confirmText: 'Merge',
-			onConfirm: () => void runMergeBranch(name, false)
+			onConfirm: () => void runMergeBranch(name, 'default')
 		});
 	}
 
@@ -2878,8 +3240,62 @@
 			message: `Merge "${name}" into "${nested.info.current}"?`,
 			type: 'info',
 			confirmText: 'Merge',
-			onConfirm: () => void runMergeBranch(name, false, repoPath)
+			onConfirm: () => void runMergeBranch(name, 'default', repoPath)
 		});
+	}
+
+	/**
+	 * Rebase the current branch onto another local branch. `--autostash` is on by
+	 * default server-side: git otherwise refuses to start on a dirty tree, which
+	 * from the panel reads as the button doing nothing.
+	 */
+	async function runRebaseOnto(name: string, repoPath?: string) {
+		if (!projectId || !name) return;
+		const activeRepoPath = repoPath ?? mergeRepoPath ?? undefined;
+		if (!activeRepoPath && blockedWhileBusy('rebase')) return;
+		if (getGitOps(watchScope, activeRepoPath).isMoreBusy) return;
+
+		await runMore(async () => {
+			try {
+				const result = await ws.http('git:rebase', {
+					projectId,
+					upstream: name,
+					...(activeRepoPath && { repoPath: activeRepoPath })
+				});
+				showMergeBranchModal = false;
+				await loadAll();
+
+				if (result.hasConflicts) {
+					await loadConflicts();
+					conflictInitialPath = conflictFiles[0]?.path ?? null;
+					showConflictResolver = true;
+				} else if (result.success) {
+					showInfo('Rebase Complete', `Rebased onto "${name}".`);
+				} else {
+					showError('Rebase Failed', result.message);
+				}
+			} catch (err) {
+				debug.error('git', 'Failed to rebase:', err);
+				showError('Rebase Failed', err instanceof Error ? err.message : 'Unknown error');
+			}
+		}, activeRepoPath);
+	}
+
+	/** Leave a detached HEAD (or just go back one checkout). */
+	async function returnToPreviousBranch(repoPath?: string) {
+		if (!projectId) return;
+		await runMore(async () => {
+			try {
+				await ws.http('git:return-to-branch', { projectId, ...(repoPath && { repoPath }) });
+				await loadAll();
+				showInfo('Branch Restored', 'Returned to the previous branch.');
+			} catch (err) {
+				showError(
+					'Could Not Return',
+					err instanceof Error ? err.message : 'No previous branch was recorded.'
+				);
+			}
+		}, repoPath);
 	}
 
 	// ============================
@@ -2991,15 +3407,24 @@
 					useRemote = selectedRemote;
 				}
 			}
+			// `useUpstream` (the backend default) means a tracked branch goes where
+			// git says it goes; `useRemote` is only the fallback for a branch that
+			// tracks nothing. Reporting `useRemote` unconditionally would name the
+			// wrong destination for every fork PR under review.
 			const result = await ws.http('git:push', { projectId: pid, remote: useRemote, branch: info?.current, repoPath });
 			if (!result.success) {
 				showError('Push Failed', result.message);
 			} else {
-				await loadBranches();
+				await Promise.all([loadBranches(), loadPushTarget()]);
+				const destination = repoPath
+					? useRemote
+					: pushTarget?.hasUpstream
+						? describePushTarget(pushTarget)
+						: useRemote;
 				if (prevAhead > 0) {
-					showInfo('Push Complete', `Pushed ${prevAhead} commit${prevAhead > 1 ? 's' : ''} to ${useRemote}.`);
+					showInfo('Push Complete', `Pushed ${prevAhead} commit${prevAhead > 1 ? 's' : ''} to ${destination}.`);
 				} else {
-					showInfo('Push Complete', `Branch pushed to ${useRemote}.`);
+					showInfo('Push Complete', `Branch pushed to ${destination}.`);
 				}
 			}
 		} catch (err) {
@@ -3251,6 +3676,17 @@
 		switch (action) {
 			case 'merge-branch':
 				return void openMergeBranchModal(repoPath);
+			case 'rebase-onto':
+				return void openMergeBranchModal(repoPath, 'rebase');
+			case 'return-to-branch':
+				return void returnToPreviousBranch(repoPath);
+			case 'set-upstream':
+				// The editor is scoped to the outer repo's current branch.
+				return openUpstreamModal();
+			case 'stash-apply':
+				return void applyLatestStash(repoPath);
+			case 'reflog':
+				return openReflog(repoPath);
 			case 'push-follow-tags':
 				return void pushVariant('with-tags', 'Pushed branch with tags', repoPath, info.current, subRemote);
 			case 'push-all-tags':
@@ -3318,6 +3754,16 @@
 		switch (action) {
 			case 'merge-branch':
 				return void openMergeBranchModal();
+			case 'rebase-onto':
+				return void openMergeBranchModal(undefined, 'rebase');
+			case 'return-to-branch':
+				return void returnToPreviousBranch();
+			case 'set-upstream':
+				return openUpstreamModal();
+			case 'stash-apply':
+				return void applyLatestStash();
+			case 'reflog':
+				return openReflog();
 			case 'push-follow-tags':
 				return void pushVariant('with-tags', 'Pushed branch with tags');
 			case 'push-all-tags':
@@ -3385,37 +3831,203 @@
 	// Conflict Resolution
 	// ============================
 
-	async function resolveConflict(filePath: string, resolution: 'ours' | 'theirs' | 'custom', customContent?: string) {
+	async function resolveConflict(
+		filePath: string,
+		resolution: GitConflictResolution,
+		customContent?: string
+	) {
 		await runGitOp(watchScope, 'isResolving', async () => {
 		try {
 			await ws.http('git:resolve-conflict', { projectId, filePath, resolution, customContent });
 			await loadConflicts();
 			await loadStatus();
+			await loadOperationState();
 			if (conflictFiles.length === 0) {
 				showConflictResolver = false;
 			}
 		} catch (err) {
 			debug.error('git', 'Failed to resolve conflict:', err);
+			// The backend refuses to stage leftover `<<<<<<<` markers, and that
+			// refusal is the whole point — it has to reach the user, not the log.
+			showError(
+				'Could Not Resolve',
+				err instanceof Error ? err.message : 'The conflict could not be resolved.'
+			);
 		}
 		});
 	}
 
-	function buildAIPromptForFile(file: GitConflictFile): string {
-		const lang = detectLanguageFromFilename(file.path);
-		const count = file.markers.length;
-		return `Please help me resolve the merge conflict${count === 1 ? '' : 's'} in \`${file.path}\`. Analyze the conflict${count === 1 ? '' : 's'} and edit the file directly using your tools to apply the resolution, then stage it with \`git add\`.
+	// ============================
+	// AI conflict brief
+	// ============================
+	//
+	// This used to paste every conflicted file's ENTIRE contents into the chat
+	// message — tens of thousands of tokens for a handful of files, repeated on
+	// every retry. The agent already has file-reading tools, so the full text was
+	// redundant; what it actually lacked was the context git holds and the file
+	// system does not: which operation is running, and which side is which.
+	//
+	// So we send a brief plus a hard-capped excerpt of the conflicting regions
+	// only, and tell the agent to read the rest itself.
 
-The file currently has ${count} conflict marker${count === 1 ? '' : 's'}:
+	/** Max characters of conflict excerpt inlined into one chat message. */
+	const AI_CONFLICT_EXCERPT_BUDGET = 8 * 1024;
+	/** Max lines kept from either side of a single conflict. */
+	const AI_CONFLICT_SIDE_LINES = 40;
 
-\`\`\`${lang}
-${file.content}
-\`\`\``;
+	function clampLines(text: string, maxLines: number): string {
+		const lines = text.split('\n');
+		if (lines.length <= maxLines) return text;
+		const omitted = lines.length - maxLines;
+		return [...lines.slice(0, maxLines), `… ${omitted} more line${omitted === 1 ? '' : 's'}`].join('\n');
 	}
 
-	async function resolveWithAI(filePath: string) {
-		const file = conflictFiles.find((f) => f.path === filePath);
-		if (!file) return;
-		const prompt = buildAIPromptForFile(file);
+	/** One-line description of what the two sides did to a path. */
+	function describeConflictForAI(file: GitConflictFile, ours: string, theirs: string): string {
+		if (file.omitReason === 'binary') return 'binary file — pick one side, no text merge is possible';
+		if (file.omitReason === 'too-large') return 'file too large to inline — read it directly';
+		switch (file.kind) {
+			case 'both-modified':
+			case 'both-added': {
+				const count = file.markers.length;
+				if (count === 0) return 'conflicted, but no markers found — inspect the file';
+				const lines = file.markers.slice(0, 8).map((m) => m.ourStart + 1).join(', ');
+				const more = file.markers.length > 8 ? ', …' : '';
+				return `${count} conflict${count === 1 ? '' : 's'} at line${count === 1 ? '' : 's'} ${lines}${more}`;
+			}
+			case 'added-by-us':
+				return `added on ${ours} only — keep it or delete it`;
+			case 'added-by-them':
+				return `added on ${theirs} only — keep it or delete it`;
+			case 'deleted-by-us':
+				return `deleted on ${ours}, modified on ${theirs} — keep it or delete it`;
+			case 'deleted-by-them':
+				return `modified on ${ours}, deleted on ${theirs} — keep it or delete it`;
+			case 'both-deleted':
+				return 'deleted on both sides — resolve with `git rm`';
+		}
+	}
+
+	/**
+	 * The shared header: what git is doing, and what `ours`/`theirs` mean right
+	 * now. During a rebase those two words are inverted relative to a merge, which
+	 * is the single most common way an AI-assisted resolution goes wrong.
+	 */
+	function buildConflictHeader(): { text: string; ours: string; theirs: string } {
+		const state = operationState;
+		const ours = state?.oursLabel || 'ours (HEAD)';
+		const theirs = state?.theirsLabel || 'theirs (incoming)';
+		const lines: string[] = [];
+
+		if (state?.operation === 'rebase') {
+			const progress = state.step && state.total ? ` (commit ${state.step} of ${state.total})` : '';
+			lines.push(`A rebase is in progress${progress}.`);
+			lines.push(
+				`Because this is a rebase the sides are inverted from a merge: \`ours\` is \`${ours}\` (the branch being rebased onto) and \`theirs\` is ${theirs}. Keep both sets of changes unless they genuinely contradict.`
+			);
+		} else if (state?.operation === 'merge') {
+			lines.push(`A merge is in progress: \`ours\` is \`${ours}\`, \`theirs\` is \`${theirs}\`.`);
+		} else if (state?.operation === 'cherry-pick' || state?.operation === 'revert') {
+			lines.push(
+				`A ${state.operation} is in progress: \`ours\` is \`${ours}\`, \`theirs\` is \`${theirs}\`.`
+			);
+		} else if (state?.stashConflict) {
+			lines.push('A stash could not be applied cleanly: `ours` is the working tree, `theirs` is the stashed change.');
+		} else {
+			lines.push(`Conflicts are outstanding: \`ours\` is \`${ours}\`, \`theirs\` is \`${theirs}\`.`);
+		}
+
+		if (state?.currentCommit) lines.push(`Commit being applied: "${state.currentCommit}".`);
+
+		return { text: lines.join('\n'), ours, theirs };
+	}
+
+	/** Instructions block, including the right cwd for conflicts inside sub-repos. */
+	function buildConflictInstructions(files: GitConflictFile[]): string {
+		const lines = [
+			'For each file: read it, resolve the conflict, remove every conflict marker, then stage it with `git add <path>`.',
+			'Resolve add/delete conflicts with `git add <path>` to keep the file or `git rm <path>` to drop it.'
+		];
+
+		const nestedNotes = new Set<string>();
+		for (const file of files) {
+			const nested = branchInfo?.nested?.find((n) => file.path.startsWith(n.relPath + '/'));
+			if (nested) nestedNotes.add(nested.relPath);
+		}
+		if (nestedNotes.size > 0) {
+			lines.push(
+				`Paths under ${[...nestedNotes].map((p) => `\`${p}/\``).join(', ')} belong to nested git repositories — run \`git add\`/\`git rm\` for those from inside that directory, not the project root.`
+			);
+		}
+
+		lines.push(
+			'Do not run `git rebase --continue`, `git merge --continue` or `git commit` — I will finish the operation from the Git panel once everything is staged.'
+		);
+		return lines.join('\n');
+	}
+
+	/** Conflict regions only, hard-capped. Never the whole file. */
+	function buildConflictExcerpts(
+		files: GitConflictFile[],
+		ours: string,
+		theirs: string
+	): { text: string; omitted: number } {
+		const blocks: string[] = [];
+		let used = 0;
+		let omitted = 0;
+
+		for (const file of files) {
+			for (const [index, marker] of file.markers.entries()) {
+				const block = [
+					`--- ${file.path} · conflict ${index + 1} of ${file.markers.length} (line ${marker.ourStart + 1}) ---`,
+					`<<<<<<< ours: ${ours}`,
+					clampLines(marker.ourContent, AI_CONFLICT_SIDE_LINES),
+					'=======',
+					clampLines(marker.theirContent, AI_CONFLICT_SIDE_LINES),
+					`>>>>>>> theirs: ${theirs}`
+				].join('\n');
+
+				if (used + block.length > AI_CONFLICT_EXCERPT_BUDGET) {
+					omitted++;
+					continue;
+				}
+				blocks.push(block);
+				used += block.length;
+			}
+		}
+
+		return { text: blocks.join('\n\n'), omitted };
+	}
+
+	function buildConflictPrompt(files: GitConflictFile[]): string {
+		const header = buildConflictHeader();
+		const list = files
+			.map((f, i) => `${i + 1}. \`${f.path}\` — ${describeConflictForAI(f, header.ours, header.theirs)}`)
+			.join('\n');
+		const excerpts = buildConflictExcerpts(files, header.ours, header.theirs);
+
+		const sections = [
+			`Resolve the git conflicts in this repository.`,
+			header.text,
+			`Conflicted file${files.length === 1 ? '' : 's'} (${files.length}):\n${list}`
+		];
+
+		if (excerpts.text) {
+			const note = excerpts.omitted > 0
+				? ` ${excerpts.omitted} further conflict${excerpts.omitted === 1 ? ' was' : 's were'} left out to save context — read those files directly.`
+				: '';
+			sections.push(
+				`Conflict regions (excerpt only — open the files for surrounding context):${note}\n\n${excerpts.text}`
+			);
+		}
+
+		sections.push(buildConflictInstructions(files));
+		return sections.join('\n\n');
+	}
+
+	async function sendConflictPrompt(files: GitConflictFile[]) {
+		if (files.length === 0) return;
+		const prompt = buildConflictPrompt(files);
 		showConflictResolver = false;
 		showPanel('chat');
 		try {
@@ -3424,69 +4036,48 @@ ${file.content}
 			debug.error('git', 'Failed to send AI conflict resolution prompt:', err);
 			showError(
 				'AI Resolution Failed',
-				err instanceof Error ? err.message : 'Could not send conflict to chat.'
+				err instanceof Error ? err.message : 'Could not send the conflicts to chat.'
 			);
 		}
+	}
+
+	async function resolveWithAI(filePath: string) {
+		const file = conflictFiles.find((f) => f.path === filePath);
+		if (!file) return;
+		await sendConflictPrompt([file]);
 	}
 
 	async function resolveAllWithAI() {
-		if (conflictFiles.length === 0) return;
-		const summary = conflictFiles
-			.map(
-				(f, i) =>
-					`${i + 1}. \`${f.path}\` (${f.markers.length} conflict${f.markers.length === 1 ? '' : 's'})`
-			)
-			.join('\n');
-		const bodies = conflictFiles
-			.map((f) => {
-				const lang = detectLanguageFromFilename(f.path);
-				return `### \`${f.path}\`\n\n\`\`\`${lang}\n${f.content}\n\`\`\``;
-			})
-			.join('\n\n');
-		const prompt = `Please help me resolve merge conflicts in these files. For each file, analyze the conflicts, edit the file directly using your tools to apply the resolution, then stage each one with \`git add\`.
-
-${summary}
-
-${bodies}`;
-		showConflictResolver = false;
-		showPanel('chat');
-		try {
-			await chatService.sendMessage(prompt);
-		} catch (err) {
-			debug.error('git', 'Failed to send AI bulk conflict resolution prompt:', err);
-			showError(
-				'AI Resolution Failed',
-				err instanceof Error ? err.message : 'Could not send conflicts to chat.'
-			);
-		}
+		await sendConflictPrompt(conflictFiles);
 	}
 
+	/**
+	 * Abort from inside the resolver. The repo is picked from the file the user is
+	 * actually looking at, not from `conflictFiles[0]` — with conflicts in both the
+	 * outer repo and a sub-repo, that guess aborted whichever happened to sort
+	 * first and then closed the dialog as if everything was done.
+	 */
 	async function abortMerge() {
-		requestConfirm({
-			title: 'Abort Merge',
-			message: 'Abort the current merge? All conflict resolutions will be lost.',
-			type: 'error',
-			confirmText: 'Abort Merge',
-			onConfirm: async () => {
-				await runGitOp(watchScope, 'isResolving', async () => {
-				try {
-					let targetRepoPath: string | undefined = undefined;
-					const anyConflictFile = conflictFiles[0]?.path || conflictInitialPath;
-					if (anyConflictFile && branchInfo?.nested) {
-						const matchingNested = branchInfo.nested.find(n => anyConflictFile.startsWith(n.relPath + '/'));
-						if (matchingNested) {
-							targetRepoPath = matchingNested.path;
-						}
-					}
-					await ws.http('git:abort-merge', { projectId, repoPath: targetRepoPath });
-					showConflictResolver = false;
-					await loadAll();
-				} catch (err) {
-					debug.error('git', 'Failed to abort merge:', err);
-				}
-				});
-			}
-		});
+		const focusedPath = conflictInitialPath || conflictFiles[0]?.path;
+		const repoPath = focusedPath ? nestedRepoPathFor(focusedPath) : undefined;
+		const state = repoPath
+			? nestedOperations[
+					branchInfo?.nested?.find((n) => n.path === repoPath)?.relPath ?? ''
+				]
+			: operationState;
+
+		confirmAbortOperation(
+			state ?? {
+				operation: null,
+				oursLabel: 'ours',
+				theirsLabel: 'theirs',
+				unmergedCount: conflictFiles.length,
+				canContinue: false,
+				canSkip: false,
+				stashConflict: false
+			},
+			repoPath
+		);
 	}
 
 	function openConflictResolver(path: string) {
@@ -3584,29 +4175,49 @@ ${bodies}`;
 	// pops stash@{0}, then whatever re-indexed into its place. The guard is what
 	// makes the second click impossible, and `isStashing` disables the section's
 	// buttons so it reads as busy rather than as nothing happening.
-	async function handleStashPop(entry: StashEntryExtended) {
+	/**
+	 * Restore a stash. `apply` keeps the entry, `pop` removes it on success —
+	 * apply is the safer choice when the changes might conflict, because a
+	 * conflicted pop is easy to abort into a state where the work looks lost.
+	 */
+	async function handleStashRestore(entry: StashEntryExtended, mode: 'pop' | 'apply' = 'pop') {
+		const verb = mode === 'pop' ? 'Pop' : 'Apply';
 		await runGitOp(watchScope, 'isStashing', async () => {
 		try {
-			const result = await ws.http('git:stash-pop', { projectId, index: entry.index, repoPath: entry.repoPath });
+			const endpoint = mode === 'pop' ? 'git:stash-pop' : 'git:stash-apply';
+			const result = await ws.http(endpoint, { projectId, index: entry.index, repoPath: entry.repoPath });
 			await Promise.all([loadStash(), loadStatus()]);
+			await loadOperationState();
 			if (!result.success && result.hasConflicts) {
 				await loadConflicts();
 				const count = conflictFiles.length;
 				showError(
-					'Stash Pop — Conflicts',
+					`Stash ${verb} — Conflicts`,
 					`Applied the stash but ${count} file${count === 1 ? '' : 's'} ${count === 1 ? 'has' : 'have'} conflicts. Opening the resolver — the stash is still saved in case you need to abort.`
 				);
 				conflictInitialPath = conflictFiles[0]?.path ?? null;
 				showConflictResolver = true;
 			} else if (result.success) {
-				showInfo('Stash Applied', 'Stash popped successfully.');
+				showInfo(
+					'Stash Applied',
+					mode === 'pop'
+						? 'Stash popped successfully.'
+						: 'Stash applied — the entry is still in the list.'
+				);
 			}
 		} catch (err) {
-			debug.error('git', 'Stash pop failed:', err);
+			debug.error('git', `Stash ${mode} failed:`, err);
 			const msg = err instanceof Error ? err.message : 'Unknown error';
-			showError('Stash Pop Failed', msg.replace(/^git stash pop failed:\s*/i, '').trim() || msg);
+			showError(
+				`Stash ${verb} Failed`,
+				msg.replace(/^git stash (pop|apply) failed:\s*/i, '').trim() || msg
+			);
 		}
 		}, entry.repoPath);
+	}
+
+	function handleStashPop(entry: StashEntryExtended) {
+		return handleStashRestore(entry, 'pop');
 	}
 
 	async function handleStashDrop(entry: StashEntryExtended) {
@@ -4055,8 +4666,10 @@ ${bodies}`;
 				if (selectedCommit) await refreshSelectedCommit();
 
 				// An external merge or rebase can raise (or resolve) conflicts while
-				// the resolver is open on screen.
-				if (conflictFiles.length > 0 || branchInfo?.operation) {
+				// the resolver is open on screen — and can start or finish an
+				// operation the banner is describing.
+				await loadOperationState();
+				if (conflictFiles.length > 0 || branchInfo?.operation || operationState?.operation) {
 					clearGitSectionStale('conflicts');
 					await loadConflicts();
 				}
@@ -4445,6 +5058,24 @@ ${bodies}`;
 			</div>
 			<!-- Nested repo changes content -->
 			{#if !nested.error}
+				{#if nestedOperations[nested.relPath]}
+					<!-- A sub-repo can be mid-rebase while the outer tree is clean, so
+						it gets its own banner rather than borrowing the outer one. -->
+					<div class="pt-2">
+						<GitOperationBanner
+							state={nestedOperations[nested.relPath]}
+							busy={isOperationBusy}
+							repoLabel={nested.relPath}
+							onContinue={() => void runOperationAction('continue', nested.path)}
+							onSkip={() => void runOperationAction('skip', nested.path)}
+							onAbort={() =>
+								confirmAbortOperation(nestedOperations[nested.relPath], nested.path)}
+							onResolve={nestedConflicted.length > 0
+								? () => openConflictResolver(nestedConflicted[0].path)
+								: undefined}
+						/>
+					</div>
+				{/if}
 				<!-- Nested commit form -->
 				<CommitForm
 					stagedCount={nestedStaged.length}
@@ -4913,7 +5544,7 @@ ${bodies}`;
 											</p>
 										</div>
 										<div class="flex items-center gap-1 shrink-0">
-											<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-emerald-500/10 hover:text-emerald-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashPop(entry); }} title="Pop" disabled={getGitOps(watchScope, nested.path).isStashing}><Icon name="lucide:archive-restore" class="w-3.5 h-3.5" /></button>
+											<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-emerald-500/10 hover:text-emerald-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashPop(entry); }} title="Pop — apply and remove this entry" disabled={getGitOps(watchScope, nested.path).isStashing}><Icon name="lucide:archive-restore" class="w-3.5 h-3.5" /></button><button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashRestore(entry, 'apply'); }} title="Apply — keep this entry in the stash list" disabled={getGitOps(watchScope, nested.path).isStashing}><Icon name="lucide:copy-plus" class="w-3.5 h-3.5" /></button>
 											<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashDrop(entry); }} title="Drop" disabled={getGitOps(watchScope, nested.path).isStashing}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
 										</div>
 									</div>
@@ -5343,6 +5974,48 @@ ${bodies}`;
 {#snippet changesList()}
 	{#if activeView === 'changes'}
 		<div class="flex-1 flex flex-col min-h-0 overflow-hidden">
+		{#if operationState && (operationState.operation || operationState.stashConflict)}
+			<!-- The panel already knew about this state; it just never said so.
+				Without the banner a stalled rebase reads as broken buttons. -->
+			<div class="pt-2">
+				<GitOperationBanner
+					state={operationState}
+					busy={isOperationBusy}
+					onContinue={() => void runOperationAction('continue')}
+					onSkip={() => void runOperationAction('skip')}
+					onAbort={() => confirmAbortOperation(operationState!)}
+					onResolve={mainConflictedFiles.length > 0
+						? () => openConflictResolver(mainConflictedFiles[0].path)
+						: undefined}
+				/>
+			</div>
+		{/if}
+
+		{#if pushTargetDiffers && pushTarget}
+			<!-- Only rendered when the destination is surprising. A fork PR checked
+				out for review tracks the contributor's repository, not this one, and
+				the panel used to give no sign of that at all. -->
+			<div class="px-2 pt-2">
+				<div
+					class="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg border border-sky-400/40 bg-sky-500/10 px-2.5 py-1.5 dark:border-sky-500/40"
+				>
+					<Icon name="lucide:arrow-up-from-line" class="w-3.5 h-3.5 shrink-0 text-sky-600 dark:text-sky-400" />
+					<span class="min-w-0 flex-1 truncate text-3xs text-sky-800 dark:text-sky-200">
+						Pushes to <span class="font-mono font-semibold">{describePushTarget(pushTarget)}</span>
+						{#if pushTarget.isUrl}(a remote URL, not <span class="font-mono">{selectedRemote}</span>){/if}
+					</span>
+					<button
+						type="button"
+						class="shrink-0 cursor-pointer rounded-md border-none bg-sky-500/15 px-2 py-0.5 text-3xs font-semibold text-sky-800 transition-colors hover:bg-sky-500/25 dark:text-sky-100"
+						onclick={openUpstreamModal}
+						title="Change which remote branch this branch tracks"
+					>
+						Change
+					</button>
+				</div>
+			</div>
+		{/if}
+
 		<!-- Commit form -->
 		<CommitForm
 			stagedCount={mainStagedFiles.length}
@@ -5358,6 +6031,7 @@ ${bodies}`;
 			{isMoreBusy}
 			{repoBusy}
 			{repoBusyReason}
+			pushDestination={pushDestinationLabel}
 			onCreateBranch={createBranch}
 			onPush={() => handlePush()}
 			onPull={() => handlePull()}
@@ -6076,7 +6750,7 @@ ${bodies}`;
 												</p>
 											</div>
 											<div class="flex items-center gap-1 shrink-0">
-												<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-emerald-500/10 hover:text-emerald-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashPop(entry); }} title="Pop" disabled={ops.isStashing}><Icon name="lucide:archive-restore" class="w-3.5 h-3.5" /></button>
+												<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-emerald-500/10 hover:text-emerald-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashPop(entry); }} title="Pop — apply and remove this entry" disabled={ops.isStashing}><Icon name="lucide:archive-restore" class="w-3.5 h-3.5" /></button><button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-violet-500/10 hover:text-violet-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashRestore(entry, 'apply'); }} title="Apply — keep this entry in the stash list" disabled={ops.isStashing}><Icon name="lucide:copy-plus" class="w-3.5 h-3.5" /></button>
 												<button type="button" class="flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:bg-red-500/10 hover:text-red-500 transition-colors bg-transparent border-none cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onclick={(e) => { e.stopPropagation(); handleStashDrop(entry); }} title="Drop" disabled={ops.isStashing}><Icon name="lucide:trash-2" class="w-3.5 h-3.5" /></button>
 											</div>
 										</div>
@@ -6331,11 +7005,18 @@ ${bodies}`;
 		{#snippet header()}
 			<div class="flex items-center justify-between px-4 py-3 md:px-6 md:py-4">
 				<div class="flex items-center gap-2.5">
-					<Icon name="lucide:git-merge" class="w-5 h-5 text-violet-600" />
+					<Icon
+						name={mergeIntent === 'rebase' ? 'lucide:git-pull-request-arrow' : 'lucide:git-merge'}
+						class="w-5 h-5 text-violet-600"
+					/>
 					<div>
-						<h2 class="text-base md:text-lg font-bold text-slate-900 dark:text-slate-100">Merge Branch</h2>
+						<h2 class="text-base md:text-lg font-bold text-slate-900 dark:text-slate-100">
+							{mergeIntent === 'rebase' ? 'Rebase Branch' : 'Merge Branch'}
+						</h2>
 						<p class="text-xs text-slate-500 dark:text-slate-400">
-							Merge into <span class="font-mono text-slate-700 dark:text-slate-300">{branchInfo?.current ?? 'current branch'}</span>
+							{mergeIntent === 'rebase' ? 'Replay' : 'Merge into'}
+							<span class="font-mono text-slate-700 dark:text-slate-300">{mergeTargetBranch}</span>
+							{mergeIntent === 'rebase' ? 'onto the branch below' : ''}
 						</p>
 					</div>
 				</div>
@@ -6376,6 +7057,16 @@ ${bodies}`;
 					{/if}
 				</div>
 
+				{#if mergeIntent === 'rebase'}
+					<div class="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3">
+						<p class="text-xs text-amber-800 dark:text-amber-200">
+							Runs <code class="font-mono">git rebase --autostash {mergeBranchName || '<branch>'}</code>.
+							This rewrites your commits on top of that branch, so don't rebase a branch
+							you have already shared unless you intend to force-push. Local changes are
+							stashed and restored automatically.
+						</p>
+					</div>
+				{:else}
 				<div>
 					<div class="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-2">Merge Mode</div>
 					<div class="grid grid-cols-1 gap-2">
@@ -6422,8 +7113,31 @@ ${bodies}`;
 								</span>
 							</span>
 						</button>
+
+						<button
+							type="button"
+							class="flex items-start gap-3 p-3 rounded-lg border text-left transition-colors
+								{mergeMode === 'squash'
+									? 'border-violet-500 bg-violet-500/10'
+									: 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 hover:border-violet-400'}"
+							onclick={() => mergeMode = 'squash'}
+							disabled={isMoreBusy}
+						>
+							<span class="mt-0.5 flex-none flex h-4 w-4 items-center justify-center rounded-full border {mergeMode === 'squash' ? 'border-violet-600 bg-violet-600' : 'border-slate-300 dark:border-slate-600'}">
+								{#if mergeMode === 'squash'}
+									<span class="flex-none h-1.5 w-1.5 rounded-full bg-white"></span>
+								{/if}
+							</span>
+							<span class="min-w-0">
+								<span class="block text-sm font-semibold text-slate-900 dark:text-slate-100">--squash</span>
+								<span class="block text-xs text-slate-500 dark:text-slate-400">
+									Runs <code class="font-mono">git merge --squash {mergeBranchName || '<branch>'}</code>. Collapses the branch into staged changes — you still write the commit yourself.
+								</span>
+							</span>
+						</button>
 					</div>
 				</div>
+				{/if}
 			</div>
 		{/snippet}
 
@@ -6442,15 +7156,21 @@ ${bodies}`;
 					{mergeBranchName && !isMoreBusy
 						? 'bg-violet-600 text-white hover:bg-violet-700 cursor-pointer'
 						: 'bg-slate-200 dark:bg-slate-700 text-slate-400 dark:text-slate-500 cursor-not-allowed'}"
-				onclick={() => void runMergeBranch(mergeBranchName, mergeMode === 'no-ff')}
+				onclick={() =>
+					mergeIntent === 'rebase'
+						? void runRebaseOnto(mergeBranchName)
+						: void runMergeBranch(mergeBranchName, mergeMode)}
 				disabled={!mergeBranchName || isMoreBusy}
 			>
 				{#if isMoreBusy}
 					<div class="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>
 				{:else}
-					<Icon name="lucide:git-merge" class="w-3.5 h-3.5" />
+					<Icon
+						name={mergeIntent === 'rebase' ? 'lucide:git-pull-request-arrow' : 'lucide:git-merge'}
+						class="w-3.5 h-3.5"
+					/>
 				{/if}
-				Merge Branch
+				{mergeIntent === 'rebase' ? 'Rebase Branch' : 'Merge Branch'}
 			</button>
 		{/snippet}
 	</Modal>
@@ -6463,13 +7183,130 @@ ${bodies}`;
 		isLoading={isConflictLoading}
 		initialPath={conflictInitialPath}
 		onResolve={resolveConflict}
+		operation={resolverOperation}
 		onResolveWithAI={resolveWithAI}
 		onResolveAllWithAI={resolveAllWithAI}
 		onAbortMerge={abortMerge}
-		busy={ops.isResolving}
+		busy={ops.isResolving || isOperationBusy}
 		onClose={() => {
 			showConflictResolver = false;
 			conflictInitialPath = null;
+		}}
+	/>
+
+	<!-- Upstream Modal -->
+	<Modal isOpen={showUpstreamModal} onClose={() => (showUpstreamModal = false)} size="sm">
+		{#snippet header()}
+			<div class="flex items-center justify-between px-4 py-3 md:px-6 md:py-4">
+				<div class="flex items-center gap-2.5">
+					<Icon name="lucide:git-branch" class="w-5 h-5 text-violet-600" />
+					<div>
+						<h2 class="text-base font-bold text-slate-900 md:text-lg dark:text-slate-100">
+							Branch Upstream
+						</h2>
+						<p class="text-xs text-slate-500 dark:text-slate-400">
+							Where <span class="font-mono text-slate-700 dark:text-slate-300">{branchInfo?.current ?? ''}</span>
+							pushes and pulls
+						</p>
+					</div>
+				</div>
+				<button
+					type="button"
+					class="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-violet-500/10 hover:text-slate-900 md:p-2 dark:hover:text-slate-100"
+					onclick={() => (showUpstreamModal = false)}
+					aria-label="Close upstream modal"
+				>
+					<Icon name="lucide:x" class="w-4 h-4 md:w-5 md:h-5" />
+				</button>
+			</div>
+		{/snippet}
+
+		{#snippet children()}
+			<div class="flex flex-col gap-3 px-4 py-2 md:px-6">
+				<div>
+					<label
+						for="upstream-remote"
+						class="mb-1 block text-sm font-semibold text-slate-700 dark:text-slate-300"
+					>
+						Remote
+					</label>
+					<select
+						id="upstream-remote"
+						bind:value={upstreamRemote}
+						class="w-full rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm text-slate-900 outline-none focus:ring-1 focus:ring-violet-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+					>
+						{#each remotes as remote (remote.name)}
+							<option value={remote.name}>{remote.name}</option>
+						{/each}
+					</select>
+				</div>
+				<div>
+					<label
+						for="upstream-branch"
+						class="mb-1 block text-sm font-semibold text-slate-700 dark:text-slate-300"
+					>
+						Remote branch
+					</label>
+					<input
+						id="upstream-branch"
+						type="text"
+						bind:value={upstreamBranch}
+						placeholder={branchInfo?.current ?? 'branch'}
+						class="w-full rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm text-slate-900 outline-none focus:ring-1 focus:ring-violet-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+					/>
+					<p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+						The remote-tracking ref must already exist — fetch first if it does not.
+					</p>
+				</div>
+				{#if pushTarget?.isUrl}
+					<p class="rounded-lg bg-amber-500/10 px-2.5 py-2 text-xs text-amber-800 dark:text-amber-200">
+						This branch currently tracks a URL
+						(<span class="font-mono">{shortRemoteLabel(pushTarget.remote)}</span>), which is normal
+						for a pull request checked out from a fork. Changing it here will redirect future
+						pushes to a named remote instead.
+					</p>
+				{/if}
+			</div>
+		{/snippet}
+
+		{#snippet footer()}
+			<button
+				type="button"
+				class="cursor-pointer rounded-lg border-none bg-transparent px-3 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-500/10 dark:text-red-400"
+				onclick={clearUpstream}
+			>
+				Clear upstream
+			</button>
+			<button
+				type="button"
+				class="cursor-pointer rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-800"
+				onclick={() => (showUpstreamModal = false)}
+			>
+				Cancel
+			</button>
+			<button
+				type="button"
+				class="rounded-lg px-3 py-2 text-sm font-semibold transition-colors
+					{upstreamRemote.trim()
+					? 'cursor-pointer bg-violet-600 text-white hover:bg-violet-700'
+					: 'cursor-not-allowed bg-slate-200 text-slate-400 dark:bg-slate-700 dark:text-slate-500'}"
+				onclick={() => void saveUpstream()}
+				disabled={!upstreamRemote.trim()}
+			>
+				Set Upstream
+			</button>
+		{/snippet}
+	</Modal>
+
+	<GitReflogModal
+		isOpen={showReflog}
+		entries={reflogEntries}
+		isLoading={isReflogLoading}
+		onClose={() => (showReflog = false)}
+		onCreateBranch={(hash, name) => void createBranchAtCommit(hash, name)}
+		onCheckout={(hash) => {
+			showReflog = false;
+			checkoutCommit(hash, reflogRepoPath ?? undefined);
 		}}
 	/>
 

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -46,6 +46,12 @@ export interface GitBranch {
 	name: string;
 	isCurrent: boolean;
 	isRemote: boolean;
+	/**
+	 * The branch this one tracks, e.g. `origin/main`. Populated from
+	 * `%(upstream:short)`, or from `branch.<name>.remote`/`.merge` when the
+	 * configured remote is a bare URL — which is what `gh pr checkout` writes for
+	 * a fork PR, and which has no remote-tracking ref for git to name.
+	 */
 	upstream?: string;
 	ahead: number;
 	behind: number;
@@ -163,10 +169,107 @@ export interface GitConflictMarker {
 	baseContent?: string;
 }
 
+/**
+ * How git recorded the conflict, derived from the porcelain XY code. Only
+ * `both-modified` and `both-added` carry inline `<<<<<<<` markers; the rest are
+ * add/delete disagreements where the only meaningful answer is "keep the file"
+ * or "delete the file", which is why they need their own UI affordance.
+ */
+export type GitConflictKind =
+	| 'both-modified'   // UU
+	| 'both-added'      // AA
+	| 'added-by-us'     // AU
+	| 'added-by-them'   // UA
+	| 'deleted-by-us'   // DU
+	| 'deleted-by-them' // UD
+	| 'both-deleted';   // DD
+
+/** Ways a single conflicted path can be resolved. */
+export type GitConflictResolution =
+	/** Take the whole file from our side (`git checkout --ours`). */
+	| 'ours'
+	/** Take the whole file from their side (`git checkout --theirs`). */
+	| 'theirs'
+	/** Write caller-supplied content, then stage it. */
+	| 'custom'
+	/** Keep the working-tree file as it stands (`git add`). */
+	| 'keep'
+	/** Resolve as deleted (`git rm`). */
+	| 'delete'
+	/** Put the conflict markers back (`git checkout --merge`). */
+	| 'reset';
+
 export interface GitConflictFile {
 	path: string;
+	/** Working-tree text. Empty when `contentOmitted` is true. */
 	content: string;
 	markers: GitConflictMarker[];
+	kind: GitConflictKind;
+	/** True when the file has no text side to edit (binary, missing, or oversized). */
+	contentOmitted: boolean;
+	/** Why the content was omitted — drives the resolver's fallback UI. */
+	omitReason?: 'binary' | 'missing' | 'too-large';
+	/** Working-tree size in bytes, when the file exists. */
+	size?: number;
+}
+
+/**
+ * Everything the UI needs to explain (and finish) an in-progress operation.
+ *
+ * `oursLabel`/`theirsLabel` exist because the two sides swap meaning between
+ * merge and rebase: rebasing replays your commits onto the upstream, so `ours`
+ * is the branch you are rebasing *onto* and `theirs` is your own commit — the
+ * exact opposite of a merge. Showing the raw words without the branch names is
+ * the single biggest source of wrong resolutions.
+ */
+export interface GitOperationState {
+	operation: GitOperation | null;
+	/** 1-based position in a multi-commit replay (rebase only). */
+	step?: number;
+	/** Total commits in the replay (rebase only). */
+	total?: number;
+	/** Human label for the `ours` side, e.g. "main". */
+	oursLabel: string;
+	/** Human label for the `theirs` side, e.g. "your commit". */
+	theirsLabel: string;
+	/** Subject of the commit being replayed, when there is one. */
+	currentCommit?: string;
+	/** Paths still unmerged. `--continue` is refused while this is non-zero. */
+	unmergedCount: number;
+	canContinue: boolean;
+	canSkip: boolean;
+	/**
+	 * Unmerged paths with no operation sentinel — a `stash pop`/`apply` that hit
+	 * a conflict. The stash entry survives a failed pop, so aborting here must
+	 * say so rather than implying the work is gone.
+	 */
+	stashConflict: boolean;
+}
+
+// ============================================
+// Push Target
+// ============================================
+
+/**
+ * Where `git push` will actually send this branch.
+ *
+ * The panel used to push to whichever remote its dropdown had selected, with
+ * `-u`. On a fork PR checked out for review that pushed the contributor's work
+ * into the main repository as a new branch, and the `-u` rewrote the branch's
+ * remote so every later push went there too. Resolving the real destination —
+ * and showing it — is what keeps that from happening.
+ */
+export interface GitPushTarget {
+	/** Remote name, or a bare URL when that is how the branch is configured. */
+	remote: string;
+	/** Branch name on the far side, which need not match the local name. */
+	remoteBranch: string;
+	/** False when the branch tracks nothing, so a push has to pick a destination. */
+	hasUpstream: boolean;
+	/** True when `remote` is a URL rather than a configured remote name. */
+	isUrl: boolean;
+	/** The local branch this was resolved for. */
+	branch: string;
 }
 
 // ============================================
@@ -206,6 +309,26 @@ export interface GitTag {
 	message: string;
 	date: string;
 	isAnnotated: boolean;
+}
+
+// ============================================
+// Reflog
+// ============================================
+
+/**
+ * One `git reflog` row. This is the repo's undo journal: it still holds commits
+ * that branch deletes, resets and rebases have orphaned, so it is the only way
+ * back from a destructive action.
+ */
+export interface GitReflogEntry {
+	hash: string;
+	hashShort: string;
+	/** Reflog selector, e.g. `HEAD@{3}`. */
+	selector: string;
+	/** The recorded action, e.g. `rebase (finish)` or `commit`. */
+	action: string;
+	subject: string;
+	date: string;
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
Make push and pull follow the branch's own upstream instead of the panel's remote
dropdown, give the panel a real conflict workflow with Continue/Skip/Abort, and
bound the three AI prompts that previously had no size limit.

## Why
**Push went to the wrong repository.** The panel ran
`git push <selectedRemote> <localBranch> -u`, ignoring `branch.<name>.remote` and
`branch.<name>.merge`. Reviewing a fork PR — where `gh pr checkout` records the
contributor's repository, often as a bare URL — pushed the review commits into the
maintainer's repository as a new branch. Worse, `-u` then rewrote the branch's remote
to `origin`, so every later push, including a manual `git push`, went there too.

Reproduced against real repositories:
$ git push origin their-branch -u [new branch] their-branch -> their-branch
branch 'their-branch' set up to track 'origin/their-branch'.
$ git config --get branch.their-branch.remote origin # was the fork's URL

The same assumption ran through the panel: pull named the remote and local branch
explicitly, ahead/behind was measured against `<selectedRemote>/<localName>` (0/0 for
any fork PR), and `parseBranches` never populated `GitBranch.upstream`, so the UI that
was already laid out to show tracking always rendered nothing.

**Conflicts dead-ended.** `branchInfo.operation` was detected but only used to disable
buttons, and there was no `--continue` anywhere. Resolving every conflict during a
rebase left the repo mid-rebase with Abort as the only button.

**The AI prompts were unbounded.** `resolveWithAI` inlined every conflicted file's full
contents; both generators sent raw `git diff --cached`, lockfiles included.

## Changes

### Push target
- `getPushTarget()` resolves the destination from git config
  (`branch.<n>.pushRemote` > `remote.pushDefault` > `branch.<n>.remote`) rather than
  `@{push}` — with a URL remote, `@{push}` and `@{upstream}` both fail outright.
- `push()` / `pushAdvanced()` / `pull()` run bare when the branch is tracked and let git
  resolve everything. `-u` only for the first push of an untracked branch.
- `parseBranches` reads `%(upstream:short)` (appended after a `%1f`, since a subject can
  contain `|`), backfilled from config for URL upstreams.
- Ahead/behind measured against the real upstream; reports 0 rather than comparing
  against an unrelated same-named branch when the upstream has no local ref.
- New `git:push-target`, `git:set-upstream`, `git:unset-upstream`; `git:push` gains
  `useUpstream`.
- Push destination shown in the Push/Pull tooltips, a banner when it is not the obvious
  `<selected remote>/<same name>`, and a Branch Upstream editor to repair repositories
  the old behaviour already retargeted.
- `--force-with-lease` against a URL upstream now explains itself instead of surfacing
  git's bare "stale info".

### In-progress operations
- `getOperationState()` — rebase progress, replayed commit, unmerged count, resolved
  `ours`/`theirs` labels; `git:operation-state`, `git:continue-operation`,
  `git:skip-operation`, `git:abort-operation`.
- `GitOperationBanner.svelte` for the outer repo and each nested repo, with Continue
  (blocked while paths are unmerged), Skip and an operation-correct Abort label.
- `GIT_EDITOR`/`GIT_SEQUENCE_EDITOR=true` — `rebase --continue` otherwise blocks on
  `$EDITOR` until the timeout kills it.

### AI prompt budgets
- `backend/ws/git/diff-budget.ts` — `--stat` always kept, generated/binary paths skipped
  but still named, patch filled per file until the budget is spent, truncation announced.
- Conflict prompt replaced with an operation brief plus capped excerpts of the conflict
  regions only (8 KB total, 40 lines per side), naming the correct sub-repo cwd.

### Conflict handling
- Conflicts sourced from `git ls-files -u` and classified by index stage, so
  both-deleted paths stop disappearing; binary detected via NUL; content capped at 2 MB.
- Structural pane (keep / delete / use-ours / use-theirs / reset-to-conflict) for
  marker-less conflicts. `--ours` on a path the other side deleted resolves as a deletion.
- `stageAll` and `resolveConflict` refuse leftover `<<<<<<<`; `discardAll` refuses while
  paths are unmerged (it previously half-succeeded with both exit codes ignored).
- Abort targets the repo the user is viewing rather than `conflictFiles[0]`;
  `parseConflictMarkers` requires exactly seven characters and recovers from a nested
  opener; side labels use real branch names with a rebase-inversion warning.

### Also added
Standalone `git rebase` (`--autostash`), `--squash` as a third mode in the existing merge
modal, per-entry stash **apply**, reflog browser with branch-at-commit recovery,
return-to-branch, and a Base ↔ Ours / Base ↔ Theirs comparison toggle that finally uses
the `baseContent` the parser was already producing.

## Test plan
- `bun run check` — clean
- `bun run lint` — clean (the one warning is pre-existing, in `AboutDeviceSettings.svelte`)
- `bun run test` — 943 pass / 0 fail, including 50 new tests
- `backend/git/push-target.test.ts` — real bare repos standing in for an upstream and a
  fork. Asserts the review commit reaches the fork, that `upstream.git` still contains
  only `main`, and that `branch.<name>.remote` is unchanged after a push; plus
  pushRemote precedence, renamed local branches, upstream exposure and ahead/behind.
- `backend/git/conflict-state.test.ts` — marker parsing edge cases, delete/modify and
  binary conflicts, marker guards, merge/rebase/stash operation state, continue.
- `backend/ws/git/diff-budget.test.ts` — stat header, skipping, clipping, budget
  exhaustion, renames.
- Runtime QA still pending — the panel has not been exercised in a browser.

## Notes
- Large for one commit, at the author's explicit request. The riskiest surfaces are
  `push`/`pull`/`getPushTarget` in `git-service.ts` and the resolver's structural branch.
- `git:abort-merge` is retained as an alias for `git:abort-operation`.
- Merge modes stay in the merge modal only. Listing `--no-ff`/`--squash` in the Branch
  menu as well would give two routes to the same choice.
- `--force-with-lease` genuinely cannot work against a URL upstream: the lease needs a
  remote-tracking ref, and fetching one first would only lease against what was just
  read, removing the protection. It now says so; plain force push still works.
- Reflog recovery is deliberately additive (branch at the commit, never reset onto it).
- No screenshots: running the app is out of scope per `CLAUDE.md`, so the before/after
  pair needs to come from runtime QA.

## Follow-ups
- Fetching a GitHub PR ref (`refs/pull/N/head`) without the `gh` CLI would round out the
  review workflow, but those refs are read-only, so such branches need to be marked
  unpushable first.
- `rerere` support and a `mergetool` hand-off were considered and left out.