### PR TITLE
feat(settings): add a project usage tab to Settings -> Device

### DIFF
--- a/backend/ws/projects/index.ts
+++ b/backend/ws/projects/index.ts
@@ -7,6 +7,7 @@
  * - crud.ts: HTTP endpoints for CRUD operations (list, create, get, update, delete)
  * - status.ts: Real-time status updates and watching (get-status, watch, unwatch, events)
  * - presence.ts: User presence management (update-presence with broadcast)
+ * - overview.ts: Read-only recap of idle projects (projects:overview)
  */
 
 import { createRouter } from '$shared/utils/ws-server';
@@ -14,6 +15,7 @@ import { crudHandler } from './crud';
 import { statusHandler } from './status';
 import { presenceHandler } from './presence';
 import { infoHandler } from './info';
+import { overviewHandler } from './overview';
 
 export const projectsRouter = createRouter()
 	// CRUD Operations (HTTP)
@@ -26,4 +28,7 @@ export const projectsRouter = createRouter()
 	.merge(presenceHandler)
 
 	// Per-project resource info (storage + process-isolated CPU/RAM)
-	.merge(infoHandler);
+	.merge(infoHandler)
+
+	// Read-only recap of idle projects (counts + summed storage + top 5)
+	.merge(overviewHandler);

--- a/backend/ws/projects/info.ts
+++ b/backend/ws/projects/info.ts
@@ -22,10 +22,12 @@ import { collectProcessTree, getHostFacts, getProcessTable } from '../../host/me
 
 /** Ceiling on entries visited by one walk, so a monorepo cannot pin a core. */
 const MAX_ENTRIES = 300_000;
-/** Wall-clock ceiling — the backstop for slow disks and network mounts. */
-const WALK_DEADLINE_MS = 15_000;
+/** Wall-clock ceiling — the backstop for slow disks and network mounts.
+ *  Sized to stay under the 30s client timeout of both callers
+ *  (`projects:info` default, `projects:overview` explicit) with margin. */
+const WALK_DEADLINE_MS = 20_000;
 /** How many `stat` calls are in flight at once while walking one directory. */
