### PR TITLE
refactor(workspace): lay More Tools out as a grouped icon grid

### DIFF
--- a/frontend/components/workspace/ToolsMenu.svelte
+++ b/frontend/components/workspace/ToolsMenu.svelte
@@ -66,87 +66,104 @@
 		accent: string;
 	}
 
-	const items = $derived<ToolItem[]>([
+	interface ToolGroup {
+		name: string;
+		items: ToolItem[];
+	}
+
+	// Tiles carry an icon and a label only, so the description moves to the
+	// tooltip: it is worth reading once and costs height on every open.
+	const groups = $derived<ToolGroup[]>([
 		{
-			label: 'Remote Access',
-			description: 'Share a link to reach this Clopen',
-			icon: 'lucide:radio',
-			onClick: onRemoteAccess,
-			count: remoteCount,
-			accent: 'text-violet-600 dark:text-violet-400'
+			name: 'Connections',
+			items: [
+				{
+					label: 'Remote Access',
+					description: 'Share a link to reach this Clopen',
+					icon: 'lucide:radio',
+					onClick: onRemoteAccess,
+					count: remoteCount,
+					accent: 'text-violet-600 dark:text-violet-400'
+				},
+				{
+					label: 'Public Tunnel',
+					description: 'Expose a local port via Cloudflare',
+					icon: 'lucide:cloud-upload',
+					onClick: onPublicTunnel,
+					count: tunnelCount,
+					accent: 'text-green-600 dark:text-green-400'
+				},
+				{
+					label: 'DB Client',
+					description: 'Connect to a database',
+					icon: 'lucide:database',
+					onClick: onDbClient,
+					count: dbCount,
+					accent: 'text-emerald-600 dark:text-emerald-400'
+				},
+				{
+					label: 'SSH Client',
+					description: 'Shell, files, and port forwarding',
+					icon: 'lucide:server',
+					onClick: onSshClient,
+					count: sshCount,
+					accent: 'text-sky-600 dark:text-sky-400'
+				},
+				{
+					label: 'Ports',
+					description: 'What is listening on this machine',
+					icon: 'lucide:cable',
+					onClick: onPorts,
+					// Counts ports born in a Clopen terminal, not every port on the box —
+					// a machine's own listeners are a constant, not a sign of activity.
+					count: portsCount,
+					accent: 'text-amber-600 dark:text-amber-400'
+				},
+				{
+					label: 'Containers',
+					description: 'Docker and Podman on this machine',
+					icon: 'lucide:container',
+					onClick: onContainers,
+					// Containers running here. Unlike ports, every one of these is
+					// something someone chose to start, so all of them count.
+					count: containersCount,
+					accent: 'text-blue-600 dark:text-blue-400'
+				}
+			]
 		},
 		{
-			label: 'Public Tunnel',
-			description: 'Expose a local port via Cloudflare',
-			icon: 'lucide:cloud-upload',
-			onClick: onPublicTunnel,
-			count: tunnelCount,
-			accent: 'text-green-600 dark:text-green-400'
-		},
-		{
-			label: 'DB Client',
-			description: 'Connect to a database',
-			icon: 'lucide:database',
-			onClick: onDbClient,
-			count: dbCount,
-			accent: 'text-emerald-600 dark:text-emerald-400'
-		},
-		{
-			label: 'SSH Client',
-			description: 'Shell, files, and port forwarding',
-			icon: 'lucide:server',
-			onClick: onSshClient,
-			count: sshCount,
-			accent: 'text-sky-600 dark:text-sky-400'
-		},
-		{
-			label: 'Ports',
-			description: 'What is listening on this machine',
-			icon: 'lucide:cable',
-			onClick: onPorts,
-			// Counts ports born in a Clopen terminal, not every port on the box —
-			// a machine's own listeners are a constant, not a sign of activity.
-			count: portsCount,
-			accent: 'text-amber-600 dark:text-amber-400'
-		},
-		{
-			label: 'Containers',
-			description: 'Docker and Podman on this machine',
-			icon: 'lucide:container',
-			onClick: onContainers,
-			// Containers running here. Unlike ports, every one of these is
-			// something someone chose to start, so all of them count.
-			count: containersCount,
-			accent: 'text-blue-600 dark:text-blue-400'
-		},
-		{
-			label: 'Memory',
-			description: 'What this workspace has learned',
-			icon: 'lucide:brain',
-			onClick: onMemory,
-			// No live count: memory is not a connection you open, it just accrues.
-			count: 0,
-			accent: 'text-violet-600 dark:text-violet-400'
-		},
-		{
-			label: 'Notes',
-			description: 'Project notes with images',
-			icon: 'lucide:sticky-note',
-			onClick: onNotes,
-			count: 0,
-			accent: 'text-amber-600 dark:text-amber-400'
-		},
-		{
-			// "Issues" alone was a lie by omission: pull requests are half of what
-			// is behind it, and the only half with CI, commits and a diff.
-			label: 'Issues & PRs',
-			description: 'Issues, pull requests and CI',
-			icon: 'lucide:circle-dot',
-			onClick: onWork,
-			// No live count: an open issue is not a connection this machine holds,
-			// and a badge counting someone's backlog would nag rather than inform.
-			count: 0,
-			accent: 'text-rose-600 dark:text-rose-400'
+			name: 'Workspace',
+			items: [
+				{
+					label: 'Memory',
+					description: 'What this workspace has learned',
+					icon: 'lucide:brain',
+					onClick: onMemory,
+					// No live count: memory is not a connection you open, it just accrues.
+					count: 0,
+					accent: 'text-violet-600 dark:text-violet-400'
+				},
+				{
+					label: 'Notes',
+					description: 'Project notes with images',
+					icon: 'lucide:sticky-note',
+					onClick: onNotes,
+					count: 0,
+					accent: 'text-amber-600 dark:text-amber-400'
+				},
+				{
+					// "Issues" alone was a lie by omission: pull requests are half of what
+					// is behind it, and the only half with CI, commits and a diff.
+					label: 'Issues & PRs',
+					description: 'Issues, pull requests and CI',
+					icon: 'lucide:circle-dot',
+					onClick: onWork,
+					// No live count: an open issue is not a connection this machine holds,
+					// and a badge counting someone's backlog would nag rather than inform.
+					count: 0,
+					accent: 'text-rose-600 dark:text-rose-400'
+				}
+			]
 		}
 	]);
 
@@ -215,33 +232,44 @@
 			upward from a button that sits at the bottom of the sidebar, so an
 			uncapped list ran off the top of the screen — and did so first on the
 			small screens that can least afford it.
-
-			The heading stays put while the list moves under it: losing "More
-			Tools" on the first scroll leaves an unlabelled list of icons.
 		-->
 		<div
-			class="absolute {mobile ? 'top-full right-0 mt-1' : 'bottom-full left-0 mb-1'} flex flex-col w-64 max-h-[min(28rem,70dvh)] bg-white dark:bg-slate-800 border border-violet-500/20 rounded-lg shadow-2xl shadow-slate-900/20 dark:shadow-black/40 z-50 overflow-hidden"
+			class="absolute {mobile ? 'top-full right-0 mt-1' : 'bottom-full left-0 mb-1'} flex flex-col w-80 max-w-[calc(100vw-1.5rem)] max-h-[min(28rem,70dvh)] bg-white dark:bg-slate-800 border border-violet-500/20 rounded-lg shadow-2xl shadow-slate-900/20 dark:shadow-black/40 z-50 overflow-hidden"
 			transition:scale={{ duration: 150, easing: cubicOut, start: 0.95, opacity: 0 }}
 		>
-			<div class="px-3 pt-2 pb-1.5 shrink-0 text-xs font-semibold text-slate-600 dark:text-slate-500 uppercase tracking-wider">
-				More Tools
-			</div>
-			<div class="flex flex-col min-h-0 overflow-y-auto pb-1.5">
-				{#each items as item (item.label)}
-					<button
-						type="button"
-						class="flex items-center gap-3 w-full shrink-0 px-3 py-2 bg-transparent border-none text-left cursor-pointer transition-all duration-150 hover:bg-violet-500/10"
-						onclick={() => select(item)}
-					>
-						<Icon name={item.icon} class="w-4 h-4 shrink-0 {item.count > 0 ? item.accent : 'text-slate-500 dark:text-slate-400'}" />
-						<div class="flex flex-col min-w-0 flex-1">
-							<span class="text-sm font-medium text-slate-800 dark:text-slate-200">{item.label}</span>
-							<span class="text-xs text-slate-500 dark:text-slate-500 truncate">{item.description}</span>
-						</div>
-						{#if item.count > 0}
-							<span class="text-xs font-semibold {item.accent} shrink-0">{item.count}</span>
-						{/if}
-					</button>
+			<div class="flex flex-col min-h-0 overflow-y-auto py-2">
+				{#each groups as group, groupIndex (group.name)}
+					{#if groupIndex > 0}
+						<div class="my-2 mx-3 border-t border-slate-200 dark:border-slate-800"></div>
+					{/if}
+					<div class="px-3 pb-1.5 text-xs font-medium text-violet-600 dark:text-violet-400 uppercase tracking-wide">
+						{group.name}
+					</div>
+					<div class="grid grid-cols-3 gap-1.5 px-3">
+						{#each group.items as item (item.label)}
+							<button
+								type="button"
+								class="flex flex-col items-center gap-1.5 {mobile ? 'py-2.5' : 'py-2'} px-1 bg-transparent border border-slate-200 dark:border-slate-800 rounded-lg cursor-pointer transition-all duration-150 hover:bg-violet-500/10 hover:border-violet-500/20"
+								onclick={() => select(item)}
+								title={item.description}
+							>
+								<div class="relative">
+									<Icon name={item.icon} class="w-5 h-5 {item.count > 0 ? item.accent : 'text-slate-500 dark:text-slate-400'}" />
+									{#if item.count > 0}
+										<span
+											class="absolute -top-1.5 -right-2.5 px-1 min-w-3.5 h-3.5 rounded-full bg-slate-100 dark:bg-slate-700 text-[10px] leading-[14px] font-semibold text-center {item.accent}"
+										>
+											{item.count}
+										</span>
+									{/if}
+								</div>
+								<!-- One line only: a wrapping label would make its tile taller than the rest of the row. -->
+								<span class="w-full text-[11px] leading-[13px] font-medium text-center text-slate-800 dark:text-slate-200 truncate">
+									{item.label}
+								</span>
+							</button>
+						{/each}
+					</div>
 				{/each}
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
Reworks the More Tools menu from a vertical list of two-line rows into a
three-column grid of icon tiles, grouped into Connections and Workspace
sections.

## Why
The menu grows with every tool that ships. At nine tools the two-line
rows already stood ~460px tall and hit the menu's own max-height cap on
short screens, so it scrolled. The per-row description was the costly
part: useful the first time you meet "Ports" or "Memory", pure height
on every open after that.

## Changes
- `ToolsMenu.svelte`: flat `items` array becomes `groups` — Connections
  (Remote Access, Public Tunnel, DB Client, SSH Client, Ports,
  Containers) and Workspace (Memory, Notes, Issues & PRs), rendered with
  a violet category label and divider, matching `ViewMenu.svelte`
- Rows become `grid-cols-3` tiles: icon above a centered single-line
  label that truncates instead of wrapping, so every tile is one height
- Description moves from a visible line to the tile's `title` tooltip
- Live counts move from a trailing number to a badge on the icon corner,
  keeping their existing accent colors
- Popover widens `w-64` → `w-80` (capped at the viewport) so the longest
  labels fit on one line; tiles take extra padding on mobile for touch
- Drops the "More Tools" heading — the section labels carry the
  structure, and the trigger button already labels the menu

## Notes
No behavior change beyond layout — the same nine handlers, counts, and
activity dot logic. Section membership is the only new decision, and it
is a plain grouping of the existing items.

## Test plan
- [x] `bun run check` — 0 errors
- [x] `bun run lint` — no new findings
- [x] Manual: open the menu collapsed and expanded, desktop and mobile;
      confirm counts, tooltips, and that no label clips