### PR TITLE
fix(git): keep the panel readable at dock width

### DIFF
--- a/frontend/components/git/GitOperationBanner.svelte
+++ b/frontend/components/git/GitOperationBanner.svelte
@@ -85,90 +85,94 @@
 </script>
 
 <div
-	class="mx-2 mb-2 rounded-lg border border-amber-400/50 bg-amber-500/10 dark:border-amber-500/40 dark:bg-amber-500/10"
+	class="mx-2 mb-2 rounded-lg border border-amber-400/50 bg-amber-500/10 px-2.5 py-2 dark:border-amber-500/40 dark:bg-amber-500/10"
 >
-	<div class="flex flex-wrap items-start gap-x-2 gap-y-1 px-2.5 py-2">
-		<Icon name={icon} class="w-4 h-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
-		<div class="min-w-0 flex-1">
-			<div class="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
-				<span class="text-xs font-semibold text-amber-800 dark:text-amber-200">{title}</span>
-				{#if progress}
-					<span
-						class="rounded px-1 py-px text-3xs font-semibold text-amber-800 dark:text-amber-200 bg-amber-500/20"
-					>
-						{progress}
-					</span>
-				{/if}
-				{#if repoLabel}
-					<span class="truncate text-3xs text-amber-700/80 dark:text-amber-300/80">in {repoLabel}</span>
-				{/if}
-			</div>
+	<!-- Stacked on purpose: the panel is a narrow dock, and sitting the buttons
+		beside the text squeezed the heading into a one-word-per-line column. -->
+	<div class="flex items-center gap-1.5">
+		<Icon name={icon} class="w-4 h-4 shrink-0 text-amber-600 dark:text-amber-400" />
+		<span class="shrink-0 text-xs font-semibold whitespace-nowrap text-amber-800 dark:text-amber-200">
+			{title}
+		</span>
+		{#if progress}
+			<span
+				class="shrink-0 rounded bg-amber-500/20 px-1 py-px text-3xs font-semibold text-amber-800 dark:text-amber-200"
+			>
+				{progress}
+			</span>
+		{/if}
+		{#if repoLabel}
+			<span class="min-w-0 truncate text-3xs text-amber-700/80 dark:text-amber-300/80" title={repoLabel}>
+				in {repoLabel}
+			</span>
+		{/if}
+	</div>
 
-			{#if state.currentCommit}
-				<p class="mt-0.5 truncate text-3xs text-amber-800/90 dark:text-amber-200/90" title={state.currentCommit}>
-					{state.currentCommit}
-				</p>
-			{/if}
+	{#if state.currentCommit}
+		<p class="mt-1 truncate text-3xs text-amber-800/90 dark:text-amber-200/90" title={state.currentCommit}>
+			{state.currentCommit}
+		</p>
+	{/if}
 
-			{#if sidesHint}
-				<p class="mt-0.5 truncate text-3xs text-amber-700/80 dark:text-amber-300/80" title={sidesHint}>
-					{sidesHint}
-				</p>
-			{/if}
+	{#if sidesHint}
+		<p class="mt-0.5 truncate text-3xs text-amber-700/80 dark:text-amber-300/80" title={sidesHint}>
+			{sidesHint}
+		</p>
+	{/if}
 
-			{#if state.unmergedCount > 0}
-				<button
-					type="button"
-					class="mt-1 inline-flex items-center gap-1 rounded-md border-none bg-amber-500/20 px-1.5 py-0.5 text-3xs font-medium text-amber-900 transition-colors hover:bg-amber-500/30 dark:text-amber-100 {onResolve ? 'cursor-pointer' : 'cursor-default'}"
-					onclick={onResolve}
-					disabled={!onResolve}
-				>
-					<Icon name="lucide:git-compare-arrows" class="w-3 h-3" />
-					{state.unmergedCount} unresolved file{state.unmergedCount === 1 ? '' : 's'}
-				</button>
-			{/if}
-		</div>
+	{#if state.unmergedCount > 0}
+		<button
+			type="button"
+			class="mt-1.5 flex w-full items-center gap-1 rounded-md border-none bg-amber-500/20 px-1.5 py-1 text-3xs font-medium text-amber-900 transition-colors hover:bg-amber-500/30 dark:text-amber-100 {onResolve ? 'cursor-pointer' : 'cursor-default'}"
+			onclick={onResolve}
+			disabled={!onResolve}
+		>
+			<Icon name="lucide:git-compare-arrows" class="w-3 h-3 shrink-0" />
+			<span class="truncate">
+				{state.unmergedCount} unresolved file{state.unmergedCount === 1 ? '' : 's'}
+			</span>
+		</button>
+	{/if}
 
-		<div class="flex shrink-0 flex-wrap items-center gap-1">
-			{#if !state.stashConflict && state.operation !== 'bisect'}
-				<button
-					type="button"
-					class="flex items-center gap-1 rounded-md border-none px-2 py-1 text-3xs font-semibold transition-colors
-						{state.canContinue && !busy
-							? 'bg-emerald-600 text-white hover:bg-emerald-700 cursor-pointer'
-							: 'bg-slate-200 text-slate-400 dark:bg-slate-700 dark:text-slate-500 cursor-not-allowed'}"
-					onclick={onContinue}
-					disabled={!state.canContinue || busy}
-					title={continueTitle}
-				>
-					<Icon name="lucide:play" class="w-3 h-3" />
-					Continue
-				</button>
-			{/if}
-			{#if state.canSkip}
-				<button
-					type="button"
-					class="flex items-center gap-1 rounded-md border-none bg-white/70 px-2 py-1 text-3xs font-semibold text-amber-900 transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-800/70 dark:text-amber-100 dark:hover:bg-slate-800 cursor-pointer"
-					onclick={onSkip}
-					disabled={busy}
-					title="Drop the commit git is stuck on and move to the next one"
-				>
-					<Icon name="lucide:skip-forward" class="w-3 h-3" />
-					Skip
-				</button>
-			{/if}
+	<div class="mt-2 flex items-center gap-1">
+		{#if !state.stashConflict && state.operation !== 'bisect'}
 			<button
 				type="button"
-				class="flex items-center gap-1 rounded-md border-none bg-red-500/10 px-2 py-1 text-3xs font-semibold text-red-600 transition-colors hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400 cursor-pointer"
-				onclick={onAbort}
-				disabled={busy}
-				title={state.stashConflict
-					? 'Unwind the unmerged paths — the stash entry itself is kept'
-					: 'Undo this operation and return to the previous state'}
+				class="flex min-w-0 flex-1 items-center justify-center gap-1 rounded-md border-none px-2 py-1 text-3xs font-semibold transition-colors
+					{state.canContinue && !busy
+						? 'bg-emerald-600 text-white hover:bg-emerald-700 cursor-pointer'
+						: 'bg-slate-200 text-slate-400 dark:bg-slate-700 dark:text-slate-500 cursor-not-allowed'}"
+				onclick={onContinue}
+				disabled={!state.canContinue || busy}
+				title={continueTitle}
 			>
-				<Icon name="lucide:octagon-x" class="w-3 h-3" />
-				{abortLabel}
+				<Icon name="lucide:play" class="w-3 h-3 shrink-0" />
+				<span class="truncate">Continue</span>
 			</button>
-		</div>
+		{/if}
+		{#if state.canSkip}
+			<button
+				type="button"
+				class="flex min-w-0 flex-1 items-center justify-center gap-1 rounded-md border-none bg-white/70 px-2 py-1 text-3xs font-semibold text-amber-900 transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-800/70 dark:text-amber-100 dark:hover:bg-slate-800 cursor-pointer"
+				onclick={onSkip}
+				disabled={busy}
+				title="Drop the commit git is stuck on and move to the next one"
+			>
+				<Icon name="lucide:skip-forward" class="w-3 h-3 shrink-0" />
+				<span class="truncate">Skip</span>
+			</button>
+		{/if}
+		<button
+			type="button"
+			class="flex min-w-0 flex-1 items-center justify-center gap-1 rounded-md border-none bg-red-500/10 px-2 py-1 text-3xs font-semibold text-red-600 transition-colors hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400 cursor-pointer"
+			onclick={onAbort}
+			disabled={busy}
+			title={state.stashConflict
+				? 'Unwind the unmerged paths — the stash entry itself is kept'
+				: 'Undo this operation and return to the previous state'}
+		>
+			<Icon name="lucide:octagon-x" class="w-3 h-3 shrink-0" />
+			<span class="truncate">{abortLabel}</span>
+		</button>
 	</div>
 </div>

--- a/frontend/components/workspace/panels/GitPanel.svelte
+++ b/frontend/components/workspace/panels/GitPanel.svelte
@@ -2892,7 +2892,19 @@
 		if (matched) {
 			return { remote: matched.name, branch: upstream.slice(matched.name.length + 1) };
 		}
-		// A URL upstream: everything up to the last slash is the remote.
+		// A URL upstream. Its branch half can itself contain slashes, so cutting at
+		// the last one labelled `.../clopen.git/dev` the remote and
+		// `trello-task-client` the branch — match the configured remote URLs first,
+		// then the `.git/` boundary, and only then fall back to that cut.
+		const url = remotes
+			.flatMap(remote => [remote.pushUrl, remote.fetchUrl])
+			.filter(candidate => candidate && upstream.startsWith(candidate + '/'))
+			.sort((a, b) => b.length - a.length)[0];
+		if (url) return { remote: url, branch: upstream.slice(url.length + 1) };
+		const gitSuffix = upstream.indexOf('.git/');
+		if (gitSuffix > 0) {
+			return { remote: upstream.slice(0, gitSuffix + 4), branch: upstream.slice(gitSuffix + 5) };
+		}
 		const cut = upstream.lastIndexOf('/');
 		if (cut <= 0) return { remote: '', branch: upstream };
 		return { remote: upstream.slice(0, cut), branch: upstream.slice(cut + 1) };
@@ -2914,11 +2926,18 @@
 		return splitUpstream(branch.upstream).remote || null;
 	}
 
-	function getBranchRemoteName(branch: GitBranch): string | null {
+	/**
+	 * What a branch row prints beside the name. The upstream is nearly always the
+	 * same name on the same remote, and spelling it out in full left no room for
+	 * the branch name itself — so the remote alone is enough whenever the two
+	 * names agree, and the full upstream stays available as the row's tooltip.
+	 */
+	function getBranchUpstreamLabel(branch: GitBranch): string | null {
 		if (!branch.upstream) return null;
 		const { remote, branch: remoteBranch } = splitUpstream(branch.upstream);
 		if (!remote) return remoteBranch;
-		return `${shortRemoteLabel(remote)}/${remoteBranch}`;
+		const remoteLabel = shortRemoteLabel(remote);
+		return remoteBranch === branch.name ? remoteLabel : `${remoteLabel}/${remoteBranch}`;
 	}
 
 	const BRANCH_COMMIT_PAGE_SIZE = 8;
@@ -4885,7 +4904,7 @@
 
 <!-- Nested repo branch row snippet (mirrors main branch row) -->
 {#snippet nestedRepoBranchRow(nested: GitNestedRepoInfo, branch: GitBranch)}
-	{@const upstreamName = getBranchRemoteName(branch)}
+	{@const upstreamName = getBranchUpstreamLabel(branch)}
 	{@const branchKey = branchCommitStateKey(branch.name, nested.path)}
 	{@const isExpanded = expandedBranches.has(branchKey)}
 	{@const commitState = branchCommitState[branchKey]}
@@ -4903,7 +4922,7 @@
 			<div class="flex-1 min-w-0 flex flex-col justify-center overflow-hidden">
 				<div class="flex min-w-0 items-center gap-2">
 					<span class="flex-1 min-w-0 text-sm text-slate-900 dark:text-slate-100 leading-tight truncate" title={branch.name}>{branch.name}</span>
-					{#if upstreamName}<span class="text-3xs text-slate-400 shrink-0">{upstreamName}</span>{/if}
+					{#if upstreamName}<span class="min-w-0 max-w-[45%] truncate text-3xs text-slate-400" title="Tracks {branch.upstream}">{upstreamName}</span>{/if}
 				</div>
 				<div class="flex min-w-0 items-center gap-1.5 mt-0.5 text-xs text-slate-500 leading-tight">
 					{#if branch.ahead > 0}<span class="shrink-0">{branch.ahead} ahead</span>{/if}
@@ -6004,16 +6023,29 @@
 				the panel used to give no sign of that at all. -->
 			<div class="px-2 pt-2">
 				<div
-					class="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg border border-sky-400/40 bg-sky-500/10 px-2.5 py-1.5 dark:border-sky-500/40"
+					class="flex items-start gap-2 rounded-lg border border-sky-400/40 bg-sky-500/10 px-2.5 py-1.5 dark:border-sky-500/40"
 				>
-					<Icon name="lucide:arrow-up-from-line" class="w-3.5 h-3.5 shrink-0 text-sky-600 dark:text-sky-400" />
-					<span class="min-w-0 flex-1 truncate text-3xs text-sky-800 dark:text-sky-200">
-						Pushes to <span class="font-mono font-semibold">{describePushTarget(pushTarget)}</span>
-						{#if pushTarget.isUrl}(a remote URL, not <span class="font-mono">{selectedRemote}</span>){/if}
-					</span>
+					<Icon name="lucide:arrow-up-from-line" class="mt-0.5 w-3.5 h-3.5 shrink-0 text-sky-600 dark:text-sky-400" />
+					<div class="min-w-0 flex-1">
+						<!-- The destination goes on its own line and wraps: a fork URL is far
+							wider than this dock, and truncating it hid the branch — the one part
+							that says where the commits land. -->
+						<div class="text-3xs text-sky-700/90 dark:text-sky-300/90">Pushes to</div>
+						<div
+							class="font-mono text-3xs font-semibold break-all text-sky-800 dark:text-sky-100"
+							title={describePushTarget(pushTarget)}
+						>
+							{describePushTarget(pushTarget)}
+						</div>
+						{#if pushTarget.isUrl}
+							<div class="text-3xs text-sky-700/80 dark:text-sky-300/80">
+								a remote URL, not <span class="font-mono">{selectedRemote}</span>
+							</div>
+						{/if}
+					</div>
 					<button
 						type="button"
-						class="shrink-0 cursor-pointer rounded-md border-none bg-sky-500/15 px-2 py-0.5 text-3xs font-semibold text-sky-800 transition-colors hover:bg-sky-500/25 dark:text-sky-100"
+						class="mt-0.5 shrink-0 cursor-pointer rounded-md border-none bg-sky-500/15 px-2 py-0.5 text-3xs font-semibold text-sky-800 transition-colors hover:bg-sky-500/25 dark:text-sky-100"
 						onclick={openUpstreamModal}
 						title="Change which remote branch this branch tracks"
 					>
@@ -6330,7 +6362,7 @@
 						{:else}
 							<div class="space-y-0.5">
 								{#each filteredLocalBranches as branch (branch.name)}
-									{@const upstreamName = getBranchRemoteName(branch)}
+									{@const upstreamName = getBranchUpstreamLabel(branch)}
 									{@const isExpanded = expandedBranches.has(branch.name)}
 									{@const commitState = branchCommitState[branch.name]}
 									{@const branchRelativeDate = formatRelativeTime(branch.lastCommitDate)}
@@ -6346,7 +6378,7 @@
 											<div class="flex-1 min-w-0 flex flex-col justify-center overflow-hidden">
 												<div class="flex min-w-0 items-center gap-2">
 													<span class="flex-1 min-w-0 text-sm text-slate-900 dark:text-slate-100 leading-tight truncate" title={branch.name}>{branch.name}</span>
-													{#if upstreamName}<span class="text-3xs text-slate-400 shrink-0">{upstreamName}</span>{/if}
+													{#if upstreamName}<span class="min-w-0 max-w-[45%] truncate text-3xs text-slate-400" title="Tracks {branch.upstream}">{upstreamName}</span>{/if}
 												</div>
 												<div class="flex min-w-0 items-center gap-1.5 mt-0.5 text-xs text-slate-500 leading-tight">
 													{#if branch.ahead > 0}<span class="shrink-0">{branch.ahead} ahead</span>{/if}


### PR DESCRIPTION
## Summary
Relayout three rows in the Git panel — branch rows, the in-progress
operation banner, and the push-target banner — so they stay readable at
the width the panel actually has.

## Why
The panel is a narrow dock, but these rows were laid out as if they had a
page's width. The branch row printed the full upstream with `shrink-0`, so
a long `origin/<branch>` pushed the branch name out of the row entirely.
The operation banner placed its action buttons beside the text, which
collapsed "Rebase in progress" into a one-word-per-line column. The
push-target banner truncated the destination, hiding the branch name.

## Changes
- `GitPanel.svelte`: `getBranchUpstreamLabel()` prints the remote alone
  when the tracked branch name matches the local one, and the full
  `remote/branch` only when they differ; the label is capped at 45% of the
  row and truncates, with the full upstream as the tooltip. Applied to
  both the main and nested-repo branch rows.
- `GitPanel.svelte`: `splitUpstream()` resolves URL upstreams against the
  configured remote URLs and the `.git/` boundary before falling back to
  the last-slash cut, which mislabelled branches containing a slash.
- `GitPanel.svelte`: the push-target banner gives the destination its own
  line with `break-all` instead of truncating it.
- `GitOperationBanner.svelte`: stacked layout — heading row, detail lines,
  then an action row whose buttons share the width via `flex-1`.
- Removed `getBranchRemoteName()`, now unused.

## Test plan
- `bun run check` — 0 errors, 0 warnings
- `bun run lint` — clean (one pre-existing warning in an unrelated file)
- Pending on your side: visual check of a branch list with long upstreams,
  a repo mid-rebase and mid-cherry-pick, and a branch whose push target
  differs from the selected remote.