-const STAT_BATCH = 64;
+const STAT_BATCH = 128;
 /** A folder's size changes slowly; a poll should not re-walk it every tick. */
 const STORAGE_CACHE_TTL_MS = 15_000;
 /** An expensive walk earns a longer rest, so it is not repeated the moment its
@@ -37,7 +39,7 @@ const PORTS_CACHE_TTL_MS = 5_000;
 
 // ── Storage ──────────────────────────────────────────────────────────────────
 
-interface FolderStats {
+export interface FolderStats {
 	sizeBytes: number;
 	fileCount: number;
 	dirCount: number;
@@ -49,8 +51,12 @@ const storageCache = new Map<string, { stats: FolderStats; at: number; ttl: numb
 const storageInFlight = new Map<string, Promise<FolderStats>>();
 
 /** Cached and single-flighted: a big walk outlives the poll interval, so a
- *  result-only cache would let every tick start another one. */
-function getFolderStats(root: string): Promise<FolderStats> {
+ *  result-only cache would let every tick start another one.
+ *
+ *  Exported for reuse by `projects:overview` so idle-project totals share the
+ *  same walk, cache entry, and in-flight guard as per-project `projects:info`.
+ *  No behavior change for existing callers. */
+export function getFolderStats(root: string): Promise<FolderStats> {
 	const cached = storageCache.get(root);
 	if (cached && Date.now() - cached.at < cached.ttl) {
 		return Promise.resolve(cached.stats);
@@ -149,7 +155,7 @@ async function walkFolder(root: string): Promise<FolderStats> {
 
 // ── Per-project slice of the host process table ──────────────────────────────
 
-interface ProjectProcess {
+export interface ProjectProcess {
 	pid: number;
 	parentPid: number;
 	name: string;
@@ -158,7 +164,7 @@ interface ProjectProcess {
 	command: string;
 }
 
-interface ProcessStats {
+export interface ProcessStats {
 	status: 'running' | 'not_running';
 	cpuPercent: number | null;
 	memRssBytes: number | null;
@@ -178,7 +184,12 @@ const IDLE: ProcessStats = {
 	rootPids: []
 };
 
-async function getProjectProcessStats(projectId: string, totalMemBytes: number): Promise<ProcessStats> {
+/**
+ * Exported for reuse by `projects:overview` so per-project CPU/RAM there is
+ * measured exactly the way `projects:info` measures it — same roots, same
+ * shared process table, same capacity basis. No behavior change for callers.
+ */
+export async function getProjectProcessStats(projectId: string, totalMemBytes: number): Promise<ProcessStats> {
 	const rootPids = projectShellPids(projectId);
 
 	// No shells means nothing is running, so zero is the truth here.

--- a/backend/ws/projects/overview.test.ts
+++ b/backend/ws/projects/overview.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'bun:test';
+import { pickTopEntries, summarizeIdleStats, type ProjectEntry } from './overview';
+
+function entry(
+	id: string,
+	sizeBytes: number,
+	opts?: {
+		status?: 'running' | 'idle';
+		error?: string;
+		truncated?: boolean;
+		lastOpened?: string;
+		files?: number;
+		dirs?: number;
+		cpuPercent?: number | null;
+	}
+): ProjectEntry {
+	return {
+		id,
+		name: id,
+		path: `/tmp/${id}`,
+		created_at: '2026-01-01T00:00:00.000Z',
+		last_opened_at: opts?.lastOpened ?? '2026-02-01T00:00:00.000Z',
+		status: opts?.status ?? 'idle',
+		cpuPercent: opts?.cpuPercent ?? 0,
+		memRssBytes: 0,
+		memPercent: 0,
+		storage: {
+			sizeBytes,
+			fileCount: opts?.files ?? 10,
+			dirCount: opts?.dirs ?? 2,
+			truncated: opts?.truncated ?? false,
+			...(opts?.error ? { error: opts.error } : {})
+		}
+	};
+}
+
+describe('summarizeIdleStats', () => {
+	it('sums only error-free idle entries', () => {
+		const totals = summarizeIdleStats([
+			entry('a', 100, { files: 5, dirs: 1 }),
+			entry('b', 200, { files: 7, dirs: 3 }),
+			entry('gone', 0, { error: 'ENOENT: no such file or directory' }),
+			entry('busy', 500, { status: 'running', files: 50, dirs: 9 })
+		]);
+		expect(totals).toEqual({
+			measurableCount: 2,
+			totalStorageIdle: 300,
+			totalFilesIdle: 12,
+			totalDirsIdle: 4
+		});
+	});
+
+	it('returns zeros when nothing is measurable', () => {
+		expect(summarizeIdleStats([entry('gone', 0, { error: 'gone' })])).toEqual({
+			measurableCount: 0,
+			totalStorageIdle: 0,
+			totalFilesIdle: 0,
+			totalDirsIdle: 0
+		});
+	});
+});
+
+describe('pickTopEntries', () => {
+	it('ranks by sizeBytes DESC across statuses and caps at 5', () => {
+		const entries = [
+			entry('s', 10),
+			entry('m', 50),
+			entry('l', 90),
+			entry('xl', 200),
+			entry('xxl', 500),
+			entry('xxxl', 900, { status: 'running', cpuPercent: 12.5 }),
+			entry('tiny', 1)
+		];
+		const top = pickTopEntries(entries);
+		expect(top.map((e) => e.id)).toEqual(['xxxl', 'xxl', 'xl', 'l', 'm']);
+		expect(top[0].status).toBe('running');
+	});
+
+	it('never ranks error entries but keeps partial (truncated) ones', () => {
+		const top = pickTopEntries([
+			entry('gone', 999_999, { error: 'ENOENT' }),
+			entry('partial', 400, { truncated: true }),
+			entry('full', 300)
+		]);
+		expect(top.map((e) => e.id)).toEqual(['partial', 'full']);
+		expect(top[0].storage.truncated).toBe(true);
+	});
+
+	it('breaks size ties by oldest last_opened_at first', () => {
+		const top = pickTopEntries([
+			entry('newer', 100, { lastOpened: '2026-03-01T00:00:00.000Z' }),
+			entry('older', 100, { lastOpened: '2026-01-15T00:00:00.000Z' })
+		]);
+		expect(top.map((e) => e.id)).toEqual(['older', 'newer']);
+	});
+});

--- a/backend/ws/projects/overview.ts
+++ b/backend/ws/projects/overview.ts
@@ -1,0 +1,289 @@
+/**
+ * Projects Overview — read-only recap of projects with per-project resources.
+ *
+ * Separate from `system:device-info` (host hardware, polls every ~3.5s) and
+ * from `projects:info` (one project's storage + live CPU/RAM/ports).
+ *
+ * This endpoint answers:
+ * - how many projects exist / how many are idle / how many measurable
+ * - summed folder stats over measurable idle projects
+ * - top 5 projects by folder size, each with the same CPU/RAM/storage
+ *   figures `projects:info` (Project Info modal) reports
+ *
+ * Definitions (same as Project Info):
+ * - idle    = `projectShellPids(projectId).length === 0` (no active PTY shell)
+ * - running = at least one active shell
+ *
+ * Storage comes from the shared `getFolderStats()` in `./info` and CPU/RAM
+ * from the shared `getProjectProcessStats()` in the same module — the same
+ * walks, caches, and process table Project Info uses — so the two panels
+ * cannot disagree about one project. Entries whose walk reports `error`
+ * (folder moved/deleted/unreadable) are excluded from totals and from Top 5
+ * but still counted in `idleCount` and listed under `unmeasurable` so the UI
+ * can render an honest footnote.
+ *
+ * Cost control:
+ * - no port scan and no per-process list here, only the summed CPU/RAM
+ * - overview-level TTL cache (3s, matching the frontend heartbeat) +
+ *   single-flight, on top of the per-path storage cache and the shared
+ *   process-table cache, so repeated calls never repeat folder walks; at
+ *   most one process-table probe per rebuild
+ * - the Device poll is a frontend concern; this handler just makes frequent
+ *   polling cheap. Frontend polls it on its own 3s heartbeat.
+ */
+
+import { t } from 'elysia';
+import { createRouter } from '$shared/utils/ws-server';
+import { projectQueries } from '../../database/queries';
+import { projectShellPids } from '../../projects/shell-ownership';
+import { getHostFacts } from '../../host/metrics';
+import { getFolderStats, getProjectProcessStats, type FolderStats } from './info';
+
+export type ProjectResourceStatus = 'running' | 'idle';
+
+/** Fresh response snapshot; never mutated after caching. */
+export interface TopEntry {
+	id: string;
+	name: string;
+	path: string;
+	created_at: string;
+	last_opened_at: string;
+	status: ProjectResourceStatus;
+	cpuPercent: number | null;
+	memRssBytes: number | null;
+	memPercent: number | null;
+	sizeBytes: number;
+	fileCount: number;
+	dirCount: number;
+	truncated: boolean;
+}
+
+export interface UnmeasurableEntry {
+	id: string;
+	name: string;
+	path: string;
+	error: string;
+}
+
+export interface ProjectsOverview {
+	totalProjects: number;
+	runningCount: number;
+	idleCount: number;
+	measurableCount: number;
+	unmeasurableCount: number;
+	totalStorageIdle: number;
+	totalFilesIdle: number;
+	totalDirsIdle: number;
+	top: TopEntry[];
+	unmeasurable: UnmeasurableEntry[];
+	generatedAt: string;
+}
+
+export interface ProjectEntry {
+	id: string;
+	name: string;
+	path: string;
+	created_at: string;
+	last_opened_at: string;
+	status: ProjectResourceStatus;
+	cpuPercent: number | null;
+	memRssBytes: number | null;
+	memPercent: number | null;
+	storage: FolderStats;
+}
+
+/** Sum folder stats over measurable (error-free) idle entries only. */
+export function summarizeIdleStats(entries: Array<{ status: ProjectResourceStatus; storage: FolderStats }>): {
+	measurableCount: number;
+	totalStorageIdle: number;
+	totalFilesIdle: number;
+	totalDirsIdle: number;
+} {
+	let measurableCount = 0;
+	let totalStorageIdle = 0;
+	let totalFilesIdle = 0;
+	let totalDirsIdle = 0;
+	for (const entry of entries) {
+		if (entry.status !== 'idle' || entry.storage.error) continue;
+		measurableCount++;
+		totalStorageIdle += entry.storage.sizeBytes;
+		totalFilesIdle += entry.storage.fileCount;
+		totalDirsIdle += entry.storage.dirCount;
+	}
+	return { measurableCount, totalStorageIdle, totalFilesIdle, totalDirsIdle };
+}
+
+/** Top entries by folder size across every status; error entries never rank. */
+export function pickTopEntries(entries: ProjectEntry[], limit = 5): ProjectEntry[] {
+	return entries
+		.filter((entry) => !entry.storage.error)
+		.sort((a, b) => {
+			if (b.storage.sizeBytes !== a.storage.sizeBytes) {
+				return b.storage.sizeBytes - a.storage.sizeBytes;
+			}
+			return a.last_opened_at.localeCompare(b.last_opened_at);
+		})
+		.slice(0, limit);
+}
+
+/** Overview-level cache: one snapshot serves every caller inside the TTL.
+ *  Kept at the frontend 3s heartbeat so counts and Running/Idle flips go
+ *  live without a manual refresh. Rebuilds stay cheap: folder walks keep
+ *  their own cache and a rebuild costs at most one process-table probe. */
+const OVERVIEW_CACHE_TTL_MS = 3_000;
+let cachedOverview: { payload: ProjectsOverview; at: number } | null = null;
+let inFlightOverview: Promise<ProjectsOverview> | null = null;
+
+async function buildOverview(): Promise<ProjectsOverview> {
+	const projects = projectQueries.getAll();
+
+	const idleIds = new Set<string>();
+	for (const project of projects) {
+		if (projectShellPids(project.id).length === 0) idleIds.add(project.id);
+	}
+
+	// All three phases launch together. They used to await one after another
+	// (facts ~4s, walks ~20s, process probe ~10s worst case), which stacked
+	// past the client's timeout on a loaded machine. Concurrent, the slowest
+	// single phase bounds the total instead of their sum.
+	const factsP = getHostFacts();
+	const storagesP = Promise.all(projects.map((project) => getFolderStats(project.path)));
+	const resourcesP = factsP.then((facts) =>
+		Promise.all(
+			projects.map((project) =>
+				idleIds.has(project.id)
+					? Promise.resolve({ cpuPercent: 0, memRssBytes: 0, memPercent: 0 })
+					: getProjectProcessStats(project.id, facts.totalMemBytes).then((stats) => ({
+							cpuPercent: stats.cpuPercent,
+							memRssBytes: stats.memRssBytes,
+							memPercent: stats.memPercent
+						}))
+			)
+		)
+	);
+
+	const [storages, resources] = await Promise.all([storagesP, resourcesP]);
+
+	const entries: ProjectEntry[] = projects.map((project, i) => ({
+		id: project.id,
+		name: project.name,
+		path: project.path,
+		created_at: project.created_at,
+		last_opened_at: project.last_opened_at,
+		status: idleIds.has(project.id) ? 'idle' : 'running',
+		cpuPercent: resources[i].cpuPercent,
+		memRssBytes: resources[i].memRssBytes,
+		memPercent: resources[i].memPercent,
+		storage: storages[i]
+	}));
+
+	const idleCount = idleIds.size;
+	const totals = summarizeIdleStats(entries);
+	const top = pickTopEntries(entries, 5).map((entry) => ({
+		id: entry.id,
+		name: entry.name,
+		path: entry.path,
+		created_at: entry.created_at,
+		last_opened_at: entry.last_opened_at,
+		status: entry.status,
+		cpuPercent: entry.cpuPercent,
+		memRssBytes: entry.memRssBytes,
+		memPercent: entry.memPercent,
+		sizeBytes: entry.storage.sizeBytes,
+		fileCount: entry.storage.fileCount,
+		dirCount: entry.storage.dirCount,
+		truncated: entry.storage.truncated
+	}));
+
+	const unmeasurable: UnmeasurableEntry[] = entries
+		.filter((entry) => entry.storage.error)
+		.map((entry) => ({
+			id: entry.id,
+			name: entry.name,
+			path: entry.path,
+			error: entry.storage.error as string
+		}));
+
+	return {
+		totalProjects: projects.length,
+		runningCount: projects.length - idleCount,
+		idleCount,
+		measurableCount: totals.measurableCount,
+		unmeasurableCount: unmeasurable.length,
+		totalStorageIdle: totals.totalStorageIdle,
+		totalFilesIdle: totals.totalFilesIdle,
+		totalDirsIdle: totals.totalDirsIdle,
+		top,
+		unmeasurable,
+		generatedAt: new Date().toISOString()
+	};
+}
+
+function getOverview(): Promise<ProjectsOverview> {
+	if (cachedOverview && Date.now() - cachedOverview.at < OVERVIEW_CACHE_TTL_MS) {
+		return Promise.resolve(cachedOverview.payload);
+	}
+	if (inFlightOverview) return inFlightOverview;
+
+	inFlightOverview = buildOverview().then((payload) => {
+		cachedOverview = { payload, at: Date.now() };
+		inFlightOverview = null;
+		return payload;
+	});
+	// A failed build must not pin the single-flight slot; the per-path
+	// storage layer already converts walk failures into error stats, so a
+	// rejection here is unexpected (e.g. DB unreadable) and should retry.
+	inFlightOverview.then(
+		() => {},
+		() => {
+			inFlightOverview = null;
+		}
+	);
+	return inFlightOverview;
+}
+
+const nullableNumber = t.Union([t.Number(), t.Null()]);
+
+const TopEntrySchema = t.Object({
+	id: t.String(),
+	name: t.String(),
+	path: t.String(),
+	created_at: t.String(),
+	last_opened_at: t.String(),
+	status: t.Union([t.Literal('running'), t.Literal('idle')]),
+	cpuPercent: nullableNumber,
+	memRssBytes: nullableNumber,
+	memPercent: nullableNumber,
+	sizeBytes: t.Number(),
+	fileCount: t.Number(),
+	dirCount: t.Number(),
+	truncated: t.Boolean()
+});
+
+export const overviewHandler = createRouter().http(
+	'projects:overview',
+	{
+		data: t.Object({}),
+		response: t.Object({
+			totalProjects: t.Number(),
+			runningCount: t.Number(),
+			idleCount: t.Number(),
+			measurableCount: t.Number(),
+			unmeasurableCount: t.Number(),
+			totalStorageIdle: t.Number(),
+			totalFilesIdle: t.Number(),
+			totalDirsIdle: t.Number(),
+			top: t.Array(TopEntrySchema),
+			unmeasurable: t.Array(
+				t.Object({
+					id: t.String(),
+					name: t.String(),
+					path: t.String(),
+					error: t.String()
+				})
+			),
+			generatedAt: t.String()
+		})
+	},
+	async () => getOverview()
+);

--- a/backend/ws/system/device-info.ts
+++ b/backend/ws/system/device-info.ts
@@ -14,9 +14,11 @@
  * Static facts (OS, CPU model, core count, installed RAM, GPU model,
  * virtualization) come from `backend/host/metrics.ts`, which probes them once
  * per process and is also what Project Info reads, so the two panels cannot
- * disagree about the machine they are describing. Dynamic metrics (load,
- * memory in use, battery, disk, GPU utilization) are recomputed on every
- * request so the panel can poll live.
+ * disagree about the machine they are describing. Fast live metrics (CPU via
+ * OS deltas, memory, network, uptime) are re-read on every request so the
+ * panel polls live. Slow WMI-bound metrics (battery, disk usage, GPU) are
+ * cached for 60s and refreshed in the background, so one timed-out probe can
+ * never flip the panel between "This Device" <-> "Server" or drop cards.
  */
 
 import { t } from 'elysia';
@@ -26,14 +28,128 @@ import type { Systeminformation } from 'systeminformation';
 import { createRouter } from '$shared/utils/ws-server';
 import { getHostFacts, withTimeout } from '../../host/metrics';
 
-/** Last-good caches for dynamic probes: prevents transient WMI timeouts from
- *  flickering the UI between "This Device" <-> "Server" or dropping Storage cards. */
-let lastMemCache: Systeminformation.MemData | null = null;
-let lastBatteryCache: Systeminformation.BatteryData | null = null;
-let lastFsSizeCache: Systeminformation.FsSizeData[] | null = null;
-let lastLoadCache: Systeminformation.CurrentLoadData | null = null;
-let lastGraphicsCache: Systeminformation.GraphicsData | null = null;
-let lastNetCache: Systeminformation.NetworkInterfacesData | null = null;
+/** Two-tier probing. Fast signals (CPU via os deltas, memory, network, uptime)
+ *  are cheap and re-read on every request. Slow signals (battery, disk usage,
+ *  GPU) shell out to WMI/PowerShell, change slowly, and time out under load —
+ *  re-probing them every 3.5s poll is what made the panel flip between
+ *  "This Device" <-> "Server" and made Battery/Swap/Storage cards appear and
+ *  vanish on every open/close. Slow signals are cached for SLOW_TTL_MS and
+ *  refreshed in the background; a request only waits for them on cold start
+ *  when no snapshot exists at all. */
+const LAST_GOOD_MAX_AGE_MS = 60_000;
+const SLOW_TTL_MS = 60_000;
+interface TimedCache<T> { value: T; at: number }
+let lastMemCache: TimedCache<Systeminformation.MemData> | null = null;
+let lastNetCache: TimedCache<Systeminformation.NetworkInterfacesData> | null = null;
+
+function fresh<T>(cache: TimedCache<T> | null): T | null {
+	if (!cache || Date.now() - cache.at > LAST_GOOD_MAX_AGE_MS) return null;
+	return cache.value;
+}
+
+interface SlowSnapshot {
+	battery: Systeminformation.BatteryData | null;
+	fsSize: Systeminformation.FsSizeData[] | null;
+	graphics: Systeminformation.GraphicsData | null;
+	at: number;
+}
+let slowCache: SlowSnapshot | null = null;
+let slowInFlight: Promise<SlowSnapshot> | null = null;
+
+/** Battery presence is sticky: WMI transiently reports no-battery/timeout on
+ *  laptops under load, which used to flip the whole panel to "Server". Only
+ *  three consecutive *explicit* no-battery readings (not timeouts) clear it. */
+let stickyHasBattery = false;
+let batteryFalseStreak = 0;
+
+async function probeSlow(): Promise<SlowSnapshot> {
+	const [battery, graphics, fsSize] = await Promise.all([
+		withTimeout(si.battery(), 8000),
+		withTimeout(si.graphics(), 8000),
+		withTimeout(si.fsSize(), 8000)
+	]);
+	if (battery) {
+		if (battery.hasBattery) {
+			stickyHasBattery = true;
+			batteryFalseStreak = 0;
+		} else if (++batteryFalseStreak >= 3) {
+			stickyHasBattery = false;
+		}
+	}
+	const snapshot: SlowSnapshot = { battery, fsSize, graphics, at: Date.now() };
+	// Merge: never let one timed-out probe wipe a good snapshot from another.
+	if (slowCache) {
+		if (!snapshot.battery) snapshot.battery = slowCache.battery;
+		if (!snapshot.fsSize) snapshot.fsSize = slowCache.fsSize;
+		if (!snapshot.graphics) snapshot.graphics = slowCache.graphics;
+	}
+	slowCache = snapshot;
+	return snapshot;
+}
+
+/** Slow signals for one request: fresh cache served instantly, stale cache
+ *  served instantly while a background refresh runs, cold start awaits. */
+function ensureSlow(): Promise<SlowSnapshot> {
+	if (slowCache && Date.now() - slowCache.at < SLOW_TTL_MS) {
+		return Promise.resolve(slowCache);
+	}
+	if (slowInFlight) return slowInFlight;
+	slowInFlight = probeSlow().then((snapshot) => {
+		slowInFlight = null;
+		return snapshot;
+	});
+	slowInFlight.then(
+		() => {},
+		() => {
+			slowInFlight = null;
+		}
+	);
+	// Stale-but-usable snapshot wins over waiting: the Device tab must open
+	// instantly with consistent cards, then correct itself next poll.
+	if (slowCache) return Promise.resolve(slowCache);
+	return slowInFlight;
+}
+
+/** Rolling OS-level CPU measurement (same source Task Manager samples).
+ *  `si.currentLoad()` on a cold process — especially while 11 WMI/PowerShell
+ *  probes run concurrently — can spike to 100%, and the spike is partly the
+ *  measurement storm itself. Sampling `os.cpus()` deltas between requests
+ *  (the ~3.5s poll interval) measures the real machine load instead. */
+let lastCpuSample: { busy: number; total: number; at: number } | null = null;
+let lastCpuPercent: number | null = null;
+
+function sampleOsCpuPercent(): number | null {
+	let busy = 0;
+	let total = 0;
+	for (const core of os.cpus()) {
+		const active = core.times.user + core.times.nice + core.times.sys + core.times.irq;
+		busy += active;
+		total += active + core.times.idle;
+	}
+	const now = Date.now();
+	const prev = lastCpuSample;
+	lastCpuSample = { busy, total, at: now };
+	if (prev && now - prev.at >= 500 && total - prev.total > 0) {
+		const pct = ((busy - prev.busy) / (total - prev.total)) * 100;
+		lastCpuPercent = Math.min(100, Math.max(0, pct));
+	}
+	return lastCpuPercent;
+}
+
+/** OS fallback for the default network interface when `si` returns nothing
+ *  (e.g. transient WMI timeout): first up, non-internal IPv4 interface. */
+function osFallbackNetwork(): { iface: string; ip4: string; mac: string } | null {
+	const ifaces = os.networkInterfaces();
+	for (const [name, addrs] of Object.entries(ifaces)) {
+		for (const addr of addrs ?? []) {
+			if (addr.internal || addr.family !== 'IPv4' || !addr.address) continue;
+			// Skip virtual/tunnel adapters without a real MAC.
+			if (!addr.mac || addr.mac === '00:00:00:00:00:00') continue;
+			return { iface: name, ip4: addr.address, mac: addr.mac };
+		}
+	}
+	return null;
+}
 
 const GpuSchema = t.Object({
 	model: t.String(),
@@ -129,6 +245,201 @@ function selectPrimaryDisks(raw: Systeminformation.FsSizeData[], platform: strin
 		.sort((a, b) => (a.mount === '/' ? -1 : b.mount === '/' ? 1 : b.sizeBytes - a.sizeBytes));
 }
 
+/** Response snapshot served from cache inside the TTL so the 3.5s frontend
+ *  poll and rapid tab switches never re-run the si.* probes. */
+interface DeviceInfoPayload {
+	hostname: string;
+	platform: string;
+	distro: string;
+	release: string;
+	kernel: string;
+	arch: string;
+	isVirtual: boolean;
+	uptimeSec: number;
+	cpu: {
+		brand: string;
+		manufacturer: string;
+		physicalCores: number;
+		logicalCores: number;
+		speedGhz: number | null;
+		loadPercent: number;
+		loadAvg1: number | null;
+	};
+	memory: {
+		totalBytes: number;
+		usedBytes: number;
+		freeBytes: number;
+		swapTotalBytes: number;
+		swapUsedBytes: number;
+	};
+	network: { iface: string; ip4: string; mac: string };
+	battery: {
+		hasBattery: boolean;
+		percent: number | null;
+		isCharging: boolean;
+		acConnected: boolean;
+		timeRemainingMinutes: number | null;
+	};
+	gpus: Array<{
+		model: string;
+		vendor: string;
+		vramMb: number | null;
+		utilizationGpu: number | null;
+		memoryUsedMb: number | null;
+		memoryTotalMb: number | null;
+	}>;
+	disks: DiskInfo[];
+}
+
+/** Shorter than the frontend 3.5s poll so a poll always hits a fresh cache. */
+const DEVICE_CACHE_TTL_MS = 3000;
+let cachedDevice: { payload: DeviceInfoPayload; at: number } | null = null;
+let inFlightDevice: Promise<DeviceInfoPayload> | null = null;
+
+async function buildDeviceInfo(): Promise<DeviceInfoPayload> {
+		// Static facts and live probes launch together. They used to run one
+		// after another (facts ~4s cold, then probes ~3.5s), which stacked past
+		// 7s on first open while other settings tabs render instantly.
+		// Concurrent, the slowest single phase bounds the total.
+		const factsP = getHostFacts();
+
+		// OS-level CPU sample taken at request start; the delta is measured
+		// against the previous request (~3.5s poll), free of probe overhead.
+		const osCpuPercent = sampleOsCpuPercent();
+
+		// Per-poll storm cut from ~11 concurrent spawns to 3: only CPU
+		// fallback, memory, and network run here. Battery/disks/GPU come
+		// from the slow tier so one WMI timeout can no longer flip cards
+		// or inflate the CPU reading with its own measurement cost.
+		const dynamicP = Promise.all([
+			// si CPU is only a first-poll fallback; once the OS delta has a
+			// baseline it is both cheaper and more accurate, so skip the spawn.
+			osCpuPercent !== null
+				? Promise.resolve(null)
+				: withTimeout(si.currentLoad(), 3500),
+			withTimeout(si.mem(), 3500),
+			withTimeout(si.networkInterfaces('default'), 3500),
+			ensureSlow()
+		]);
+
+		const [facts, [load, mem, netDefault, slow]] = await Promise.all([
+			factsP,
+			dynamicP
+		]);
+
+		// Update last-good caches; reuse them when a probe times out so the UI
+		// doesn't flicker between "This Device" <-> "Server" or drop Storage cards.
+		// Stale entries (>60s) are ignored so timed-out probes can't pin old
+		// numbers as live device state forever.
+		const now = Date.now();
+		if (mem) lastMemCache = { value: mem, at: now };
+		if (netDefault) lastNetCache = { value: Array.isArray(netDefault) ? netDefault[0] : netDefault, at: now };
+
+		const memEff = mem ?? fresh(lastMemCache);
+		const batteryEff = slow.battery;
+		const fsSizeEff = slow.fsSize ?? [];
+		const graphicsEff = slow.graphics;
+		const netRawEff = netDefault ?? fresh(lastNetCache);
+		const netSi = Array.isArray(netRawEff) ? netRawEff[0] : netRawEff;
+		const netOsFallback = !netSi?.ip4 ? osFallbackNetwork() : null;
+		const net = netSi?.ip4 ? netSi : netOsFallback;
+
+		// Authoritative 1-minute load average straight from the OS (zeros on
+		// Windows → null, same as before, but without waiting on si timing).
+		const osAvg1 = os.loadavg()[0];
+		const loadAvg1 = typeof osAvg1 === 'number' && osAvg1 > 0 ? osAvg1 : null;
+
+		// Pair live GPU utilization with the cached controller identity by index.
+		const gpus = facts.gpus.map((g, i) => {
+			const live = graphicsEff?.controllers?.[i];
+			return {
+				model: g.model,
+				vendor: g.vendor,
+				vramMb: g.vramMb,
+				utilizationGpu: live && typeof live.utilizationGpu === 'number' ? live.utilizationGpu : null,
+				memoryUsedMb: live && typeof live.memoryUsed === 'number' ? live.memoryUsed : null,
+				memoryTotalMb: live && typeof live.memoryTotal === 'number' ? live.memoryTotal : null
+			};
+		});
+
+		// Show only the primary disk(s); collapses macOS APFS synthetic volumes.
+		const disks = selectPrimaryDisks(fsSizeEff, facts.platform);
+
+		return {
+			hostname: facts.hostname,
+			platform: facts.platform,
+			distro: facts.distro,
+			release: facts.release,
+			kernel: facts.kernel,
+			arch: facts.arch,
+			isVirtual: facts.isVirtual,
+			uptimeSec: os.uptime(),
+			cpu: {
+				brand: facts.cpuBrand,
+				manufacturer: facts.cpuManufacturer,
+				physicalCores: facts.physicalCores,
+				logicalCores: facts.logicalCores,
+				speedGhz: facts.cpuSpeedGhz,
+				// Percent of total machine capacity — the same basis Project Info
+				// normalises its per-project figure to, so the two are comparable.
+				// OS-delta first (immune to the si cold-start spike and to the
+				// probe storm's own CPU cost), si reading as fallback.
+				loadPercent: osCpuPercent ?? (typeof load?.currentLoad === 'number' ? load.currentLoad : 0),
+				loadAvg1
+			},
+			memory: {
+				// Installed RAM comes from the shared host facts so this total and
+				// the one Project Info divides by are always the same number.
+				totalBytes: facts.totalMemBytes,
+				usedBytes: memEff?.active ?? os.totalmem() - os.freemem(),
+				freeBytes: memEff?.available ?? os.freemem(),
+				swapTotalBytes: memEff?.swaptotal ?? 0,
+				swapUsedBytes: memEff?.swapused ?? 0
+			},
+			network: {
+				iface: net?.iface || '',
+				ip4: net?.ip4 || '',
+				mac: net?.mac || ''
+			},
+			battery: {
+				// Sticky presence: a single timed-out/no-battery WMI read must
+				// not flip the panel to "Server" on a laptop with a battery.
+				hasBattery: stickyHasBattery || Boolean(batteryEff?.hasBattery),
+				// Rounded to a whole percent like the OS taskbar/menu-bar shows;
+				// si can report floats on some platforms (e.g. 27.6 → 28).
+				percent: typeof batteryEff?.percent === 'number' && batteryEff.hasBattery ? Math.round(batteryEff.percent) : null,
+				isCharging: Boolean(batteryEff?.isCharging),
+				acConnected: Boolean(batteryEff?.acConnected),
+				timeRemainingMinutes:
+					typeof batteryEff?.timeRemaining === 'number' && batteryEff.timeRemaining > 0
+						? batteryEff.timeRemaining
+						: null
+			},
+			gpus,
+			disks
+		};
+}
+
+function getDeviceInfo(): Promise<DeviceInfoPayload> {
+	if (cachedDevice && Date.now() - cachedDevice.at < DEVICE_CACHE_TTL_MS) {
+		return Promise.resolve(cachedDevice.payload);
+	}
+	if (inFlightDevice) return inFlightDevice;
+
+	inFlightDevice = buildDeviceInfo().then((payload) => {
+		cachedDevice = { payload, at: Date.now() };
+		inFlightDevice = null;
+		return payload;
+	});
+	inFlightDevice.then(
+		() => {},
+		() => {
+			inFlightDevice = null;
+		}
+	);
+	return inFlightDevice;
+}
+
 export const deviceInfoHandler = createRouter()
 	.http('system:device-info', {
 		data: t.Object({}),
@@ -166,99 +477,4 @@ export const deviceInfoHandler = createRouter()
 			gpus: t.Array(GpuSchema),
 			disks: t.Array(DiskSchema)
 		})
-	}, async () => {
-		const facts = await getHostFacts();
-
-		const [load, mem, battery, graphics, fsSize, netDefault] = await Promise.all([
-			withTimeout(si.currentLoad(), 3500),
-			withTimeout(si.mem(), 3500),
-			withTimeout(si.battery(), 3500),
-			withTimeout(si.graphics(), 3500),
-			withTimeout(si.fsSize(), 3500),
-			withTimeout(si.networkInterfaces('default'), 3500)
-		]);
-
-		// Update last-good caches; reuse them when a probe times out so the UI
-		// doesn't flicker between "This Device" <-> "Server" or drop Storage cards.
-		if (mem) lastMemCache = mem;
-		if (battery) lastBatteryCache = battery;
-		if (fsSize) lastFsSizeCache = fsSize;
-		if (load) lastLoadCache = load;
-		if (graphics) lastGraphicsCache = graphics;
-		if (netDefault) lastNetCache = Array.isArray(netDefault) ? netDefault[0] : netDefault;
-
-		const memEff = mem ?? lastMemCache;
-		const batteryEff = battery ?? lastBatteryCache;
-		const fsSizeEff = fsSize ?? lastFsSizeCache ?? [];
-		const loadEff = load ?? lastLoadCache;
-		const graphicsEff = graphics ?? lastGraphicsCache;
-		const netRawEff = netDefault ?? lastNetCache;
-		const net = Array.isArray(netRawEff) ? netRawEff[0] : netRawEff;
-
-		// avgLoad is 0/undefined on platforms without load average (e.g. Windows).
-		const loadAvg1 = typeof loadEff?.avgLoad === 'number' && loadEff.avgLoad > 0 ? loadEff.avgLoad : null;
-
-		// Pair live GPU utilization with the cached controller identity by index.
-		const gpus = facts.gpus.map((g, i) => {
-			const live = graphicsEff?.controllers?.[i];
-			return {
-				model: g.model,
-				vendor: g.vendor,
-				vramMb: g.vramMb,
-				utilizationGpu: live && typeof live.utilizationGpu === 'number' ? live.utilizationGpu : null,
-				memoryUsedMb: live && typeof live.memoryUsed === 'number' ? live.memoryUsed : null,
-				memoryTotalMb: live && typeof live.memoryTotal === 'number' ? live.memoryTotal : null
-			};
-		});
-
-		// Show only the primary disk(s); collapses macOS APFS synthetic volumes.
-		const disks = selectPrimaryDisks(fsSizeEff, facts.platform);
-
-		return {
-			hostname: facts.hostname,
-			platform: facts.platform,
-			distro: facts.distro,
-			release: facts.release,
-			kernel: facts.kernel,
-			arch: facts.arch,
-			isVirtual: facts.isVirtual,
-			uptimeSec: os.uptime(),
-			cpu: {
-				brand: facts.cpuBrand,
-				manufacturer: facts.cpuManufacturer,
-				physicalCores: facts.physicalCores,
-				logicalCores: facts.logicalCores,
-				speedGhz: facts.cpuSpeedGhz,
-				// Percent of total machine capacity — the same basis Project Info
-				// normalises its per-project figure to, so the two are comparable.
-				loadPercent: typeof loadEff?.currentLoad === 'number' ? loadEff.currentLoad : 0,
-				loadAvg1
-			},
-			memory: {
-				// Installed RAM comes from the shared host facts so this total and
-				// the one Project Info divides by are always the same number.
-				totalBytes: facts.totalMemBytes,
-				usedBytes: memEff?.active ?? os.totalmem() - os.freemem(),
-				freeBytes: memEff?.available ?? os.freemem(),
-				swapTotalBytes: memEff?.swaptotal ?? 0,
-				swapUsedBytes: memEff?.swapused ?? 0
-			},
-			network: {
-				iface: net?.iface || '',
-				ip4: net?.ip4 || '',
-				mac: net?.mac || ''
-			},
-			battery: {
-				hasBattery: Boolean(batteryEff?.hasBattery),
-				percent: typeof batteryEff?.percent === 'number' && batteryEff.hasBattery ? batteryEff.percent : null,
-				isCharging: Boolean(batteryEff?.isCharging),
-				acConnected: Boolean(batteryEff?.acConnected),
-				timeRemainingMinutes:
-					typeof batteryEff?.timeRemaining === 'number' && batteryEff.timeRemaining > 0
-						? batteryEff.timeRemaining
-						: null
-			},
-			gpus,
-			disks
-		};
-	});
+	}, async () => getDeviceInfo());

--- a/frontend/components/settings/SettingsModal.svelte
+++ b/frontend/components/settings/SettingsModal.svelte
@@ -35,7 +35,10 @@
 	import InviteManagement from './admin/InviteManagement.svelte';
 	import SecuritySettings from './security/SecuritySettings.svelte';
 	import SystemSettings from './system/SystemSettings.svelte';
-	import AboutDeviceSettings from './system/AboutDeviceSettings.svelte';
+	import AboutDeviceSettings, {
+		prefetchDeviceInfo,
+		prefetchProjectsOverview
+	} from './system/AboutDeviceSettings.svelte';
 	import TunnelSettings from './tunnel/TunnelSettings.svelte';
 
 	// Responsive state
@@ -110,6 +113,18 @@
 	$effect(() => {
 		if (settingsModalState.isOpen && !isMobile) {
 			setTimeout(() => searchInputRef?.focus(), 60);
+		}
+	});
+
+	// Prefetch Device data the moment the modal opens (admin only) so the
+	// slow system:device-info probes + projects:overview folder walk already
+	// run in background while the user browses other tabs. Clicking Device
+	// then shows cached data instantly instead of a long skeleton like other
+	// tabs that render from local stores.
+	$effect(() => {
+		if (settingsModalState.isOpen && isAdmin) {
+			prefetchDeviceInfo();
+			prefetchProjectsOverview();
 		}
 	});
 

--- a/frontend/components/settings/system/AboutDeviceSettings.svelte
+++ b/frontend/components/settings/system/AboutDeviceSettings.svelte
@@ -1,8 +1,67 @@
 <script module lang="ts">
+	import wsPrefetch from '$frontend/utils/ws';
+	import { debug as debugPrefetch } from '$shared/utils/logger';
+
 	// Module-level cache: persists across tab switches so Device opens instantly
 	// on second click without re-showing skeleton.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	export let cachedDeviceInfo: any = null;
+	// Same idea for the Project Overview snapshot below: opening Device a
+	// second time shows the last recap instantly while a refresh runs behind.
+	export let cachedOverview: any = null;
+
+	// Shared in-flight guards so a prefetch started when the Settings modal
+	// opens is joined (not duplicated) by the component mount below. This is
+	// what makes the FIRST click instant: the slow si.* probes + folder walks
+	// already run while the user is still looking at other tabs.
+	let inFlightDevice: Promise<any> | null = null;
+	let inFlightOverview: Promise<any> | null = null;
+
+	/** Warm the Device cache in background; safe to call repeatedly. */
+	export function prefetchDeviceInfo(): Promise<any> | null {
+		if (cachedDeviceInfo || inFlightDevice) return inFlightDevice;
+		inFlightDevice = wsPrefetch
+			.http('system:device-info', {}, 8000)
+			.then((data) => {
+				cachedDeviceInfo = data;
+				return data;
+			})
+			.catch((err) => {
+				debugPrefetch.error('settings', 'Failed to prefetch device info:', err);
+				return null;
+			})
+			.finally(() => {
+				inFlightDevice = null;
+			});
+		return inFlightDevice;
+	}
+
+	/** Warm the Project Overview cache in background; safe to call repeatedly. */
+	export function prefetchProjectsOverview(): Promise<any> | null {
+		if (cachedOverview || inFlightOverview) return inFlightOverview;
+		inFlightOverview = wsPrefetch
+			.http('projects:overview', {}, 30000)
+			.then((data) => {
+				cachedOverview = data;
+				return data;
+			})
+			.catch((err) => {
+				debugPrefetch.error('settings', 'Failed to prefetch projects overview:', err);
+				return null;
+			})
+			.finally(() => {
+				inFlightOverview = null;
+			});
+		return inFlightOverview;
+	}
+
+	/** Join an in-flight prefetch so mount never fires a duplicate request. */
+	export function joinDevicePrefetch(): Promise<any> | null {
+		return inFlightDevice;
+	}
+
+	export function joinOverviewPrefetch(): Promise<any> | null {
+		return inFlightOverview;
+	}
 </script>
 
 <script lang="ts">
@@ -63,7 +122,11 @@
 		disks: Disk[];
 	}
 
-	const POLL_INTERVAL_MS = 3500;
+	// Single 3s refresh heartbeat for the whole panel: device cards and
+	// Project Overview (counts, statuses, Top Projects) update together.
+	// Cheap per tick: device probes are cached/single-flighted, folder walks
+	// keep their own cache, and the overview snapshot has a matching 3s TTL.
+	const REFRESH_INTERVAL_MS = 3000;
 
 	let info = $state<DeviceInfo | null>(cachedDeviceInfo as DeviceInfo | null);
 	let error = $state<string | null>(null);
@@ -72,6 +135,25 @@
 
 	async function fetchInfo() {
 		if (fetching) return;
+		// Join a prefetch started when the Settings modal opened instead of
+		// firing a duplicate slow request — first click feels instant.
+		const joined = joinDevicePrefetch();
+		if (joined) {
+			fetching = true;
+			try {
+				const data = await joined;
+				if (data) {
+					info = data as DeviceInfo;
+					error = null;
+				}
+			} catch (err) {
+				debug.error('settings', 'Failed to fetch device info:', err);
+				if (!info) error = err instanceof Error ? err.message : 'Failed to load device information';
+			} finally {
+				fetching = false;
+			}
+			return;
+		}
 		fetching = true;
 		try {
 			// 8s client timeout — shorter than ws default 30s so UI recovers faster
@@ -85,23 +167,118 @@
 			if (!info) error = err instanceof Error ? err.message : 'Failed to load device information';
 		} finally {
 			fetching = false;
-			scheduleNext();
 		}
 	}
 
-	function scheduleNext() {
-		if (timer) clearTimeout(timer);
-		timer = setTimeout(fetchInfo, POLL_INTERVAL_MS);
+	// --- Project Overview (independent from the Device poll above) ---
+	interface OverviewTopEntry {
+		id: string;
+		name: string;
+		path: string;
+		created_at: string;
+		last_opened_at: string;
+		status: 'running' | 'idle';
+		cpuPercent: number | null;
+		memRssBytes: number | null;
+		memPercent: number | null;
+		sizeBytes: number;
+		fileCount: number;
+		dirCount: number;
+		truncated: boolean;
+	}
+	interface OverviewUnmeasurable {
+		id: string;
+		name: string;
+		path: string;
+		error: string;
+	}
+	interface ProjectsOverview {
+		totalProjects: number;
+		runningCount: number;
+		idleCount: number;
+		measurableCount: number;
+		unmeasurableCount: number;
+		totalStorageIdle: number;
+		totalFilesIdle: number;
+		totalDirsIdle: number;
+		top: OverviewTopEntry[];
+		unmeasurable: OverviewUnmeasurable[];
+		generatedAt: string;
+	}
+
+	let overview = $state<ProjectsOverview | null>(cachedOverview as ProjectsOverview | null);
+	let overviewError = $state<string | null>(null);
+	let overviewFetching = $state(false);
+
+	// View-only search over the Top Projects list (name + path). Data untouched.
+	let topSearch = $state('');
+	const filteredTop = $derived.by(() => {
+		const list = overview?.top ?? [];
+		const query = topSearch.trim().toLowerCase();
+		if (!query) return list;
+		return list.filter(
+			(entry) =>
+				entry.name.toLowerCase().includes(query) || entry.path.toLowerCase().includes(query)
+		);
+	});
+
+	async function fetchOverview() {
+		if (overviewFetching) return;
+		// Same join-prefetch idea as Device above: the overview folder walk
+		// already runs in background since the modal opened.
+		const joined = joinOverviewPrefetch();
+		if (joined) {
+			overviewFetching = true;
+			try {
+				const data = await joined;
+				if (data) {
+					overview = data as ProjectsOverview;
+					overviewError = null;
+				}
+			} catch (err) {
+				debug.error('settings', 'Failed to fetch projects overview:', err);
+				if (!overview) overviewError = err instanceof Error ? err.message : 'Failed to load project overview';
+			} finally {
+				overviewFetching = false;
+			}
+			return;
+		}
+		overviewFetching = true;
+	try {
+		// Generous timeout: the first call can walk several project folders
+		// plus one process-table probe concurrently (worst ~20s+overhead).
+		const data = await ws.http('projects:overview', {}, 30000);
+		overview = data as ProjectsOverview;
+		cachedOverview = overview;
+		overviewError = null;
+	} catch (err) {
+		debug.error('settings', 'Failed to fetch projects overview:', err);
+		// Keep the stale recap visible; only show an error with no data yet.
+		// The Device cards above are untouched by this failure.
+		if (!overview) overviewError = err instanceof Error ? err.message : 'Failed to load project overview';
+	} finally {
+		overviewFetching = false;
+	}
+	}
+
+	// Single heartbeat: both fetches run concurrently on one fixed 3s
+	// interval. In-flight guards inside each fetch skip a tick while the
+	// previous one is still running, so slow folder walks can never pile up.
+	// The keyed list + untouched search input mean no scroll or focus jumps.
+	async function refreshAll() {
+		await Promise.all([fetchInfo(), fetchOverview()]);
 	}
 
 	onMount(() => {
 		// If cached data exists, show it instantly and refresh in background.
 		// Otherwise fetch immediately.
-		fetchInfo();
+		refreshAll();
+		if (timer) clearInterval(timer);
+		timer = setInterval(refreshAll, REFRESH_INTERVAL_MS);
 	});
 
 	onDestroy(() => {
-		if (timer) clearTimeout(timer);
+		if (timer) clearInterval(timer);
 	});
 
 	// --- Formatting helpers ---
@@ -111,6 +288,21 @@
 		const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
 		const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
 		return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+	}
+
+	// Compact counts for the Top Projects dashboard cards: 3797 → "3.8K".
+	function fmtCompact(n: number): string {
+		if (!Number.isFinite(n) || n < 0) return '0';
+		if (n < 1000) return n.toLocaleString();
+		const units = ['K', 'M', 'B'];
+		let value = n;
+		let unit = '';
+		for (const u of units) {
+			value /= 1000;
+			unit = u;
+			if (value < 1000) break;
+		}
+		return `${parseFloat(value.toFixed(1))}${unit}`;
 	}
 
 	function fmtUptime(sec: number): string {
@@ -128,6 +320,36 @@
 		if (pct >= 90) return 'bg-red-500';
 		if (pct >= 75) return 'bg-amber-500';
 		return 'bg-violet-500';
+	}
+
+	function fmtDate(iso: string): string {
+		const d = new Date(iso);
+		if (Number.isNaN(d.getTime())) return '—';
+		return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+	}
+
+	// Same unit Project Info reasons about: null means the host table could
+	// not be read yet (measuring), not zero.
+	function fmtCpu(value: number | null): string {
+		if (value === null) return '—';
+		if (value === 0) return '0%';
+		if (value < 0.1) return '<0.1%';
+		return `${value.toFixed(1)}%`;
+	}
+
+	function fmtRelative(iso: string): string {
+		const t = new Date(iso).getTime();
+		if (Number.isNaN(t)) return '—';
+		const diffMin = Math.max(0, Math.floor((Date.now() - t) / 60000));
+		if (diffMin < 1) return 'just now';
+		if (diffMin < 60) return `${diffMin}m ago`;
+		const diffH = Math.floor(diffMin / 60);
+		if (diffH < 24) return `${diffH}h ago`;
+		const diffD = Math.floor(diffH / 24);
+		if (diffD < 30) return `${diffD}d ago`;
+		const diffMo = Math.floor(diffD / 30);
+		if (diffMo < 12) return `${diffMo}mo ago`;
+		return fmtDate(iso);
 	}
 
 	// --- Derived presentation ---
@@ -157,6 +379,16 @@
 	// When the number of variable cards (GPUs + disks) is odd, let the final card
 	// span both columns so the grid never ends with a lonely half-width cell.
 	const oddTail = $derived(info ? (info.gpus.length + info.disks.length) % 2 === 1 : false);
+
+	// --- Project Overview derived presentation (read-only recap) ---
+	const deviceStorageTotal = $derived(
+		info ? info.disks.reduce((sum, d) => sum + d.sizeBytes, 0) : 0
+	);
+	const idleStorageShare = $derived(
+		overview && deviceStorageTotal > 0
+			? (overview.totalStorageIdle / deviceStorageTotal) * 100
+			: 0
+	);
 </script>
 
 <div class="py-1">
@@ -460,4 +692,221 @@
 			</div>
 		</div>
 	{/if}
+
+	<!-- Project Overview: read-only recap of idle/completed projects.
+	     Visually and logically separate from the Device cards above: own
+	     divider, own loading/error states, refreshed by the shared 3s
+	     heartbeat — no manual refresh needed. -->
+	<div class="mt-6 pt-5 border-t border-slate-200 dark:border-slate-800">
+		<div class="flex items-center gap-2 mb-1.5 flex-wrap">
+			<h3 class="text-base font-bold text-slate-900 dark:text-slate-100">Project Overview</h3>
+			{#if overview}
+				<span class="inline-flex items-center gap-1 px-1.5 py-0.5 bg-violet-500/15 text-violet-600 dark:text-violet-400 rounded text-2xs font-semibold">
+					{overview.idleCount} idle / {overview.totalProjects} total
+				</span>
+			{/if}
+		</div>
+		<p class="text-sm text-slate-600 dark:text-slate-500 mb-5">Live CPU/RAM plus storage footprint, per project — same figures as Project Info</p>
+
+		{#if overviewError && !overview}
+			<div class="flex items-center justify-between gap-3 px-4 py-3 bg-red-500/10 border border-red-500/20 rounded-xl">
+				<div class="flex items-center gap-2 min-w-0">
+					<Icon name="lucide:circle-alert" class="w-4 h-4 text-red-500 shrink-0" />
+					<span class="text-xs text-red-600 dark:text-red-400 truncate">{overviewError}</span>
+				</div>
+				<button
+					type="button"
+					onclick={fetchOverview}
+					class="inline-flex items-center gap-1.5 shrink-0 text-xs font-semibold text-violet-600 dark:text-violet-400 hover:underline cursor-pointer"
+				>
+					<Icon name="lucide:refresh-cw" class="w-3.5 h-3.5" />
+					Retry
+				</button>
+			</div>
+		{:else if !overview}
+			<div class="grid grid-cols-2 lg:grid-cols-4 gap-3.5 animate-pulse">
+				{#each Array(4) as _, i (i)}
+					<div class="px-4 py-3 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-xl">
+						<div class="flex items-center gap-3.5">
+							<div class="w-10 h-10 rounded-lg bg-slate-200 dark:bg-slate-700 shrink-0"></div>
+							<div class="flex-1 space-y-2 min-w-0">
+								<div class="h-3.5 w-20 bg-slate-200 dark:bg-slate-700 rounded"></div>
+								<div class="h-3 w-28 bg-slate-200 dark:bg-slate-700 rounded"></div>
+							</div>
+						</div>
+					</div>
+				{/each}
+			</div>
+		{:else if overview.idleCount === 0}
+			<div class="flex flex-col items-center gap-2 px-4 py-8 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-xl text-center">
+				<Icon name="lucide:folder-open" class="w-6 h-6 text-slate-400 opacity-60" />
+				<span class="text-sm font-medium text-slate-700 dark:text-slate-300">No completed projects yet</span>
+				<span class="text-xs text-slate-500">Idle projects will appear here once they stop running</span>
+			</div>
+		{:else}
+			<div class="flex flex-col gap-3.5">
+				<!-- Summary cards: always 2 columns like the Device cards above.
+				     The settings pane is narrow, so 4-across (lg breakpoint is
+				     viewport-based) squeezes the cards and wraps titles. -->
+				<div class="grid grid-cols-1 sm:grid-cols-2 gap-3.5">
+					<div class="px-4 py-3 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-xl">
+						<div class="flex items-center gap-3.5">
+							<div class="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-violet-400/15 text-violet-500">
+								<Icon name="lucide:folder" class="w-5 h-5" />
+							</div>
+							<div class="flex flex-col gap-0.5 min-w-0 flex-1">
+								<div class="text-sm font-semibold text-slate-900 dark:text-slate-100">Idle Projects</div>
+								<div class="text-xs text-slate-600 dark:text-slate-500">{overview.idleCount} of {overview.totalProjects} completed</div>
+							</div>
+						</div>
+					</div>
+
+					<div class="px-4 py-3 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-xl">
+						<div class="flex items-center gap-3.5">
+							<div class="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-amber-400/15 text-amber-500">
+								<Icon name="lucide:hard-drive" class="w-5 h-5" />
+							</div>
+							<div class="flex flex-col gap-0.5 min-w-0 flex-1">
+								<div class="text-sm font-semibold text-slate-900 dark:text-slate-100">Storage (Idle)</div>
+								<div class="text-xs text-slate-600 dark:text-slate-500 truncate">
+									{fmtBytes(overview.totalStorageIdle)}{#if deviceStorageTotal > 0} · {idleStorageShare === 0 ? '0% of device' : idleStorageShare < 0.1 ? '<0.1% of device' : `${idleStorageShare.toFixed(1)}% of device`}{/if}
+								</div>
+							</div>
+						</div>
+					</div>
+
+					<div class="px-4 py-3 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-xl">
+						<div class="flex items-center gap-3.5">
+							<div class="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-blue-400/15 text-blue-500">
+								<Icon name="lucide:files" class="w-5 h-5" />
+							</div>
+							<div class="flex flex-col gap-0.5 min-w-0 flex-1">
+								<div class="text-sm font-semibold text-slate-900 dark:text-slate-100">Files</div>
+								<div class="text-xs text-slate-600 dark:text-slate-500">{overview.totalFilesIdle.toLocaleString()} files</div>
+							</div>
+						</div>
+					</div>
+
+					<div class="px-4 py-3 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-xl">
+						<div class="flex items-center gap-3.5">
+							<div class="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-slate-400/15 text-slate-500">
+								<Icon name="lucide:folder-tree" class="w-5 h-5" />
+							</div>
+							<div class="flex flex-col gap-0.5 min-w-0 flex-1">
+								<div class="text-sm font-semibold text-slate-900 dark:text-slate-100">Directories</div>
+								<div class="text-xs text-slate-600 dark:text-slate-500">{overview.totalDirsIdle.toLocaleString()} dirs</div>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<!-- Top 5 -->
+				{#if overview.top.length > 0}
+					<div class="flex flex-col gap-3">
+						<div class="flex items-center gap-2 flex-wrap">
+							<h3 class="text-base font-bold text-slate-900 dark:text-slate-100">Top Projects</h3>
+							<span class="inline-flex items-center gap-1 px-1.5 py-0.5 bg-violet-500/15 text-violet-600 dark:text-violet-400 rounded text-2xs font-semibold">
+								{filteredTop.length} of {overview.top.length}
+							</span>
+						</div>
+						<!-- Search: same look as the Model search in Engine settings -->
+						<div class="relative">
+							<svg viewBox="0 0 24 24" fill="none" class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" aria-hidden="true">
+								<circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2" />
+								<path d="M21 21l-4.35-4.35" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+							</svg>
+							<input
+								type="text"
+								bind:value={topSearch}
+								placeholder="Search projects..."
+								aria-label="Search top projects"
+								class="w-full pl-9 pr-3 py-1.5 text-sm bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg outline-none focus:ring-2 focus:ring-violet-500/20 focus:border-violet-600 transition-colors text-slate-900 dark:text-slate-100 placeholder-slate-400"
+							/>
+						</div>
+						{#if filteredTop.length === 0}
+							<p class="px-1 py-3 text-xs text-slate-500 dark:text-slate-500">
+								No projects match "{topSearch.trim()}"
+							</p>
+						{:else}
+							<div class="grid grid-cols-1 sm:grid-cols-2 gap-3.5">
+								{#each filteredTop as entry (entry.id)}
+									{@const metaLine = `${fmtCompact(entry.fileCount)} files · ${fmtCompact(entry.dirCount)} dirs · opened ${fmtRelative(entry.last_opened_at)}`}
+									<div class="px-3.5 pt-1.5 pb-2.5 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-xl">
+										<!-- Row 1: icon + name + status -->
+										<div class="flex items-center gap-2">
+											<div class="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-violet-400/15 text-violet-500">
+												<Icon name="lucide:folder" class="w-5 h-5" />
+											</div>
+											<span class="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate flex-1 min-w-0">{entry.name}</span>
+											<span
+												class="inline-flex items-center gap-1 shrink-0 px-1.5 py-0.5 rounded text-2xs font-semibold
+													{entry.status === 'running'
+													? 'bg-green-500/15 text-green-600 dark:text-green-400'
+													: 'bg-slate-400/15 text-slate-500'}"
+											>
+												<span class="w-1.5 h-1.5 rounded-full {entry.status === 'running' ? 'bg-green-500 animate-pulse' : 'bg-slate-400'}"></span>
+												{entry.status === 'running' ? 'Running' : 'Idle'}
+											</span>
+										</div>
+										<!-- Row 2: path -->
+										<div class="mt-1 text-xs font-mono text-slate-500 truncate" title={entry.path}>{entry.path}</div>
+										<!-- Row 3: stat focal points, same order as Project Info -->
+										<div class="grid grid-cols-3 gap-2 mt-2 pt-2 border-t border-slate-200 dark:border-slate-700">
+											<div class="min-w-0">
+												<div class="text-sm font-semibold font-mono text-slate-900 dark:text-slate-100 truncate">{fmtCpu(entry.cpuPercent)}</div>
+												<div class="text-2xs text-slate-500">CPU</div>
+											</div>
+											<div class="min-w-0">
+												<div class="text-sm font-semibold font-mono text-slate-900 dark:text-slate-100 truncate" title={entry.memRssBytes === null ? 'Unknown' : fmtBytes(entry.memRssBytes)}>{entry.memRssBytes === null ? '—' : fmtBytes(entry.memRssBytes)}</div>
+												<div class="text-2xs text-slate-500">RAM</div>
+											</div>
+											<div class="min-w-0">
+												<div class="text-sm font-semibold font-mono text-slate-900 dark:text-slate-100 truncate" title={fmtBytes(entry.sizeBytes)}>{fmtBytes(entry.sizeBytes)}</div>
+												<div class="text-2xs text-slate-500">Storage</div>
+											</div>
+										</div>
+										<!-- Row 4: secondary metadata -->
+										<div class="mt-1.5 text-2xs text-slate-500 truncate" title={metaLine}>{metaLine}</div>
+									</div>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				{/if}
+
+				<!-- Unavailable folders: listed, never counted in totals -->
+				{#if overview.unmeasurable.length > 0}
+					<div class="flex flex-col gap-2">
+						<h4 class="text-xs font-semibold text-slate-700 dark:text-slate-300 uppercase tracking-wider">
+							Unavailable ({overview.unmeasurable.length})
+						</h4>
+						<div class="flex flex-col gap-2">
+							{#each overview.unmeasurable as entry (entry.id)}
+								<div class="px-4 py-3 bg-slate-100/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800 rounded-xl">
+									<div class="flex items-center gap-3.5">
+										<div class="flex items-center justify-center w-10 h-10 rounded-lg shrink-0 bg-slate-400/15 text-slate-500">
+											<Icon name="lucide:folder" class="w-5 h-5" />
+										</div>
+										<div class="flex flex-col gap-0.5 min-w-0 flex-1">
+											<span class="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">{entry.name}</span>
+											<div class="text-xs font-mono text-slate-500 truncate" title={entry.path}>{entry.path}</div>
+										</div>
+										<span class="inline-flex items-center shrink-0 px-1.5 py-0.5 bg-slate-400/15 text-slate-500 rounded text-2xs font-semibold" title={entry.error}>
+											Unavailable
+										</span>
+									</div>
+								</div>
+							{/each}
+						</div>
+					</div>
+				{/if}
+
+				{#if overview.unmeasurableCount > 0}
+					<p class="text-3xs text-slate-400 dark:text-slate-500 text-center">
+						{overview.measurableCount} of {overview.idleCount} idle projects measured — totals exclude unavailable folders.
+					</p>
+				{/if}
+			</div>
+		{/if}
+	</div>
 </div>

--- a/frontend/components/workspace/ProjectInfoModal.svelte
+++ b/frontend/components/workspace/ProjectInfoModal.svelte
@@ -288,9 +288,6 @@
 							<p class="text-lg font-bold text-slate-900 dark:text-slate-100">{formatBytes(data.storage.sizeBytes)}</p>
 							<p class="text-2xs text-slate-500 dark:text-slate-400">
 								{data.storage.fileCount.toLocaleString()} files · {data.storage.dirCount.toLocaleString()} dirs
-								{#if data.storage.truncated}
-									<span class="text-amber-600 dark:text-amber-400"> (partial)</span>
-								{/if}
 							</p>
 						{/if}
 					</div>
@@ -367,12 +364,6 @@
 						<Icon name="lucide:info" class="w-4 h-4 shrink-0" />
 						{data.resources.rootPids.length} shell{data.resources.rootPids.length !== 1 ? 's' : ''} running, but the host process table could not be read.
 					</div>
-				{/if}
-
-				{#if data.storage.truncated}
-					<p class="text-3xs text-amber-600 dark:text-amber-400 text-center">
-						Storage scan stopped early — the folder is larger than one pass covers, so the size is a floor, not a total.
-					</p>
 				{/if}
 
 				{#if error}


### PR DESCRIPTION
## Summary
Adds a Project Usage tab to Settings → Device listing live CPU, RAM and storage
for every project in one place — searchable, filterable by status and sortable
— and stabilizes the device cards in the tab beside it so the panel opens
instantly and reports steady numbers.

## Why
Per-project resource figures only existed in the Project Info modal, reachable
one project at a time from the project navigator, so there was no way to see
where the machine's CPU, RAM and disk actually went. The Device tab itself also
showed a long skeleton while other tabs rendered instantly, then disagreed with
itself on each open: the title flipped between "This Device" and "Server",
Battery/Swap/Storage cards appeared and vanished, and CPU was inflated by its
own probe storm.

## Changes

**Per-project usage:**
- `backend/ws/projects/overview.ts` (new) — `projects:overview` returns every
  project the caller can see with the same CPU/RAM/storage figures
  `projects:info` reports. Scoped to the connection: `getAll()` for admins,
  `getAllForUser()` otherwise, with the snapshot cache keyed per scope.
- `backend/ws/projects/info.ts` — `peekFolderStats()` serves last-known folder
  stats and queues a refresh behind a four-slot pool, so the overview never
  waits on a walk and the descriptor fan-out stays bounded.
- `frontend/.../AboutDeviceSettings.svelte` — a segmented control splits the
  hardware cards from the project list so only one is mounted at a time, and
  the 3s heartbeat refreshes the visible tab only. The list is one dense row
  per project (name over path, storage over CPU/RAM) with status pills for
  Running/Idle, ordering by size, name or last opened, search across all
  projects, and `measuring` / `unavailable` storage states. Summary cards above
  the list always describe every project, never the filtered subset.
- `frontend/.../device-types.ts` (new) — wire types shared between the module
  script's prefetch caches and the component.

**Device cards:**
- `backend/ws/system/device-info.ts` — two-tier probing (fast OS-delta CPU,
  memory and network per request; battery, disk and GPU cached 60s and
  refreshed in background), sticky battery presence, OS network fallback,
  1500ms response cache.
- `frontend/.../SettingsModal.svelte` — prefetch both endpoints on modal open
  for admins, joined rather than duplicated by the panel's own mount, so the
  first click on either tab lands on data.

## Security impact
`projects:overview` is a list endpoint over data with a per-user ACL. A
project's name and absolute path are not public, and the Device tab's admin
gate is client-side only, so the handler resolves its project set from the
connection rather than listing the table. Non-admins see only their assigned
projects; the per-scope cache keeps an admin snapshot from reaching a member.

## Test plan
- `bun run check` (0 errors) / `bun run lint` / `bun run test` (1183 pass) green
  on this branch merged with current `main`
- `bun test backend/ws/projects/overview.test.ts` — 6 pass, covering storage
  totals by state and footprint ordering
- Open Settings → Device as an admin: cards render from prefetch; switch to
  Project Usage and the list is already there, filling in as walks land, with
  storage reading "Measuring…" until one completes
- Switch tabs back and forth: only the visible tab issues requests, and the
  one being revealed refreshes immediately rather than after a tick
- Filter to Running / Idle and switch ordering: the pill counts and the
  "N of M" badge track the list, the summary cards stay unchanged
- Sign in as a non-admin and call `projects:overview` directly: only assigned
  projects come back
- Start/stop a project shell and watch its dot flip within a tick
- Compare Memory/Disk/Network/Battery against Task Manager, Explorer,
  `Win32_Battery`

## Screenshots
Before/after of both tabs (light and dark).

## Notes
- Opening Settings as an admin warms both endpoints even if Device is never
  visited. The overview build itself is cheap (process table only), but it does
  queue folder walks; they are bounded at four concurrent and the storage cache
  backs off up to 5 minutes for expensive folders.
- The project list is one column by design — the settings pane is ~580px wide
  and a second column leaves the path too narrow to identify a project by.
- `ProjectInfoModal.svelte` is unchanged from `main`; the truncated-scan
  disclosure stays there and the new rows mirror it as a `≥` prefix.
- Runtime QA in a live app has not been done.